### PR TITLE
Update Component Providers

### DIFF
--- a/base-v3/build.gradle
+++ b/base-v3/build.gradle
@@ -50,8 +50,7 @@ dependencies {
     api project(':core-v3')
 
     // Dependencies
-    api "androidx.fragment:fragment:$fragment_version"
-    api "androidx.lifecycle:lifecycle-extensions:$lifecycle_extensions_version"
+    api "androidx.fragment:fragment-ktx:$fragment_version"
 }
 
 // This sharedTasks.gradle script is applied at the end of this build.gradle script,

--- a/base-v3/src/main/java/com/adyen/checkout/base/ActionComponentProvider.java
+++ b/base-v3/src/main/java/com/adyen/checkout/base/ActionComponentProvider.java
@@ -8,10 +8,11 @@
 
 package com.adyen.checkout.base;
 
+import android.app.Application;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentActivity;
+import androidx.lifecycle.ViewModelStoreOwner;
 
 import com.adyen.checkout.base.component.Configuration;
 
@@ -20,45 +21,13 @@ public interface ActionComponentProvider<ComponentT extends ActionComponent> ext
     /**
      * Get an {@link ActionComponent}.
      *
-     * @param activity The Activity to associate lifecycle.
-     * @return The Component
-     * @deprecated in favor of{@link #get(FragmentActivity, Configuration)} with a possible configuration.
-     */
-    @Deprecated
-    @NonNull
-    ComponentT get(@NonNull FragmentActivity activity);
-
-    /**
-     * Get an {@link ActionComponent}.
-     *
-     * @param fragment The Fragment to associate lifecycle.
-     * @return The Component
-     * @deprecated in favor of{@link #get(Fragment, Configuration)} with a possible configuration.
-     */
-    @Deprecated
-    @NonNull
-    ComponentT get(@NonNull Fragment fragment);
-
-    /**
-     * Get an {@link ActionComponent}.
-     *
-     * @param activity The Activity to associate lifecycle.
+     * @param viewModelStoreOwner The Activity or Fragment to associate the lifecycle.
      * @param configuration The Configuration of the component. Can be null in most cases.
      * @return The Component
      */
+    @SuppressWarnings("LambdaLast")
     @NonNull
-    ComponentT get(@NonNull FragmentActivity activity, @Nullable Configuration configuration);
-
-
-    /**
-     * Get an {@link ActionComponent}.
-     *
-     * @param fragment The Fragment to associate lifecycle.
-     * @param configuration The Configuration of the component. Can be null in most cases.
-     * @return The Component
-     */
-    @NonNull
-    ComponentT get(@NonNull Fragment fragment, @Nullable Configuration configuration);
+    ComponentT get(@NonNull ViewModelStoreOwner viewModelStoreOwner, @NonNull Application application, @Nullable Configuration configuration);
 
     /**
      * @return If the Configuration is required for this Component.

--- a/base-v3/src/main/java/com/adyen/checkout/base/PaymentComponentProvider.java
+++ b/base-v3/src/main/java/com/adyen/checkout/base/PaymentComponentProvider.java
@@ -11,8 +11,7 @@ package com.adyen.checkout.base;
 import android.app.Application;
 
 import androidx.annotation.NonNull;
-import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentActivity;
+import androidx.lifecycle.ViewModelStoreOwner;
 
 import com.adyen.checkout.base.component.Configuration;
 import com.adyen.checkout.base.model.paymentmethods.PaymentMethod;
@@ -27,13 +26,13 @@ import com.adyen.checkout.core.exception.CheckoutException;
 public interface PaymentComponentProvider<ComponentT extends PaymentComponent, ConfigurationT extends Configuration>
         extends ComponentProvider<ComponentT> {
 
+    @SuppressWarnings("LambdaLast")
     @NonNull
-    ComponentT get(@NonNull FragmentActivity activity, @NonNull PaymentMethod paymentMethod, @NonNull ConfigurationT configuration)
-            throws CheckoutException;
-
-    @NonNull
-    ComponentT get(@NonNull Fragment fragment, @NonNull PaymentMethod paymentMethod, @NonNull ConfigurationT configuration)
-            throws CheckoutException;
+    ComponentT get(
+            @NonNull ViewModelStoreOwner viewModelStoreOwner,
+            @NonNull PaymentMethod paymentMethod,
+            @NonNull ConfigurationT configuration
+    ) throws CheckoutException;
 
     void isAvailable(
             @NonNull Application applicationContext,

--- a/base-v3/src/main/java/com/adyen/checkout/base/StoredPaymentComponentProvider.java
+++ b/base-v3/src/main/java/com/adyen/checkout/base/StoredPaymentComponentProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by caiof on 6/11/2020.
+ */
+
+package com.adyen.checkout.base;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.ViewModelStoreOwner;
+
+import com.adyen.checkout.base.component.Configuration;
+import com.adyen.checkout.base.model.paymentmethods.StoredPaymentMethod;
+import com.adyen.checkout.core.exception.CheckoutException;
+
+
+public interface StoredPaymentComponentProvider<ComponentT extends PaymentComponent, ConfigurationT extends Configuration>
+        extends PaymentComponentProvider<ComponentT, ConfigurationT> {
+
+    @SuppressWarnings("LambdaLast")
+    @NonNull
+    ComponentT get(
+            @NonNull ViewModelStoreOwner viewModelStoreOwner,
+            @NonNull StoredPaymentMethod storedPaymentMethod,
+            @NonNull ConfigurationT configuration
+    ) throws CheckoutException;
+}

--- a/base-v3/src/main/java/com/adyen/checkout/base/component/ActionComponentProviderImpl.java
+++ b/base-v3/src/main/java/com/adyen/checkout/base/component/ActionComponentProviderImpl.java
@@ -8,19 +8,16 @@
 
 package com.adyen.checkout.base.component;
 
-import android.app.Activity;
 import android.app.Application;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentActivity;
-import androidx.lifecycle.ViewModelProviders;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.lifecycle.ViewModelStoreOwner;
 
 import com.adyen.checkout.base.ActionComponentProvider;
 import com.adyen.checkout.base.component.lifecycle.ActionComponentViewModel;
 import com.adyen.checkout.base.component.lifecycle.ActionComponentViewModelFactory;
-import com.adyen.checkout.core.exception.ComponentException;
 
 public class ActionComponentProviderImpl<ConfigurationT extends Configuration, ComponentT extends ActionComponentViewModel<ConfigurationT>>
         implements ActionComponentProvider<ComponentT> {
@@ -55,38 +52,10 @@ public class ActionComponentProviderImpl<ConfigurationT extends Configuration, C
 
     @NonNull
     @Override
-    public ComponentT get(@NonNull FragmentActivity activity) {
-        if (requiresConfiguration()) {
-            throw new ComponentException("This Component requires a Configuration object to be initialized.");
-        }
-
-        return get(activity, null);
-    }
-
-    @NonNull
-    @Override
-    public ComponentT get(@NonNull Fragment fragment) {
-        if (requiresConfiguration()) {
-            throw new ComponentException("This Component requires a Configuration object to be initialized.");
-        }
-
-        return get(fragment, null);
-    }
-
-    @NonNull
-    @Override
-    public ComponentT get(@NonNull FragmentActivity activity, @Nullable Configuration configuration) {
-        final ActionComponentViewModelFactory factory =
-                new ActionComponentViewModelFactory(checkApplication(activity), mConfigurationClass, configuration);
-        return ViewModelProviders.of(activity, factory).get(mComponentClass);
-    }
-
-    @NonNull
-    @Override
-    public ComponentT get(@NonNull Fragment fragment, @Nullable Configuration configuration) {
-        final ActionComponentViewModelFactory factory =
-                new ActionComponentViewModelFactory(checkApplication(fragment.getActivity()), mConfigurationClass, configuration);
-        return ViewModelProviders.of(fragment, factory).get(mComponentClass);
+    @SuppressWarnings("LambdaLast")
+    public ComponentT get(@NonNull ViewModelStoreOwner viewModelStoreOwner, @NonNull Application application, @Nullable Configuration configuration) {
+        final ActionComponentViewModelFactory factory = new ActionComponentViewModelFactory(application, mConfigurationClass, configuration);
+        return new ViewModelProvider(viewModelStoreOwner, factory).get(mComponentClass);
     }
 
     @Override
@@ -94,15 +63,4 @@ public class ActionComponentProviderImpl<ConfigurationT extends Configuration, C
         return mRequiresConfiguration;
     }
 
-    @NonNull
-    private static Application checkApplication(@Nullable Activity activity) {
-        if (activity != null) {
-            final Application application = activity.getApplication();
-            if (application != null) {
-                return application;
-            }
-        }
-        throw new IllegalStateException("Your activity/fragment is not yet attached to "
-                + "Application. You can't request ViewModel before onCreate call.");
-    }
 }

--- a/base-v3/src/main/java/com/adyen/checkout/base/component/PaymentComponentProviderImpl.java
+++ b/base-v3/src/main/java/com/adyen/checkout/base/component/PaymentComponentProviderImpl.java
@@ -11,15 +11,13 @@ package com.adyen.checkout.base.component;
 import android.app.Application;
 
 import androidx.annotation.NonNull;
-import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentActivity;
-import androidx.lifecycle.ViewModelProviders;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.lifecycle.ViewModelStoreOwner;
 
 import com.adyen.checkout.base.ComponentAvailableCallback;
 import com.adyen.checkout.base.PaymentComponentProvider;
 import com.adyen.checkout.base.component.lifecycle.PaymentComponentViewModelFactory;
 import com.adyen.checkout.base.model.paymentmethods.PaymentMethod;
-import com.adyen.checkout.core.exception.CheckoutException;
 
 public final class PaymentComponentProviderImpl<BaseComponentT extends BasePaymentComponent, ConfigurationT extends Configuration>
         implements PaymentComponentProvider<BaseComponentT, ConfigurationT> {
@@ -30,20 +28,15 @@ public final class PaymentComponentProviderImpl<BaseComponentT extends BasePayme
         mComponentClass = modelClass;
     }
 
-    @NonNull
     @Override
-    public BaseComponentT get(@NonNull FragmentActivity activity, @NonNull PaymentMethod paymentMethod, @NonNull ConfigurationT configuration)
-            throws CheckoutException {
-        final PaymentComponentViewModelFactory factory = new PaymentComponentViewModelFactory(paymentMethod, configuration);
-        return ViewModelProviders.of(activity, factory).get(mComponentClass);
-    }
-
     @NonNull
-    @Override
-    public BaseComponentT get(@NonNull Fragment fragment, @NonNull PaymentMethod paymentMethod, @NonNull ConfigurationT configuration)
-            throws CheckoutException {
+    @SuppressWarnings("LambdaLast")
+    public BaseComponentT get(
+            @NonNull ViewModelStoreOwner viewModelStoreOwner,
+            @NonNull PaymentMethod paymentMethod,
+            @NonNull ConfigurationT configuration) {
         final PaymentComponentViewModelFactory factory = new PaymentComponentViewModelFactory(paymentMethod, configuration);
-        return ViewModelProviders.of(fragment, factory).get(mComponentClass);
+        return new ViewModelProvider(viewModelStoreOwner, factory).get(mComponentClass);
     }
 
     @Override

--- a/base-v3/src/main/java/com/adyen/checkout/base/component/lifecycle/PaymentComponentViewModelFactory.java
+++ b/base-v3/src/main/java/com/adyen/checkout/base/component/lifecycle/PaymentComponentViewModelFactory.java
@@ -14,6 +14,7 @@ import androidx.annotation.NonNull;
 
 import com.adyen.checkout.base.component.Configuration;
 import com.adyen.checkout.base.model.paymentmethods.PaymentMethod;
+import com.adyen.checkout.base.model.paymentmethods.StoredPaymentMethod;
 
 /**
  * A {@link ViewModelProvider.Factory} to create {@link PaymentComponentViewModel}.
@@ -21,16 +22,30 @@ import com.adyen.checkout.base.model.paymentmethods.PaymentMethod;
 public final class PaymentComponentViewModelFactory implements ViewModelProvider.Factory {
 
     private final PaymentMethod mPaymentMethod;
+    private final StoredPaymentMethod mStoredPaymentMethod;
     private final Configuration mConfiguration;
 
     /**
      * Creates a {@code AndroidViewModelFactory}.
      *
-     * @param paymentMethod a {@link PaymentMethod} to pass in {@link PaymentComponentViewModel}
-     * @param configuration a {@link Configuration} to pass in {@link PaymentComponentViewModel}
+     * @param paymentMethod the {@link PaymentMethod} to pass in {@link PaymentComponentViewModel}
+     * @param configuration the {@link Configuration} to pass in {@link PaymentComponentViewModel}
      */
     public PaymentComponentViewModelFactory(@NonNull PaymentMethod paymentMethod, @NonNull Configuration configuration) {
         mPaymentMethod = paymentMethod;
+        mStoredPaymentMethod = null;
+        mConfiguration = configuration;
+    }
+
+    /**
+     * Creates a {@code AndroidViewModelFactory}.
+     *
+     * @param storedPaymentMethod the {@link StoredPaymentMethod} to pass in {@link PaymentComponentViewModel}
+     * @param configuration the {@link Configuration} to pass in {@link PaymentComponentViewModel}
+     */
+    public PaymentComponentViewModelFactory(@NonNull StoredPaymentMethod storedPaymentMethod, @NonNull Configuration configuration) {
+        mPaymentMethod = null;
+        mStoredPaymentMethod = storedPaymentMethod;
         mConfiguration = configuration;
     }
 
@@ -38,7 +53,17 @@ public final class PaymentComponentViewModelFactory implements ViewModelProvider
     @NonNull
     public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
         try {
-            return modelClass.getConstructor(mPaymentMethod.getClass(), mConfiguration.getClass()).newInstance(mPaymentMethod, mConfiguration);
+            if (mStoredPaymentMethod == null) {
+                return modelClass.getConstructor(
+                        mPaymentMethod.getClass(),
+                        mConfiguration.getClass()
+                ).newInstance(mPaymentMethod, mConfiguration);
+            } else {
+                return modelClass.getConstructor(
+                        mStoredPaymentMethod.getClass(),
+                        mConfiguration.getClass()
+                ).newInstance(mPaymentMethod, mConfiguration);
+            }
         } catch (Exception e) {
             throw new RuntimeException("Failed to create an instance of component: " + modelClass, e);
         }

--- a/bcmc-base/src/main/java/com/adyen/checkout/bcmc/BcmcComponentProvider.java
+++ b/bcmc-base/src/main/java/com/adyen/checkout/bcmc/BcmcComponentProvider.java
@@ -12,9 +12,8 @@ import android.app.Application;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
-import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentActivity;
-import androidx.lifecycle.ViewModelProviders;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.lifecycle.ViewModelStoreOwner;
 
 import com.adyen.checkout.base.ComponentAvailableCallback;
 import com.adyen.checkout.base.PaymentComponentProvider;
@@ -23,18 +22,15 @@ import com.adyen.checkout.base.model.paymentmethods.PaymentMethod;
 
 public class BcmcComponentProvider implements PaymentComponentProvider<BcmcComponent, BcmcConfiguration> {
 
-    @NonNull
+    @SuppressWarnings("LambdaLast")
     @Override
-    public BcmcComponent get(@NonNull FragmentActivity activity, @NonNull PaymentMethod paymentMethod, @NonNull BcmcConfiguration configuration) {
-        final PaymentComponentViewModelFactory factory = new PaymentComponentViewModelFactory(paymentMethod, configuration);
-        return ViewModelProviders.of(activity, factory).get(BcmcComponent.class);
-    }
-
     @NonNull
-    @Override
-    public BcmcComponent get(@NonNull Fragment fragment, @NonNull PaymentMethod paymentMethod, @NonNull BcmcConfiguration configuration) {
+    public BcmcComponent get(
+            @NonNull ViewModelStoreOwner viewModelStoreOwner,
+            @NonNull PaymentMethod paymentMethod,
+            @NonNull BcmcConfiguration configuration) {
         final PaymentComponentViewModelFactory factory = new PaymentComponentViewModelFactory(paymentMethod, configuration);
-        return ViewModelProviders.of(fragment, factory).get(BcmcComponent.class);
+        return new ViewModelProvider(viewModelStoreOwner, factory).get(BcmcComponent.class);
     }
 
     @Override

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,6 @@ allprojects {
     ext.annotation_version = "1.1.0"
     ext.fragment_version = "1.2.5"
     ext.appcompat_version = "1.2.0"
-    ext.lifecycle_extensions_version = "2.2.0"
     ext.recyclerview_version = "1.1.0"
     ext.material_version = "1.2.1"
     ext.browser_version = "1.2.0"

--- a/card-base/src/main/java/com/adyen/checkout/card/CardComponentProvider.java
+++ b/card-base/src/main/java/com/adyen/checkout/card/CardComponentProvider.java
@@ -16,9 +16,10 @@ import androidx.lifecycle.ViewModelProvider;
 import androidx.lifecycle.ViewModelStoreOwner;
 
 import com.adyen.checkout.base.ComponentAvailableCallback;
-import com.adyen.checkout.base.PaymentComponentProvider;
+import com.adyen.checkout.base.StoredPaymentComponentProvider;
 import com.adyen.checkout.base.component.lifecycle.PaymentComponentViewModelFactory;
 import com.adyen.checkout.base.model.paymentmethods.PaymentMethod;
+import com.adyen.checkout.base.model.paymentmethods.StoredPaymentMethod;
 import com.adyen.checkout.card.data.CardType;
 import com.adyen.checkout.core.log.LogUtil;
 import com.adyen.checkout.core.log.Logger;
@@ -26,7 +27,7 @@ import com.adyen.checkout.core.log.Logger;
 import java.util.ArrayList;
 import java.util.List;
 
-public class CardComponentProvider implements PaymentComponentProvider<CardComponent, CardConfiguration> {
+public class CardComponentProvider implements StoredPaymentComponentProvider<CardComponent, CardConfiguration> {
     private static final String TAG = LogUtil.getTag();
 
     @SuppressWarnings("LambdaLast")
@@ -38,6 +39,17 @@ public class CardComponentProvider implements PaymentComponentProvider<CardCompo
             @NonNull CardConfiguration configuration) {
         final CardConfiguration verifiedConfiguration = checkSupportedCardTypes(paymentMethod, configuration);
         final PaymentComponentViewModelFactory factory = new PaymentComponentViewModelFactory(paymentMethod, verifiedConfiguration);
+        return new ViewModelProvider(viewModelStoreOwner, factory).get(CardComponent.class);
+    }
+
+    @SuppressWarnings("LambdaLast")
+    @Override
+    @NonNull
+    public CardComponent get(
+            @NonNull ViewModelStoreOwner viewModelStoreOwner,
+            @NonNull StoredPaymentMethod storedPaymentMethod,
+            @NonNull CardConfiguration configuration) {
+        final PaymentComponentViewModelFactory factory = new PaymentComponentViewModelFactory(storedPaymentMethod, configuration);
         return new ViewModelProvider(viewModelStoreOwner, factory).get(CardComponent.class);
     }
 

--- a/card-base/src/main/java/com/adyen/checkout/card/CardComponentProvider.java
+++ b/card-base/src/main/java/com/adyen/checkout/card/CardComponentProvider.java
@@ -12,9 +12,8 @@ import android.app.Application;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
-import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentActivity;
-import androidx.lifecycle.ViewModelProviders;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.lifecycle.ViewModelStoreOwner;
 
 import com.adyen.checkout.base.ComponentAvailableCallback;
 import com.adyen.checkout.base.PaymentComponentProvider;
@@ -30,20 +29,16 @@ import java.util.List;
 public class CardComponentProvider implements PaymentComponentProvider<CardComponent, CardConfiguration> {
     private static final String TAG = LogUtil.getTag();
 
-    @NonNull
+    @SuppressWarnings("LambdaLast")
     @Override
-    public CardComponent get(@NonNull FragmentActivity activity, @NonNull PaymentMethod paymentMethod, @NonNull CardConfiguration configuration) {
+    @NonNull
+    public CardComponent get(
+            @NonNull ViewModelStoreOwner viewModelStoreOwner,
+            @NonNull PaymentMethod paymentMethod,
+            @NonNull CardConfiguration configuration) {
         final CardConfiguration verifiedConfiguration = checkSupportedCardTypes(paymentMethod, configuration);
         final PaymentComponentViewModelFactory factory = new PaymentComponentViewModelFactory(paymentMethod, verifiedConfiguration);
-        return ViewModelProviders.of(activity, factory).get(CardComponent.class);
-    }
-
-    @NonNull
-    @Override
-    public CardComponent get(@NonNull Fragment fragment, @NonNull PaymentMethod paymentMethod, @NonNull CardConfiguration configuration) {
-        final CardConfiguration verifiedConfiguration = checkSupportedCardTypes(paymentMethod, configuration);
-        final PaymentComponentViewModelFactory factory = new PaymentComponentViewModelFactory(paymentMethod, verifiedConfiguration);
-        return ViewModelProviders.of(fragment, factory).get(CardComponent.class);
+        return new ViewModelProvider(viewModelStoreOwner, factory).get(CardComponent.class);
     }
 
     @Override

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ActionHandler.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ActionHandler.kt
@@ -8,11 +8,11 @@
 
 package com.adyen.checkout.dropin
 
-import androidx.lifecycle.Observer
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.Observer
 import com.adyen.checkout.adyen3ds2.Adyen3DS2Component
 import com.adyen.checkout.base.ActionComponentData
 import com.adyen.checkout.base.model.payments.response.Action
@@ -36,11 +36,18 @@ class ActionHandler(
     // Actions which will be handled by the Fragment with it's associated view
     private val viewableActionTypes = listOf(ActionTypes.AWAIT)
 
-    private val redirectComponent = RedirectComponent.PROVIDER.get(activity, dropInConfiguration.getConfigurationFor(ActionTypes.REDIRECT, activity))
-    private val adyen3DS2Component =
-        Adyen3DS2Component.PROVIDER.get(activity, dropInConfiguration.getConfigurationFor(ActionTypes.THREEDS2_FINGERPRINT, activity))
+    private val redirectComponent = RedirectComponent.PROVIDER.get(
+        activity,
+        activity.application,
+        dropInConfiguration.getConfigurationFor(ActionTypes.REDIRECT, activity)
+    )
+    private val adyen3DS2Component = Adyen3DS2Component.PROVIDER.get(
+        activity,
+        activity.application,
+        dropInConfiguration.getConfigurationFor(ActionTypes.THREEDS2_FINGERPRINT, activity)
+    )
     // get config from Drop-in when available
-    private val weChatPayActionComponent = WeChatPayActionComponent.PROVIDER.get(activity, null)
+    private val weChatPayActionComponent = WeChatPayActionComponent.PROVIDER.get(activity, activity.application, null)
 
     init {
         redirectComponent.observe(activity, this)

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInActivity.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInActivity.kt
@@ -13,11 +13,11 @@ import android.content.Context
 import android.content.Intent
 import android.content.res.Configuration
 import android.os.Bundle
+import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import com.adyen.checkout.base.ActionComponentData
 import com.adyen.checkout.base.ComponentError
@@ -80,7 +80,7 @@ class DropInActivity : AppCompatActivity(), DropInBottomSheetDialogFragment.Prot
         }
     }
 
-    private lateinit var dropInViewModel: DropInViewModel
+    private val dropInViewModel: DropInViewModel by viewModels()
 
     private lateinit var googlePayComponent: GooglePayComponent
 
@@ -112,9 +112,6 @@ class DropInActivity : AppCompatActivity(), DropInBottomSheetDialogFragment.Prot
         Logger.d(TAG, "onCreate - $savedInstanceState")
         setContentView(R.layout.activity_drop_in)
         overridePendingTransition(0, 0)
-
-        // If we add fragment-ktx dependency we can replace this with `by viewModels()` on the declaration
-        dropInViewModel = ViewModelProvider(this, defaultViewModelProviderFactory).get(DropInViewModel::class.java)
 
         val bundle = savedInstanceState ?: intent.extras
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
@@ -124,23 +124,17 @@ class ActionComponentDialogFragment : DropInBottomSheetDialogFragment(), Observe
      * Return the possible viewable action components
      */
     private fun getComponent(actionType: String): ViewableComponent<*, *, ActionComponentData> {
-        val application = activity?.application
-
-        if (application != null) {
-            return when (actionType) {
-                ActionTypes.AWAIT -> {
-                    AwaitComponent.PROVIDER.get(
-                        this,
-                        application,
-                        dropInViewModel.dropInConfiguration.getConfigurationFor(ActionTypes.AWAIT, requireContext())
-                    )
-                }
-                else -> {
-                    throw ComponentException("Unexpected Action component type - $actionType")
-                }
+        return when (actionType) {
+            ActionTypes.AWAIT -> {
+                AwaitComponent.PROVIDER.get(
+                    this,
+                    requireActivity().application,
+                    dropInViewModel.dropInConfiguration.getConfigurationFor(ActionTypes.AWAIT, requireContext())
+                )
             }
-        } else {
-            throw ComponentException("Unexpected Action component type - $actionType")
+            else -> {
+                throw ComponentException("Unexpected Action component type - $actionType")
+            }
         }
     }
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
@@ -8,13 +8,13 @@
 
 package com.adyen.checkout.dropin.ui.action
 
-import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
 import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
 import com.adyen.checkout.await.AwaitComponent
 import com.adyen.checkout.base.ActionComponent
 import com.adyen.checkout.base.ActionComponentData
@@ -67,7 +67,7 @@ class ActionComponentDialogFragment : DropInBottomSheetDialogFragment(), Observe
         action = arguments?.getParcelable(ACTION) ?: throw IllegalArgumentException("Action not found")
         actionType = action.type ?: throw IllegalArgumentException("Action type not found")
         // Get the same instance as the Activity
-        dropInViewModel = ViewModelProviders.of(requireActivity()).get(DropInViewModel::class.java)
+        dropInViewModel = ViewModelProvider(requireActivity()).get(DropInViewModel::class.java)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -124,15 +124,23 @@ class ActionComponentDialogFragment : DropInBottomSheetDialogFragment(), Observe
      * Return the possible viewable action components
      */
     private fun getComponent(actionType: String): ViewableComponent<*, *, ActionComponentData> {
-        return when (actionType) {
-            ActionTypes.AWAIT -> {
-                AwaitComponent.PROVIDER.get(
-                    this, dropInViewModel.dropInConfiguration.getConfigurationFor(ActionTypes.AWAIT, requireContext())
-                )
+        val application = activity?.application
+
+        if (application != null) {
+            return when (actionType) {
+                ActionTypes.AWAIT -> {
+                    AwaitComponent.PROVIDER.get(
+                        this,
+                        application,
+                        dropInViewModel.dropInConfiguration.getConfigurationFor(ActionTypes.AWAIT, requireContext())
+                    )
+                }
+                else -> {
+                    throw ComponentException("Unexpected Action component type - $actionType")
+                }
             }
-            else -> {
-                throw ComponentException("Unexpected Action component type - $actionType")
-            }
+        } else {
+            throw ComponentException("Unexpected Action component type - $actionType")
         }
     }
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/CardComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/CardComponentDialogFragment.kt
@@ -8,12 +8,11 @@
 
 package com.adyen.checkout.dropin.ui.component
 
-import androidx.lifecycle.ViewModelProviders
 import android.os.Bundle
-import com.google.android.material.bottomsheet.BottomSheetBehavior
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.ViewModelProvider
 import com.adyen.checkout.base.PaymentComponentState
 import com.adyen.checkout.base.model.payments.request.PaymentMethodDetails
 import com.adyen.checkout.base.util.CurrencyUtils
@@ -25,6 +24,7 @@ import com.adyen.checkout.core.log.Logger
 import com.adyen.checkout.dropin.R
 import com.adyen.checkout.dropin.ui.DropInViewModel
 import com.adyen.checkout.dropin.ui.base.BaseComponentDialogFragment
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import kotlinx.android.synthetic.main.fragment_card_component.dropInCardView
 import kotlinx.android.synthetic.main.view_card_component_dropin.view.header
 import kotlinx.android.synthetic.main.view_card_component_dropin.view.payButton
@@ -63,10 +63,8 @@ class CardComponentDialogFragment : BaseComponentDialogFragment() {
         cardComponent.observeErrors(this, createErrorHandlerObserver())
 
         // try to get the name from the payment methods response
-        activity?.let { activity ->
-            val dropInViewModel = ViewModelProviders.of(activity).get(DropInViewModel::class.java)
-            dropInCardView.header.text = dropInViewModel.paymentMethodsApiResponse.paymentMethods?.find { it.type == PaymentMethodTypes.SCHEME }?.name
-        }
+        val dropInViewModel = ViewModelProvider(requireActivity()).get(DropInViewModel::class.java)
+        dropInCardView.header.text = dropInViewModel.paymentMethodsApiResponse.paymentMethods?.find { it.type == PaymentMethodTypes.SCHEME }?.name
 
         dropInCardView.attach(cardComponent, this)
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/paymentmethods/PaymentMethodListDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/paymentmethods/PaymentMethodListDialogFragment.kt
@@ -13,7 +13,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.adyen.checkout.base.api.ImageLoader
@@ -52,7 +52,7 @@ class PaymentMethodListDialogFragment : DropInBottomSheetDialogFragment(), Payme
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         Logger.d(TAG, "onCreateView")
-        mDropInViewModel = ViewModelProviders.of(requireActivity()).get(DropInViewModel::class.java)
+        mDropInViewModel = ViewModelProvider(requireActivity()).get(DropInViewModel::class.java)
         val view = inflater.inflate(R.layout.fragment_payment_methods_list, container, false)
         addObserver(view.findViewById(R.id.recyclerView_paymentMethods))
         return view

--- a/example-app/build.gradle
+++ b/example-app/build.gradle
@@ -84,7 +84,6 @@ dependencies {
     implementation "androidx.multidex:multidex:$multidex_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "androidx.recyclerview:recyclerview:$recyclerview_version"
-    implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_extensions_version"
     implementation "androidx.constraintlayout:constraintlayout:$constraintlayout_version"
     implementation "androidx.preference:preference-ktx:$preference_version"
 

--- a/googlepay-base/src/main/java/com/adyen/checkout/googlepay/GooglePayProvider.java
+++ b/googlepay-base/src/main/java/com/adyen/checkout/googlepay/GooglePayProvider.java
@@ -31,6 +31,7 @@ import java.lang.ref.WeakReference;
 
 public class GooglePayProvider implements PaymentComponentProvider<GooglePayComponent, GooglePayConfiguration> {
 
+    @SuppressWarnings("LambdaLast")
     @Override
     @NonNull
     public GooglePayComponent get(

--- a/googlepay-base/src/main/java/com/adyen/checkout/googlepay/GooglePayProvider.java
+++ b/googlepay-base/src/main/java/com/adyen/checkout/googlepay/GooglePayProvider.java
@@ -11,15 +11,13 @@ package com.adyen.checkout.googlepay;
 import android.app.Application;
 
 import androidx.annotation.NonNull;
-import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentActivity;
-import androidx.lifecycle.ViewModelProviders;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.lifecycle.ViewModelStoreOwner;
 
 import com.adyen.checkout.base.ComponentAvailableCallback;
 import com.adyen.checkout.base.PaymentComponentProvider;
 import com.adyen.checkout.base.component.lifecycle.PaymentComponentViewModelFactory;
 import com.adyen.checkout.base.model.paymentmethods.PaymentMethod;
-import com.adyen.checkout.core.exception.CheckoutException;
 import com.adyen.checkout.googlepay.util.GooglePayUtils;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
@@ -33,20 +31,14 @@ import java.lang.ref.WeakReference;
 
 public class GooglePayProvider implements PaymentComponentProvider<GooglePayComponent, GooglePayConfiguration> {
 
-    @NonNull
     @Override
-    public GooglePayComponent get(@NonNull FragmentActivity activity, @NonNull PaymentMethod paymentMethod,
-            @NonNull GooglePayConfiguration configuration) throws CheckoutException {
-        final PaymentComponentViewModelFactory factory = new PaymentComponentViewModelFactory(paymentMethod, configuration);
-        return ViewModelProviders.of(activity, factory).get(GooglePayComponent.class);
-    }
-
     @NonNull
-    @Override
-    public GooglePayComponent get(@NonNull Fragment fragment, @NonNull PaymentMethod paymentMethod, @NonNull GooglePayConfiguration configuration)
-            throws CheckoutException {
+    public GooglePayComponent get(
+            @NonNull ViewModelStoreOwner viewModelStoreOwner,
+            @NonNull PaymentMethod paymentMethod,
+            @NonNull GooglePayConfiguration configuration) {
         final PaymentComponentViewModelFactory factory = new PaymentComponentViewModelFactory(paymentMethod, configuration);
-        return ViewModelProviders.of(fragment, factory).get(GooglePayComponent.class);
+        return new ViewModelProvider(viewModelStoreOwner, factory).get(GooglePayComponent.class);
     }
 
     @Override

--- a/wechatpay-base/src/main/java/com/adyen/checkout/wechatpay/WeChatPayProvider.java
+++ b/wechatpay-base/src/main/java/com/adyen/checkout/wechatpay/WeChatPayProvider.java
@@ -11,36 +11,24 @@ package com.adyen.checkout.wechatpay;
 import android.app.Application;
 
 import androidx.annotation.NonNull;
-import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentActivity;
-import androidx.lifecycle.ViewModelProviders;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.lifecycle.ViewModelStoreOwner;
 
 import com.adyen.checkout.base.ComponentAvailableCallback;
 import com.adyen.checkout.base.PaymentComponentProvider;
 import com.adyen.checkout.base.component.lifecycle.PaymentComponentViewModelFactory;
 import com.adyen.checkout.base.model.paymentmethods.PaymentMethod;
-import com.adyen.checkout.core.exception.CheckoutException;
 
 public class WeChatPayProvider implements PaymentComponentProvider<WeChatPayComponent, WeChatPayConfiguration> {
 
-    @NonNull
     @Override
-    public WeChatPayComponent get(@NonNull FragmentActivity activity, @NonNull PaymentMethod paymentMethod,
-            @NonNull WeChatPayConfiguration configuration) throws CheckoutException {
-        final PaymentComponentViewModelFactory factory = new PaymentComponentViewModelFactory(paymentMethod, configuration);
-        return ViewModelProviders.of(activity, factory).get(WeChatPayComponent.class);
-    }
-
     @NonNull
-    @Override
-    public WeChatPayComponent get(@NonNull Fragment fragment, @NonNull PaymentMethod paymentMethod, @NonNull WeChatPayConfiguration configuration)
-            throws CheckoutException {
+    public WeChatPayComponent get(
+            @NonNull ViewModelStoreOwner viewModelStoreOwner,
+            @NonNull PaymentMethod paymentMethod,
+            @NonNull WeChatPayConfiguration configuration) {
         final PaymentComponentViewModelFactory factory = new PaymentComponentViewModelFactory(paymentMethod, configuration);
-        final WeChatPayComponent component = ViewModelProviders.of(fragment, factory).get(WeChatPayComponent.class);
-        if (fragment.getActivity() == null) {
-            throw new CheckoutException("WeChatPay Component needs to be initiated on a Fragment that is attached to an Activity.");
-        }
-        return component;
+        return new ViewModelProvider(viewModelStoreOwner, factory).get(WeChatPayComponent.class);
     }
 
     @Override

--- a/wechatpay-base/src/main/java/com/adyen/checkout/wechatpay/WeChatPayProvider.java
+++ b/wechatpay-base/src/main/java/com/adyen/checkout/wechatpay/WeChatPayProvider.java
@@ -21,6 +21,7 @@ import com.adyen.checkout.base.model.paymentmethods.PaymentMethod;
 
 public class WeChatPayProvider implements PaymentComponentProvider<WeChatPayComponent, WeChatPayConfiguration> {
 
+    @SuppressWarnings("LambdaLast")
     @Override
     @NonNull
     public WeChatPayComponent get(


### PR DESCRIPTION
## Summary
- Update the Payment and Action Component Providers to use `ViewModelProvider`.
- Merge `PROVIDER` get methods for Activity and Fragment into  ViewModelStoreOwner.
- Create `StoredPaymentComponentProvider` to separate initialization with `PaymentMethod` and `StoredPaymentMethod` to prepare for API model separation.
- Remove deprecated methods.
