### PR TITLE
Add ProGuard/R8 consumer rules to the release artifacts.

### DIFF
--- a/checkout-core/consumer-rules.pro
+++ b/checkout-core/consumer-rules.pro
@@ -1,0 +1,2 @@
+# Keep the model classes for JSON parsing.
+-keep class com.adyen.checkout.core.model.** { * ;}

--- a/components-core/consumer-rules.pro
+++ b/components-core/consumer-rules.pro
@@ -1,0 +1,10 @@
+# Keep the model classes for JSON parsing.
+-keep class com.adyen.checkout.components.model.** { *; }
+
+# Keep the Component constructors for reflection initialization in the Factory.
+-keepclassmembers public class * implements com.adyen.checkout.components.PaymentComponent {
+   public <init>(...);
+}
+-keepclassmembers public class * implements com.adyen.checkout.components.ActionComponent {
+   public <init>(...);
+}

--- a/example-app/build.gradle
+++ b/example-app/build.gradle
@@ -57,7 +57,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
@@ -71,6 +71,7 @@ android {
 dependencies {
     // Checkout
     implementation project(':drop-in')
+//    implementation "com.adyen.checkout:drop-in:4.1.1"
 
     // Dependencies
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinx_version"

--- a/example-app/proguard-rules.pro
+++ b/example-app/proguard-rules.pro
@@ -20,7 +20,4 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
--keep class com.adyen.checkout.components.model.** { *; }
--keepclassmembers public class * implements com.adyen.checkout.components.PaymentComponent {
-   public <init>(...);
-}
+-keep class com.adyen.checkout.example.data.api.model.paymentsRequest.** { *; }


### PR DESCRIPTION
This way merchants don't have to add the ProGuard rules themselves anymore.