### PR TITLE
Allow CardComponent to not request CVC

### DIFF
--- a/base-v3/src/main/java/com/adyen/checkout/base/component/BasePaymentComponent.java
+++ b/base-v3/src/main/java/com/adyen/checkout/base/component/BasePaymentComponent.java
@@ -98,6 +98,7 @@ public abstract class BasePaymentComponent<
      * @param inputData {@link InputDataT}
      */
     public final void inputDataChanged(@NonNull InputDataT inputData) {
+        Logger.v(TAG, "inputDataChanged");
         final OutputDataT newOutputData = onInputDataChanged(inputData);
         if (!newOutputData.equals(mOutputData)) {
             mOutputData = newOutputData;

--- a/card-base-core/src/main/java/com/adyen/checkout/card/data/CardType.java
+++ b/card-base-core/src/main/java/com/adyen/checkout/card/data/CardType.java
@@ -93,7 +93,7 @@ public enum CardType {
 
     /**
      * Get CardType from the brand name as it appears in the Checkout API.
-     * @see  <a href="https://docs.adyen.com/api-explorer/#/CheckoutService/v65/post/paymentMethods__resParam_storedPaymentMethods-brand></a>"/>
+     * @see  <a href="https://docs.adyen.com/api-explorer/#/CheckoutService/v65/post/paymentMethods__resParam_storedPaymentMethods-brand"></a>
      */
     @Nullable
     public static CardType getByBrandName(@NonNull String brand) {

--- a/card-base-core/src/main/java/com/adyen/checkout/card/data/CardType.java
+++ b/card-base-core/src/main/java/com/adyen/checkout/card/data/CardType.java
@@ -92,13 +92,24 @@ public enum CardType {
     }
 
     /**
-     * Get CardType from txVariant.
+     * Get CardType from the brand name as it appears in the Checkout API.
+     * @see  <a href="https://docs.adyen.com/api-explorer/#/CheckoutService/v65/post/paymentMethods__resParam_storedPaymentMethods-brand></a>"/>
      */
     @Nullable
-    public static CardType getCardTypeByTxVariant(@NonNull String txVariant) {
-        return MAPPED_BY_NAME.get(txVariant);
+    public static CardType getByBrandName(@NonNull String brand) {
+        return MAPPED_BY_NAME.get(brand);
     }
 
+    /**
+     * Get CardType from txVariant.
+     *
+     * @deprecated Renamed to {@link #getByBrandName(String)}
+     */
+    @Deprecated
+    @Nullable
+    public static CardType getCardTypeByTxVariant(@NonNull String txVariant) {
+        return getByBrandName(txVariant);
+    }
 
     CardType(@NonNull String txVariant, @NonNull Pattern pattern) {
         mTxVariant = txVariant;

--- a/card-base/src/main/java/com/adyen/checkout/card/CardComponent.java
+++ b/card-base/src/main/java/com/adyen/checkout/card/CardComponent.java
@@ -14,7 +14,6 @@ import android.text.TextUtils;
 
 import com.adyen.checkout.base.PaymentComponentProvider;
 import com.adyen.checkout.base.component.BasePaymentComponent;
-import com.adyen.checkout.base.model.paymentmethods.InputDetail;
 import com.adyen.checkout.base.model.paymentmethods.PaymentMethod;
 import com.adyen.checkout.base.model.paymentmethods.StoredPaymentMethod;
 import com.adyen.checkout.base.model.payments.request.CardPaymentMethod;
@@ -32,7 +31,9 @@ import com.adyen.checkout.cse.Encryptor;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public final class CardComponent extends BasePaymentComponent<
         CardConfiguration,
@@ -45,6 +46,14 @@ public final class CardComponent extends BasePaymentComponent<
 
     private static final String[] PAYMENT_METHOD_TYPES = {PaymentMethodTypes.SCHEME};
     private static final int BIN_VALUE_LENGTH = 6;
+
+    private static final Set<CardType> NO_CVC_BRANDS;
+
+    static {
+        HashSet<CardType> brandSet = new HashSet<>();
+        brandSet.add(CardType.BCMC);
+        NO_CVC_BRANDS = Collections.unmodifiableSet(brandSet);
+    }
 
     private List<CardType> mFilteredSupportedCards = Collections.emptyList();
     private CardInputData mStoredPaymentInputData;
@@ -162,7 +171,7 @@ public final class CardComponent extends BasePaymentComponent<
                 card.setNumber(outputData.getCardNumberField().getValue());
             }
 
-            card.setSecurityCode(outputData.getSecurityCodeField().getValue());
+            card.setSecurityCode(isCvcHidden() ? null : outputData.getSecurityCodeField().getValue());
 
             final ExpiryDate expiryDateResult = outputData.getExpiryDateField().getValue();
 
@@ -242,14 +251,27 @@ public final class CardComponent extends BasePaymentComponent<
     }
 
     private ValidatedField<String> validateSecurityCode(@NonNull String securityCode) {
-        final InputDetail securityCodeInputDetail = getInputDetail("cvc");
-        final boolean isRequired = securityCodeInputDetail == null || !securityCodeInputDetail.isOptional();
-        if (isRequired) {
+        if (isCvcHidden()) {
+            return new ValidatedField<>(securityCode, ValidatedField.Validation.VALID);
+        } else {
             final CardType firstCardType = !mFilteredSupportedCards.isEmpty() ? mFilteredSupportedCards.get(0) : null;
             return CardValidationUtils.validateSecurityCode(securityCode, firstCardType);
-        } else {
-            return new ValidatedField<>(securityCode, ValidatedField.Validation.VALID);
         }
+    }
+
+    private boolean isCvcHidden() {
+        if (isStoredPaymentMethod()) {
+            return getConfiguration().isHideCvcStoredCard() || isBrandWithoutCvc(((StoredPaymentMethod) getPaymentMethod()).getBrand());
+        } else {
+            return getConfiguration().isHideCvc();
+        }
+    }
+
+    private boolean isBrandWithoutCvc(@Nullable String brand) {
+        if (TextUtils.isEmpty(brand)) {
+            return false;
+        }
+        return NO_CVC_BRANDS.contains(CardType.getByBrandName(brand));
     }
 
     private ValidatedField<String> validateHolderName(@NonNull String holderName) {
@@ -258,20 +280,6 @@ public final class CardComponent extends BasePaymentComponent<
         } else {
             return new ValidatedField<>(holderName, ValidatedField.Validation.VALID);
         }
-    }
-
-    @Nullable
-    private InputDetail getInputDetail(@NonNull String key) {
-        final List<InputDetail> details = getPaymentMethod().getDetails();
-        if (details != null) {
-            for (InputDetail inputDetail : getPaymentMethod().getDetails()) {
-                if (key.equals(inputDetail.getKey())) {
-                    return inputDetail;
-                }
-            }
-        }
-
-        return null;
     }
 
     private String getBinValueFromCardNumber(String cardNumber) {

--- a/card-base/src/main/java/com/adyen/checkout/card/CardComponent.java
+++ b/card-base/src/main/java/com/adyen/checkout/card/CardComponent.java
@@ -50,7 +50,7 @@ public final class CardComponent extends BasePaymentComponent<
     private static final Set<CardType> NO_CVC_BRANDS;
 
     static {
-        HashSet<CardType> brandSet = new HashSet<>();
+        final HashSet<CardType> brandSet = new HashSet<>();
         brandSet.add(CardType.BCMC);
         NO_CVC_BRANDS = Collections.unmodifiableSet(brandSet);
     }
@@ -172,7 +172,9 @@ public final class CardComponent extends BasePaymentComponent<
                 card.setNumber(outputData.getCardNumberField().getValue());
             }
 
-            card.setSecurityCode(isCvcHidden() ? null : outputData.getSecurityCodeField().getValue());
+            if (!isCvcHidden()) {
+                card.setSecurityCode(outputData.getSecurityCodeField().getValue());
+            }
 
             final ExpiryDate expiryDateResult = outputData.getExpiryDateField().getValue();
 

--- a/card-base/src/main/java/com/adyen/checkout/card/CardComponent.java
+++ b/card-base/src/main/java/com/adyen/checkout/card/CardComponent.java
@@ -131,7 +131,8 @@ public final class CardComponent extends BasePaymentComponent<
                 validateExpiryDate(inputData.getExpiryDate()),
                 validateSecurityCode(inputData.getSecurityCode()),
                 validateHolderName(inputData.getHolderName()),
-                inputData.isStorePaymentEnable()
+                inputData.isStorePaymentEnable(),
+                isCvcHidden()
         );
     }
 

--- a/card-base/src/main/java/com/adyen/checkout/card/CardConfiguration.java
+++ b/card-base/src/main/java/com/adyen/checkout/card/CardConfiguration.java
@@ -47,6 +47,8 @@ public class CardConfiguration extends Configuration {
     private final boolean mHolderNameRequire;
     private final List<CardType> mSupportedCardTypes;
     private final boolean mShowStorePaymentField;
+    private final boolean mHideCvc;
+    private final boolean mHideCvcStoredCard;
 
     public static final Parcelable.Creator<CardConfiguration> CREATOR = new Parcelable.Creator<CardConfiguration>() {
         public CardConfiguration createFromParcel(@NonNull Parcel in) {
@@ -66,6 +68,8 @@ public class CardConfiguration extends Configuration {
      * @param holderNameRequire     If the holder name of the card should be shown as a required field.
      * @param showStorePaymentField If the component should show the option to store the card for later use.
      * @param supportCardTypes      The list of supported card brands to be shown to the user.
+     * @param hideCvc               Hides the CVC field on the payment flow so that it's not required.
+     * @param hideCvcStoredCard     Hides the CVC field on the stored payment flow so that it's not required.
      */
     CardConfiguration(
             @NonNull Locale shopperLocale,
@@ -75,7 +79,10 @@ public class CardConfiguration extends Configuration {
             boolean holderNameRequire,
             @NonNull String shopperReference,
             boolean showStorePaymentField,
-            @NonNull List<CardType> supportCardTypes) {
+            @NonNull List<CardType> supportCardTypes,
+            boolean hideCvc,
+            boolean hideCvcStoredCard
+            ) {
         super(shopperLocale, environment, clientKey);
 
         mPublicKey = publicKey;
@@ -83,6 +90,8 @@ public class CardConfiguration extends Configuration {
         mSupportedCardTypes = supportCardTypes;
         mShopperReference = shopperReference;
         mShowStorePaymentField = showStorePaymentField;
+        mHideCvc = hideCvc;
+        mHideCvcStoredCard = hideCvcStoredCard;
     }
 
     CardConfiguration(@NonNull Parcel in) {
@@ -92,6 +101,8 @@ public class CardConfiguration extends Configuration {
         mHolderNameRequire = ParcelUtils.readBoolean(in);
         mSupportedCardTypes = in.readArrayList(CardType.class.getClassLoader());
         mShowStorePaymentField = ParcelUtils.readBoolean(in);
+        mHideCvc = ParcelUtils.readBoolean(in);
+        mHideCvcStoredCard = ParcelUtils.readBoolean(in);
     }
 
     @Override
@@ -102,6 +113,8 @@ public class CardConfiguration extends Configuration {
         ParcelUtils.writeBoolean(dest, mHolderNameRequire);
         dest.writeList(mSupportedCardTypes);
         ParcelUtils.writeBoolean(dest, mShowStorePaymentField);
+        ParcelUtils.writeBoolean(dest, mHideCvc);
+        ParcelUtils.writeBoolean(dest, mHideCvcStoredCard);
     }
 
     /**
@@ -145,6 +158,16 @@ public class CardConfiguration extends Configuration {
         return new Builder(this);
     }
 
+    @Nullable
+    public boolean isHideCvc() {
+        return mHideCvc;
+    }
+
+    @Nullable
+    public boolean isHideCvcStoredCard() {
+        return mHideCvcStoredCard;
+    }
+
     /**
      * Builder to create a {@link CardConfiguration}.
      */
@@ -156,7 +179,8 @@ public class CardConfiguration extends Configuration {
         private boolean mBuilderHolderNameRequire;
         private boolean mBuilderShowStorePaymentField = true;
         private String mShopperReference;
-
+        private boolean mBuilderHideCvc;
+        private boolean mBuilderHideCvcStoredCard;
 
         /**
          * Constructor of Card Configuration Builder with instance of CardConfiguration.
@@ -170,10 +194,12 @@ public class CardConfiguration extends Configuration {
             mBuilderHolderNameRequire = cardConfiguration.isHolderNameRequire();
             mBuilderShowStorePaymentField = cardConfiguration.isShowStorePaymentFieldEnable();
             mShopperReference = cardConfiguration.getShopperReference();
+            mBuilderHideCvc = cardConfiguration.isHideCvc();
+            mBuilderHideCvcStoredCard = cardConfiguration.isHideCvcStoredCard();
         }
 
         /**
-         * Constructor of Card Configuration Builder with default values.
+         * Constructor of Card Configuration Builder with default values from Context.
          *
          * @param context   A context
          */
@@ -182,7 +208,7 @@ public class CardConfiguration extends Configuration {
         }
 
         /**
-         * Builder with required parameters for a {@link CardConfiguration}.
+         * Builder with parameters for a {@link CardConfiguration}.
          *
          * @param shopperLocale The Locale of the shopper.
          * @param environment   The {@link Environment} to be used for network calls to Adyen.
@@ -251,7 +277,7 @@ public class CardConfiguration extends Configuration {
         }
 
         /**
-         * Set supported card types for card-payment.
+         * Set the supported card types for this payment. Supported types will be shown as user inputs the card number.
          *
          * @param supportCardTypes array of {@link CardType}
          * @return {@link CardConfiguration.Builder}
@@ -267,7 +293,7 @@ public class CardConfiguration extends Configuration {
         }
 
         /**
-         * Set that if holder name require.
+         * Set if the holder name is required and should be shown as an input field.
          *
          * @param holderNameRequire {@link Boolean}
          * @return {@link CardConfiguration.Builder}
@@ -279,7 +305,7 @@ public class CardConfiguration extends Configuration {
         }
 
         /**
-         * Show store payment field.
+         * Set if the option to store the card for future payments should be shown as an input field.
          *
          * @param showStorePaymentField {@link Boolean}
          * @return {@link CardConfiguration.Builder}
@@ -290,9 +316,42 @@ public class CardConfiguration extends Configuration {
             return this;
         }
 
+        /**
+         * Set the unique reference for the shopper doing this transaction.
+         * This value will simply be passed back to you in the {@link com.adyen.checkout.base.model.payments.request.PaymentComponentData} for convenience.
+         *
+         * @param shopperReference The unique shopper reference
+         * @return {@link CardConfiguration.Builder}
+         */
         @NonNull
         public Builder setShopperReference(@NonNull String shopperReference) {
             mShopperReference = shopperReference;
+            return this;
+        }
+
+        /**
+         * Set if the CVC field should be hidden from the Component and not requested to the shopper on a regular payment.
+         * Note that this might have implications for the risk of the transaction. Talk to Adyen Support before enabling this.
+         *
+         * @param hideCvc If CVC should be hidden or not.
+         * @return {@link CardConfiguration.Builder}
+         */
+        @NonNull
+        public Builder setHideCvc(boolean hideCvc) {
+            mBuilderHideCvc = hideCvc;
+            return this;
+        }
+
+        /**
+         * Set if the CVC field should be hidden from the Component and not requested to the shopper on a stored payment flow.
+         * Note that this has implications for the risk of the transaction. Talk to Adyen Support before enabling this.
+         *
+         * @param hideCvcStoredCard If CVC should be hidden or not for stored payments.
+         * @return {@link CardConfiguration.Builder}
+         */
+        @NonNull
+        public Builder setHideCvcStoredCard(boolean hideCvcStoredCard) {
+            mBuilderHideCvcStoredCard = hideCvcStoredCard;
             return this;
         }
 
@@ -308,7 +367,7 @@ public class CardConfiguration extends Configuration {
                 throw new CheckoutException("Invalid Public Key. Please find the valid public key on the Customer Area.");
             }
 
-            // This will not be triggered until the public key check above is removed as it takes prioriy.
+            // This will not be triggered until the public key check above is removed as it takes priority.
             if (!CardValidationUtils.isPublicKeyValid(mBuilderPublicKey) && !ValidationUtils.isClientKeyValid(mBuilderClientKey)) {
                 throw new CheckoutException("You need either a valid Client key or Public key to use the Card Component.");
             }
@@ -321,7 +380,9 @@ public class CardConfiguration extends Configuration {
                     mBuilderHolderNameRequire,
                     mShopperReference,
                     mBuilderShowStorePaymentField,
-                    mBuilderSupportedCardTypes
+                    mBuilderSupportedCardTypes,
+                    mBuilderHideCvc,
+                    mBuilderHideCvcStoredCard
             );
         }
     }

--- a/card-base/src/main/java/com/adyen/checkout/card/CardConfiguration.java
+++ b/card-base/src/main/java/com/adyen/checkout/card/CardConfiguration.java
@@ -82,7 +82,7 @@ public class CardConfiguration extends Configuration {
             @NonNull List<CardType> supportCardTypes,
             boolean hideCvc,
             boolean hideCvcStoredCard
-            ) {
+    ) {
         super(shopperLocale, environment, clientKey);
 
         mPublicKey = publicKey;
@@ -318,7 +318,8 @@ public class CardConfiguration extends Configuration {
 
         /**
          * Set the unique reference for the shopper doing this transaction.
-         * This value will simply be passed back to you in the {@link com.adyen.checkout.base.model.payments.request.PaymentComponentData} for convenience.
+         * This value will simply be passed back to you in the {@link com.adyen.checkout.base.model.payments.request.PaymentComponentData}
+         * for convenience.
          *
          * @param shopperReference The unique shopper reference
          * @return {@link CardConfiguration.Builder}

--- a/card-base/src/main/java/com/adyen/checkout/card/CardOutputData.java
+++ b/card-base/src/main/java/com/adyen/checkout/card/CardOutputData.java
@@ -21,7 +21,8 @@ final class CardOutputData implements OutputData {
     private final ValidatedField<ExpiryDate> mExpiryDateField;
     private final ValidatedField<String> mSecurityCodeField;
 
-    private boolean mIsStoredPaymentMethodEnable;
+    private final boolean mIsStoredPaymentMethodEnable;
+    private final boolean mIsCvcHidden;
 
     /**
      * Constructs a {@link com.adyen.checkout.card.CardComponent} object.
@@ -31,13 +32,15 @@ final class CardOutputData implements OutputData {
             @NonNull ValidatedField<ExpiryDate> expiryDateField,
             @NonNull ValidatedField<String> securityCodeField,
             @NonNull ValidatedField<String> holderNameField,
-            boolean isStoredPaymentMethodEnable
+            boolean isStoredPaymentMethodEnable,
+            boolean isCvcHidden
     ) {
         mCardNumberField = cardNumberField;
         mExpiryDateField = expiryDateField;
         mSecurityCodeField = securityCodeField;
         mHolderNameField = holderNameField;
         mIsStoredPaymentMethodEnable = isStoredPaymentMethodEnable;
+        mIsCvcHidden = isCvcHidden;
     }
 
     @NonNull
@@ -68,11 +71,11 @@ final class CardOutputData implements OutputData {
                 && mHolderNameField.isValid();
     }
 
-    public void setStoredPaymentMethodStatus(boolean storedPaymentMethodEnable) {
-        mIsStoredPaymentMethodEnable = storedPaymentMethodEnable;
-    }
-
     public boolean isStoredPaymentMethodEnable() {
         return mIsStoredPaymentMethodEnable;
+    }
+
+    public boolean isCvcHidden() {
+        return mIsCvcHidden;
     }
 }

--- a/card-ui/src/main/java/com/adyen/checkout/card/CardView.java
+++ b/card-ui/src/main/java/com/adyen/checkout/card/CardView.java
@@ -128,6 +128,8 @@ public final class CardView extends AdyenLinearLayout<CardOutputData, CardConfig
             mCardHolderInput.setVisibility(getComponent().isHolderNameRequire() ? VISIBLE : GONE);
             mStorePaymentMethodSwitch.setVisibility(getComponent().showStorePaymentField() ? VISIBLE : GONE);
         }
+
+        notifyInputDataChanged();
     }
 
     @Override
@@ -173,6 +175,7 @@ public final class CardView extends AdyenLinearLayout<CardOutputData, CardConfig
         if (cardOutputData != null) {
             onCardNumberValidated(cardOutputData.getCardNumberField());
             onExpiryDateValidated(cardOutputData.getExpiryDateField());
+            mSecurityCodeInput.setVisibility( cardOutputData.isCvcHidden() ? GONE : VISIBLE);
         }
 
         if (getComponent().isStoredPaymentMethod()) {

--- a/card-ui/src/main/java/com/adyen/checkout/card/CardView.java
+++ b/card-ui/src/main/java/com/adyen/checkout/card/CardView.java
@@ -175,7 +175,7 @@ public final class CardView extends AdyenLinearLayout<CardOutputData, CardConfig
         if (cardOutputData != null) {
             onCardNumberValidated(cardOutputData.getCardNumberField());
             onExpiryDateValidated(cardOutputData.getExpiryDateField());
-            mSecurityCodeInput.setVisibility( cardOutputData.isCvcHidden() ? GONE : VISIBLE);
+            mSecurityCodeInput.setVisibility(cardOutputData.isCvcHidden() ? GONE : VISIBLE);
         }
 
         if (getComponent().isStoredPaymentMethod()) {

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/base/BaseComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/base/BaseComponentDialogFragment.kt
@@ -113,6 +113,7 @@ open abstract class BaseComponentDialogFragment : DropInBottomSheetDialogFragmen
     protected fun createErrorHandlerObserver(): Observer<ComponentError> {
         return Observer {
             if (it != null) {
+                Logger.e(TAG, "ComponentError", it.exception)
                 handleError(it)
             }
         }

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/main/MainActivity.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/main/MainActivity.kt
@@ -131,7 +131,7 @@ class MainActivity : AppCompatActivity() {
             .setPublicKey(BuildConfig.PUBLIC_KEY)
             .setShopperReference(keyValueStorage.getShopperReference())
             .setShopperLocale(shopperLocale)
-                .setEnvironment(Environment.TEST)
+            .setEnvironment(Environment.TEST)
             .build()
 
         val googlePayConfig = GooglePayConfiguration.Builder(this@MainActivity, keyValueStorage.getMerchantAccount())


### PR DESCRIPTION
## Summary
- Allow CardComponent to not request CVC for regular and stored card flows.
- Create `hideCvc` and `hideCvcStoredCard` flags on `CardConfiguration`
- Automatically hide the CVC field on stored BCMC cards.
- Remove relying on `InputDetails` for CVC optionality.

## Tested scenarios
Tested BCMC card on regular and stored flows.
Tested Visa card on regular and stored flows.
