### PR TITLE
Pass builder instances while instantiating Configuration classes

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Configuration.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Configuration.kt
@@ -17,11 +17,7 @@ import java.util.Locale
 
 class Adyen3DS2Configuration : Configuration {
 
-    private constructor(
-        shopperLocale: Locale,
-        environment: Environment,
-        clientKey: String
-    ) : super(shopperLocale, environment, clientKey)
+    private constructor(builder: Builder) : super(builder.builderShopperLocale, builder.builderEnvironment, builder.builderClientKey)
 
     private constructor(inputParcel: Parcel) : super(inputParcel)
 
@@ -56,7 +52,7 @@ class Adyen3DS2Configuration : Configuration {
         }
 
         override fun buildInternal(): Adyen3DS2Configuration {
-            return Adyen3DS2Configuration(builderShopperLocale, builderEnvironment, builderClientKey)
+            return Adyen3DS2Configuration(this)
         }
     }
 

--- a/await/src/main/java/com/adyen/checkout/await/AwaitConfiguration.java
+++ b/await/src/main/java/com/adyen/checkout/await/AwaitConfiguration.java
@@ -32,11 +32,8 @@ public class AwaitConfiguration extends Configuration {
         }
     };
 
-    protected AwaitConfiguration(
-            @NonNull Locale shopperLocale,
-            @NonNull Environment environment,
-            @NonNull String clientKey) {
-        super(shopperLocale, environment, clientKey);
+    protected AwaitConfiguration(@NonNull Builder builder) {
+        super(builder.getBuilderShopperLocale(), builder.getBuilderEnvironment(), builder.getBuilderClientKey());
     }
 
     protected AwaitConfiguration(@NonNull Parcel in) {
@@ -84,7 +81,7 @@ public class AwaitConfiguration extends Configuration {
         @NonNull
         @Override
         protected AwaitConfiguration buildInternal() {
-            return new AwaitConfiguration(getBuilderShopperLocale(), getBuilderEnvironment(), getBuilderClientKey());
+            return new AwaitConfiguration(this);
         }
     }
 }

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcConfiguration.java
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcConfiguration.java
@@ -35,11 +35,8 @@ public class BcmcConfiguration extends Configuration {
         }
     };
 
-    BcmcConfiguration(
-            @NonNull Locale shopperLocale,
-            @NonNull Environment environment,
-            @NonNull String clientKey) {
-        super(shopperLocale, environment, clientKey);
+    BcmcConfiguration(@NonNull Builder builder) {
+        super(builder.getBuilderShopperLocale(), builder.getBuilderEnvironment(), builder.getBuilderClientKey());
     }
 
     BcmcConfiguration(@NonNull Parcel in) {
@@ -100,11 +97,7 @@ public class BcmcConfiguration extends Configuration {
          */
         @NonNull
         protected BcmcConfiguration buildInternal() {
-            return new BcmcConfiguration(
-                    getBuilderShopperLocale(),
-                    getBuilderEnvironment(),
-                    getBuilderClientKey()
-            );
+            return new BcmcConfiguration(this);
         }
     }
 

--- a/blik/src/main/java/com/adyen/checkout/blik/BlikConfiguration.java
+++ b/blik/src/main/java/com/adyen/checkout/blik/BlikConfiguration.java
@@ -32,12 +32,8 @@ public class BlikConfiguration extends Configuration {
         }
     };
 
-    BlikConfiguration(
-            @NonNull Locale shopperLocale,
-            @NonNull Environment environment,
-            @NonNull String clientKey
-    ) {
-        super(shopperLocale, environment, clientKey);
+    BlikConfiguration(@NonNull Builder builder) {
+        super(builder.getBuilderShopperLocale(), builder.getBuilderEnvironment(), builder.getBuilderClientKey());
     }
 
     BlikConfiguration(@NonNull Parcel in) {
@@ -85,7 +81,7 @@ public class BlikConfiguration extends Configuration {
         @NonNull
         @Override
         protected BlikConfiguration buildInternal() {
-            return new BlikConfiguration(getBuilderShopperLocale(), getBuilderEnvironment(), getBuilderClientKey());
+            return new BlikConfiguration(this);
         }
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/CardConfiguration.java
+++ b/card/src/main/java/com/adyen/checkout/card/CardConfiguration.java
@@ -60,36 +60,20 @@ public class CardConfiguration extends Configuration {
     };
 
     /**
-     * @param shopperLocale         The locale that should be used to display strings and layouts. Can differ from device default.
-     * @param environment           The environment to be used to make network calls.
-     * @param shopperReference      The unique identifier of the shopper.
-     * @param holderNameRequired    If the holder name of the card should be shown as a required field.
-     * @param showStorePaymentField If the component should show the option to store the card for later use.
-     * @param supportCardTypes      The list of supported card brands to be shown to the user.
-     * @param hideCvc               Hides the CVC field on the payment flow so that it's not required.
-     * @param hideCvcStoredCard     Hides the CVC field on the stored payment flow so that it's not required.
+     * @param builder The Builder instance to create the configuration.
      */
     CardConfiguration(
-            @NonNull Locale shopperLocale,
-            @NonNull Environment environment,
-            @NonNull String clientKey,
-            boolean holderNameRequired,
-            @NonNull String shopperReference,
-            boolean showStorePaymentField,
-            @NonNull List<CardType> supportCardTypes,
-            boolean hideCvc,
-            boolean hideCvcStoredCard,
-            SocialSecurityNumberVisibility socialSecurityNumberVisibility
+            Builder builder
     ) {
-        super(shopperLocale, environment, clientKey);
+        super(builder.getBuilderShopperLocale(), builder.getBuilderEnvironment(), builder.getBuilderClientKey());
 
-        mHolderNameRequired = holderNameRequired;
-        mSupportedCardTypes = supportCardTypes;
-        mShopperReference = shopperReference;
-        mShowStorePaymentField = showStorePaymentField;
-        mHideCvc = hideCvc;
-        mHideCvcStoredCard = hideCvcStoredCard;
-        mSocialSecurityNumberVisibility = socialSecurityNumberVisibility;
+        mHolderNameRequired = builder.mBuilderHolderNameRequired;
+        mSupportedCardTypes = builder.mBuilderSupportedCardTypes;
+        mShopperReference = builder.mShopperReference;
+        mShowStorePaymentField = builder.mBuilderShowStorePaymentField;
+        mHideCvc = builder.mBuilderHideCvc;
+        mHideCvcStoredCard = builder.mBuilderHideCvcStoredCard;
+        mSocialSecurityNumberVisibility = builder.mBuilderSocialSecurityNumberVisibility;
     }
 
     CardConfiguration(@NonNull Parcel in) {
@@ -324,18 +308,7 @@ public class CardConfiguration extends Configuration {
          */
         @NonNull
         protected CardConfiguration buildInternal() {
-            return new CardConfiguration(
-                    getBuilderShopperLocale(),
-                    getBuilderEnvironment(),
-                    getBuilderClientKey(),
-                    mBuilderHolderNameRequired,
-                    mShopperReference,
-                    mBuilderShowStorePaymentField,
-                    mBuilderSupportedCardTypes,
-                    mBuilderHideCvc,
-                    mBuilderHideCvcStoredCard,
-                    mBuilderSocialSecurityNumberVisibility
-            );
+            return new CardConfiguration(this);
         }
     }
 

--- a/components-core/src/main/java/com/adyen/checkout/components/base/BaseConfigurationBuilder.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/base/BaseConfigurationBuilder.kt
@@ -12,12 +12,12 @@ import java.util.*
  *
  * @param shopperLocale The Locale of the shopper.
  * @param environment   The {@link Environment} to be used for network calls to Adyen.
- * @param clientKey Your Client Key used for network calls from the SDK to Adyen.
+ * @param clientKey     Your Client Key used for network calls from the SDK to Adyen.
  */
 abstract class BaseConfigurationBuilder<ConfigurationT : Configuration>(
-    protected var builderShopperLocale: Locale,
-    protected var builderEnvironment: Environment,
-    protected var builderClientKey: String
+    var builderShopperLocale: Locale,
+    var builderEnvironment: Environment,
+    var builderClientKey: String
 ) {
 
     init {

--- a/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayConfiguration.java
+++ b/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayConfiguration.java
@@ -32,15 +32,10 @@ public class DotpayConfiguration extends IssuerListConfiguration {
     };
 
     /**
-     * @param shopperLocale The locale that should be used to display strings and layouts. Can differ from device default.
-     * @param environment   The environment to be used to make network calls.
+     * @param builder The Builder instance to create the configuration.
      */
-    DotpayConfiguration(
-            @NonNull Locale shopperLocale,
-            @NonNull Environment environment,
-            @NonNull String clientKey
-    ) {
-        super(shopperLocale, environment, clientKey);
+    DotpayConfiguration(@NonNull Builder builder) {
+        super(builder.getBuilderShopperLocale(), builder.getBuilderEnvironment(), builder.getBuilderClientKey());
     }
 
     DotpayConfiguration(@NonNull Parcel in) {
@@ -88,7 +83,7 @@ public class DotpayConfiguration extends IssuerListConfiguration {
         @NonNull
         @Override
         protected DotpayConfiguration buildInternal() {
-            return new DotpayConfiguration(getBuilderShopperLocale(), getBuilderEnvironment(), getBuilderClientKey());
+            return new DotpayConfiguration(this);
         }
     }
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
@@ -69,20 +69,13 @@ class DropInConfiguration : Configuration, Parcelable {
 
     @Suppress("LongParameterList")
     constructor(
-        shopperLocale: Locale,
-        environment: Environment,
-        clientKey: String,
-        availablePaymentConfigs: HashMap<String, Configuration>,
-        availableActionConfigs: HashMap<Class<*>, Configuration>,
-        serviceComponentName: ComponentName,
-        amount: Amount,
-        showPreselectedStoredPaymentMethod: Boolean
-    ) : super(shopperLocale, environment, clientKey) {
-        this.availablePaymentConfigs = availablePaymentConfigs
-        this.availableActionConfigs = availableActionConfigs
-        this.serviceComponentName = serviceComponentName
-        this.amount = amount
-        this.showPreselectedStoredPaymentMethod = showPreselectedStoredPaymentMethod
+        builder: Builder
+    ) : super(builder.shopperLocale, builder.environment, builder.clientKey) {
+        this.availablePaymentConfigs = builder.availablePaymentConfigs
+        this.availableActionConfigs = builder.availableActionConfigs
+        this.serviceComponentName = builder.serviceComponentName
+        this.amount = builder.amount
+        this.showPreselectedStoredPaymentMethod = builder.showPreselectedStoredPaymentMethod
     }
 
     constructor(parcel: Parcel) : super(parcel) {
@@ -144,15 +137,21 @@ class DropInConfiguration : Configuration, Parcelable {
             val TAG = LogUtil.getTag()
         }
 
-        private val availablePaymentConfigs = HashMap<String, Configuration>()
-        private val availableActionConfigs = HashMap<Class<*>, Configuration>()
+        val availablePaymentConfigs = HashMap<String, Configuration>()
+        val availableActionConfigs = HashMap<Class<*>, Configuration>()
 
-        private var shopperLocale: Locale
-        private var environment: Environment = Environment.EUROPE
-        private var clientKey: String
-        private var serviceComponentName: ComponentName
-        private var amount: Amount = Amount.EMPTY
-        private var showPreselectedStoredPaymentMethod: Boolean = true
+        var shopperLocale: Locale
+            private set
+        var environment: Environment = Environment.EUROPE
+            private set
+        var clientKey: String
+            private set
+        var serviceComponentName: ComponentName
+            private set
+        var amount: Amount = Amount.EMPTY
+            private set
+        var showPreselectedStoredPaymentMethod: Boolean = true
+            private set
 
         private val packageName: String
         private val serviceClassName: String
@@ -388,16 +387,7 @@ class DropInConfiguration : Configuration, Parcelable {
                 throw CheckoutException("Client key does not match the environment.")
             }
 
-            return DropInConfiguration(
-                shopperLocale,
-                environment,
-                clientKey,
-                availablePaymentConfigs,
-                availableActionConfigs,
-                serviceComponentName,
-                amount,
-                showPreselectedStoredPaymentMethod
-            )
+            return DropInConfiguration(this)
         }
     }
 }

--- a/entercash/src/main/java/com/adyen/checkout/entercash/EntercashConfiguration.java
+++ b/entercash/src/main/java/com/adyen/checkout/entercash/EntercashConfiguration.java
@@ -32,15 +32,10 @@ public class EntercashConfiguration extends IssuerListConfiguration {
     };
 
     /**
-     * @param shopperLocale The locale that should be used to display strings and layouts. Can differ from device default.
-     * @param environment   The environment to be used to make network calls.
+     * @param builder The Builder instance to create the configuration.
      */
-    EntercashConfiguration(
-            @NonNull Locale shopperLocale,
-            @NonNull Environment environment,
-            @NonNull String clientKey
-    ) {
-        super(shopperLocale, environment, clientKey);
+    EntercashConfiguration(@NonNull Builder builder) {
+        super(builder.getBuilderShopperLocale(), builder.getBuilderEnvironment(), builder.getBuilderClientKey());
     }
 
     EntercashConfiguration(@NonNull Parcel in) {
@@ -88,7 +83,7 @@ public class EntercashConfiguration extends IssuerListConfiguration {
         @NonNull
         @Override
         protected EntercashConfiguration buildInternal() {
-            return new EntercashConfiguration(getBuilderShopperLocale(), getBuilderEnvironment(), getBuilderClientKey());
+            return new EntercashConfiguration(this);
         }
     }
 }

--- a/eps/src/main/java/com/adyen/checkout/eps/EPSConfiguration.java
+++ b/eps/src/main/java/com/adyen/checkout/eps/EPSConfiguration.java
@@ -33,15 +33,10 @@ public class EPSConfiguration extends IssuerListConfiguration {
     };
 
     /**
-     * @param shopperLocale The locale that should be used to display strings and layouts. Can differ from device default.
-     * @param environment   The environment to be used to make network calls.
+     * @param builder The Builder instance to create the configuration.
      */
-    EPSConfiguration(
-            @NonNull Locale shopperLocale,
-            @NonNull Environment environment,
-            @NonNull String clientKey
-    ) {
-        super(shopperLocale, environment, clientKey);
+    EPSConfiguration(@NonNull Builder builder) {
+        super(builder.getBuilderShopperLocale(), builder.getBuilderEnvironment(), builder.getBuilderClientKey());
     }
 
     EPSConfiguration(@NonNull Parcel in) {
@@ -89,7 +84,7 @@ public class EPSConfiguration extends IssuerListConfiguration {
         @NonNull
         @Override
         public EPSConfiguration buildInternal() {
-            return new EPSConfiguration(getBuilderShopperLocale(), getBuilderEnvironment(), getBuilderClientKey());
+            return new EPSConfiguration(this);
         }
     }
 }

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.java
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.java
@@ -60,43 +60,23 @@ public class GooglePayConfiguration extends Configuration {
         }
     };
 
-    @SuppressWarnings("ParameterNumber")
-    GooglePayConfiguration(
-            @NonNull Locale shopperLocale,
-            @NonNull Environment environment,
-            @NonNull String clientKey,
-            @Nullable String merchantAccount,
-            int googlePayEnvironment,
-            @NonNull Amount amount,
-            @NonNull String totalPriceStatus,
-            @Nullable String countryCode,
-            @Nullable MerchantInfo merchantInfo,
-            @NonNull List<String> allowedAuthMethods,
-            @NonNull List<String> allowedCardNetworks,
-            boolean allowPrepaidCards,
-            boolean emailRequired,
-            boolean existingPaymentMethodRequired,
-            boolean shippingAddressRequired,
-            @Nullable ShippingAddressParameters shippingAddressParameters,
-            boolean billingAddressRequired,
-            @Nullable BillingAddressParameters billingAddressParameters
-    ) {
-        super(shopperLocale, environment, clientKey);
-        mMerchantAccount = merchantAccount;
-        mGooglePayEnvironment = googlePayEnvironment;
-        mAmount = amount;
-        mTotalPriceStatus = totalPriceStatus;
-        mCountryCode = countryCode;
-        mMerchantInfo = merchantInfo;
-        mAllowedAuthMethods = allowedAuthMethods;
-        mAllowedCardNetworks = allowedCardNetworks;
-        mAllowPrepaidCards = allowPrepaidCards;
-        mEmailRequired = emailRequired;
-        mExistingPaymentMethodRequired = existingPaymentMethodRequired;
-        mShippingAddressRequired = shippingAddressRequired;
-        mShippingAddressParameters = shippingAddressParameters;
-        mBillingAddressRequired = billingAddressRequired;
-        mBillingAddressParameters = billingAddressParameters;
+    GooglePayConfiguration(@NonNull Builder builder) {
+        super(builder.getBuilderShopperLocale(), builder.getBuilderEnvironment(), builder.getBuilderClientKey());
+        mMerchantAccount = builder.mBuilderMerchantAccount;
+        mGooglePayEnvironment = builder.mBuilderGooglePayEnvironment;
+        mAmount = builder.mBuilderAmount;
+        mTotalPriceStatus = builder.mBuilderTotalPriceStatus;
+        mCountryCode = builder.mBuilderCountryCode;
+        mMerchantInfo = builder.mBuilderMerchantInfo;
+        mAllowedAuthMethods = builder.mBuilderAllowedAuthMethods;
+        mAllowedCardNetworks = builder.mBuilderAllowedCardNetworks;
+        mAllowPrepaidCards = builder.mBuilderAllowPrepaidCards;
+        mEmailRequired = builder.mBuilderEmailRequired;
+        mExistingPaymentMethodRequired = builder.mBuilderExistingPaymentMethodRequired;
+        mShippingAddressRequired = builder.mBuilderShippingAddressRequired;
+        mShippingAddressParameters = builder.mBuilderShippingAddressParameters;
+        mBillingAddressRequired = builder.mBuilderBillingAddressRequired;
+        mBillingAddressParameters = builder.mBuilderBillingAddressParameters;
     }
 
     GooglePayConfiguration(@NonNull Parcel in) {
@@ -284,26 +264,7 @@ public class GooglePayConfiguration extends Configuration {
         @NonNull
         @Override
         protected GooglePayConfiguration buildInternal() {
-            return new GooglePayConfiguration(
-                    getBuilderShopperLocale(),
-                    getBuilderEnvironment(),
-                    getBuilderClientKey(),
-                    mBuilderMerchantAccount,
-                    mBuilderGooglePayEnvironment,
-                    mBuilderAmount,
-                    mBuilderTotalPriceStatus,
-                    mBuilderCountryCode,
-                    mBuilderMerchantInfo,
-                    mBuilderAllowedAuthMethods,
-                    mBuilderAllowedCardNetworks,
-                    mBuilderAllowPrepaidCards,
-                    mBuilderEmailRequired,
-                    mBuilderExistingPaymentMethodRequired,
-                    mBuilderShippingAddressRequired,
-                    mBuilderShippingAddressParameters,
-                    mBuilderBillingAddressRequired,
-                    mBuilderBillingAddressParameters
-            );
+            return new GooglePayConfiguration(this);
         }
 
         /**

--- a/ideal/src/main/java/com/adyen/checkout/ideal/IdealConfiguration.java
+++ b/ideal/src/main/java/com/adyen/checkout/ideal/IdealConfiguration.java
@@ -32,15 +32,10 @@ public class IdealConfiguration extends IssuerListConfiguration {
     };
 
     /**
-     * @param shopperLocale The locale that should be used to display strings and layouts. Can differ from device default.
-     * @param environment   The environment to be used to make network calls.
+     * @param builder The Builder instance to create the configuration.
      */
-    IdealConfiguration(
-            @NonNull Locale shopperLocale,
-            @NonNull Environment environment,
-            @NonNull String clientKey
-    ) {
-        super(shopperLocale, environment, clientKey);
+    IdealConfiguration(@NonNull Builder builder) {
+        super(builder.getBuilderShopperLocale(), builder.getBuilderEnvironment(), builder.getBuilderClientKey());
     }
 
     IdealConfiguration(@NonNull Parcel in) {
@@ -88,7 +83,7 @@ public class IdealConfiguration extends IssuerListConfiguration {
         @NonNull
         @Override
         protected IdealConfiguration buildInternal() {
-            return new IdealConfiguration(getBuilderShopperLocale(), getBuilderEnvironment(), getBuilderClientKey());
+            return new IdealConfiguration(this);
         }
     }
 }

--- a/mbway/src/main/java/com/adyen/checkout/mbway/MBWayConfiguration.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/MBWayConfiguration.kt
@@ -31,7 +31,7 @@ class MBWayConfiguration : Configuration {
         }
     }
 
-    internal constructor(shopperLocale: Locale, environment: Environment, clientKey: String) : super(shopperLocale, environment, clientKey)
+    internal constructor(builder: Builder) : super(builder.builderShopperLocale, builder.builderEnvironment, builder.builderClientKey)
     internal constructor(parcel: Parcel) : super(parcel)
 
     /**
@@ -64,7 +64,7 @@ class MBWayConfiguration : Configuration {
         }
 
         override fun buildInternal(): MBWayConfiguration {
-            return MBWayConfiguration(builderShopperLocale, builderEnvironment, builderClientKey)
+            return MBWayConfiguration(this)
         }
     }
 }

--- a/molpay/src/main/java/com/adyen/checkout/molpay/MolpayConfiguration.java
+++ b/molpay/src/main/java/com/adyen/checkout/molpay/MolpayConfiguration.java
@@ -32,15 +32,10 @@ public class MolpayConfiguration extends IssuerListConfiguration {
     };
 
     /**
-     * @param shopperLocale The locale that should be used to display strings and layouts. Can differ from device default.
-     * @param environment   The environment to be used to make network calls.
+     * @param builder The Builder instance to create the configuration.
      */
-    MolpayConfiguration(
-            @NonNull Locale shopperLocale,
-            @NonNull Environment environment,
-            @NonNull String clientKey
-    ) {
-        super(shopperLocale, environment, clientKey);
+    MolpayConfiguration(@NonNull Builder builder) {
+        super(builder.getBuilderShopperLocale(), builder.getBuilderEnvironment(), builder.getBuilderClientKey());
     }
 
     MolpayConfiguration(@NonNull Parcel in) {
@@ -88,7 +83,7 @@ public class MolpayConfiguration extends IssuerListConfiguration {
         @NonNull
         @Override
         protected MolpayConfiguration buildInternal() {
-            return new MolpayConfiguration(getBuilderShopperLocale(), getBuilderEnvironment(), getBuilderClientKey());
+            return new MolpayConfiguration(this);
         }
     }
 }

--- a/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingConfiguration.java
+++ b/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingConfiguration.java
@@ -32,15 +32,10 @@ public class OpenBankingConfiguration extends IssuerListConfiguration {
     };
 
     /**
-     * @param shopperLocale The locale that should be used to display strings and layouts. Can differ from device default.
-     * @param environment   The environment to be used to make network calls.
+     * @param builder The Builder instance to create the configuration.
      */
-    OpenBankingConfiguration(
-            @NonNull Locale shopperLocale,
-            @NonNull Environment environment,
-            @NonNull String clientKey
-    ) {
-        super(shopperLocale, environment, clientKey);
+    OpenBankingConfiguration(@NonNull Builder builder) {
+        super(builder.getBuilderShopperLocale(), builder.getBuilderEnvironment(), builder.getBuilderClientKey());
     }
 
     OpenBankingConfiguration(@NonNull Parcel in) {
@@ -88,7 +83,7 @@ public class OpenBankingConfiguration extends IssuerListConfiguration {
         @NonNull
         @Override
         protected OpenBankingConfiguration buildInternal() {
-            return new OpenBankingConfiguration(getBuilderShopperLocale(), getBuilderEnvironment(), getBuilderClientKey());
+            return new OpenBankingConfiguration(this);
         }
     }
 }

--- a/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeConfiguration.kt
+++ b/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeConfiguration.kt
@@ -31,7 +31,7 @@ class QRCodeConfiguration : Configuration {
         }
     }
 
-    internal constructor(shopperLocale: Locale, environment: Environment, clientKey: String) : super(shopperLocale, environment, clientKey)
+    internal constructor(builder: Builder) : super(builder.builderShopperLocale, builder.builderEnvironment, builder.builderClientKey)
     internal constructor(parcel: Parcel) : super(parcel)
 
     /**
@@ -64,7 +64,7 @@ class QRCodeConfiguration : Configuration {
         }
 
         override fun buildInternal(): QRCodeConfiguration {
-            return QRCodeConfiguration(builderShopperLocale, builderEnvironment, builderClientKey)
+            return QRCodeConfiguration(this)
         }
     }
 }

--- a/redirect/src/main/java/com/adyen/checkout/redirect/RedirectConfiguration.java
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/RedirectConfiguration.java
@@ -32,11 +32,8 @@ public class RedirectConfiguration extends Configuration {
         }
     };
 
-    protected RedirectConfiguration(
-            @NonNull Locale shopperLocale,
-            @NonNull Environment environment,
-            @NonNull String clientKey) {
-        super(shopperLocale, environment, clientKey);
+    protected RedirectConfiguration(@NonNull Builder builder) {
+        super(builder.getBuilderShopperLocale(), builder.getBuilderEnvironment(), builder.getBuilderClientKey());
     }
 
     protected RedirectConfiguration(@NonNull Parcel in) {
@@ -84,7 +81,7 @@ public class RedirectConfiguration extends Configuration {
         @NonNull
         @Override
         protected RedirectConfiguration buildInternal() {
-            return new RedirectConfiguration(getBuilderShopperLocale(), getBuilderEnvironment(), getBuilderClientKey());
+            return new RedirectConfiguration(this);
         }
     }
 }

--- a/sepa/src/main/java/com/adyen/checkout/sepa/SepaConfiguration.java
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/SepaConfiguration.java
@@ -32,12 +32,8 @@ public class SepaConfiguration extends Configuration {
         }
     };
 
-    SepaConfiguration(
-            @NonNull Locale shopperLocale,
-            @NonNull Environment environment,
-            @NonNull String clientKey
-    ) {
-        super(shopperLocale, environment, clientKey);
+    SepaConfiguration(@NonNull Builder builder) {
+        super(builder.getBuilderShopperLocale(), builder.getBuilderEnvironment(), builder.getBuilderClientKey());
     }
 
     SepaConfiguration(@NonNull Parcel in) {
@@ -85,7 +81,7 @@ public class SepaConfiguration extends Configuration {
         @NonNull
         @Override
         protected SepaConfiguration buildInternal() {
-            return new SepaConfiguration(getBuilderShopperLocale(), getBuilderEnvironment(), getBuilderClientKey());
+            return new SepaConfiguration(this);
         }
     }
 }

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionConfiguration.java
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionConfiguration.java
@@ -32,11 +32,8 @@ public class WeChatPayActionConfiguration extends Configuration {
         }
     };
 
-    protected WeChatPayActionConfiguration(
-            @NonNull Locale shopperLocale,
-            @NonNull Environment environment,
-            @NonNull String clientKey) {
-        super(shopperLocale, environment, clientKey);
+    protected WeChatPayActionConfiguration(@NonNull Builder builder) {
+        super(builder.getBuilderShopperLocale(), builder.getBuilderEnvironment(), builder.getBuilderClientKey());
     }
 
     protected WeChatPayActionConfiguration(@NonNull Parcel in) {
@@ -84,7 +81,7 @@ public class WeChatPayActionConfiguration extends Configuration {
         @NonNull
         @Override
         protected WeChatPayActionConfiguration buildInternal() {
-            return new WeChatPayActionConfiguration(getBuilderShopperLocale(), getBuilderEnvironment(), getBuilderClientKey());
+            return new WeChatPayActionConfiguration(this);
         }
     }
 }


### PR DESCRIPTION
Instead of passing parameters one by one to the constructors of
Configuration classes pass the builder instance to make it cleaner.