### PR TITLE
Correcting the reference to googlepay in Proguard configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ If you are using ProGuard add the following options:
 #### Adyen Checkout ####
 -keep class com.adyen.checkout.core.** { *; }
 -dontwarn com.adyen.checkout.nfc.**
--dontwarn com.adyen.checkout.googlewallet.**
+-dontwarn com.adyen.checkout.googlepay.**
 -dontwarn com.adyen.checkout.wechatpay.**
 ```
 

--- a/example-app/proguard-rules.pro
+++ b/example-app/proguard-rules.pro
@@ -58,5 +58,5 @@
 #### Adyen Checkout ####
 -keep class com.adyen.checkout.core.** { *; }
 -dontwarn com.adyen.checkout.nfc.**
--dontwarn com.adyen.checkout.googlewallet.**
+-dontwarn com.adyen.checkout.googlepay.**
 -dontwarn com.adyen.checkout.wechatpay.**


### PR DESCRIPTION
The current Proguard configurations are using the old "googlewallet" package instead of "googlepay".