### PR TITLE
Disable signing on Bintray task.

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -35,7 +35,7 @@ jobs:
         env:
           BINTRAY_USER: ${{secrets.BINTRAY_USER}}
           BINTRAY_KEY: ${{secrets.BINTRAY_KEY}}
-          BINTRAY_GPG_PASSPHRASE: ${{secrets.BINTRAY_GPG_PASSPHRASE}}
+#          BINTRAY_GPG_PASSPHRASE: ${{secrets.BINTRAY_GPG_PASSPHRASE}}
 
       # Get the version name from a script and save to environment variable.
       - name: Set PROJECT_VERSION

--- a/config/gradle/release.gradle
+++ b/config/gradle/release.gradle
@@ -5,9 +5,6 @@
  *
  * Created by ran on 6/2/2019.
  */
-
-import groovy.json.JsonSlurper
-
 apply plugin: "maven-publish"
 // https://github.com/bintray/gradle-bintray-plugin
 apply plugin: "com.jfrog.bintray"
@@ -133,26 +130,9 @@ bintray {
             vcsTag = theVersion
 
             gpg {
-                sign = true
-                passphrase = System.env.BINTRAY_GPG_PASSPHRASE
+                sign = false
+//                passphrase = System.env.BINTRAY_GPG_PASSPHRASE
             }
         }
     }
 }
-
-task publishAndUploadToBintray {
-    doLast {
-        def req = ['curl', '-s -X', 'POST',
-                   "-u${System.env.BINTRAY_USER}:${System.env.BINTRAY_KEY}",
-                   "${System.env.BINTRAY_API}/${theArtifactId}/${theVersion}/publish"].execute()
-        def response = req.text
-        if (response) {
-            def json = new JsonSlurper().parseText(response)
-            println "${json.files} files from ${theArtifactId} module have been published"
-        } else {
-            throw new GradleException("Publishing ${theArtifactId} failed")
-        }
-    }
-}
-
-publishAndUploadToBintray.dependsOn "bintrayUpload"


### PR DESCRIPTION
Failure on publish action happens when trying to sign the artifacts.
Which is useless since we don't have a GPG key setup for this project yet.