### PR TITLE
Call Bin Lookup every time

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/NewCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/NewCardDelegate.kt
@@ -8,7 +8,6 @@
 
 package com.adyen.checkout.card
 
-import com.adyen.checkout.card.api.BinLookupConnection
 import com.adyen.checkout.card.api.model.Brand
 import com.adyen.checkout.card.data.CardType
 import com.adyen.checkout.card.data.DetectedCardType
@@ -90,8 +89,7 @@ class NewCardDelegate(
                 return binLookupRepository.get(cardNumber)
             }
 
-            // if length is exactly the size, we call bin lookup API
-            if (cardNumber.length == BinLookupConnection.REQUIRED_BIN_SIZE && publicKey != null) {
+            if (publicKey != null) {
                 Logger.d(TAG, "Launching Bin Lookup")
                 coroutineScope.launch {
                     val detectedCardTypes = binLookupRepository.fetch(cardNumber, publicKey, cardConfiguration)

--- a/card/src/main/java/com/adyen/checkout/card/api/BinLookupConnection.kt
+++ b/card/src/main/java/com/adyen/checkout/card/api/BinLookupConnection.kt
@@ -35,8 +35,4 @@ class BinLookupConnection(
         Logger.v(TAG, "response: ${resultJson.toStringPretty()}")
         return BinLookupResponse.SERIALIZER.deserialize(resultJson)
     }
-
-    companion object {
-        const val REQUIRED_BIN_SIZE = 11
-    }
 }

--- a/card/src/main/java/com/adyen/checkout/card/repository/BinLookupRepository.kt
+++ b/card/src/main/java/com/adyen/checkout/card/repository/BinLookupRepository.kt
@@ -34,7 +34,7 @@ class BinLookupRepository {
     private val cachedBinLookup = HashMap<String, List<DetectedCardType>>()
 
     fun isRequiredSize(cardNumber: String): Boolean {
-        return cardNumber.length >= BinLookupConnection.REQUIRED_BIN_SIZE
+        return cardNumber.length >= REQUIRED_BIN_SIZE
     }
 
     fun contains(cardNumber: String): Boolean {
@@ -46,7 +46,7 @@ class BinLookupRepository {
     }
 
     private fun hashBin(cardNumber: String): String {
-        return Sha256.hashString(cardNumber.take(BinLookupConnection.REQUIRED_BIN_SIZE))
+        return Sha256.hashString(cardNumber.take(REQUIRED_BIN_SIZE))
     }
 
     fun get(cardNumber: String): List<DetectedCardType> {
@@ -106,5 +106,9 @@ class BinLookupRepository {
                 cvcPolicy = Brand.CvcPolicy.parse(it.cvcPolicy ?: Brand.CvcPolicy.REQUIRED.value)
             )
         }
+    }
+
+    companion object {
+        private const val REQUIRED_BIN_SIZE = 11
     }
 }


### PR DESCRIPTION
## Summary
Call BinLookup every time the  Card number is big enough.
Caching is handled by the repository to avoid doing multiple calls.
Fix properly updating the `CardOutputData` when the binLookup flow is emitted to reflect the UI state correctly.