### PR TITLE
Update 3DS2 version.

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
@@ -232,7 +232,12 @@ class Adyen3DS2Component(
 
             mTransaction = try {
                 Logger.d(TAG, "create transaction")
-                ThreeDS2Service.INSTANCE.createTransaction(null, fingerprintToken.threeDSMessageVersion)
+                if (fingerprintToken.threeDSMessageVersion != null) {
+                    ThreeDS2Service.INSTANCE.createTransaction(null, fingerprintToken.threeDSMessageVersion)
+                } else {
+                    notifyException(ComponentException("Failed to create 3DS2 Transaction. Missing threeDSMessageVersion inside fingerprintToken."))
+                    return@launch
+                }
             } catch (e: SDKNotInitializedException) {
                 notifyException(ComponentException("Failed to create 3DS2 Transaction", e))
                 return@launch

--- a/build.gradle
+++ b/build.gradle
@@ -61,8 +61,7 @@ allprojects {
     ext.browser_version = "1.3.0"
 
     // Adyen Dependencies
-    ext.adyen_cse_version = "1.0.5"
-    ext.adyen3ds2_version = "2.2.2"
+    ext.adyen3ds2_version = "2.2.4"
 
     // External Dependencies
     ext.play_services_wallet_version = '18.1.3'

--- a/config/gradle/checksums.gradle
+++ b/config/gradle/checksums.gradle
@@ -9,7 +9,7 @@
 if (!hasProperty("checksums")) {
     final checksums = [
             // Adyen dependencies
-            "com.adyen.threeds:adyen-3ds2:2.2.2:3cfb727e53792118335d1632f2455870:MD5",
+            "com.adyen.threeds:adyen-3ds2:2.2.4:99922f9831cb0aaeb7d4d16e9d33f21c:MD5",
 
             // Kotlin
             "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.21:02ff117102ed2651e8ad98b39e9dbe50:MD5",


### PR DESCRIPTION
Update 3DS2 SDK to version `2.2.4` which contains some fixes, new certificates and support for tagetApi 31.