### PR TITLE
Make Adyen3DS2Component return error instead of crash in case transaction missing on challengeShopper

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.java
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.java
@@ -175,6 +175,11 @@ public final class Adyen3DS2Component extends BaseActionComponent implements Cha
         closeTransaction(getApplication());
     }
 
+    private void noActiveTransaction() {
+        Logger.d(TAG, "no active transaction");
+        notifyException(new Authentication3DS2Exception("No active transaction"));
+    }
+
     private void identifyShopper(final Context context, final String encodedFingerprintToken) throws ComponentException {
         Logger.d(TAG, "identifyShopper");
         final String decodedFingerprintToken = Base64Encoder.decode(encodedFingerprintToken);
@@ -234,6 +239,11 @@ public final class Adyen3DS2Component extends BaseActionComponent implements Cha
 
     private void challengeShopper(Activity activity, String encodedChallengeToken) throws ComponentException {
         Logger.d(TAG, "challengeShopper");
+
+        if (mTransaction == null) {
+            noActiveTransaction();
+            return;
+        }
 
         final String decodedChallengeToken = Base64Encoder.decode(encodedChallengeToken);
 


### PR DESCRIPTION
Please see related iOS SDK pull request https://github.com/Adyen/adyen-ios/pull/101

We ran into a situation where we received ChallengeShopper after we responded for ChallengeShopper, which makes the app crash. The iOS SDK has detailed steps.
We are currently in talks with Adyen support to find the issue in this "shouldn't happen" scenario.

iOS SDK developers agreed to handle this problem regardless, so I'd like to offer the matching fix for Android SDK.