### PR TITLE
DropIn initialization with activityResult

### DIFF
--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropIn.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropIn.kt
@@ -52,14 +52,16 @@ object DropIn {
     fun startPayment(
         activity: Activity,
         paymentMethodsApiResponse: PaymentMethodsApiResponse,
-        dropInConfiguration: DropInConfiguration
+        dropInConfiguration: DropInConfiguration,
+        resultHandlerIntent: Intent? = null
     ) {
         Logger.d(TAG, "startPayment from Activity")
 
         val intent = preparePayment(
             activity,
             paymentMethodsApiResponse,
-            dropInConfiguration
+            dropInConfiguration,
+            resultHandlerIntent
         )
         activity.startActivityForResult(intent, DROP_IN_REQUEST_CODE)
     }
@@ -77,14 +79,16 @@ object DropIn {
     fun startPayment(
         fragment: Fragment,
         paymentMethodsApiResponse: PaymentMethodsApiResponse,
-        dropInConfiguration: DropInConfiguration
+        dropInConfiguration: DropInConfiguration,
+        resultHandlerIntent: Intent? = null
     ) {
         Logger.d(TAG, "startPayment from Fragment")
 
         val intent = preparePayment(
             fragment.requireContext(),
             paymentMethodsApiResponse,
-            dropInConfiguration
+            dropInConfiguration,
+            resultHandlerIntent
         )
         fragment.startActivityForResult(intent, DROP_IN_REQUEST_CODE)
     }
@@ -92,13 +96,19 @@ object DropIn {
     private fun preparePayment(
         context: Context,
         paymentMethodsApiResponse: PaymentMethodsApiResponse,
-        dropInConfiguration: DropInConfiguration
+        dropInConfiguration: DropInConfiguration,
+        resultHandlerIntent: Intent?
     ): Intent {
         // Add locale to prefs
         context.getSharedPreferences(DROP_IN_PREFS, Context.MODE_PRIVATE).edit()
             .putString(LOCALE_PREF, dropInConfiguration.shopperLocale.toString())
             .apply()
 
-        return DropInActivity.createIntent(context, dropInConfiguration, paymentMethodsApiResponse)
+        return DropInActivity.createIntent(
+            context,
+            dropInConfiguration,
+            paymentMethodsApiResponse,
+            resultHandlerIntent
+        )
     }
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropIn.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropIn.kt
@@ -50,10 +50,10 @@ object DropIn {
      * the stack of the checkout activities.
      *
      * 3 states can occur from this operation:
-     * * Cancelled by user: the user dismissed the Drop-in before it has completed.
-     * * Error: a [DropInServiceResult.Error] was returned in the [DropInService], or an error
+     * - Cancelled by user: the user dismissed the Drop-in before it has completed.
+     * - Error: a [DropInServiceResult.Error] was returned in the [DropInService], or an error
      * has occurred.
-     * * Finished: a [DropInServiceResult.Finished] was returned in the [DropInService].
+     * - Finished: a [DropInServiceResult.Finished] was returned in the [DropInService].
      *
      * You should always handle the cases of cancellation and error in [Activity.onActivityResult]
      * (request code [DROP_IN_REQUEST_CODE]).
@@ -67,7 +67,8 @@ object DropIn {
      * also receive the result in [Activity.onActivityResult]. You can make use of the
      * [handleActivityResult] helper method. If you prefer to handle the activity result
      * manually, you should expect an [Activity.RESULT_OK] result code. The data intent will
-     * contain the result string extra with key [RESULT_KEY].
+     * contain the result string extra with key [RESULT_KEY] and will hold the same value as the
+     * [DropInServiceResult.Finished.result] returned inside the [DropInService].
      *
      * However, if you do specify a [resultHandlerIntent], [Activity.onActivityResult] will not
      * receive the result. Instead, that [resultHandlerIntent] will be launched when the
@@ -108,10 +109,10 @@ object DropIn {
      * the stack of the checkout activities.
      *
      * 3 states can occur from this operation:
-     * * Cancelled by user: the user dismissed the Drop-in before it has completed.
-     * * Error: a [DropInServiceResult.Error] was returned in the [DropInService], or an error
+     * - Cancelled by user: the user dismissed the Drop-in before it has completed.
+     * - Error: a [DropInServiceResult.Error] was returned in the [DropInService], or an error
      * has occurred.
-     * * Finished: a [DropInServiceResult.Finished] was returned in the [DropInService].
+     * - Finished: a [DropInServiceResult.Finished] was returned in the [DropInService].
      *
      * You should always handle the cases of cancellation and error in [Fragment.onActivityResult]
      * (request code [DROP_IN_REQUEST_CODE]).
@@ -125,7 +126,8 @@ object DropIn {
      * also receive the result in [Fragment.onActivityResult]. You can make use of the
      * [handleActivityResult] helper method. If you prefer to handle the activity result
      * manually, you should expect an [Activity.RESULT_OK] result code. The data intent will
-     * contain the result string extra with key [RESULT_KEY].
+     * contain the result string extra with key [RESULT_KEY] and will hold the same value as the
+     * [DropInServiceResult.Finished.result] returned inside the [DropInService].
      *
      * However, if you do specify a [resultHandlerIntent], [Fragment.onActivityResult] will not
      * receive the result. Instead, that [resultHandlerIntent] will be launched when the

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropIn.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropIn.kt
@@ -31,6 +31,7 @@ class DropIn private constructor() {
         private val TAG = LogUtil.getTag()
 
         const val RESULT_KEY = "payment_result"
+        const val RESULT_ERROR_REASON = "error_reason"
 
         const val DROP_IN_PREFS = "drop-in-shared-prefs"
         const val LOCALE_PREF = "drop-in-locale"

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropIn.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropIn.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.dropin
 
 import android.app.Activity
 import android.content.Context
+import androidx.fragment.app.Fragment
 import com.adyen.checkout.components.model.PaymentMethodsApiResponse
 import com.adyen.checkout.core.log.LogUtil
 import com.adyen.checkout.core.log.Logger
@@ -63,10 +64,10 @@ class DropIn private constructor() {
                 .apply()
 
             val intent = DropInActivity.createIntent(context, dropInConfiguration, paymentMethodsApiResponse)
-            if (context is Activity) {
-                context.startActivityForResult(intent, DROP_IN_REQUEST_CODE)
-            } else {
-                context.startActivity(intent)
+            when (context) {
+                is Activity -> context.startActivityForResult(intent, DROP_IN_REQUEST_CODE)
+                is Fragment -> context.startActivityForResult(intent, DROP_IN_REQUEST_CODE)
+                else -> context.startActivity(intent)
             }
         }
     }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropIn.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropIn.kt
@@ -21,13 +21,12 @@ import com.adyen.checkout.dropin.service.DropInServiceResult
 import com.adyen.checkout.dropin.ui.DropInActivity
 
 /**
- * Drop-in is the easy solution to using components. The Merchant only needs to provide the response of the paymentMethods/ endpoint
- * and some configuration data. Then we will handle the UI flow to get all the needed payment information.
+ * Drop-in is our pre-built checkout UI for accepting payments. You only need to provide
+ * the /paymentMethods response and some configuration data - Drop-in will handle the rest of the
+ * payment flow.
  *
- * Merchant needs to extend [DropInService] and put it in the manifest. That service is where the merchant will make the calls to the
- * server for the payments/ and payments/details/ endpoints/.
- *
- * After setting up the [DropInService], just call [startPayment] and the checkout process will start.
+ * To start the payment flow, first extend the [DropInService] class, and add it to your manifest
+ * file. Then call [startPayment].
  */
 object DropIn {
     private val TAG = LogUtil.getTag()

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropIn.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropIn.kt
@@ -33,7 +33,8 @@ class DropIn private constructor() {
         private val TAG = LogUtil.getTag()
 
         const val RESULT_KEY = "payment_result"
-        const val RESULT_ERROR_REASON = "error_reason"
+        const val ERROR_REASON_KEY = "error_reason"
+        const val ERROR_REASON_USER_CANCELED = "Canceled by user"
 
         const val DROP_IN_PREFS = "drop-in-shared-prefs"
         const val LOCALE_PREF = "drop-in-locale"

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
@@ -8,11 +8,13 @@
 
 package com.adyen.checkout.dropin
 
+import android.app.Activity
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.os.Parcel
 import android.os.Parcelable
+import androidx.fragment.app.Fragment
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.model.payments.Amount
 import com.adyen.checkout.components.util.CheckoutCurrency
@@ -148,15 +150,31 @@ class DropInConfiguration : Configuration, Parcelable {
          *
          * Create a [DropInConfiguration] without a [resultHandlerIntent], the payment result should be handled in [Activity.onActivityResult]
          *
-         * @param context
+         * @param activity
          * @param serviceClass Service that extended from [DropInService] that would handle network requests.
          */
-        constructor(context: Context, serviceClass: Class<out Any?>) {
-            this.packageName = context.packageName
+        constructor(activity: Activity, serviceClass: Class<out Any?>) {
+            this.packageName = activity.packageName
             this.serviceClassName = serviceClass.name
 
             this.serviceComponentName = ComponentName(packageName, serviceClassName)
-            this.shopperLocale = LocaleUtil.getLocale(context)
+            this.shopperLocale = LocaleUtil.getLocale(activity)
+        }
+
+        /**
+         *
+         * Create a [DropInConfiguration] without a [resultHandlerIntent], the payment result should be handled in [Fragment.onActivityResult]
+         *
+         * @param fragment
+         * @param serviceClass Service that extended from [DropInService] that would handle network requests.
+         */
+        constructor(fragment: Fragment, serviceClass: Class<out Any?>) {
+            val activity = fragment.requireActivity()
+            this.packageName = activity.packageName
+            this.serviceClassName = serviceClass.name
+
+            this.serviceComponentName = ComponentName(packageName, serviceClassName)
+            this.shopperLocale = LocaleUtil.getLocale(activity)
         }
 
         /**

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
@@ -49,7 +49,7 @@ class DropInConfiguration : Configuration, Parcelable {
 
     private val availableConfigs: HashMap<String, Configuration>
     val serviceComponentName: ComponentName
-    val resultHandlerIntent: Intent
+    val resultHandlerIntent: Intent?
     val amount: Amount
 
     companion object {
@@ -67,7 +67,7 @@ class DropInConfiguration : Configuration, Parcelable {
         clientKey: String,
         availableConfigs: HashMap<String, Configuration>,
         serviceComponentName: ComponentName,
-        resultHandlerIntent: Intent,
+        resultHandlerIntent: Intent?,
         amount: Amount
     ) : super(shopperLocale, environment, clientKey) {
         this.availableConfigs = availableConfigs
@@ -80,7 +80,7 @@ class DropInConfiguration : Configuration, Parcelable {
         @Suppress("UNCHECKED_CAST")
         availableConfigs = parcel.readHashMap(Configuration::class.java.classLoader) as HashMap<String, Configuration>
         serviceComponentName = parcel.readParcelable(ComponentName::class.java.classLoader)!!
-        resultHandlerIntent = parcel.readParcelable(Intent::class.java.classLoader)!!
+        resultHandlerIntent = parcel.readParcelable(Intent::class.java.classLoader)
         amount = Amount.CREATOR.createFromParcel(parcel)
     }
 
@@ -120,15 +120,19 @@ class DropInConfiguration : Configuration, Parcelable {
         private var environment: Environment = Environment.EUROPE
         private var clientKey: String = ""
         private var serviceComponentName: ComponentName
-        private var resultHandlerIntent: Intent
+        private var resultHandlerIntent: Intent? = null
         private var amount: Amount = Amount.EMPTY
 
         private val packageName: String
         private val serviceClassName: String
 
         /**
+         *
+         * Create a [DropInConfiguration] with a [resultHandlerIntent] which will be launched after the Drop-In is finished
+         *
          * @param context
-         * @param resultHandlerIntent The Intent used with [Activity.startActivity] that will contain the payment result extra with key [RESULT_KEY].
+         * @param resultHandlerIntent The Intent used with [Context.startActivity] that will contain
+         * the payment result extra with key [DropIn.RESULT_KEY].
          * @param serviceClass Service that extended from [DropInService] that would handle network requests.
          */
         constructor(context: Context, resultHandlerIntent: Intent, serviceClass: Class<out Any?>) {
@@ -136,6 +140,21 @@ class DropInConfiguration : Configuration, Parcelable {
             this.serviceClassName = serviceClass.name
 
             this.resultHandlerIntent = resultHandlerIntent
+            this.serviceComponentName = ComponentName(packageName, serviceClassName)
+            this.shopperLocale = LocaleUtil.getLocale(context)
+        }
+
+        /**
+         *
+         * Create a [DropInConfiguration] without a [resultHandlerIntent], the payment result should be handled in [Activity.onActivityResult]
+         *
+         * @param context
+         * @param serviceClass Service that extended from [DropInService] that would handle network requests.
+         */
+        constructor(context: Context, serviceClass: Class<out Any?>) {
+            this.packageName = context.packageName
+            this.serviceClassName = serviceClass.name
+
             this.serviceComponentName = ComponentName(packageName, serviceClassName)
             this.shopperLocale = LocaleUtil.getLocale(context)
         }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
@@ -10,7 +10,6 @@ package com.adyen.checkout.dropin
 
 import android.content.ComponentName
 import android.content.Context
-import android.content.Intent
 import android.os.Parcel
 import android.os.Parcelable
 import com.adyen.checkout.components.base.Configuration
@@ -49,7 +48,6 @@ class DropInConfiguration : Configuration, Parcelable {
 
     private val availableConfigs: HashMap<String, Configuration>
     val serviceComponentName: ComponentName
-    val resultHandlerIntent: Intent?
     val amount: Amount
 
     companion object {
@@ -67,12 +65,10 @@ class DropInConfiguration : Configuration, Parcelable {
         clientKey: String,
         availableConfigs: HashMap<String, Configuration>,
         serviceComponentName: ComponentName,
-        resultHandlerIntent: Intent?,
         amount: Amount
     ) : super(shopperLocale, environment, clientKey) {
         this.availableConfigs = availableConfigs
         this.serviceComponentName = serviceComponentName
-        this.resultHandlerIntent = resultHandlerIntent
         this.amount = amount
     }
 
@@ -80,7 +76,6 @@ class DropInConfiguration : Configuration, Parcelable {
         @Suppress("UNCHECKED_CAST")
         availableConfigs = parcel.readHashMap(Configuration::class.java.classLoader) as HashMap<String, Configuration>
         serviceComponentName = parcel.readParcelable(ComponentName::class.java.classLoader)!!
-        resultHandlerIntent = parcel.readParcelable(Intent::class.java.classLoader)
         amount = Amount.CREATOR.createFromParcel(parcel)
     }
 
@@ -88,7 +83,6 @@ class DropInConfiguration : Configuration, Parcelable {
         super.writeToParcel(dest, flags)
         dest.writeMap(availableConfigs)
         dest.writeParcelable(serviceComponentName, flags)
-        dest.writeParcelable(resultHandlerIntent, flags)
         JsonUtils.writeToParcel(dest, Amount.SERIALIZER.serialize(amount))
     }
 
@@ -120,7 +114,6 @@ class DropInConfiguration : Configuration, Parcelable {
         private var environment: Environment = Environment.EUROPE
         private var clientKey: String = ""
         private var serviceComponentName: ComponentName
-        private var resultHandlerIntent: Intent? = null
         private var amount: Amount = Amount.EMPTY
 
         private val packageName: String
@@ -128,7 +121,7 @@ class DropInConfiguration : Configuration, Parcelable {
 
         /**
          *
-         * Create a [DropInConfiguration] with a [resultHandlerIntent] which will be launched after the Drop-In is finished
+         * Create a [DropInConfiguration]
          *
          * @param context
          * @param serviceClass Service that extended from [DropInService] that would handle network requests.
@@ -151,7 +144,6 @@ class DropInConfiguration : Configuration, Parcelable {
             this.serviceComponentName = dropInConfiguration.serviceComponentName
             this.shopperLocale = dropInConfiguration.shopperLocale
             this.environment = dropInConfiguration.environment
-            this.resultHandlerIntent = dropInConfiguration.resultHandlerIntent
             this.amount = dropInConfiguration.amount
         }
 
@@ -181,11 +173,6 @@ class DropInConfiguration : Configuration, Parcelable {
             }
 
             this.clientKey = clientKey
-            return this
-        }
-
-        fun setResultHandlerIntent(resultHandlerIntent: Intent): Builder {
-            this.resultHandlerIntent = resultHandlerIntent
             return this
         }
 
@@ -319,7 +306,6 @@ class DropInConfiguration : Configuration, Parcelable {
                 clientKey,
                 availableConfigs,
                 serviceComponentName,
-                resultHandlerIntent,
                 amount
             )
         }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
@@ -8,13 +8,11 @@
 
 package com.adyen.checkout.dropin
 
-import android.app.Activity
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.os.Parcel
 import android.os.Parcelable
-import androidx.fragment.app.Fragment
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.model.payments.Amount
 import com.adyen.checkout.components.util.CheckoutCurrency
@@ -133,48 +131,14 @@ class DropInConfiguration : Configuration, Parcelable {
          * Create a [DropInConfiguration] with a [resultHandlerIntent] which will be launched after the Drop-In is finished
          *
          * @param context
-         * @param resultHandlerIntent The Intent used with [Context.startActivity] that will contain
-         * the payment result extra with key [DropIn.RESULT_KEY].
          * @param serviceClass Service that extended from [DropInService] that would handle network requests.
          */
-        constructor(context: Context, resultHandlerIntent: Intent, serviceClass: Class<out Any?>) {
+        constructor(context: Context, serviceClass: Class<out Any?>) {
             this.packageName = context.packageName
             this.serviceClassName = serviceClass.name
 
-            this.resultHandlerIntent = resultHandlerIntent
             this.serviceComponentName = ComponentName(packageName, serviceClassName)
             this.shopperLocale = LocaleUtil.getLocale(context)
-        }
-
-        /**
-         *
-         * Create a [DropInConfiguration] without a [resultHandlerIntent], the payment result should be handled in [Activity.onActivityResult]
-         *
-         * @param activity
-         * @param serviceClass Service that extended from [DropInService] that would handle network requests.
-         */
-        constructor(activity: Activity, serviceClass: Class<out Any?>) {
-            this.packageName = activity.packageName
-            this.serviceClassName = serviceClass.name
-
-            this.serviceComponentName = ComponentName(packageName, serviceClassName)
-            this.shopperLocale = LocaleUtil.getLocale(activity)
-        }
-
-        /**
-         *
-         * Create a [DropInConfiguration] without a [resultHandlerIntent], the payment result should be handled in [Fragment.onActivityResult]
-         *
-         * @param fragment
-         * @param serviceClass Service that extended from [DropInService] that would handle network requests.
-         */
-        constructor(fragment: Fragment, serviceClass: Class<out Any?>) {
-            val activity = fragment.requireActivity()
-            this.packageName = activity.packageName
-            this.serviceClassName = serviceClass.name
-
-            this.serviceComponentName = ComponentName(packageName, serviceClassName)
-            this.shopperLocale = LocaleUtil.getLocale(activity)
         }
 
         /**

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropInResult.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropInResult.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2021 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 4/2/2021.
+ */
+
+package com.adyen.checkout.dropin
+
+sealed class DropInResult {
+    class CancelledByUser : DropInResult()
+    class Error(val reason: String?) : DropInResult()
+    class Finished(val result: String) : DropInResult()
+}

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/service/DropInService.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/service/DropInService.kt
@@ -95,19 +95,26 @@ abstract class DropInService : Service(), CoroutineScope, DropInServiceInterface
      * payment component JSON and might also contain more details about the state of the
      * component at the moment in which the payment is confirmed by the user.
      *
-     * This method does not have a return type and therefore allows asynchronous handling of the
-     * payment data. However you must eventually call [sendResult] with a [DropInServiceResult]
-     * containing the result of the network request. The base class will handle messaging the UI
-     * afterwards, based on the [DropInServiceResult].
+     * - Asynchronous handling:
      *
-     * This method runs on the main thread, you should make sure the payments/ call and any other
-     * long running operation is made on a background thread.
+     *     Since this method runs on the main thread, you should make sure the payments/ call and
+     * any other long running operation is made on a background thread. You should eventually call
+     * [sendResult] with a [DropInServiceResult] containing the result of the network request.
+     * The base class will handle messaging the UI afterwards, based on the [DropInServiceResult].
      *
-     * Note that overriding this method means that the [makePaymentsCall] method will not be
-     * called anymore and therefore you should only implement one of these 2 methods depending on
-     * which behavior you prefer.
+     *     Note that overriding this method means that the [makePaymentsCall] method will not be
+     * called anymore and therefore you can disregard it.
      *
-     * Also note that the [PaymentComponentState] is a abstract class, you can check and cast to
+     * - Synchronous handling:
+     *
+     *     Alternatively, if you don't need asynchronous handling but you still want to access
+     * the [PaymentComponentState], you will still need to implement [makePaymentsCall]. After you
+     * are done handling the [PaymentComponentState] inside [onPaymentsCallRequested], call
+     * [super.onPaymentsCallRequested] to proceed. This will internally invoke your
+     * implementation of [makePaymentsCall] in a background thread so you won't need to
+     * manage the threads yourself.
+     *
+     * Note that the [PaymentComponentState] is a abstract class, you can check and cast to
      * one of its child classes for a more component specific state.
      *
      * See https://docs.adyen.com/api-explorer/ for more information on the API documentation.
@@ -143,17 +150,25 @@ abstract class DropInService : Service(), CoroutineScope, DropInServiceInterface
      * We also provide an [ActionComponentData] that contains a non-serialized version of the
      * action component JSON.
      *
-     * This method does not have a return type and therefore allows asynchronous handling of the
-     * action data. However you must eventually call [sendResult] with a [DropInServiceResult]
-     * containing the result of the network request. The base class will handle messaging the UI
-     * afterwards, based on the [DropInServiceResult].
+     * - Asynchronous handling:
      *
-     * This method runs on the main thread, you should make sure the payments/details/ call and
-     * any other long running operation is made on a background thread.
+     *     Since this method runs on the main thread, you should make sure the payments/details/
+     * call and any other long running operation is made on a background thread. You should
+     * eventually call [sendResult] with a [DropInServiceResult] containing the result of the
+     * network request. The base class will handle messaging the UI afterwards, based on the
+     * [DropInServiceResult].
      *
-     * Note that overriding this method means that the [makeDetailsCall] method will not be
-     * called anymore and therefore you should only implement one of these 2 methods depending on
-     * which behavior you prefer.
+     *     Note that overriding this method means that the [makeDetailsCall] method will not be
+     * called anymore and therefore you can disregard it.
+     *
+     * - Synchronous handling:
+     *
+     *     Alternatively, if you don't need asynchronous handling but you still want to access
+     * the [ActionComponentData], you will still need to implement [makeDetailsCall]. After you
+     * are done handling the [ActionComponentData] inside [onDetailsCallRequested], call
+     * [super.onDetailsCallRequested] to proceed. This will internally invoke your
+     * implementation of [makeDetailsCall] in a background thread so you won't need to
+     * manage the threads yourself.
      *
      * See https://docs.adyen.com/api-explorer/ for more information on the API documentation.
      *
@@ -207,9 +222,7 @@ abstract class DropInService : Service(), CoroutineScope, DropInServiceInterface
      * [DropInServiceResult].
      *
      * If you want to make the call asynchronously, or get a more detailed, non-serialized
-     * version of the payment component data, override [onPaymentsCallRequested] instead (note
-     * that you should either override [makePaymentsCall] or [onPaymentsCallRequested]
-     * not both at the same time).
+     * version of the payment component data, override [onPaymentsCallRequested] instead.
      *
      * See https://docs.adyen.com/api-explorer/ for more information on the API documentation.
      *
@@ -237,8 +250,7 @@ abstract class DropInService : Service(), CoroutineScope, DropInServiceInterface
      * [DropInServiceResult].
      *
      * If you want to make the call asynchronously, or get a non-serialized version of the action
-     * component data, override [onDetailsCallRequested] instead (note that you should either
-     * override [makeDetailsCall] or [onDetailsCallRequested] not both at the same time).
+     * component data, override [onDetailsCallRequested] instead.
      *
      * See https://docs.adyen.com/api-explorer/ for more information on the API documentation.
      *

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/service/DropInServiceResult.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/service/DropInServiceResult.kt
@@ -14,7 +14,9 @@ package com.adyen.checkout.dropin.service
 sealed class DropInServiceResult {
 
     /**
-     * Call was successful and payment is finished.
+     * Call was successful and payment is finished. This does not necessarily mean that the
+     * payment was authorized, it can simply indicate that all the necessary network calls were
+     * made without any exceptions or unexpected errors.
      */
     class Finished(val result: String) : DropInServiceResult()
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInActivity.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInActivity.kt
@@ -64,6 +64,7 @@ private const val LOADING_FRAGMENT_TAG = "LOADING_DIALOG_FRAGMENT"
 
 private const val PAYMENT_METHODS_RESPONSE_KEY = "PAYMENT_METHODS_RESPONSE_KEY"
 private const val DROP_IN_CONFIGURATION_KEY = "DROP_IN_CONFIGURATION_KEY"
+private const val DROP_IN_RESULT_INTENT = "DROP_IN_RESULT_INTENT"
 private const val IS_WAITING_FOR_RESULT = "IS_WAITING_FOR_RESULT"
 
 private const val GOOGLE_PAY_REQUEST_CODE = 1
@@ -183,8 +184,15 @@ class DropInActivity : AppCompatActivity(), DropInBottomSheetDialogFragment.Prot
         isWaitingResult = bundle.getBoolean(IS_WAITING_FOR_RESULT, false)
         val dropInConfiguration: DropInConfiguration? = bundle.getParcelable(DROP_IN_CONFIGURATION_KEY)
         val paymentMethodsApiResponse: PaymentMethodsApiResponse? = bundle.getParcelable(PAYMENT_METHODS_RESPONSE_KEY)
+        val resultHandlerIntent: Intent? = bundle.getParcelable(DROP_IN_RESULT_INTENT)
         return if (dropInConfiguration != null && paymentMethodsApiResponse != null) {
-            dropInViewModel = getViewModel { DropInViewModel(paymentMethodsApiResponse, dropInConfiguration) }
+            dropInViewModel = getViewModel {
+                DropInViewModel(
+                    paymentMethodsApiResponse,
+                    dropInConfiguration,
+                    resultHandlerIntent
+                )
+            }
             true
         } else {
             Logger.e(
@@ -398,7 +406,7 @@ class DropInActivity : AppCompatActivity(), DropInBottomSheetDialogFragment.Prot
     }
 
     private fun sendResult(content: String) {
-        val resultHandlerIntent = dropInViewModel.dropInConfiguration.resultHandlerIntent
+        val resultHandlerIntent = dropInViewModel.resultHandlerIntent
         // Merchant requested the result to be sent back with a result intent
         if (resultHandlerIntent != null) {
             resultHandlerIntent.putExtra(DropIn.RESULT_KEY, content)
@@ -486,10 +494,16 @@ class DropInActivity : AppCompatActivity(), DropInBottomSheetDialogFragment.Prot
     }
 
     companion object {
-        fun createIntent(context: Context, dropInConfiguration: DropInConfiguration, paymentMethodsApiResponse: PaymentMethodsApiResponse): Intent {
+        fun createIntent(
+            context: Context,
+            dropInConfiguration: DropInConfiguration,
+            paymentMethodsApiResponse: PaymentMethodsApiResponse,
+            resultHandlerIntent: Intent?
+        ): Intent {
             val intent = Intent(context, DropInActivity::class.java)
             intent.putExtra(PAYMENT_METHODS_RESPONSE_KEY, paymentMethodsApiResponse)
             intent.putExtra(DROP_IN_CONFIGURATION_KEY, dropInConfiguration)
+            intent.putExtra(DROP_IN_RESULT_INTENT, resultHandlerIntent)
             return intent
         }
     }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInActivity.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInActivity.kt
@@ -398,15 +398,22 @@ class DropInActivity : AppCompatActivity(), DropInBottomSheetDialogFragment.Prot
     }
 
     private fun sendResult(content: String) {
-        dropInViewModel.dropInConfiguration.resultHandlerIntent.putExtra(DropIn.RESULT_KEY, content).let { intent ->
-            startActivity(intent)
-            terminateSuccessfully()
+        val resultHandlerIntent = dropInViewModel.dropInConfiguration.resultHandlerIntent
+        // Merchant requested the result to be sent back with a result intent
+        if (resultHandlerIntent != null) {
+            resultHandlerIntent.putExtra(DropIn.RESULT_KEY, content)
+            startActivity(resultHandlerIntent)
         }
+        // Merchant did not specify a result intent and should handle the result in onActivityResult
+        else {
+            val resultIntent = Intent().putExtra(DropIn.RESULT_KEY, content)
+            setResult(Activity.RESULT_OK, resultIntent)
+        }
+        terminateSuccessfully()
     }
 
     private fun terminateSuccessfully() {
         Logger.d(TAG, "terminateSuccessfully")
-        setResult(Activity.RESULT_OK)
         terminate()
     }
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInActivity.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInActivity.kt
@@ -361,7 +361,7 @@ class DropInActivity : AppCompatActivity(), DropInBottomSheetDialogFragment.Prot
 
     override fun terminateDropIn() {
         Logger.d(TAG, "terminateDropIn")
-        terminateWithError("Canceled by user")
+        terminateWithError(DropIn.ERROR_REASON_USER_CANCELED)
     }
 
     override fun startGooglePay(paymentMethod: PaymentMethod, googlePayConfiguration: GooglePayConfiguration) {
@@ -419,7 +419,7 @@ class DropInActivity : AppCompatActivity(), DropInBottomSheetDialogFragment.Prot
 
     private fun terminateWithError(reason: String) {
         Logger.d(TAG, "terminateWithError")
-        val resultIntent = Intent().putExtra(DropIn.RESULT_ERROR_REASON, reason)
+        val resultIntent = Intent().putExtra(DropIn.ERROR_REASON_KEY, reason)
         setResult(Activity.RESULT_CANCELED, resultIntent)
         terminate()
     }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInViewModel.kt
@@ -8,6 +8,7 @@
 
 package com.adyen.checkout.dropin.ui
 
+import android.content.Intent
 import androidx.lifecycle.ViewModel
 import com.adyen.checkout.components.model.PaymentMethodsApiResponse
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
@@ -17,7 +18,8 @@ import com.adyen.checkout.dropin.DropInConfiguration
 
 class DropInViewModel(
     val paymentMethodsApiResponse: PaymentMethodsApiResponse,
-    val dropInConfiguration: DropInConfiguration
+    val dropInConfiguration: DropInConfiguration,
+    val resultHandlerIntent: Intent?
 ) : ViewModel() {
 
     val showPreselectedStored = paymentMethodsApiResponse.storedPaymentMethods?.isNotEmpty() ?: false

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
@@ -155,6 +155,6 @@ class ActionComponentDialogFragment : DropInBottomSheetDialogFragment(), Observe
 
     private fun handleError(componentError: ComponentError) {
         Logger.e(TAG, componentError.errorMessage)
-        protocol.showError(getString(R.string.action_failed), true)
+        protocol.showError(getString(R.string.action_failed), componentError.errorMessage, true)
     }
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/base/BaseComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/base/BaseComponentDialogFragment.kt
@@ -149,6 +149,6 @@ abstract class BaseComponentDialogFragment : DropInBottomSheetDialogFragment(), 
 
     fun handleError(componentError: ComponentError) {
         Logger.e(TAG, componentError.errorMessage)
-        protocol.showError(getString(R.string.component_error), true)
+        protocol.showError(getString(R.string.component_error), componentError.errorMessage, true)
     }
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/base/DropInBottomSheetDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/base/DropInBottomSheetDialogFragment.kt
@@ -95,7 +95,7 @@ abstract class DropInBottomSheetDialogFragment : BottomSheetDialogFragment() {
         fun showComponentDialog(paymentMethod: PaymentMethod)
         fun requestPaymentsCall(paymentComponentState: PaymentComponentState<*>)
         fun requestDetailsCall(actionComponentData: ActionComponentData)
-        fun showError(errorMessage: String, terminate: Boolean)
+        fun showError(errorMessage: String, reason: String, terminate: Boolean)
         fun terminateDropIn()
         fun startGooglePay(paymentMethod: PaymentMethod, googlePayConfiguration: GooglePayConfiguration)
     }

--- a/example-app/src/main/java/com/adyen/checkout/example/ResultActivity.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ResultActivity.kt
@@ -20,8 +20,9 @@ class ResultActivity : AppCompatActivity() {
         val binding = ActivityResultBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        if (intent.hasExtra(DropIn.RESULT_KEY)) {
-            binding.resultText.text = intent.getStringExtra(DropIn.RESULT_KEY)
+        val result = DropIn.getDropInResultFromIntent(intent)
+        if (result != null) {
+            binding.resultText.text = result
         }
     }
 }

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/main/MainActivity.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/main/MainActivity.kt
@@ -129,8 +129,12 @@ class MainActivity : AppCompatActivity() {
         if (requestCode == DropIn.DROP_IN_REQUEST_CODE)
             if (resultCode == Activity.RESULT_CANCELED) {
                 Logger.d(TAG, "DropIn CANCELED")
-                if (data?.hasExtra(DropIn.RESULT_ERROR_REASON) == true) {
-                    Toast.makeText(this, data.getStringExtra(DropIn.RESULT_ERROR_REASON), Toast.LENGTH_SHORT).show()
+                if (data?.hasExtra(DropIn.ERROR_REASON_KEY) == true) {
+                    val reason = data.getStringExtra(DropIn.ERROR_REASON_KEY)
+                    if (reason == DropIn.ERROR_REASON_USER_CANCELED) {
+                        Logger.d(TAG, "DropIn canceled by the user")
+                    }
+                    Toast.makeText(this, reason, Toast.LENGTH_SHORT).show()
                 }
             } else if (resultCode == Activity.RESULT_OK) {
                 Logger.d(TAG, "DropIn COMPLETED")

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/main/MainActivity.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/main/MainActivity.kt
@@ -171,9 +171,9 @@ class MainActivity : AppCompatActivity() {
 
         val dropInConfigurationBuilder = DropInConfiguration.Builder(
             this@MainActivity,
-            resultIntent,
             ExampleDropInService::class.java
         )
+            .setResultHandlerIntent(resultIntent)
             .setEnvironment(Environment.TEST)
             .setClientKey(BuildConfig.CLIENT_KEY)
             .setShopperLocale(shopperLocale)
@@ -189,7 +189,7 @@ class MainActivity : AppCompatActivity() {
             Logger.e(TAG, "Amount $amount not valid", e)
         }
 
-        DropIn.startPayment(this@MainActivity, paymentMethodsApiResponse, dropInConfigurationBuilder.build())
+        DropIn.startPayment(this, paymentMethodsApiResponse, dropInConfigurationBuilder.build())
     }
 
     private fun setLoading(isLoading: Boolean) {

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/main/MainActivity.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/main/MainActivity.kt
@@ -128,6 +128,9 @@ class MainActivity : AppCompatActivity() {
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode == DropIn.DROP_IN_REQUEST_CODE && resultCode == Activity.RESULT_CANCELED) {
             Logger.d(TAG, "DropIn CANCELED")
+            if (data?.hasExtra(DropIn.RESULT_ERROR_REASON) == true) {
+                Toast.makeText(this, data.getStringExtra(DropIn.RESULT_ERROR_REASON), Toast.LENGTH_SHORT).show()
+            }
         }
     }
 

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/main/MainActivity.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/main/MainActivity.kt
@@ -126,12 +126,18 @@ class MainActivity : AppCompatActivity() {
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
-        if (requestCode == DropIn.DROP_IN_REQUEST_CODE && resultCode == Activity.RESULT_CANCELED) {
-            Logger.d(TAG, "DropIn CANCELED")
-            if (data?.hasExtra(DropIn.RESULT_ERROR_REASON) == true) {
-                Toast.makeText(this, data.getStringExtra(DropIn.RESULT_ERROR_REASON), Toast.LENGTH_SHORT).show()
+        if (requestCode == DropIn.DROP_IN_REQUEST_CODE)
+            if (resultCode == Activity.RESULT_CANCELED) {
+                Logger.d(TAG, "DropIn CANCELED")
+                if (data?.hasExtra(DropIn.RESULT_ERROR_REASON) == true) {
+                    Toast.makeText(this, data.getStringExtra(DropIn.RESULT_ERROR_REASON), Toast.LENGTH_SHORT).show()
+                }
+            } else if (resultCode == Activity.RESULT_OK) {
+                Logger.d(TAG, "DropIn COMPLETED")
+                if (data?.hasExtra(DropIn.RESULT_KEY) == true) {
+                    Toast.makeText(this, data.getStringExtra(DropIn.RESULT_KEY), Toast.LENGTH_SHORT).show()
+                }
             }
-        }
     }
 
     private fun startDropIn(paymentMethodsApiResponse: PaymentMethodsApiResponse) {

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/main/MainActivity.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/main/MainActivity.kt
@@ -170,14 +170,10 @@ class MainActivity : AppCompatActivity() {
             .setEnvironment(Environment.TEST)
             .build()
 
-        val resultIntent = Intent(this, MainActivity::class.java)
-        resultIntent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
-
         val dropInConfigurationBuilder = DropInConfiguration.Builder(
             this@MainActivity,
             ExampleDropInService::class.java
         )
-            .setResultHandlerIntent(resultIntent)
             .setEnvironment(Environment.TEST)
             .setClientKey(BuildConfig.CLIENT_KEY)
             .setShopperLocale(shopperLocale)
@@ -193,7 +189,10 @@ class MainActivity : AppCompatActivity() {
             Logger.e(TAG, "Amount $amount not valid", e)
         }
 
-        DropIn.startPayment(this, paymentMethodsApiResponse, dropInConfigurationBuilder.build())
+        val resultIntent = Intent(this, MainActivity::class.java)
+        resultIntent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
+
+        DropIn.startPayment(this, paymentMethodsApiResponse, dropInConfigurationBuilder.build(), resultIntent)
     }
 
     private fun setLoading(isLoading: Boolean) {


### PR DESCRIPTION
## Summary
Currently the only way to handle the drop in successful response is with the `resultHandlerIntent`. We want to allow the option to handle the drop in solely using `onActivityResult`:
* Make `resultHandlerIntent` optional.
* Return the result using `setResult` if `resultHandlerIntent` is not set.
* Allow fragments to use `startActivityForResult` also.