### PR TITLE
Release workflow opens PR to merge back to develop.

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches: [ develop ]
     types: [ opened, synchronize, reopened ]
+  workflow_dispatch:
 
 jobs:
   gradle-check:

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -61,3 +61,12 @@ jobs:
           body_path: ${{ github.workspace }}/RELEASE_NOTES.md
           draft: false
           prerelease: false
+
+      - name: Create release Pull Request
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: "main"
+          destination_branch: "develop"
+          pr_title: "Merging back release ${{ env.PROJECT_VERSION }}"
+          pr_allow_empty: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Create PR back to `develop` after a release. 
  - Could be just the merge commit or a hotfix branch.
- Allow manual trigger of check_pr
  - PRs from a workflow don't trigger other Actions.