### PR TITLE
Fix clientKey validation for BaseConfiguration on DropIn.

### DIFF
--- a/base-v3/src/main/java/com/adyen/checkout/base/component/BaseConfigurationBuilder.java
+++ b/base-v3/src/main/java/com/adyen/checkout/base/component/BaseConfigurationBuilder.java
@@ -27,7 +27,7 @@ public abstract class BaseConfigurationBuilder<ConfigurationT extends Configurat
     protected Environment mBuilderEnvironment;
 
     @NonNull
-    protected String mBuilderClientKey = Configuration.DEFAULT_EMPTY_CLIENT_KEY;
+    protected String mBuilderClientKey = "";
 
     /**
      * Constructor that provides default values.
@@ -54,7 +54,7 @@ public abstract class BaseConfigurationBuilder<ConfigurationT extends Configurat
      * @return The builder instance to chain calls.
      */
     @NonNull
-    public BaseConfigurationBuilder setShopperLocale(@NonNull Locale builderShopperLocale) {
+    public BaseConfigurationBuilder<ConfigurationT> setShopperLocale(@NonNull Locale builderShopperLocale) {
         mBuilderShopperLocale = builderShopperLocale;
         return this;
     }
@@ -64,7 +64,7 @@ public abstract class BaseConfigurationBuilder<ConfigurationT extends Configurat
      * @return The builder instance to chain calls.
      */
     @NonNull
-    public BaseConfigurationBuilder setEnvironment(@NonNull Environment builderEnvironment) {
+    public BaseConfigurationBuilder<ConfigurationT> setEnvironment(@NonNull Environment builderEnvironment) {
         mBuilderEnvironment = builderEnvironment;
         return this;
     }
@@ -74,7 +74,7 @@ public abstract class BaseConfigurationBuilder<ConfigurationT extends Configurat
      * @return The builder instance to chain calls.
      */
     @NonNull
-    public BaseConfigurationBuilder setClientKey(@NonNull String builderClientKey) {
+    public BaseConfigurationBuilder<ConfigurationT> setClientKey(@NonNull String builderClientKey) {
         if (!ValidationUtils.isClientKeyValid(builderClientKey)) {
             throw new CheckoutException("Client key is not valid.");
         }

--- a/base-v3/src/main/java/com/adyen/checkout/base/component/Configuration.java
+++ b/base-v3/src/main/java/com/adyen/checkout/base/component/Configuration.java
@@ -20,8 +20,6 @@ import java.util.Locale;
 
 public abstract class Configuration implements Parcelable {
 
-    public static final String DEFAULT_EMPTY_CLIENT_KEY = "";
-
     private final Locale mShopperLocale;
     private final Environment mEnvironment;
     private final String mClientKey;

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
@@ -139,7 +139,9 @@ internal fun <T : Configuration> getDefaultConfigFor(
 
     builder.setShopperLocale(dropInConfiguration.shopperLocale)
     builder.setEnvironment(dropInConfiguration.environment)
-    builder.setClientKey(dropInConfiguration.clientKey)
+    if (dropInConfiguration.clientKey.isNotEmpty()) {
+        builder.setClientKey(dropInConfiguration.clientKey)
+    }
 
     @Suppress("UNCHECKED_CAST")
     return builder.build() as T

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
@@ -117,7 +117,7 @@ class DropInConfiguration : Configuration, Parcelable {
 
         private var shopperLocale: Locale
         private var environment: Environment = Environment.EUROPE
-        private var clientKey: String = DEFAULT_EMPTY_CLIENT_KEY
+        private var clientKey: String = ""
         private var serviceComponentName: ComponentName
         private var resultHandlerIntent: Intent
         private var amount: Amount = Amount.EMPTY


### PR DESCRIPTION
## Summary
When no Configuration is defined for a payment method on the Drop-in, it creates a base generic one if possible. 
It sets the `clientKey` from the `DropInConfiguration` to propagate it automatically, but if there is no `clientKey` defined it tries to set the default emtpy value and throws the validation exception.

Fix: Only set the `clientKey` on generic configurations if it's not empty.

## Tested scenarios
- Reproduced issue and confirmed the problem
- Tested flow with and without the clientKey