### PR TITLE
Split action configurations handling from payment method configurations

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
@@ -94,6 +94,8 @@ class Adyen3DS2Component(application: Application, configuration: Adyen3DS2Confi
         )
     }
 
+    override fun getSupportedPaymentMethodTypes(): List<String>? = null
+
     @Throws(ComponentException::class)
     override fun handleActionInternal(activity: Activity, action: Action) {
         when (action.type) {

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
@@ -310,7 +310,7 @@ class Adyen3DS2Component(application: Application, configuration: Adyen3DS2Confi
         val TAG = LogUtil.getTag()
 
         @JvmField
-        val PROVIDER: ActionComponentProvider<Adyen3DS2Component> = ActionComponentProviderImpl(
+        val PROVIDER: ActionComponentProvider<Adyen3DS2Component, Adyen3DS2Configuration> = ActionComponentProviderImpl(
             Adyen3DS2Component::class.java, Adyen3DS2Configuration::class.java
         )
 

--- a/await/src/main/java/com/adyen/checkout/await/AwaitComponent.java
+++ b/await/src/main/java/com/adyen/checkout/await/AwaitComponent.java
@@ -31,6 +31,7 @@ import com.adyen.checkout.components.base.lifecycle.BaseLifecycleObserver;
 import com.adyen.checkout.components.model.payments.response.Action;
 import com.adyen.checkout.components.model.payments.response.AwaitAction;
 import com.adyen.checkout.components.status.StatusRepository;
+import com.adyen.checkout.components.util.PaymentMethodTypes;
 import com.adyen.checkout.core.exception.CheckoutException;
 import com.adyen.checkout.core.exception.ComponentException;
 import com.adyen.checkout.core.log.LogUtil;
@@ -93,6 +94,13 @@ public class AwaitComponent extends BaseActionComponent<AwaitConfiguration>
     protected List<String> getSupportedActionTypes() {
         final String[] supportedCodes = {AwaitAction.ACTION_TYPE};
         return Collections.unmodifiableList(Arrays.asList(supportedCodes));
+    }
+
+    @NonNull
+    @Override
+    protected List<String> getSupportedPaymentMethodTypes() {
+        final String[] supportedPaymentMethods = {PaymentMethodTypes.BLIK, PaymentMethodTypes.MB_WAY};
+        return Collections.unmodifiableList(Arrays.asList(supportedPaymentMethods));
     }
 
     @Override

--- a/await/src/main/java/com/adyen/checkout/await/AwaitComponent.java
+++ b/await/src/main/java/com/adyen/checkout/await/AwaitComponent.java
@@ -50,7 +50,7 @@ public class AwaitComponent extends BaseActionComponent<AwaitConfiguration>
 
     private static final String PAYLOAD_DETAILS_KEY = "payload";
 
-    public static final ActionComponentProvider<AwaitComponent> PROVIDER
+    public static final ActionComponentProvider<AwaitComponent, AwaitConfiguration> PROVIDER
             = new ActionComponentProviderImpl<>(AwaitComponent.class, AwaitConfiguration.class, true);
 
     final StatusRepository mStatusRepository;

--- a/await/src/main/java/com/adyen/checkout/await/AwaitView.java
+++ b/await/src/main/java/com/adyen/checkout/await/AwaitView.java
@@ -115,7 +115,9 @@ public class AwaitView extends AdyenLinearLayout<AwaitOutputData, AwaitConfigura
     }
 
     private void updateMessageText() {
-        if(getMessageTextResource() == null) return;
+        if (getMessageTextResource() == null) {
+            return;
+        }
         mTextViewOpenApp.setText(getMessageTextResource());
     }
 

--- a/await/src/main/java/com/adyen/checkout/await/AwaitView.java
+++ b/await/src/main/java/com/adyen/checkout/await/AwaitView.java
@@ -115,6 +115,7 @@ public class AwaitView extends AdyenLinearLayout<AwaitOutputData, AwaitConfigura
     }
 
     private void updateMessageText() {
+        if(getMessageTextResource() == null) return;
         mTextViewOpenApp.setText(getMessageTextResource());
     }
 
@@ -126,7 +127,7 @@ public class AwaitView extends AdyenLinearLayout<AwaitOutputData, AwaitConfigura
             case PaymentMethodTypes.MB_WAY:
                 return R.string.checkout_await_message_mbway;
             default:
-                return R.string.checkout_await_message_blik;
+                return null;
         }
     }
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/ActionComponentProvider.java
+++ b/components-core/src/main/java/com/adyen/checkout/components/ActionComponentProvider.java
@@ -11,13 +11,12 @@ package com.adyen.checkout.components;
 import android.app.Application;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.lifecycle.ViewModelStoreOwner;
 
 import com.adyen.checkout.components.base.Configuration;
 
-public interface ActionComponentProvider<ComponentT extends ActionComponent> extends ComponentProvider<ComponentT> {
-
+public interface ActionComponentProvider<ComponentT extends ActionComponent, ConfigurationT extends Configuration>
+        extends ComponentProvider<ComponentT> {
     /**
      * Get an {@link ActionComponent}.
      *
@@ -27,7 +26,7 @@ public interface ActionComponentProvider<ComponentT extends ActionComponent> ext
      */
     @SuppressWarnings("LambdaLast")
     @NonNull
-    ComponentT get(@NonNull ViewModelStoreOwner viewModelStoreOwner, @NonNull Application application, @Nullable Configuration configuration);
+    ComponentT get(@NonNull ViewModelStoreOwner viewModelStoreOwner, @NonNull Application application, @NonNull ConfigurationT configuration);
 
     /**
      * @return If the Configuration is required for this Component.

--- a/components-core/src/main/java/com/adyen/checkout/components/base/ActionComponentProviderImpl.java
+++ b/components-core/src/main/java/com/adyen/checkout/components/base/ActionComponentProviderImpl.java
@@ -20,7 +20,7 @@ import com.adyen.checkout.components.base.lifecycle.ActionComponentViewModel;
 import com.adyen.checkout.components.base.lifecycle.ActionComponentViewModelFactory;
 
 public class ActionComponentProviderImpl<ConfigurationT extends Configuration, ComponentT extends ActionComponentViewModel<ConfigurationT>>
-        implements ActionComponentProvider<ComponentT> {
+        implements ActionComponentProvider<ComponentT, ConfigurationT> {
 
     private final Class<ComponentT> mComponentClass;
     private final Class<ConfigurationT> mConfigurationClass;

--- a/components-core/src/main/java/com/adyen/checkout/components/base/BaseActionComponent.java
+++ b/components-core/src/main/java/com/adyen/checkout/components/base/BaseActionComponent.java
@@ -49,11 +49,20 @@ public abstract class BaseActionComponent<ConfigurationT extends Configuration> 
 
     @Override
     public boolean canHandleAction(@NonNull Action action) {
-        return getSupportedActionTypes().contains(action.getType());
+        return getSupportedActionTypes().contains(action.getType())
+                && (getSupportedPaymentMethodTypes() == null || getSupportedPaymentMethodTypes().contains(action.getPaymentMethodType()));
     }
 
     @NonNull
     protected abstract List<String> getSupportedActionTypes();
+
+    /**
+     * Indicates which payment methods can be handled by this action component.
+     *
+     * @return the list of supported payment method types, or null if all types are supported.
+     */
+    @Nullable
+    protected abstract List<String> getSupportedPaymentMethodTypes();
 
     @Override
     public void handleAction(@NonNull Activity activity, @NonNull Action action) {

--- a/components-core/src/main/java/com/adyen/checkout/components/util/PaymentMethodTypes.java
+++ b/components-core/src/main/java/com/adyen/checkout/components/util/PaymentMethodTypes.java
@@ -10,7 +10,7 @@ package com.adyen.checkout.components.util;
 
 import com.adyen.checkout.core.exception.NoConstructorException;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -35,11 +35,12 @@ public final class PaymentMethodTypes {
     public static final String SCHEME = "scheme";
     public static final String GOOGLE_PAY = "paywithgoogle";
     public static final String SEPA = "sepadirectdebit";
-    public static final String AFTER_PAY = "afterpay_default";
     public static final String BCMC = "bcmc";
-    public static final String WECHAT_PAY_SDK = "wechatpaySDK";
     public static final String MB_WAY = "mbway";
     public static final String BLIK = "blik";
+
+    // Payment methods that do not need a payment component, but only an action component
+    public static final String WECHAT_PAY_SDK = "wechatpaySDK";
     public static final String PIX = "pix";
 
     // Voucher payment methods that are not yet supported
@@ -79,79 +80,81 @@ public final class PaymentMethodTypes {
 
     // Payment methods that might be interpreted as redirect, but are actually not supported
     public static final String BCMC_QR = "bcmc_mobile_QR";
+    public static final String AFTER_PAY = "afterpay_default";
     public static final String WECHAT_PAY_MINI_PROGRAM = "wechatpayMiniProgram";
     public static final String WECHAT_PAY_QR = "wechatpayQR";
     public static final String WECHAT_PAY_WEB = "wechatpayWeb";
 
     // List of all payment method types.
     public static final List<String> SUPPORTED_PAYMENT_METHODS;
+    public static final List<String> SUPPORTED_ACTION_ONLY_PAYMENT_METHODS;
     public static final List<String> UNSUPPORTED_PAYMENT_METHODS;
 
     static {
-        final ArrayList<String> supportedPaymentMethods = new ArrayList<>();
+        SUPPORTED_PAYMENT_METHODS = Collections.unmodifiableList(Arrays.asList(
+                BCMC,
+                DOTPAY,
+                ENTERCASH,
+                EPS,
+                GOOGLE_PAY,
+                IDEAL,
+                MB_WAY,
+                MOLPAY_MALAYSIA,
+                MOLPAY_THAILAND,
+                MOLPAY_VIETNAM,
+                OPEN_BANKING,
+                SEPA,
+                SCHEME,
+                BLIK,
+                WECHAT_PAY_SDK,
+                PIX
+        ));
 
-        // Populate supported list
-        supportedPaymentMethods.add(BCMC);
-        supportedPaymentMethods.add(DOTPAY);
-        supportedPaymentMethods.add(ENTERCASH);
-        supportedPaymentMethods.add(EPS);
-        supportedPaymentMethods.add(GOOGLE_PAY);
-        supportedPaymentMethods.add(IDEAL);
-        supportedPaymentMethods.add(MB_WAY);
-        supportedPaymentMethods.add(MOLPAY_MALAYSIA);
-        supportedPaymentMethods.add(MOLPAY_THAILAND);
-        supportedPaymentMethods.add(MOLPAY_VIETNAM);
-        supportedPaymentMethods.add(OPEN_BANKING);
-        supportedPaymentMethods.add(SEPA);
-        supportedPaymentMethods.add(SCHEME);
-        supportedPaymentMethods.add(WECHAT_PAY_SDK);
-        supportedPaymentMethods.add(BLIK);
+        SUPPORTED_ACTION_ONLY_PAYMENT_METHODS = Collections.unmodifiableList(Arrays.asList(
+                WECHAT_PAY_SDK,
+                PIX
+        ));
 
-        SUPPORTED_PAYMENT_METHODS = Collections.unmodifiableList(supportedPaymentMethods);
+        UNSUPPORTED_PAYMENT_METHODS = Collections.unmodifiableList(Arrays.asList(
+                BCMC_QR,
+                AFTER_PAY,
+                WECHAT_PAY_MINI_PROGRAM,
+                WECHAT_PAY_QR,
+                WECHAT_PAY_WEB,
 
-        final ArrayList<String> unsupportedPaymentMethods = new ArrayList<>();
+                MULTIBANCO,
+                OXXO,
+                DOKU,
+                DOKU_ALFMART,
+                DOKU_PERMATA_LITE_ATM,
+                DOKU_INDOMARET,
+                DOKU_ATM_MANDIRI_VA,
+                DOKU_SINARMAS_VA,
+                DOKU_MANDIRI_VA,
+                DOKU_CIMB_VA,
+                DOKU_DANAMON_VA,
+                DOKU_BRI_VA,
+                DOKU_BNI_VA,
+                DOKU_BCA_VA,
+                DOKU_WALLET,
 
-        // Populate unsupported list
-        unsupportedPaymentMethods.add(BCMC_QR);
-        unsupportedPaymentMethods.add(AFTER_PAY);
-        unsupportedPaymentMethods.add(WECHAT_PAY_MINI_PROGRAM);
-        unsupportedPaymentMethods.add(WECHAT_PAY_QR);
-        unsupportedPaymentMethods.add(WECHAT_PAY_WEB);
+                BOLETOBANCARIO,
+                BOLETOBANCARIO_BANCODOBRASIL,
+                BOLETOBANCARIO_BRADESCO,
+                BOLETOBANCARIO_HSBC,
+                BOLETOBANCARIO_ITAU,
+                BOLETOBANCARIO_SANTANDER,
 
-        unsupportedPaymentMethods.add(MULTIBANCO);
-        unsupportedPaymentMethods.add(OXXO);
-        unsupportedPaymentMethods.add(DOKU);
-        unsupportedPaymentMethods.add(DOKU_ALFMART);
-        unsupportedPaymentMethods.add(DOKU_PERMATA_LITE_ATM);
-        unsupportedPaymentMethods.add(DOKU_INDOMARET);
-        unsupportedPaymentMethods.add(DOKU_ATM_MANDIRI_VA);
-        unsupportedPaymentMethods.add(DOKU_SINARMAS_VA);
-        unsupportedPaymentMethods.add(DOKU_MANDIRI_VA);
-        unsupportedPaymentMethods.add(DOKU_CIMB_VA);
-        unsupportedPaymentMethods.add(DOKU_DANAMON_VA);
-        unsupportedPaymentMethods.add(DOKU_BRI_VA);
-        unsupportedPaymentMethods.add(DOKU_BNI_VA);
-        unsupportedPaymentMethods.add(DOKU_BCA_VA);
-        unsupportedPaymentMethods.add(DOKU_WALLET);
+                DRAGONPAY_EBANKING,
+                DRAGONPAY_OTC_BANKING,
+                DRAGONPAY_OTC_NON_BANKING,
+                DRAGONPAY_OTC_PHILIPPINES,
 
-        unsupportedPaymentMethods.add(BOLETOBANCARIO);
-        unsupportedPaymentMethods.add(BOLETOBANCARIO_BANCODOBRASIL);
-        unsupportedPaymentMethods.add(BOLETOBANCARIO_BRADESCO);
-        unsupportedPaymentMethods.add(BOLETOBANCARIO_HSBC);
-        unsupportedPaymentMethods.add(BOLETOBANCARIO_ITAU);
-        unsupportedPaymentMethods.add(BOLETOBANCARIO_SANTANDER);
-
-        unsupportedPaymentMethods.add(DRAGONPAY_EBANKING);
-        unsupportedPaymentMethods.add(DRAGONPAY_OTC_BANKING);
-        unsupportedPaymentMethods.add(DRAGONPAY_OTC_NON_BANKING);
-        unsupportedPaymentMethods.add(DRAGONPAY_OTC_PHILIPPINES);
-
-        unsupportedPaymentMethods.add(ECONTEXT_SEVEN_ELEVEN);
-        unsupportedPaymentMethods.add(ECONTEXT_ATM);
-        unsupportedPaymentMethods.add(ECONTEXT_STORES);
-        unsupportedPaymentMethods.add(ECONTEXT_ONLINE);
-
-        UNSUPPORTED_PAYMENT_METHODS = Collections.unmodifiableList(unsupportedPaymentMethods);
+                ECONTEXT_SEVEN_ELEVEN,
+                ECONTEXT_ATM,
+                ECONTEXT_STORES,
+                ECONTEXT_ONLINE
+        ));
     }
 
     private PaymentMethodTypes() {

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ActionHandler.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ActionHandler.kt
@@ -14,16 +14,13 @@ import android.os.Bundle
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Observer
 import com.adyen.checkout.adyen3ds2.Adyen3DS2Component
-import com.adyen.checkout.adyen3ds2.Adyen3DS2Configuration
 import com.adyen.checkout.components.ActionComponentData
 import com.adyen.checkout.components.model.payments.response.Action
 import com.adyen.checkout.components.util.ActionTypes
 import com.adyen.checkout.core.log.LogUtil
 import com.adyen.checkout.core.log.Logger
 import com.adyen.checkout.redirect.RedirectComponent
-import com.adyen.checkout.redirect.RedirectConfiguration
 import com.adyen.checkout.wechatpay.WeChatPayActionComponent
-import com.adyen.checkout.wechatpay.WeChatPayActionConfiguration
 
 class ActionHandler(
     activity: FragmentActivity,
@@ -42,17 +39,17 @@ class ActionHandler(
     private val redirectComponent = RedirectComponent.PROVIDER.get(
         activity,
         activity.application,
-        dropInConfiguration.getConfigurationForAction<RedirectConfiguration>(activity)
+        dropInConfiguration.getConfigurationForAction(activity)
     )
     private val adyen3DS2Component = Adyen3DS2Component.PROVIDER.get(
         activity,
         activity.application,
-        dropInConfiguration.getConfigurationForAction<Adyen3DS2Configuration>(activity)
+        dropInConfiguration.getConfigurationForAction(activity)
     )
     private val weChatPayActionComponent = WeChatPayActionComponent.PROVIDER.get(
         activity,
         activity.application,
-        dropInConfiguration.getConfigurationForAction<WeChatPayActionConfiguration>(activity)
+        dropInConfiguration.getConfigurationForAction(activity)
     )
 
     init {

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ActionHandler.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ActionHandler.kt
@@ -14,13 +14,16 @@ import android.os.Bundle
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Observer
 import com.adyen.checkout.adyen3ds2.Adyen3DS2Component
+import com.adyen.checkout.adyen3ds2.Adyen3DS2Configuration
 import com.adyen.checkout.components.ActionComponentData
 import com.adyen.checkout.components.model.payments.response.Action
 import com.adyen.checkout.components.util.ActionTypes
 import com.adyen.checkout.core.log.LogUtil
 import com.adyen.checkout.core.log.Logger
 import com.adyen.checkout.redirect.RedirectComponent
+import com.adyen.checkout.redirect.RedirectConfiguration
 import com.adyen.checkout.wechatpay.WeChatPayActionComponent
+import com.adyen.checkout.wechatpay.WeChatPayActionConfiguration
 
 class ActionHandler(
     activity: FragmentActivity,
@@ -39,15 +42,18 @@ class ActionHandler(
     private val redirectComponent = RedirectComponent.PROVIDER.get(
         activity,
         activity.application,
-        dropInConfiguration.getConfigurationForAction(ActionTypes.REDIRECT, activity)
+        dropInConfiguration.getConfigurationForAction<RedirectConfiguration>(activity)
     )
     private val adyen3DS2Component = Adyen3DS2Component.PROVIDER.get(
         activity,
         activity.application,
-        dropInConfiguration.getConfigurationForAction(ActionTypes.THREEDS2, activity)
+        dropInConfiguration.getConfigurationForAction<Adyen3DS2Configuration>(activity)
     )
-    // get config from Drop-in when available
-    private val weChatPayActionComponent = WeChatPayActionComponent.PROVIDER.get(activity, activity.application, null)
+    private val weChatPayActionComponent = WeChatPayActionComponent.PROVIDER.get(
+        activity,
+        activity.application,
+        dropInConfiguration.getConfigurationForAction<WeChatPayActionConfiguration>(activity)
+    )
 
     init {
         redirectComponent.observe(activity, this)

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ActionHandler.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ActionHandler.kt
@@ -39,12 +39,12 @@ class ActionHandler(
     private val redirectComponent = RedirectComponent.PROVIDER.get(
         activity,
         activity.application,
-        dropInConfiguration.getConfigurationFor(ActionTypes.REDIRECT, activity)
+        dropInConfiguration.getConfigurationForAction(ActionTypes.REDIRECT, activity)
     )
     private val adyen3DS2Component = Adyen3DS2Component.PROVIDER.get(
         activity,
         activity.application,
-        dropInConfiguration.getConfigurationFor(ActionTypes.THREEDS2, activity)
+        dropInConfiguration.getConfigurationForAction(ActionTypes.THREEDS2, activity)
     )
     // get config from Drop-in when available
     private val weChatPayActionComponent = WeChatPayActionComponent.PROVIDER.get(activity, activity.application, null)

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
@@ -69,6 +69,7 @@ import com.adyen.checkout.redirect.RedirectConfiguration
 import com.adyen.checkout.sepa.SepaComponent
 import com.adyen.checkout.sepa.SepaConfiguration
 import com.adyen.checkout.sepa.SepaView
+import com.adyen.checkout.wechatpay.WeChatPayActionConfiguration
 import com.adyen.checkout.wechatpay.WeChatPayComponent
 import com.adyen.checkout.wechatpay.WeChatPayConfiguration
 
@@ -117,23 +118,20 @@ internal fun <T : Configuration> getDefaultConfigForPaymentMethod(
 }
 
 @Suppress("ComplexMethod", "LongMethod")
-internal fun <T : Configuration> getDefaultConfigForAction(
-    action: String,
+internal inline fun <reified T : Configuration> getDefaultConfigForAction(
     context: Context,
     dropInConfiguration: DropInConfiguration
 ): T {
     val clientKey = dropInConfiguration.clientKey
 
     // get default builder for Configuration type
-    val builder: BaseConfigurationBuilder<out Configuration> = when (action) {
-        ActionTypes.AWAIT -> AwaitConfiguration.Builder(context, clientKey)
-        ActionTypes.REDIRECT -> RedirectConfiguration.Builder(context, clientKey)
-        ActionTypes.QR_CODE -> QRCodeConfiguration.Builder(context, clientKey)
-        ActionTypes.THREEDS2_FINGERPRINT,
-        ActionTypes.THREEDS2_CHALLENGE,
-        ActionTypes.THREEDS2 -> Adyen3DS2Configuration.Builder(context, clientKey)
-        // ActionTypes.SDK is not distinguishable only by the type since we need the payment method too
-        else -> throw CheckoutException("Unable to find component configuration for action - $action")
+    val builder: BaseConfigurationBuilder<out Configuration> = when (T::class) {
+        AwaitConfiguration::class -> AwaitConfiguration.Builder(context, clientKey)
+        RedirectConfiguration::class -> RedirectConfiguration.Builder(context, clientKey)
+        QRCodeConfiguration::class -> QRCodeConfiguration.Builder(context, clientKey)
+        Adyen3DS2Configuration::class -> Adyen3DS2Configuration.Builder(context, clientKey)
+        WeChatPayActionConfiguration::class -> WeChatPayActionConfiguration.Builder(context, clientKey)
+        else -> throw CheckoutException("Unable to find component configuration for class - ${T::class}")
     }
 
     builder.setShopperLocale(dropInConfiguration.shopperLocale)

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
@@ -14,6 +14,15 @@ import androidx.fragment.app.Fragment
 import com.adyen.checkout.adyen3ds2.Adyen3DS2Configuration
 import com.adyen.checkout.await.AwaitConfiguration
 import com.adyen.checkout.await.AwaitView
+import com.adyen.checkout.bcmc.BcmcComponent
+import com.adyen.checkout.bcmc.BcmcConfiguration
+import com.adyen.checkout.bcmc.BcmcView
+import com.adyen.checkout.blik.BlikComponent
+import com.adyen.checkout.blik.BlikConfiguration
+import com.adyen.checkout.blik.BlikView
+import com.adyen.checkout.card.CardComponent
+import com.adyen.checkout.card.CardConfiguration
+import com.adyen.checkout.card.CardView
 import com.adyen.checkout.components.ComponentAvailableCallback
 import com.adyen.checkout.components.ComponentView
 import com.adyen.checkout.components.PaymentComponent
@@ -28,15 +37,6 @@ import com.adyen.checkout.components.model.paymentmethods.StoredPaymentMethod
 import com.adyen.checkout.components.model.payments.request.PaymentMethodDetails
 import com.adyen.checkout.components.util.ActionTypes
 import com.adyen.checkout.components.util.PaymentMethodTypes
-import com.adyen.checkout.bcmc.BcmcComponent
-import com.adyen.checkout.bcmc.BcmcConfiguration
-import com.adyen.checkout.bcmc.BcmcView
-import com.adyen.checkout.blik.BlikComponent
-import com.adyen.checkout.blik.BlikConfiguration
-import com.adyen.checkout.blik.BlikView
-import com.adyen.checkout.card.CardComponent
-import com.adyen.checkout.card.CardConfiguration
-import com.adyen.checkout.card.CardView
 import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.core.log.LogUtil
 import com.adyen.checkout.core.log.Logger
@@ -77,8 +77,8 @@ object ComponentParsingProvider {
 }
 
 @Suppress("ComplexMethod", "LongMethod")
-internal fun <T : Configuration> getDefaultConfigFor(
-    componentType: String,
+internal fun <T : Configuration> getDefaultConfigForPaymentMethod(
+    paymentMethod: String,
     context: Context,
     dropInConfiguration: DropInConfiguration
 ): T {
@@ -86,65 +86,54 @@ internal fun <T : Configuration> getDefaultConfigFor(
     // TODO after fetching public key is enabled, build scheme if client key is present
     val specificRequirementConfigs = listOf(PaymentMethodTypes.SCHEME, PaymentMethodTypes.GOOGLE_PAY)
 
-    if (specificRequirementConfigs.contains(componentType)) {
-        throw CheckoutException("Cannot provide default config for $componentType. Please add it to the DropInConfiguration with required fields.")
+    if (specificRequirementConfigs.contains(paymentMethod)) {
+        throw CheckoutException("Cannot provide default config for $paymentMethod. Please add it to the DropInConfiguration with required fields.")
     }
 
     val clientKey = dropInConfiguration.clientKey
 
     // get default builder for Configuration type
-    val builder: BaseConfigurationBuilder<out Configuration> = when (componentType) {
-        PaymentMethodTypes.BLIK -> {
-            BlikConfiguration.Builder(context, clientKey)
-        }
-        PaymentMethodTypes.DOTPAY -> {
-            DotpayConfiguration.Builder(context, clientKey)
-        }
-        PaymentMethodTypes.ENTERCASH -> {
-            EntercashConfiguration.Builder(context, clientKey)
-        }
-        PaymentMethodTypes.EPS -> {
-            EPSConfiguration.Builder(context, clientKey)
-        }
-        PaymentMethodTypes.IDEAL -> {
-            IdealConfiguration.Builder(context, clientKey)
-        }
-        PaymentMethodTypes.MB_WAY -> {
-            MBWayConfiguration.Builder(context, clientKey)
-        }
+    val builder: BaseConfigurationBuilder<out Configuration> = when (paymentMethod) {
+        PaymentMethodTypes.BLIK -> BlikConfiguration.Builder(context, clientKey)
+        PaymentMethodTypes.DOTPAY -> DotpayConfiguration.Builder(context, clientKey)
+        PaymentMethodTypes.ENTERCASH -> EntercashConfiguration.Builder(context, clientKey)
+        PaymentMethodTypes.EPS -> EPSConfiguration.Builder(context, clientKey)
+        PaymentMethodTypes.IDEAL -> IdealConfiguration.Builder(context, clientKey)
+        PaymentMethodTypes.MB_WAY -> MBWayConfiguration.Builder(context, clientKey)
         PaymentMethodTypes.MOLPAY_THAILAND,
         PaymentMethodTypes.MOLPAY_MALAYSIA,
-        PaymentMethodTypes.MOLPAY_VIETNAM -> {
-            MolpayConfiguration.Builder(context, clientKey)
-        }
-        PaymentMethodTypes.OPEN_BANKING -> {
-            OpenBankingConfiguration.Builder(context, clientKey)
-        }
-        PaymentMethodTypes.SEPA -> {
-            SepaConfiguration.Builder(context, clientKey)
-        }
-        PaymentMethodTypes.WECHAT_PAY_SDK -> {
-            WeChatPayConfiguration.Builder(context, clientKey)
-        }
-        ActionTypes.AWAIT -> {
-            AwaitConfiguration.Builder(context, clientKey)
-        }
-        ActionTypes.REDIRECT -> {
-            RedirectConfiguration.Builder(context, clientKey)
-        }
-        ActionTypes.QR_CODE -> {
-            QRCodeConfiguration.Builder(context, clientKey)
-        }
+        PaymentMethodTypes.MOLPAY_VIETNAM -> MolpayConfiguration.Builder(context, clientKey)
+        PaymentMethodTypes.OPEN_BANKING -> OpenBankingConfiguration.Builder(context, clientKey)
+        PaymentMethodTypes.SEPA -> SepaConfiguration.Builder(context, clientKey)
+        PaymentMethodTypes.WECHAT_PAY_SDK -> WeChatPayConfiguration.Builder(context, clientKey)
+        else -> throw CheckoutException("Unable to find component configuration for paymentMethod - $paymentMethod")
+    }
+
+    builder.setShopperLocale(dropInConfiguration.shopperLocale)
+    builder.setEnvironment(dropInConfiguration.environment)
+
+    @Suppress("UNCHECKED_CAST")
+    return builder.build() as T
+}
+
+@Suppress("ComplexMethod", "LongMethod")
+internal fun <T : Configuration> getDefaultConfigForAction(
+    action: String,
+    context: Context,
+    dropInConfiguration: DropInConfiguration
+): T {
+    val clientKey = dropInConfiguration.clientKey
+
+    // get default builder for Configuration type
+    val builder: BaseConfigurationBuilder<out Configuration> = when (action) {
+        ActionTypes.AWAIT -> AwaitConfiguration.Builder(context, clientKey)
+        ActionTypes.REDIRECT -> RedirectConfiguration.Builder(context, clientKey)
+        ActionTypes.QR_CODE -> QRCodeConfiguration.Builder(context, clientKey)
         ActionTypes.THREEDS2_FINGERPRINT,
         ActionTypes.THREEDS2_CHALLENGE,
-        ActionTypes.THREEDS2 -> {
-            Adyen3DS2Configuration.Builder(context, clientKey)
-        }
+        ActionTypes.THREEDS2 -> Adyen3DS2Configuration.Builder(context, clientKey)
         // ActionTypes.SDK is not distinguishable only by the type since we need the payment method too
-
-        else -> {
-            throw CheckoutException("Unable to find component configuration for type - $componentType")
-        }
+        else -> throw CheckoutException("Unable to find component configuration for action - $action")
     }
 
     builder.setShopperLocale(dropInConfiguration.shopperLocale)
@@ -166,7 +155,7 @@ internal fun checkComponentAvailability(
         val type = paymentMethod.type ?: throw CheckoutException("PaymentMethod type is null")
 
         val provider = getProviderForType(type)
-        val configuration = dropInConfiguration.getConfigurationFor<Configuration>(type, application)
+        val configuration = dropInConfiguration.getConfigurationForPaymentMethod<Configuration>(type, application)
 
         provider.isAvailable(application, paymentMethod, configuration, callback)
     } catch (e: CheckoutException) {
@@ -216,11 +205,11 @@ internal fun getComponentFor(
 
     val component = when (storedPaymentMethod.type) {
         PaymentMethodTypes.SCHEME -> {
-            val cardConfig: CardConfiguration = dropInConfiguration.getConfigurationFor(PaymentMethodTypes.SCHEME, context)
+            val cardConfig: CardConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.SCHEME, context)
             CardComponent.PROVIDER.get(fragment, storedPaymentMethod, cardConfig)
         }
         PaymentMethodTypes.BLIK -> {
-            val blikConfig: BlikConfiguration = dropInConfiguration.getConfigurationFor(PaymentMethodTypes.BLIK, context)
+            val blikConfig: BlikConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.BLIK, context)
             BlikComponent.PROVIDER.get(fragment, storedPaymentMethod, blikConfig)
         }
         else -> {
@@ -248,63 +237,72 @@ internal fun getComponentFor(
 
     val component = when (paymentMethod.type) {
         PaymentMethodTypes.BCMC -> {
-            val bcmcConfiguration: BcmcConfiguration = dropInConfiguration.getConfigurationFor(PaymentMethodTypes.BCMC, context)
+            val bcmcConfiguration: BcmcConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.BCMC, context)
             BcmcComponent.PROVIDER.get(fragment, paymentMethod, bcmcConfiguration)
         }
         PaymentMethodTypes.BLIK -> {
-            val blikConfiguration: BlikConfiguration = dropInConfiguration.getConfigurationFor(PaymentMethodTypes.BLIK, context)
+            val blikConfiguration: BlikConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.BLIK, context)
             BlikComponent.PROVIDER.get(fragment, paymentMethod, blikConfiguration)
         }
         PaymentMethodTypes.DOTPAY -> {
-            val dotpayConfig: DotpayConfiguration = dropInConfiguration.getConfigurationFor(PaymentMethodTypes.DOTPAY, context)
+            val dotpayConfig: DotpayConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.DOTPAY, context)
             DotpayComponent.PROVIDER.get(fragment, paymentMethod, dotpayConfig)
         }
         PaymentMethodTypes.ENTERCASH -> {
-            val entercashConfig: EntercashConfiguration = dropInConfiguration.getConfigurationFor(PaymentMethodTypes.ENTERCASH, context)
+            val entercashConfig: EntercashConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.ENTERCASH, context)
             EntercashComponent.PROVIDER.get(fragment, paymentMethod, entercashConfig)
         }
         PaymentMethodTypes.EPS -> {
-            val epsConfig: EPSConfiguration = dropInConfiguration.getConfigurationFor(PaymentMethodTypes.EPS, context)
+            val epsConfig: EPSConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.EPS, context)
             EPSComponent.PROVIDER.get(fragment, paymentMethod, epsConfig)
         }
         PaymentMethodTypes.GOOGLE_PAY -> {
-            val googlePayConfiguration: GooglePayConfiguration = dropInConfiguration.getConfigurationFor(PaymentMethodTypes.GOOGLE_PAY, context)
+            val googlePayConfiguration: GooglePayConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(
+                PaymentMethodTypes.GOOGLE_PAY,
+                context
+            )
             GooglePayComponent.PROVIDER.get(fragment, paymentMethod, googlePayConfiguration)
         }
         PaymentMethodTypes.IDEAL -> {
-            val idealConfig: IdealConfiguration = dropInConfiguration.getConfigurationFor(PaymentMethodTypes.IDEAL, context)
+            val idealConfig: IdealConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.IDEAL, context)
             IdealComponent.PROVIDER.get(fragment, paymentMethod, idealConfig)
         }
         PaymentMethodTypes.MB_WAY -> {
-            val mbWayConfiguration: MBWayConfiguration = dropInConfiguration.getConfigurationFor(PaymentMethodTypes.MB_WAY, context)
+            val mbWayConfiguration: MBWayConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.MB_WAY, context)
             MBWayComponent.PROVIDER.get(fragment, paymentMethod, mbWayConfiguration)
         }
         PaymentMethodTypes.MOLPAY_THAILAND -> {
-            val molpayConfig: MolpayConfiguration = dropInConfiguration.getConfigurationFor(PaymentMethodTypes.MOLPAY_THAILAND, context)
+            val molpayConfig: MolpayConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.MOLPAY_THAILAND, context)
             MolpayComponent.PROVIDER.get(fragment, paymentMethod, molpayConfig)
         }
         PaymentMethodTypes.MOLPAY_MALAYSIA -> {
-            val molpayConfig: MolpayConfiguration = dropInConfiguration.getConfigurationFor(PaymentMethodTypes.MOLPAY_MALAYSIA, context)
+            val molpayConfig: MolpayConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.MOLPAY_MALAYSIA, context)
             MolpayComponent.PROVIDER.get(fragment, paymentMethod, molpayConfig)
         }
         PaymentMethodTypes.MOLPAY_VIETNAM -> {
-            val molpayConfig: MolpayConfiguration = dropInConfiguration.getConfigurationFor(PaymentMethodTypes.MOLPAY_VIETNAM, context)
+            val molpayConfig: MolpayConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(
+                PaymentMethodTypes.MOLPAY_VIETNAM,
+                context
+            )
             MolpayComponent.PROVIDER.get(fragment, paymentMethod, molpayConfig)
         }
         PaymentMethodTypes.OPEN_BANKING -> {
-            val openBankingConfig: OpenBankingConfiguration = dropInConfiguration.getConfigurationFor(PaymentMethodTypes.OPEN_BANKING, context)
+            val openBankingConfig: OpenBankingConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(
+                PaymentMethodTypes.OPEN_BANKING,
+                context
+            )
             OpenBankingComponent.PROVIDER.get(fragment, paymentMethod, openBankingConfig)
         }
         PaymentMethodTypes.SCHEME -> {
-            val cardConfig: CardConfiguration = dropInConfiguration.getConfigurationFor(PaymentMethodTypes.SCHEME, context)
+            val cardConfig: CardConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.SCHEME, context)
             CardComponent.PROVIDER.get(fragment, paymentMethod, cardConfig)
         }
         PaymentMethodTypes.SEPA -> {
-            val sepaConfiguration: SepaConfiguration = dropInConfiguration.getConfigurationFor(PaymentMethodTypes.SEPA, context)
+            val sepaConfiguration: SepaConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.SEPA, context)
             SepaComponent.PROVIDER.get(fragment, paymentMethod, sepaConfiguration)
         }
         PaymentMethodTypes.WECHAT_PAY_SDK -> {
-            val weChatPayConfiguration: WeChatPayConfiguration = dropInConfiguration.getConfigurationFor(PaymentMethodTypes.WECHAT_PAY_SDK, context)
+            val weChatPayConfiguration: WeChatPayConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.WECHAT_PAY_SDK, context)
             WeChatPayComponent.PROVIDER.get(fragment, paymentMethod, weChatPayConfiguration)
         }
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
@@ -300,7 +300,10 @@ internal fun getComponentFor(
             SepaComponent.PROVIDER.get(fragment, paymentMethod, sepaConfiguration)
         }
         PaymentMethodTypes.WECHAT_PAY_SDK -> {
-            val weChatPayConfiguration: WeChatPayConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.WECHAT_PAY_SDK, context)
+            val weChatPayConfiguration: WeChatPayConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(
+                PaymentMethodTypes.WECHAT_PAY_SDK,
+                context
+            )
             WeChatPayComponent.PROVIDER.get(fragment, paymentMethod, weChatPayConfiguration)
         }
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
@@ -101,9 +101,9 @@ class DropInConfiguration : Configuration, Parcelable {
         }
     }
 
-    internal fun <T : Configuration> getConfigurationForAction(action: String, context: Context): T {
+    internal inline fun <reified T : Configuration> getConfigurationForAction(context: Context): T {
         // TODO fetch from availableConfigs after we support action configs
-        return getDefaultConfigForAction(action, context, this)
+        return getDefaultConfigForAction(context, this)
     }
 
     /**

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
@@ -12,14 +12,14 @@ import android.content.ComponentName
 import android.content.Context
 import android.os.Parcel
 import android.os.Parcelable
+import com.adyen.checkout.bcmc.BcmcConfiguration
+import com.adyen.checkout.blik.BlikConfiguration
+import com.adyen.checkout.card.CardConfiguration
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.model.payments.Amount
 import com.adyen.checkout.components.util.CheckoutCurrency
 import com.adyen.checkout.components.util.PaymentMethodTypes
 import com.adyen.checkout.components.util.ValidationUtils
-import com.adyen.checkout.bcmc.BcmcConfiguration
-import com.adyen.checkout.blik.BlikConfiguration
-import com.adyen.checkout.card.CardConfiguration
 import com.adyen.checkout.core.api.Environment
 import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.core.log.LogUtil
@@ -36,7 +36,9 @@ import com.adyen.checkout.mbway.MBWayConfiguration
 import com.adyen.checkout.molpay.MolpayConfiguration
 import com.adyen.checkout.openbanking.OpenBankingConfiguration
 import com.adyen.checkout.sepa.SepaConfiguration
-import java.util.Locale
+import java.util.*
+import kotlin.collections.HashMap
+import kotlin.collections.set
 
 /**
  * This is the base configuration for the Drop-In solution. You need to use the [Builder] to instantiate this class.
@@ -90,13 +92,18 @@ class DropInConfiguration : Configuration, Parcelable {
         return ParcelUtils.NO_FILE_DESCRIPTOR
     }
 
-    fun <T : Configuration> getConfigurationFor(componentType: String, context: Context): T {
-        return if (availableConfigs.containsKey(componentType)) {
+    internal fun <T : Configuration> getConfigurationForPaymentMethod(paymentMethod: String, context: Context): T {
+        return if (availableConfigs.containsKey(paymentMethod)) {
             @Suppress("UNCHECKED_CAST")
-            availableConfigs[componentType] as T
+            availableConfigs[paymentMethod] as T
         } else {
-            getDefaultConfigFor(componentType, context, this)
+            getDefaultConfigForPaymentMethod(paymentMethod, context, this)
         }
+    }
+
+    internal fun <T : Configuration> getConfigurationForAction(action: String, context: Context): T {
+        // TODO fetch from availableConfigs after we support action configs
+        return getDefaultConfigForAction(action, context, this)
     }
 
     /**

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
@@ -15,7 +15,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.lifecycle.Observer
 import com.adyen.checkout.await.AwaitComponent
-import com.adyen.checkout.await.AwaitConfiguration
 import com.adyen.checkout.components.ActionComponent
 import com.adyen.checkout.components.ActionComponentData
 import com.adyen.checkout.components.ComponentError
@@ -33,7 +32,6 @@ import com.adyen.checkout.dropin.databinding.FragmentActionComponentBinding
 import com.adyen.checkout.dropin.getViewFor
 import com.adyen.checkout.dropin.ui.base.DropInBottomSheetDialogFragment
 import com.adyen.checkout.qrcode.QRCodeComponent
-import com.adyen.checkout.qrcode.QRCodeConfiguration
 
 @SuppressWarnings("TooManyFunctions")
 class ActionComponentDialogFragment : DropInBottomSheetDialogFragment(), Observer<ActionComponentData> {
@@ -128,14 +126,14 @@ class ActionComponentDialogFragment : DropInBottomSheetDialogFragment(), Observe
                 AwaitComponent.PROVIDER.get(
                     this,
                     requireActivity().application,
-                    dropInViewModel.dropInConfiguration.getConfigurationForAction<AwaitConfiguration>(requireContext())
+                    dropInViewModel.dropInConfiguration.getConfigurationForAction(requireContext())
                 )
             }
             ActionTypes.QR_CODE -> {
                 QRCodeComponent.PROVIDER.get(
                     this,
                     requireActivity().application,
-                    dropInViewModel.dropInConfiguration.getConfigurationForAction<QRCodeConfiguration>(requireContext())
+                    dropInViewModel.dropInConfiguration.getConfigurationForAction(requireContext())
                 )
             }
             else -> {

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
@@ -126,14 +126,14 @@ class ActionComponentDialogFragment : DropInBottomSheetDialogFragment(), Observe
                 AwaitComponent.PROVIDER.get(
                     this,
                     requireActivity().application,
-                    dropInViewModel.dropInConfiguration.getConfigurationFor(ActionTypes.AWAIT, requireContext())
+                    dropInViewModel.dropInConfiguration.getConfigurationForAction(ActionTypes.AWAIT, requireContext())
                 )
             }
             ActionTypes.QR_CODE -> {
                 QRCodeComponent.PROVIDER.get(
                     this,
                     requireActivity().application,
-                    dropInViewModel.dropInConfiguration.getConfigurationFor(ActionTypes.QR_CODE, requireContext())
+                    dropInViewModel.dropInConfiguration.getConfigurationForAction(ActionTypes.QR_CODE, requireContext())
                 )
             }
             else -> {

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
@@ -15,6 +15,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.lifecycle.Observer
 import com.adyen.checkout.await.AwaitComponent
+import com.adyen.checkout.await.AwaitConfiguration
 import com.adyen.checkout.components.ActionComponent
 import com.adyen.checkout.components.ActionComponentData
 import com.adyen.checkout.components.ComponentError
@@ -32,6 +33,7 @@ import com.adyen.checkout.dropin.databinding.FragmentActionComponentBinding
 import com.adyen.checkout.dropin.getViewFor
 import com.adyen.checkout.dropin.ui.base.DropInBottomSheetDialogFragment
 import com.adyen.checkout.qrcode.QRCodeComponent
+import com.adyen.checkout.qrcode.QRCodeConfiguration
 
 @SuppressWarnings("TooManyFunctions")
 class ActionComponentDialogFragment : DropInBottomSheetDialogFragment(), Observer<ActionComponentData> {
@@ -126,14 +128,14 @@ class ActionComponentDialogFragment : DropInBottomSheetDialogFragment(), Observe
                 AwaitComponent.PROVIDER.get(
                     this,
                     requireActivity().application,
-                    dropInViewModel.dropInConfiguration.getConfigurationForAction(ActionTypes.AWAIT, requireContext())
+                    dropInViewModel.dropInConfiguration.getConfigurationForAction<AwaitConfiguration>(requireContext())
                 )
             }
             ActionTypes.QR_CODE -> {
                 QRCodeComponent.PROVIDER.get(
                     this,
                     requireActivity().application,
-                    dropInViewModel.dropInConfiguration.getConfigurationForAction(ActionTypes.QR_CODE, requireContext())
+                    dropInViewModel.dropInConfiguration.getConfigurationForAction<QRCodeConfiguration>(requireContext())
                 )
             }
             else -> {

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
@@ -79,7 +79,7 @@ class ActionComponentDialogFragment : DropInBottomSheetDialogFragment(), Observe
         try {
             @Suppress("UNCHECKED_CAST")
             componentView = getViewFor(requireContext(), actionType) as ComponentView<in OutputData, ViewableComponent<*, *, ActionComponentData>>
-            actionComponent = getComponent(actionType)
+            actionComponent = getComponent(action)
             attachComponent(actionComponent, componentView)
 
             if (!isHandled) {
@@ -120,8 +120,8 @@ class ActionComponentDialogFragment : DropInBottomSheetDialogFragment(), Observe
     /**
      * Return the possible viewable action components
      */
-    private fun getComponent(actionType: String): ViewableComponent<*, *, ActionComponentData> {
-        return when (actionType) {
+    private fun getComponent(action: Action): ViewableComponent<*, *, ActionComponentData> {
+        val component = when (action.type) {
             ActionTypes.AWAIT -> {
                 AwaitComponent.PROVIDER.get(
                     this,
@@ -140,6 +140,12 @@ class ActionComponentDialogFragment : DropInBottomSheetDialogFragment(), Observe
                 throw ComponentException("Unexpected Action component type - $actionType")
             }
         }
+
+        if (!component.canHandleAction(action)) {
+            throw ComponentException("Unexpected Action component type - action: ${action.type} - paymentMethod: ${action.paymentMethodType}")
+        }
+
+        return component
     }
 
     private fun attachComponent(

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/paymentmethods/PaymentMethodListDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/paymentmethods/PaymentMethodListDialogFragment.kt
@@ -111,22 +111,25 @@ class PaymentMethodListDialogFragment : DropInBottomSheetDialogFragment(), Payme
         Logger.d(TAG, "onPaymentMethodSelected - ${paymentMethod.type}")
 
         // Check some specific payment methods that don't need to show a view
-        when (paymentMethod.type) {
-            PaymentMethodTypes.GOOGLE_PAY -> {
+        when {
+            paymentMethod.type == PaymentMethodTypes.GOOGLE_PAY -> {
+                Logger.d(TAG, "onPaymentMethodSelected: starting Google Pay")
                 protocol.startGooglePay(
                     dropInViewModel.getPaymentMethod(paymentMethod.type),
                     dropInViewModel.dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.GOOGLE_PAY, requireContext())
                 )
             }
-            PaymentMethodTypes.WECHAT_PAY_SDK -> {
+            PaymentMethodTypes.SUPPORTED_ACTION_ONLY_PAYMENT_METHODS.contains(paymentMethod.type) -> {
+                Logger.d(TAG, "onPaymentMethodSelected: payment method does not need a component, sending payment")
                 sendPayment(paymentMethod.type)
             }
+            PaymentMethodTypes.SUPPORTED_PAYMENT_METHODS.contains(paymentMethod.type) -> {
+                Logger.d(TAG, "onPaymentMethodSelected: payment method is supported")
+                protocol.showComponentDialog(dropInViewModel.getPaymentMethod(paymentMethod.type))
+            }
             else -> {
-                if (PaymentMethodTypes.SUPPORTED_PAYMENT_METHODS.contains(paymentMethod.type)) {
-                    protocol.showComponentDialog(dropInViewModel.getPaymentMethod(paymentMethod.type))
-                } else {
-                    sendPayment(paymentMethod.type)
-                }
+                Logger.d(TAG, "onPaymentMethodSelected: unidentified payment method, sending payment in case of redirect")
+                sendPayment(paymentMethod.type)
             }
         }
     }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/paymentmethods/PaymentMethodListDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/paymentmethods/PaymentMethodListDialogFragment.kt
@@ -115,7 +115,7 @@ class PaymentMethodListDialogFragment : DropInBottomSheetDialogFragment(), Payme
             PaymentMethodTypes.GOOGLE_PAY -> {
                 protocol.startGooglePay(
                     dropInViewModel.getPaymentMethod(paymentMethod.type),
-                    dropInViewModel.dropInConfiguration.getConfigurationFor(PaymentMethodTypes.GOOGLE_PAY, requireContext())
+                    dropInViewModel.dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.GOOGLE_PAY, requireContext())
                 )
             }
             PaymentMethodTypes.WECHAT_PAY_SDK -> {

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/paymentmethods/PaymentMethodsListViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/paymentmethods/PaymentMethodsListViewModel.kt
@@ -84,7 +84,8 @@ class PaymentMethodsListViewModel(
                 type == null -> {
                     throw CheckoutException("PaymentMethod type is null")
                 }
-                PaymentMethodTypes.SUPPORTED_PAYMENT_METHODS.contains(type) -> {
+                PaymentMethodTypes.SUPPORTED_PAYMENT_METHODS.contains(type)
+                    && !PaymentMethodTypes.SUPPORTED_ACTION_ONLY_PAYMENT_METHODS.contains(type) -> {
                     Logger.v(TAG, "Supported payment method: $type")
                     // We assume payment method is available and remove it later when the callback comes
                     // this is the overwhelming majority of cases, and we keep the list ordered this way.

--- a/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeComponent.kt
+++ b/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeComponent.kt
@@ -164,7 +164,7 @@ class QRCodeComponent(application: Application, configuration: QRCodeConfigurati
 
     companion object {
         @JvmField
-        val PROVIDER: ActionComponentProvider<QRCodeComponent> = ActionComponentProviderImpl(
+        val PROVIDER: ActionComponentProvider<QRCodeComponent, QRCodeConfiguration> = ActionComponentProviderImpl(
             QRCodeComponent::class.java,
             QRCodeConfiguration::class.java,
             true

--- a/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeComponent.kt
+++ b/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeComponent.kt
@@ -164,7 +164,7 @@ class QRCodeComponent(application: Application, configuration: QRCodeConfigurati
 
     override fun getSupportedActionTypes(): List<String> = ACTION_TYPES
 
-    override fun getSupportedPaymentMethodTypes(): List<String>  = PAYMENT_METHODS
+    override fun getSupportedPaymentMethodTypes(): List<String> = PAYMENT_METHODS
 
     companion object {
         @JvmField

--- a/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeComponent.kt
+++ b/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeComponent.kt
@@ -25,6 +25,7 @@ import com.adyen.checkout.components.model.payments.response.QrCodeAction
 import com.adyen.checkout.components.status.StatusRepository
 import com.adyen.checkout.components.status.api.StatusResponseUtils
 import com.adyen.checkout.components.status.model.StatusResponse
+import com.adyen.checkout.components.util.PaymentMethodTypes
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.core.log.LogUtil
 import com.adyen.checkout.core.log.Logger
@@ -34,6 +35,7 @@ import java.util.concurrent.TimeUnit
 
 private val TAG = LogUtil.getTag()
 private val ACTION_TYPES = listOf(QrCodeAction.ACTION_TYPE)
+private val PAYMENT_METHODS = listOf(PaymentMethodTypes.PIX)
 private const val PAYLOAD_DETAILS_KEY = "payload"
 private val STATUS_POLLING_INTERVAL_MILLIS = TimeUnit.SECONDS.toMillis(1L) // 1 second
 private const val HUNDRED = 100
@@ -161,6 +163,8 @@ class QRCodeComponent(application: Application, configuration: QRCodeConfigurati
     }
 
     override fun getSupportedActionTypes(): List<String> = ACTION_TYPES
+
+    override fun getSupportedPaymentMethodTypes(): List<String>  = PAYMENT_METHODS
 
     companion object {
         @JvmField

--- a/redirect/src/main/java/com/adyen/checkout/redirect/RedirectComponent.java
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/RedirectComponent.java
@@ -39,7 +39,7 @@ import java.util.List;
 public final class RedirectComponent extends BaseActionComponent<RedirectConfiguration> {
     private static final String TAG = LogUtil.getTag();
 
-    public static final ActionComponentProvider<RedirectComponent> PROVIDER =
+    public static final ActionComponentProvider<RedirectComponent, RedirectConfiguration> PROVIDER =
             new ActionComponentProviderImpl<>(RedirectComponent.class, RedirectConfiguration.class);
 
     public RedirectComponent(@NonNull Application application, @Nullable RedirectConfiguration configuration) {

--- a/redirect/src/main/java/com/adyen/checkout/redirect/RedirectComponent.java
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/RedirectComponent.java
@@ -85,6 +85,12 @@ public final class RedirectComponent extends BaseActionComponent<RedirectConfigu
         return Collections.unmodifiableList(Arrays.asList(supportedCodes));
     }
 
+    @Nullable
+    @Override
+    protected List<String> getSupportedPaymentMethodTypes() {
+        return null;
+    }
+
     @Override
     protected void handleActionInternal(@NonNull Activity activity, @NonNull Action action) throws ComponentException {
         final RedirectAction redirectAction = (RedirectAction) action;

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionComponent.java
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionComponent.java
@@ -38,7 +38,7 @@ import java.util.List;
 public class WeChatPayActionComponent extends BaseActionComponent<WeChatPayActionConfiguration> {
     private static final String TAG = LogUtil.getTag();
 
-    public static final ActionComponentProvider<WeChatPayActionComponent> PROVIDER =
+    public static final ActionComponentProvider<WeChatPayActionComponent, WeChatPayActionConfiguration> PROVIDER =
             new ActionComponentProviderImpl<>(WeChatPayActionComponent.class, WeChatPayActionConfiguration.class);
 
     private final IWXAPI mApi;

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionComponent.java
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionComponent.java
@@ -79,16 +79,18 @@ public class WeChatPayActionComponent extends BaseActionComponent<WeChatPayActio
         }
     }
 
-    @Override
-    public boolean canHandleAction(@NonNull Action action) {
-        return getSupportedActionTypes().contains(action.getType()) && action.getPaymentMethodType().equals(PaymentMethodTypes.WECHAT_PAY_SDK);
-    }
-
     @NonNull
     @Override
     protected List<String> getSupportedActionTypes() {
         final String[] supportedCodes = {SdkAction.ACTION_TYPE};
         return Collections.unmodifiableList(Arrays.asList(supportedCodes));
+    }
+
+    @NonNull
+    @Override
+    protected List<String> getSupportedPaymentMethodTypes() {
+        final String[] supportedPaymentMethods = {PaymentMethodTypes.WECHAT_PAY_SDK};
+        return Collections.unmodifiableList(Arrays.asList(supportedPaymentMethods));
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Split `getConfigurationFor` in 2 methods: payment method and action.
- Add handling for payment methods that do not require a payment component.
- Validate payment method types inside action components.