### PR TITLE
Make Google Pay wallet depenency visible.

### DIFF
--- a/googlepay-base/build.gradle
+++ b/googlepay-base/build.gradle
@@ -46,8 +46,7 @@ dependencies {
     api project(':base-v3')
 
     // Dependencies
-
-    implementation "com.google.android.gms:play-services-wallet:$play_services_wallet_version"
+    api "com.google.android.gms:play-services-wallet:$play_services_wallet_version"
 }
 
 // This sharedTasks.gradle script is applied at the end of this build.gradle script,


### PR DESCRIPTION
## Summary
- Make Google Pay wallet dependency visible to merchants so that they can have access to the `WalletConstants`.