### PR TITLE
Release 3.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 [//]: <> (Add changes that not released yet into `Unreleased` section)
 [//]: <> (Comment `Unreleased` section if there are no changes)
 [//]: <> (## [Unreleased])
+## [3.8.2] - 2021-02-09
+### Fixed
+- Remove configuration object from /paymentmethods model breaking serialization in some API versions.
+
 ## [3.8.1] - 2021-01-26
 ### Fixed
 - Uncaught Exception failing silently when initializing 3DS2 Component.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,2 +1,2 @@
 ### Fixed
-- Uncaught Exception failing silently when initializing 3DS2 Component.
+- Remove configuration object from /paymentmethods model breaking serialization in some API versions.

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ allprojects {
     // just for example app, don't need to increment
     ext.version_code = 1
     // The version_name format is "major.minor.patch(-(alpha|beta|rc)[0-9]{2}){0,1}" (e.g. 3.0.0, 3.1.1-alpha04 or 3.1.4-rc01 etc).
-    ext.version_name = "3.8.1"
+    ext.version_name = "3.8.2"
 
     // Code quality
     ext.ktlint_version = '0.34.2'


### PR DESCRIPTION
### Fixed
- Remove configuration object from /paymentmethods model breaking serialization in some API versions.