### PR TITLE
Release 4.0.0-alpha01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 [//]: <> (Add changes that not released yet into `Unreleased` section)
 [//]: <> (Comment `Unreleased` section if there are no changes)
 [//]: <> (## [Unreleased])
+## 4.0.0 an above
+- Starting with 4.0.0 all changes will be on the release notes on GitHub.
+
 ## [3.7.1] - 2020-10-15
 ### Added
 - Translations for MB Way and Await Components

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,25 @@
-### Added
-- Translations for MB Way and Await Components
-- GitHub Actions workflows to run CI and Publish releases.
+
+[//]: # (This file will be used for the release notes on GitHub when publishing.)
+[//]: # (Types of changes: `Added` `Changed` `Deprecated` `Removed` `Fixed` `Security`)
+[//]: # (Example:)
+[//]: # (### Added)
+[//]: # ( - New payment method)
+[//]: # ( ### Changed)
+[//]: # ( - DropIn service's package changed from `com.adyen.dropin` to `com.adyen.dropin.services`)
+[//]: # ( ### Deprecated)
+[//]: # ( - Configurations public constructor are deprecated, please use each Configuration's builder to make a Configuration object)
+
+### Added:
+- Updated to AndroidX libraries instead of the old Support Libs.
+- Support for Kotlin in all modules except CSE.
+- Target Java 8
+- Spotbugs in place of Findbugs
+
+### Changed:
+- Min API to 21 to reduce scope of security concerns.
+- Target API to 30
+- Updated to Gradle 6.6.1
+- Updated 3DS2 SDK to version 2.2.0 with default protocol as still 2.1.0
+- Updated a bunch of libraries, including Google Pay and WeChatPay dependencies.
+- Replaced deprecated LocalBroadcast with Kotlin Flow as an experiment for communicating between DropService and DropInActivity.
+- Renamed example.local.gradle with default.local.gradle for CI builds and example app without values.

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ allprojects {
     // just for example app, don't need to increment
     ext.version_code = 1
     // The version_name format is "major.minor.patch(-(alpha|beta|rc)[0-9]{2}){0,1}" (e.g. 3.0.0, 3.1.1-alpha04 or 3.1.4-rc01 etc).
-    ext.version_name = "3.7.1"
+    ext.version_name = "4.0.0-alpha01"
 
     // Code quality
     ext.ktlint_version = '0.39.0'


### PR DESCRIPTION
## Release 4.0.0-alpha01
This alpha release has our migration to AndroidX for people who want to get rid of jetifier and help test new changes.
We will still be adding to this version so public APIs might still change in the future, that's why it's in `alpha`.

### Fixes
#217 
