### PR TITLE
fix: Handle NOT_CURRENTLY_KNOWN flag

### DIFF
--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/util/GooglePayUtils.java
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/util/GooglePayUtils.java
@@ -69,6 +69,8 @@ public final class GooglePayUtils {
     private static final String TOKENIZATION_DATA = "tokenizationData";
     private static final String TOKEN = "token";
 
+    private static final String NOT_CURRENTLY_KNOWN = "NOT_CURRENTLY_KNOWN";
+
     /**
      * Create a {@link com.google.android.gms.wallet.Wallet.WalletOptions} based on the component configuration.
      *
@@ -235,7 +237,9 @@ public final class GooglePayUtils {
         final String displayAmount = GOOGLE_PAY_DECIMAL_FORMAT.format(bigDecimal);
 
         final TransactionInfoModel transactionInfoModel = new TransactionInfoModel();
-        transactionInfoModel.setTotalPrice(displayAmount);
+        if (!params.getTotalPriceStatus().equals(NOT_CURRENTLY_KNOWN)) {
+            transactionInfoModel.setTotalPrice(displayAmount);
+        }
         transactionInfoModel.setCountryCode(params.getCountryCode());
         transactionInfoModel.setTotalPriceStatus(params.getTotalPriceStatus());
         transactionInfoModel.setCurrencyCode(params.getAmount().getCurrency());

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/util/GooglePayUtils.java
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/util/GooglePayUtils.java
@@ -237,6 +237,7 @@ public final class GooglePayUtils {
         final String displayAmount = GOOGLE_PAY_DECIMAL_FORMAT.format(bigDecimal);
 
         final TransactionInfoModel transactionInfoModel = new TransactionInfoModel();
+        // Google requires to not pass the price when the price status is NOT_CURRENTLY_KNOWN
         if (!params.getTotalPriceStatus().equals(NOT_CURRENTLY_KNOWN)) {
             transactionInfoModel.setTotalPrice(displayAmount);
         }


### PR DESCRIPTION
Consulted Google as we shouldn't pass in totalPrice when totalPriceStatus is "NOT_CURRENTLY_KNOWN". This is a quick workaround.

Logs from Logcat:
W WalletMerchantError: Error in loadPaymentData: PaymentDataRequest.transactionInfo.totalPrice should not be set for totalPriceStatus = NOT_CURRENTLY_KNOWN!

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
