### PR TITLE
Update Actions for manual releases on V3 branch.

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -1,9 +1,9 @@
-name: Check PR
+name: Check PR v3
 
 # Every PR should be checked for static analysis
 on:
   pull_request:
-    branches: [ develop ]
+    branches: [ v3 ]
     types: [ opened, synchronize, reopened ]
 
 jobs:

--- a/.github/workflows/check_release.yml
+++ b/.github/workflows/check_release.yml
@@ -1,14 +1,11 @@
-name: Check Release
+name: Check Release v3
 
-# Every time we open a PR to merge develop into main branch for a release
+# Only triggered manually
 on:
-  pull_request:
-    branches: [ main ]
-    types: [ opened, synchronize, reopened ]
   workflow_dispatch:
 
 jobs:
-  check-release:
+  check-release-v3:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,20 +1,18 @@
-name: Publish Release
+name: Publish Release v3
 
-# Every time we merge to main branch we publish a release.
+# Only triggered manually
 on:
-  push:
-    branches: [ main ]
   workflow_dispatch:
 
 jobs:
   
-  publish-release:
+  publish-release-v3:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: main
+          ref: v3
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
@@ -55,7 +53,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          commitish: main
+          commitish: v3
           tag_name: ${{ env.PROJECT_VERSION }}
           release_name: ${{ env.PROJECT_VERSION }}
           body_path: ${{ github.workspace }}/RELEASE_NOTES.md


### PR DESCRIPTION
On older release branches we only have 1 branch for dev and releases. 
The branch will accept PRs from feature branches, and releases will be triggered manually on the Actions.