### PR TITLE
Release 3.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@
 [//]: <> (Add changes that not released yet into `Unreleased` section)
 [//]: <> (Comment `Unreleased` section if there are no changes)
 [//]: <> (## [Unreleased])
+## [3.8.3] - 2021-06-01
+### Added
+- Enable showing Postal Code input in Card component.
+- Release to Maven Central.
+
+### Fixed
+- Update Google Pay logo.
+
+### Changed
+- Update 3DS2 SDK to version `2.1.0-rc09` which fixes restricted security exceptions on Android 10.
+
 ## [3.8.2] - 2021-02-09
 ### Fixed
 - Remove configuration object from /paymentmethods model breaking serialization in some API versions.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,2 +1,9 @@
+### Added
+- Enable showing Postal Code input in Card component.
+- Release to Maven Central.
+
 ### Fixed
-- Remove configuration object from /paymentmethods model breaking serialization in some API versions.
+- Update Google Pay logo.
+
+### Changed
+- Update 3DS2 SDK to version `2.1.0-rc09` which fixes restricted security exceptions on Android 10.

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ allprojects {
     // just for example app, don't need to increment
     ext.version_code = 1
     // The version_name format is "major.minor.patch(-(alpha|beta|rc)[0-9]{2}){0,1}" (e.g. 3.0.0, 3.1.1-alpha04 or 3.1.4-rc01 etc).
-    ext.version_name = "3.8.2"
+    ext.version_name = "3.8.3"
 
     // Code quality
     ext.ktlint_version = '0.34.2'


### PR DESCRIPTION
### Added
- Enable showing Postal Code input in Card component.
- Release to Maven Central.

### Fixed
- Update Google Pay logo.

### Changed
- Update 3DS2 SDK to version `2.1.0-rc09` which fixes restricted security exceptions on Android 10.
