### PR TITLE
Add option to force 3DS2 Challenge on payment request.

### DIFF
--- a/example-app/src/main/java/com/adyen/checkout/example/service/RequestUtils.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/service/RequestUtils.kt
@@ -23,7 +23,8 @@ fun createPaymentRequest(
     countryCode: String,
     merchantAccount: String,
     redirectUrl: String,
-    additionalData: AdditionalData
+    additionalData: AdditionalData,
+    force3DS2Challenge: Boolean = false
 ): JSONObject {
 
     val request = JSONObject(paymentComponentData.toString())
@@ -38,6 +39,13 @@ fun createPaymentRequest(
     request.put("channel", "android")
     request.put("additionalData", JSONObject(Gson().toJson(additionalData)))
     request.put("lineItems", JSONArray(Gson().toJson(listOf(Item()))))
+
+    if (force3DS2Challenge) {
+        val threeDS2RequestData = JSONObject()
+        threeDS2RequestData.put("deviceChannel", "app")
+        threeDS2RequestData.put("challengeIndicator", "requestChallenge")
+        request.put("threeDS2RequestData", threeDS2RequestData)
+    }
 
     return request
 }


### PR DESCRIPTION
## Summary
- Add `threeDS2RequestData` with `challengeIndicator:requestChallenge` to force challenge flow.
https://docs.adyen.com/api-explorer/#/CheckoutService/v65/post/payments__reqParam_threeDS2RequestData-challengeIndicator