### PR TITLE
Increase memory for the gradle JVM to speed up builds.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@
 # The setting is particularly useful for tweaking memory settings.
 android.enableJetifier=false
 android.useAndroidX=true
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx3072m -XX:MaxPermSize=512m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Gradle check was giving OOM errors and taking a long time. Increase available memory on the JVM.