### PR TITLE
Handle card component error in frictionless payment

### DIFF
--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/stored/PreselectedStoredPaymentViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/stored/PreselectedStoredPaymentViewModel.kt
@@ -69,6 +69,7 @@ class PreselectedStoredPaymentViewModel(
             "payButtonClicked - componentState.isReady: ${componentState?.isReady} - " +
                 "fragmentState: $fragmentState"
         )
+        // check whether an error has occurred already before Pay was clicked
         val componentError = lastComponentError
         val state = when {
             componentRequiresInput -> ShowStoredPaymentDialog


### PR DESCRIPTION
## Summary
Handle errors from `CardComponent` when directly paying from `PreselectedStoredPaymentMethodFragment`.