### PR TITLE
Add TotalPriceStatus to GooglePayCofing

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,8 @@
 
 ## Added
 - 3 new methods to `ActionComponentProvider`: `canHandleAction`, `requiresView` and `getSupportedActionTypes`.
-- `QRCodeComponent` will now redirect qr code actions that should work as a redirect on Android (e.g. `bcmc_mobile`). 
+- `QRCodeComponent` will now redirect qr code actions that should work as a redirect on Android (e.g. `bcmc_mobile`).
+- `TotalPriceStatus` to the `GooglePayConfiguration`.
 
 ## Changed
 - `WeChatPayActionComponent` is now an `IntentHandlingComponent`, the method `handleResultIntent` is renamed to `handleIntent`.

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.java
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.java
@@ -37,6 +37,7 @@ public class GooglePayConfiguration extends Configuration {
     private final String mMerchantAccount;
     private final int mGooglePayEnvironment;
     private final Amount mAmount;
+    private final String mTotalPriceStatus;
     private final String mCountryCode;
     private final MerchantInfo mMerchantInfo;
     private final List<String> mAllowedAuthMethods;
@@ -67,6 +68,7 @@ public class GooglePayConfiguration extends Configuration {
             @Nullable String merchantAccount,
             int googlePayEnvironment,
             @NonNull Amount amount,
+            @NonNull String totalPriceStatus,
             @Nullable String countryCode,
             @Nullable MerchantInfo merchantInfo,
             @NonNull List<String> allowedAuthMethods,
@@ -83,6 +85,7 @@ public class GooglePayConfiguration extends Configuration {
         mMerchantAccount = merchantAccount;
         mGooglePayEnvironment = googlePayEnvironment;
         mAmount = amount;
+        mTotalPriceStatus = totalPriceStatus;
         mCountryCode = countryCode;
         mMerchantInfo = merchantInfo;
         mAllowedAuthMethods = allowedAuthMethods;
@@ -101,6 +104,7 @@ public class GooglePayConfiguration extends Configuration {
         mMerchantAccount = in.readString();
         mGooglePayEnvironment = in.readInt();
         mAmount = in.readParcelable(Amount.class.getClassLoader());
+        mTotalPriceStatus = in.readString();
         mCountryCode = in.readString();
         mMerchantInfo = in.readParcelable(MerchantInfo.class.getClassLoader());
         mAllowedAuthMethods = in.readArrayList(String.class.getClassLoader());
@@ -120,6 +124,7 @@ public class GooglePayConfiguration extends Configuration {
         dest.writeString(mMerchantAccount);
         dest.writeInt(mGooglePayEnvironment);
         dest.writeParcelable(mAmount, flags);
+        dest.writeString(mTotalPriceStatus);
         dest.writeString(mCountryCode);
         dest.writeParcelable(mMerchantInfo, flags);
         dest.writeList(mAllowedAuthMethods);
@@ -141,6 +146,11 @@ public class GooglePayConfiguration extends Configuration {
     @NonNull
     public Amount getAmount() {
         return mAmount;
+    }
+
+    @NonNull
+    public String getTotalPriceStatus() {
+        return mTotalPriceStatus;
     }
 
     @Nullable
@@ -202,6 +212,8 @@ public class GooglePayConfiguration extends Configuration {
      */
     public static final class Builder extends BaseConfigurationBuilder<GooglePayConfiguration> {
 
+        private static final String DEFAULT_TOTAL_PRICE_STATUS = "FINAL";
+
         private String mBuilderMerchantAccount;
         private int mBuilderGooglePayEnvironment = getDefaultGooglePayEnvironment();
         private Amount mBuilderAmount = createDefaultAmount();
@@ -216,6 +228,7 @@ public class GooglePayConfiguration extends Configuration {
         private ShippingAddressParameters mBuilderShippingAddressParameters;
         private boolean mBuilderBillingAddressRequired;
         private BillingAddressParameters mBuilderBillingAddressParameters;
+        private String mBuilderTotalPriceStatus = DEFAULT_TOTAL_PRICE_STATUS;
 
         private int getDefaultGooglePayEnvironment() {
             if (mBuilderEnvironment == Environment.TEST) {
@@ -264,6 +277,10 @@ public class GooglePayConfiguration extends Configuration {
             return (Builder) super.setEnvironment(builderEnvironment);
         }
 
+        public void setTotalPriceStatus(@Nullable String builderTotalPriceStatus) {
+            mBuilderTotalPriceStatus = builderTotalPriceStatus;
+        }
+
         @NonNull
         @Override
         public GooglePayConfiguration build() {
@@ -274,6 +291,7 @@ public class GooglePayConfiguration extends Configuration {
                     mBuilderMerchantAccount,
                     mBuilderGooglePayEnvironment,
                     mBuilderAmount,
+                    mBuilderTotalPriceStatus,
                     mBuilderCountryCode,
                     mBuilderMerchantInfo,
                     mBuilderAllowedAuthMethods,

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/model/GooglePayParams.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/model/GooglePayParams.kt
@@ -22,6 +22,7 @@ data class GooglePayParams(
     val gatewayMerchantId: String = getPreferredGatewayMerchantId()
     val googlePayEnvironment: Int = googlePayConfiguration.googlePayEnvironment
     val amount: Amount = googlePayConfiguration.amount
+    val totalPriceStatus = googlePayConfiguration.totalPriceStatus
     val countryCode: String? = googlePayConfiguration.countryCode
     val merchantInfo: MerchantInfo? = googlePayConfiguration.merchantInfo
     val allowedAuthMethods: List<String>? = googlePayConfiguration.allowedAuthMethods

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/util/GooglePayUtils.java
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/util/GooglePayUtils.java
@@ -151,8 +151,8 @@ public final class GooglePayUtils {
             paymentMethod.setGooglePayToken(tokenizationDataJson.getString(TOKEN));
 
             final JSONObject infoJson = paymentMethodDataJson.optJSONObject(INFO);
-            if (infoJson != null) {
-                paymentMethod.setGooglePayCardNetwork(infoJson.optString(CARD_NETWORK, null));
+            if (infoJson != null && infoJson.has(CARD_NETWORK)) {
+                paymentMethod.setGooglePayCardNetwork(infoJson.getString(CARD_NETWORK));
             }
 
             return paymentMethod;

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/util/GooglePayUtils.java
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/util/GooglePayUtils.java
@@ -11,7 +11,6 @@ package com.adyen.checkout.googlepay.util;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.adyen.checkout.components.model.payments.Amount;
 import com.adyen.checkout.components.model.payments.request.GooglePayPaymentMethod;
 import com.adyen.checkout.components.util.AmountFormat;
 import com.adyen.checkout.core.exception.CheckoutException;
@@ -61,7 +60,7 @@ public final class GooglePayUtils {
     private static final String ADYEN_GATEWAY = "adyen";
 
     // TransactionInfoModel
-    private static final String DEFAULT_TOTAL_PRICE_STATUS = "FINAL";
+
 
     // PaymentData result JSON keys
     private static final String PAYMENT_METHOD_DATA = "paymentMethodData";
@@ -182,7 +181,7 @@ public final class GooglePayUtils {
         paymentDataRequestModel.setApiVersion(MAJOR_API_VERSION);
         paymentDataRequestModel.setApiVersionMinor(MINOT_API_VERSION);
         paymentDataRequestModel.setMerchantInfo(params.getMerchantInfo());
-        paymentDataRequestModel.setTransactionInfo(createTransactionInfo(params.getAmount(), params.getCountryCode()));
+        paymentDataRequestModel.setTransactionInfo(createTransactionInfo(params));
 
         final ArrayList<GooglePayPaymentMethodModel> allowedPaymentMethods = new ArrayList<>();
         allowedPaymentMethods.add(createCardPaymentMethod(params));
@@ -230,16 +229,16 @@ public final class GooglePayUtils {
     }
 
     @NonNull
-    private static TransactionInfoModel createTransactionInfo(@NonNull Amount amount, @Nullable String countryCode) {
-        BigDecimal bigDecimal = AmountFormat.toBigDecimal(amount);
+    private static TransactionInfoModel createTransactionInfo(@NonNull GooglePayParams params) {
+        BigDecimal bigDecimal = AmountFormat.toBigDecimal(params.getAmount());
         bigDecimal = bigDecimal.setScale(GOOGLE_PAY_DECIMAL_SCALE, RoundingMode.HALF_UP);
         final String displayAmount = GOOGLE_PAY_DECIMAL_FORMAT.format(bigDecimal);
 
         final TransactionInfoModel transactionInfoModel = new TransactionInfoModel();
         transactionInfoModel.setTotalPrice(displayAmount);
-        transactionInfoModel.setCountryCode(countryCode);
-        transactionInfoModel.setTotalPriceStatus(DEFAULT_TOTAL_PRICE_STATUS);
-        transactionInfoModel.setCurrencyCode(amount.getCurrency());
+        transactionInfoModel.setCountryCode(params.getCountryCode());
+        transactionInfoModel.setTotalPriceStatus(params.getTotalPriceStatus());
+        transactionInfoModel.setCurrencyCode(params.getAmount().getCurrency());
 
         return transactionInfoModel;
     }


### PR DESCRIPTION
## Summary
Adding TotalPriceStatus to the GooglePayConfiguration allows merchants to override that property.