### PR TITLE
Allow CardComponent to not request CVC

### DIFF
--- a/base-v3/src/main/java/com/adyen/checkout/base/component/BasePaymentComponent.java
+++ b/base-v3/src/main/java/com/adyen/checkout/base/component/BasePaymentComponent.java
@@ -99,6 +99,7 @@ public abstract class BasePaymentComponent<
      * @param inputData {@link InputDataT}
      */
     public final void inputDataChanged(@NonNull InputDataT inputData) {
+        Logger.v(TAG, "inputDataChanged");
         final OutputDataT newOutputData = onInputDataChanged(inputData);
         if (!newOutputData.equals(mOutputData)) {
             mOutputData = newOutputData;

--- a/card-base-core/src/main/java/com/adyen/checkout/card/data/CardType.java
+++ b/card-base-core/src/main/java/com/adyen/checkout/card/data/CardType.java
@@ -100,17 +100,6 @@ public enum CardType {
         return MAPPED_BY_NAME.get(brand);
     }
 
-    /**
-     * Get CardType from txVariant.
-     *
-     * @deprecated Renamed to {@link #getByBrandName(String)}
-     */
-    @Deprecated
-    @Nullable
-    public static CardType getCardTypeByTxVariant(@NonNull String txVariant) {
-        return getByBrandName(txVariant);
-    }
-
     CardType(@NonNull String txVariant, @NonNull Pattern pattern) {
         mTxVariant = txVariant;
         mPattern = pattern;

--- a/card-base-core/src/main/java/com/adyen/checkout/card/data/CardType.java
+++ b/card-base-core/src/main/java/com/adyen/checkout/card/data/CardType.java
@@ -93,7 +93,7 @@ public enum CardType {
 
     /**
      * Get CardType from the brand name as it appears in the Checkout API.
-     * @see  <a href="https://docs.adyen.com/api-explorer/#/CheckoutService/v65/post/paymentMethods__resParam_storedPaymentMethods-brand></a>"/>
+     * @see  <a href="https://docs.adyen.com/api-explorer/#/CheckoutService/v65/post/paymentMethods__resParam_storedPaymentMethods-brand"></a>
      */
     @Nullable
     public static CardType getByBrandName(@NonNull String brand) {

--- a/card-base-core/src/main/java/com/adyen/checkout/card/data/CardType.java
+++ b/card-base-core/src/main/java/com/adyen/checkout/card/data/CardType.java
@@ -92,13 +92,24 @@ public enum CardType {
     }
 
     /**
-     * Get CardType from txVariant.
+     * Get CardType from the brand name as it appears in the Checkout API.
+     * @see  <a href="https://docs.adyen.com/api-explorer/#/CheckoutService/v65/post/paymentMethods__resParam_storedPaymentMethods-brand></a>"/>
      */
     @Nullable
-    public static CardType getCardTypeByTxVariant(@NonNull String txVariant) {
-        return MAPPED_BY_NAME.get(txVariant);
+    public static CardType getByBrandName(@NonNull String brand) {
+        return MAPPED_BY_NAME.get(brand);
     }
 
+    /**
+     * Get CardType from txVariant.
+     *
+     * @deprecated Renamed to {@link #getByBrandName(String)}
+     */
+    @Deprecated
+    @Nullable
+    public static CardType getCardTypeByTxVariant(@NonNull String txVariant) {
+        return getByBrandName(txVariant);
+    }
 
     CardType(@NonNull String txVariant, @NonNull Pattern pattern) {
         mTxVariant = txVariant;

--- a/card-base/src/main/java/com/adyen/checkout/card/CardComponent.java
+++ b/card-base/src/main/java/com/adyen/checkout/card/CardComponent.java
@@ -132,7 +132,8 @@ public final class CardComponent extends BasePaymentComponent<
                 validateExpiryDate(inputData.getExpiryDate()),
                 validateSecurityCode(inputData.getSecurityCode()),
                 validateHolderName(inputData.getHolderName()),
-                inputData.isStorePaymentEnable()
+                inputData.isStorePaymentEnable(),
+                isCvcHidden()
         );
     }
 

--- a/card-base/src/main/java/com/adyen/checkout/card/CardComponent.java
+++ b/card-base/src/main/java/com/adyen/checkout/card/CardComponent.java
@@ -51,7 +51,7 @@ public final class CardComponent extends BasePaymentComponent<
     private static final Set<CardType> NO_CVC_BRANDS;
 
     static {
-        HashSet<CardType> brandSet = new HashSet<>();
+        final HashSet<CardType> brandSet = new HashSet<>();
         brandSet.add(CardType.BCMC);
         NO_CVC_BRANDS = Collections.unmodifiableSet(brandSet);
     }
@@ -173,7 +173,9 @@ public final class CardComponent extends BasePaymentComponent<
                 card.setNumber(outputData.getCardNumberField().getValue());
             }
 
-            card.setSecurityCode(isCvcHidden() ? null : outputData.getSecurityCodeField().getValue());
+            if (!isCvcHidden()) {
+                card.setSecurityCode(outputData.getSecurityCodeField().getValue());
+            }
 
             final ExpiryDate expiryDateResult = outputData.getExpiryDateField().getValue();
 

--- a/card-base/src/main/java/com/adyen/checkout/card/CardComponent.java
+++ b/card-base/src/main/java/com/adyen/checkout/card/CardComponent.java
@@ -15,7 +15,6 @@ import androidx.annotation.Nullable;
 
 import com.adyen.checkout.base.PaymentComponentProvider;
 import com.adyen.checkout.base.component.BasePaymentComponent;
-import com.adyen.checkout.base.model.paymentmethods.InputDetail;
 import com.adyen.checkout.base.model.paymentmethods.PaymentMethod;
 import com.adyen.checkout.base.model.paymentmethods.StoredPaymentMethod;
 import com.adyen.checkout.base.model.payments.request.CardPaymentMethod;
@@ -33,7 +32,9 @@ import com.adyen.checkout.cse.Encryptor;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public final class CardComponent extends BasePaymentComponent<
         CardConfiguration,
@@ -46,6 +47,14 @@ public final class CardComponent extends BasePaymentComponent<
 
     private static final String[] PAYMENT_METHOD_TYPES = {PaymentMethodTypes.SCHEME};
     private static final int BIN_VALUE_LENGTH = 6;
+
+    private static final Set<CardType> NO_CVC_BRANDS;
+
+    static {
+        HashSet<CardType> brandSet = new HashSet<>();
+        brandSet.add(CardType.BCMC);
+        NO_CVC_BRANDS = Collections.unmodifiableSet(brandSet);
+    }
 
     private List<CardType> mFilteredSupportedCards = Collections.emptyList();
     private CardInputData mStoredPaymentInputData;
@@ -163,7 +172,7 @@ public final class CardComponent extends BasePaymentComponent<
                 card.setNumber(outputData.getCardNumberField().getValue());
             }
 
-            card.setSecurityCode(outputData.getSecurityCodeField().getValue());
+            card.setSecurityCode(isCvcHidden() ? null : outputData.getSecurityCodeField().getValue());
 
             final ExpiryDate expiryDateResult = outputData.getExpiryDateField().getValue();
 
@@ -243,14 +252,27 @@ public final class CardComponent extends BasePaymentComponent<
     }
 
     private ValidatedField<String> validateSecurityCode(@NonNull String securityCode) {
-        final InputDetail securityCodeInputDetail = getInputDetail("cvc");
-        final boolean isRequired = securityCodeInputDetail == null || !securityCodeInputDetail.isOptional();
-        if (isRequired) {
+        if (isCvcHidden()) {
+            return new ValidatedField<>(securityCode, ValidatedField.Validation.VALID);
+        } else {
             final CardType firstCardType = !mFilteredSupportedCards.isEmpty() ? mFilteredSupportedCards.get(0) : null;
             return CardValidationUtils.validateSecurityCode(securityCode, firstCardType);
-        } else {
-            return new ValidatedField<>(securityCode, ValidatedField.Validation.VALID);
         }
+    }
+
+    private boolean isCvcHidden() {
+        if (isStoredPaymentMethod()) {
+            return getConfiguration().isHideCvcStoredCard() || isBrandWithoutCvc(((StoredPaymentMethod) getPaymentMethod()).getBrand());
+        } else {
+            return getConfiguration().isHideCvc();
+        }
+    }
+
+    private boolean isBrandWithoutCvc(@Nullable String brand) {
+        if (TextUtils.isEmpty(brand)) {
+            return false;
+        }
+        return NO_CVC_BRANDS.contains(CardType.getByBrandName(brand));
     }
 
     private ValidatedField<String> validateHolderName(@NonNull String holderName) {
@@ -259,20 +281,6 @@ public final class CardComponent extends BasePaymentComponent<
         } else {
             return new ValidatedField<>(holderName, ValidatedField.Validation.VALID);
         }
-    }
-
-    @Nullable
-    private InputDetail getInputDetail(@NonNull String key) {
-        final List<InputDetail> details = getPaymentMethod().getDetails();
-        if (details != null) {
-            for (InputDetail inputDetail : getPaymentMethod().getDetails()) {
-                if (key.equals(inputDetail.getKey())) {
-                    return inputDetail;
-                }
-            }
-        }
-
-        return null;
     }
 
     private String getBinValueFromCardNumber(String cardNumber) {

--- a/card-base/src/main/java/com/adyen/checkout/card/CardComponent.java
+++ b/card-base/src/main/java/com/adyen/checkout/card/CardComponent.java
@@ -82,7 +82,7 @@ public final class CardComponent extends BasePaymentComponent<
             mStoredPaymentInputData.setExpiryDate(ExpiryDate.EMPTY_DATE);
         }
 
-        final CardType cardType = CardType.getCardTypeByTxVariant(paymentMethod.getBrand());
+        final CardType cardType = CardType.getByBrandName(paymentMethod.getBrand());
         if (cardType != null) {
             final List<CardType> storedCardType = new ArrayList<>();
             storedCardType.add(cardType);

--- a/card-base/src/main/java/com/adyen/checkout/card/CardComponentProvider.java
+++ b/card-base/src/main/java/com/adyen/checkout/card/CardComponentProvider.java
@@ -75,7 +75,7 @@ public class CardComponentProvider implements PaymentComponentProvider<CardCompo
             if (brands != null && !brands.isEmpty()) {
                 supportedCardTypes = new ArrayList<>();
                 for (String brand : brands) {
-                    final CardType brandType = CardType.getCardTypeByTxVariant(brand);
+                    final CardType brandType = CardType.getByBrandName(brand);
                     if (brandType != null) {
                         supportedCardTypes.add(brandType);
                     } else {

--- a/card-base/src/main/java/com/adyen/checkout/card/CardConfiguration.java
+++ b/card-base/src/main/java/com/adyen/checkout/card/CardConfiguration.java
@@ -83,7 +83,7 @@ public class CardConfiguration extends Configuration {
             @NonNull List<CardType> supportCardTypes,
             boolean hideCvc,
             boolean hideCvcStoredCard
-            ) {
+    ) {
         super(shopperLocale, environment, clientKey);
 
         mPublicKey = publicKey;
@@ -319,7 +319,8 @@ public class CardConfiguration extends Configuration {
 
         /**
          * Set the unique reference for the shopper doing this transaction.
-         * This value will simply be passed back to you in the {@link com.adyen.checkout.base.model.payments.request.PaymentComponentData} for convenience.
+         * This value will simply be passed back to you in the {@link com.adyen.checkout.base.model.payments.request.PaymentComponentData}
+         * for convenience.
          *
          * @param shopperReference The unique shopper reference
          * @return {@link CardConfiguration.Builder}

--- a/card-base/src/main/java/com/adyen/checkout/card/CardOutputData.java
+++ b/card-base/src/main/java/com/adyen/checkout/card/CardOutputData.java
@@ -21,7 +21,8 @@ final class CardOutputData implements OutputData {
     private final ValidatedField<ExpiryDate> mExpiryDateField;
     private final ValidatedField<String> mSecurityCodeField;
 
-    private boolean mIsStoredPaymentMethodEnable;
+    private final boolean mIsStoredPaymentMethodEnable;
+    private final boolean mIsCvcHidden;
 
     /**
      * Constructs a {@link com.adyen.checkout.card.CardComponent} object.
@@ -31,13 +32,15 @@ final class CardOutputData implements OutputData {
             @NonNull ValidatedField<ExpiryDate> expiryDateField,
             @NonNull ValidatedField<String> securityCodeField,
             @NonNull ValidatedField<String> holderNameField,
-            boolean isStoredPaymentMethodEnable
+            boolean isStoredPaymentMethodEnable,
+            boolean isCvcHidden
     ) {
         mCardNumberField = cardNumberField;
         mExpiryDateField = expiryDateField;
         mSecurityCodeField = securityCodeField;
         mHolderNameField = holderNameField;
         mIsStoredPaymentMethodEnable = isStoredPaymentMethodEnable;
+        mIsCvcHidden = isCvcHidden;
     }
 
     @NonNull
@@ -68,11 +71,11 @@ final class CardOutputData implements OutputData {
                 && mHolderNameField.isValid();
     }
 
-    public void setStoredPaymentMethodStatus(boolean storedPaymentMethodEnable) {
-        mIsStoredPaymentMethodEnable = storedPaymentMethodEnable;
-    }
-
     public boolean isStoredPaymentMethodEnable() {
         return mIsStoredPaymentMethodEnable;
+    }
+
+    public boolean isCvcHidden() {
+        return mIsCvcHidden;
     }
 }

--- a/card-ui/src/main/java/com/adyen/checkout/card/CardView.java
+++ b/card-ui/src/main/java/com/adyen/checkout/card/CardView.java
@@ -176,7 +176,7 @@ public final class CardView extends AdyenLinearLayout<CardOutputData, CardConfig
         if (cardOutputData != null) {
             onCardNumberValidated(cardOutputData.getCardNumberField());
             onExpiryDateValidated(cardOutputData.getExpiryDateField());
-            mSecurityCodeInput.setVisibility( cardOutputData.isCvcHidden() ? GONE : VISIBLE);
+            mSecurityCodeInput.setVisibility(cardOutputData.isCvcHidden() ? GONE : VISIBLE);
         }
 
         if (getComponent().isStoredPaymentMethod()) {

--- a/card-ui/src/main/java/com/adyen/checkout/card/CardView.java
+++ b/card-ui/src/main/java/com/adyen/checkout/card/CardView.java
@@ -129,6 +129,8 @@ public final class CardView extends AdyenLinearLayout<CardOutputData, CardConfig
             mCardHolderInput.setVisibility(getComponent().isHolderNameRequire() ? VISIBLE : GONE);
             mStorePaymentMethodSwitch.setVisibility(getComponent().showStorePaymentField() ? VISIBLE : GONE);
         }
+
+        notifyInputDataChanged();
     }
 
     @Override
@@ -174,6 +176,7 @@ public final class CardView extends AdyenLinearLayout<CardOutputData, CardConfig
         if (cardOutputData != null) {
             onCardNumberValidated(cardOutputData.getCardNumberField());
             onExpiryDateValidated(cardOutputData.getExpiryDateField());
+            mSecurityCodeInput.setVisibility( cardOutputData.isCvcHidden() ? GONE : VISIBLE);
         }
 
         if (getComponent().isStoredPaymentMethod()) {

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/base/BaseComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/base/BaseComponentDialogFragment.kt
@@ -113,6 +113,7 @@ open abstract class BaseComponentDialogFragment : DropInBottomSheetDialogFragmen
     protected fun createErrorHandlerObserver(): Observer<ComponentError> {
         return Observer {
             if (it != null) {
+                Logger.e(TAG, "ComponentError", it.exception)
                 handleError(it)
             }
         }


### PR DESCRIPTION
## Summary
- Allow CardComponent to not request CVC for regular and stored card flows.
- Create `hideCvc` and `hideCvcStoredCard` flags on `CardConfiguration`
- Automatically hide the CVC field on stored BCMC cards.
- Remove relying on `InputDetails` for CVC optionality.

Cheery-picked from 3.7.2 release.

## Tested scenarios
Tested BCMC card on regular and stored flows.
Tested Visa card on regular and stored flows.
