### PR TITLE
Add back GPG passphrase to release.

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -35,7 +35,7 @@ jobs:
         env:
           BINTRAY_USER: ${{secrets.BINTRAY_USER}}
           BINTRAY_KEY: ${{secrets.BINTRAY_KEY}}
-#          BINTRAY_GPG_PASSPHRASE: ${{secrets.BINTRAY_GPG_PASSPHRASE}}
+          BINTRAY_GPG_PASSPHRASE: ${{secrets.BINTRAY_GPG_PASSPHRASE}}
 
       # Get the version name from a script and save to environment variable.
       - name: Set PROJECT_VERSION


### PR DESCRIPTION
This seems to be what is making the release Action fail.
https://github.com/Adyen/adyen-android/runs/1263961604

Caused by: java.net.ConnectException: Connection timed out (Connection timed out)
...
at com.jfrog.bintray.gradle.tasks.BintrayPublishTask.gpgSignVersion(BintrayPublishTask.groovy:73)