### PR TITLE
Fix local.gradle

### DIFF
--- a/example-app/build.gradle
+++ b/example-app/build.gradle
@@ -16,7 +16,8 @@ apply from: "../config/gradle/ci.gradle"
 if (file("local.gradle").exists()) {
     apply from: "local.gradle"
 } else {
-    logger.lifecycle("File example-app/local.gradle not found. Duplicate example-app/local.gradle.example and fill in your API key.")
+    logger.lifecycle("File example-app/local.gradle not found. Falling back to default file with no values.")
+    apply from: "default.local.gradle"
 }
 
 // This runConnectedAndroidTest.gradle script is applied,

--- a/example-app/default.local.gradle
+++ b/example-app/default.local.gradle
@@ -1,6 +1,8 @@
 /**
  * Replace the values in <PLACEHOLDER> with the configuration to connect to YOUR Server. The <> should also be removed.
  * Your server is the one that should connect to Adyen, DO NOT connect to Adyen directly from the App as this might expose your API keys.
+ *
+ * For a permanent local configuration file not tracked by Git, copy this file and rename it to "local.gradle" with your credentials.
  */
 android {
     buildTypes {

--- a/example-app/src/main/java/com/adyen/checkout/example/data/api/CheckoutApiService.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/data/api/CheckoutApiService.kt
@@ -21,6 +21,15 @@ import retrofit2.http.Headers
 import retrofit2.http.POST
 
 interface CheckoutApiService {
+
+    companion object {
+        private const val defaultGradleUrl = "<YOUR_SERVER_URL>"
+
+        fun isRealUrlAvailable(): Boolean {
+            return BuildConfig.MERCHANT_SERVER_URL != defaultGradleUrl
+        }
+    }
+
     @Headers(BuildConfig.API_KEY_HEADER_NAME + ":" + BuildConfig.CHECKOUT_API_KEY)
     @POST("paymentMethods")
     fun paymentMethodsAsync(@Body paymentMethodsRequest: PaymentMethodsRequest): Deferred<Response<PaymentMethodsApiResponse>>

--- a/example-app/src/main/java/com/adyen/checkout/example/di/NetworkModule.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/di/NetworkModule.kt
@@ -51,8 +51,13 @@ val networkModule = module {
     }
 
     fun provideApi(httpClient: OkHttpClient): CheckoutApiService {
+        val baseUrl =
+            if (CheckoutApiService.isRealUrlAvailable())
+                BuildConfig.MERCHANT_SERVER_URL
+            else
+                "http://myserver.com/my/endpoint/"
         return Retrofit.Builder()
-            .baseUrl(BuildConfig.MERCHANT_SERVER_URL)
+            .baseUrl(baseUrl)
             .client(httpClient)
             .addConverterFactory(
                 MoshiConverterFactory.create(

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/main/MainActivity.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/main/MainActivity.kt
@@ -30,6 +30,7 @@ import com.adyen.checkout.dropin.DropIn
 import com.adyen.checkout.dropin.DropInConfiguration
 import com.adyen.checkout.example.BuildConfig
 import com.adyen.checkout.example.R
+import com.adyen.checkout.example.data.api.CheckoutApiService
 import com.adyen.checkout.example.data.storage.KeyValueStorage
 import com.adyen.checkout.example.service.ExampleSimplifiedDropInService
 import com.adyen.checkout.example.ui.configuration.ConfigurationActivity
@@ -63,6 +64,15 @@ class MainActivity : AppCompatActivity() {
         }
 
         startCheckoutButton.setOnClickListener {
+            if (!CheckoutApiService.isRealUrlAvailable()) {
+                Toast.makeText(
+                    this@MainActivity,
+                    "No server URL configured on local.gradle file.",
+                    Toast.LENGTH_SHORT
+                ).show()
+                return@setOnClickListener
+            }
+
             val currentResponse = paymentMethodsViewModel.paymentMethodResponseLiveData.value
             if (currentResponse != null) {
                 startDropIn(currentResponse)
@@ -86,7 +96,9 @@ class MainActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
-        paymentMethodsViewModel.requestPaymentMethods()
+        if (CheckoutApiService.isRealUrlAvailable()) {
+            paymentMethodsViewModel.requestPaymentMethods()
+        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {


### PR DESCRIPTION
## Summary
Allow local.gradle to be untracked by Git again.
Using default.local.gradle with default values for CI builds.
Fail gracefully on App if MERCHANT_SERVER_URL is not properly setup on local.gradle file.