### PR TITLE
Don't pass threeDSRequestorAppURL on challenges in version 2.1.0

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
@@ -271,7 +271,10 @@ class Adyen3DS2Component(application: Application, configuration: Adyen3DS2Confi
             acsTransactionID = challenge.acsTransID
             acsRefNumber = challenge.acsReferenceNumber
             acsSignedContent = challenge.acsSignedContent
-            threeDSRequestorAppURL = ChallengeParameters.getEmbeddedRequestorAppURL(getApplication())
+            // This field was introduced in version 2.2.0 so older protocols don't expect it to be present and might throw an error.
+            if (challenge.messageVersion != PROTOCOL_VERSION_2_1_0) {
+                threeDSRequestorAppURL = ChallengeParameters.getEmbeddedRequestorAppURL(getApplication())
+            }
         }
     }
 
@@ -319,6 +322,7 @@ class Adyen3DS2Component(application: Application, configuration: Adyen3DS2Confi
         private const val FINGERPRINT_DETAILS_KEY = "threeds2.fingerprint"
         private const val CHALLENGE_DETAILS_KEY = "threeds2.challengeResult"
         private const val DEFAULT_CHALLENGE_TIME_OUT = 10
+        private const val PROTOCOL_VERSION_2_1_0 = "2.1.0"
 
         private var sGotDestroyedWhileChallenging = false
     }


### PR DESCRIPTION
This field was introduced in version 2.2.0 so older protocols don't expect it to be present and might throw an error.