### PR TITLE
Add flag for authentication only payment calls on Example App.

### DIFF
--- a/example-app/src/main/java/com/adyen/checkout/example/service/RequestUtils.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/service/RequestUtils.kt
@@ -24,7 +24,8 @@ fun createPaymentRequest(
     merchantAccount: String,
     redirectUrl: String,
     additionalData: AdditionalData,
-    force3DS2Challenge: Boolean = false
+    force3DS2Challenge: Boolean = true,
+    threeDSAuthenticationOnly: Boolean = false
 ): JSONObject {
 
     val request = JSONObject(paymentComponentData.toString())
@@ -39,6 +40,7 @@ fun createPaymentRequest(
     request.put("channel", "android")
     request.put("additionalData", JSONObject(Gson().toJson(additionalData)))
     request.put("lineItems", JSONArray(Gson().toJson(listOf(Item()))))
+    request.put("threeDSAuthenticationOnly", threeDSAuthenticationOnly)
 
     if (force3DS2Challenge) {
         val threeDS2RequestData = JSONObject()


### PR DESCRIPTION
## Summary
Adding the `threeDSAuthenticationOnly` flag allows us to make payment calls that don't charge the card.
This call will only ask for a Card Authentication. More info [here](https://docs.adyen.com/api-explorer/#/CheckoutService/v67/post/payments__reqParam_threeDSAuthenticationOnly).
False by default, can be changed in code for tests. We can add it to the settings screen later.