### PR TITLE
Skip the PaymentMethodsDialog when there is only one PaymentMethod

### DIFF
--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
@@ -158,7 +158,7 @@ internal fun checkPaymentMethodAvailability(
         val type = paymentMethod.type ?: throw CheckoutException("PaymentMethod type is null")
 
         val availabilityCheck = getPaymentMethodAvailabilityCheck(type)
-        val configuration = dropInConfiguration.getConfigurationForPaymentMethodOrNull<Configuration>(type, application)
+        val configuration = dropInConfiguration.getConfigurationForPaymentMethodOrNull<Configuration>(type)
 
         availabilityCheck.isAvailable(application, paymentMethod, configuration, callback)
     } catch (e: CheckoutException) {
@@ -192,15 +192,14 @@ internal fun getComponentFor(
     storedPaymentMethod: StoredPaymentMethod,
     dropInConfiguration: DropInConfiguration
 ): PaymentComponent<PaymentComponentState<in PaymentMethodDetails>, Configuration> {
-    val context = fragment.requireContext()
 
     val component = when (storedPaymentMethod.type) {
         PaymentMethodTypes.SCHEME -> {
-            val cardConfig: CardConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.SCHEME, context)
+            val cardConfig: CardConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.SCHEME)
             CardComponent.PROVIDER.get(fragment, storedPaymentMethod, cardConfig)
         }
         PaymentMethodTypes.BLIK -> {
-            val blikConfig: BlikConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.BLIK, context)
+            val blikConfig: BlikConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.BLIK)
             BlikComponent.PROVIDER.get(fragment, storedPaymentMethod, blikConfig)
         }
         else -> {
@@ -228,75 +227,71 @@ internal fun getComponentFor(
 
     val component = when (paymentMethod.type) {
         PaymentMethodTypes.BCMC -> {
-            val bcmcConfiguration: BcmcConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.BCMC, context)
+            val bcmcConfiguration: BcmcConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.BCMC)
             BcmcComponent.PROVIDER.get(fragment, paymentMethod, bcmcConfiguration)
         }
         PaymentMethodTypes.BLIK -> {
-            val blikConfiguration: BlikConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.BLIK, context)
+            val blikConfiguration: BlikConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.BLIK)
             BlikComponent.PROVIDER.get(fragment, paymentMethod, blikConfiguration)
         }
         PaymentMethodTypes.DOTPAY -> {
-            val dotpayConfig: DotpayConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.DOTPAY, context)
+            val dotpayConfig: DotpayConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.DOTPAY)
             DotpayComponent.PROVIDER.get(fragment, paymentMethod, dotpayConfig)
         }
         PaymentMethodTypes.ENTERCASH -> {
-            val entercashConfig: EntercashConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.ENTERCASH, context)
+            val entercashConfig: EntercashConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.ENTERCASH)
             EntercashComponent.PROVIDER.get(fragment, paymentMethod, entercashConfig)
         }
         PaymentMethodTypes.EPS -> {
-            val epsConfig: EPSConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.EPS, context)
+            val epsConfig: EPSConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.EPS)
             EPSComponent.PROVIDER.get(fragment, paymentMethod, epsConfig)
         }
         PaymentMethodTypes.GOOGLE_PAY -> {
             val googlePayConfiguration: GooglePayConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(
-                PaymentMethodTypes.GOOGLE_PAY,
-                context
+                PaymentMethodTypes.GOOGLE_PAY
             )
             GooglePayComponent.PROVIDER.get(fragment, paymentMethod, googlePayConfiguration)
         }
         PaymentMethodTypes.GOOGLE_PAY_LEGACY -> {
             val googlePayConfiguration: GooglePayConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(
-                PaymentMethodTypes.GOOGLE_PAY_LEGACY,
-                context
+                PaymentMethodTypes.GOOGLE_PAY_LEGACY
             )
             GooglePayComponent.PROVIDER.get(fragment, paymentMethod, googlePayConfiguration)
         }
         PaymentMethodTypes.IDEAL -> {
-            val idealConfig: IdealConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.IDEAL, context)
+            val idealConfig: IdealConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.IDEAL)
             IdealComponent.PROVIDER.get(fragment, paymentMethod, idealConfig)
         }
         PaymentMethodTypes.MB_WAY -> {
-            val mbWayConfiguration: MBWayConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.MB_WAY, context)
+            val mbWayConfiguration: MBWayConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.MB_WAY)
             MBWayComponent.PROVIDER.get(fragment, paymentMethod, mbWayConfiguration)
         }
         PaymentMethodTypes.MOLPAY_THAILAND -> {
-            val molpayConfig: MolpayConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.MOLPAY_THAILAND, context)
+            val molpayConfig: MolpayConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.MOLPAY_THAILAND)
             MolpayComponent.PROVIDER.get(fragment, paymentMethod, molpayConfig)
         }
         PaymentMethodTypes.MOLPAY_MALAYSIA -> {
-            val molpayConfig: MolpayConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.MOLPAY_MALAYSIA, context)
+            val molpayConfig: MolpayConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.MOLPAY_MALAYSIA)
             MolpayComponent.PROVIDER.get(fragment, paymentMethod, molpayConfig)
         }
         PaymentMethodTypes.MOLPAY_VIETNAM -> {
             val molpayConfig: MolpayConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(
-                PaymentMethodTypes.MOLPAY_VIETNAM,
-                context
+                PaymentMethodTypes.MOLPAY_VIETNAM
             )
             MolpayComponent.PROVIDER.get(fragment, paymentMethod, molpayConfig)
         }
         PaymentMethodTypes.OPEN_BANKING -> {
             val openBankingConfig: OpenBankingConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(
-                PaymentMethodTypes.OPEN_BANKING,
-                context
+                PaymentMethodTypes.OPEN_BANKING
             )
             OpenBankingComponent.PROVIDER.get(fragment, paymentMethod, openBankingConfig)
         }
         PaymentMethodTypes.SCHEME -> {
-            val cardConfig: CardConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.SCHEME, context)
+            val cardConfig: CardConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.SCHEME)
             CardComponent.PROVIDER.get(fragment, paymentMethod, cardConfig)
         }
         PaymentMethodTypes.SEPA -> {
-            val sepaConfiguration: SepaConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.SEPA, context)
+            val sepaConfiguration: SepaConfiguration = dropInConfiguration.getConfigurationForPaymentMethod(PaymentMethodTypes.SEPA)
             SepaComponent.PROVIDER.get(fragment, paymentMethod, sepaConfiguration)
         }
 
@@ -376,19 +371,19 @@ internal fun getActionComponentFor(
 ): BaseActionComponent<out Configuration> {
     return when (provider) {
         RedirectComponent.PROVIDER -> {
-            RedirectComponent.PROVIDER.get(activity, activity.application, dropInConfiguration.getConfigurationForAction(activity))
+            RedirectComponent.PROVIDER.get(activity, activity.application, dropInConfiguration.getConfigurationForAction())
         }
         Adyen3DS2Component.PROVIDER -> {
-            Adyen3DS2Component.PROVIDER.get(activity, activity.application, dropInConfiguration.getConfigurationForAction(activity))
+            Adyen3DS2Component.PROVIDER.get(activity, activity.application, dropInConfiguration.getConfigurationForAction())
         }
         WeChatPayActionComponent.PROVIDER -> {
-            WeChatPayActionComponent.PROVIDER.get(activity, activity.application, dropInConfiguration.getConfigurationForAction(activity))
+            WeChatPayActionComponent.PROVIDER.get(activity, activity.application, dropInConfiguration.getConfigurationForAction())
         }
         AwaitComponent.PROVIDER -> {
-            AwaitComponent.PROVIDER.get(activity, activity.application, dropInConfiguration.getConfigurationForAction(activity))
+            AwaitComponent.PROVIDER.get(activity, activity.application, dropInConfiguration.getConfigurationForAction())
         }
         QRCodeComponent.PROVIDER -> {
-            QRCodeComponent.PROVIDER.get(activity, activity.application, dropInConfiguration.getConfigurationForAction(activity))
+            QRCodeComponent.PROVIDER.get(activity, activity.application, dropInConfiguration.getConfigurationForAction())
         }
         else -> {
             throw CheckoutException("Unable to find component for provider - $provider")

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
@@ -101,15 +101,15 @@ class DropInConfiguration : Configuration, Parcelable {
         return ParcelUtils.NO_FILE_DESCRIPTOR
     }
 
-    internal fun <T : Configuration> getConfigurationForPaymentMethodOrNull(paymentMethod: String, context: Context): T? {
+    internal fun <T : Configuration> getConfigurationForPaymentMethodOrNull(paymentMethod: String): T? {
         return try {
-            getConfigurationForPaymentMethod(paymentMethod, context)
+            getConfigurationForPaymentMethod(paymentMethod)
         } catch (e: CheckoutException) {
             null
         }
     }
 
-    internal fun <T : Configuration> getConfigurationForPaymentMethod(paymentMethod: String, context: Context): T {
+    internal fun <T : Configuration> getConfigurationForPaymentMethod(paymentMethod: String): T {
         return if (availablePaymentConfigs.containsKey(paymentMethod)) {
             @Suppress("UNCHECKED_CAST")
             availablePaymentConfigs[paymentMethod] as T
@@ -118,7 +118,7 @@ class DropInConfiguration : Configuration, Parcelable {
         }
     }
 
-    internal inline fun <reified T : Configuration> getConfigurationForAction(context: Context): T {
+    internal inline fun <reified T : Configuration> getConfigurationForAction(): T {
         val actionClass = T::class.java
         return if (availableActionConfigs.containsKey(actionClass)) {
             @Suppress("UNCHECKED_CAST")

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
@@ -58,6 +58,7 @@ class DropInConfiguration : Configuration, Parcelable {
     val serviceComponentName: ComponentName
     val amount: Amount
     val showPreselectedStoredPaymentMethod: Boolean
+    val skipPaymentMethodsDialogWhenOnlyOnePaymentMethodIsAvailable: Boolean
 
     companion object {
         @JvmField
@@ -76,6 +77,7 @@ class DropInConfiguration : Configuration, Parcelable {
         this.serviceComponentName = builder.serviceComponentName
         this.amount = builder.amount
         this.showPreselectedStoredPaymentMethod = builder.showPreselectedStoredPaymentMethod
+        this.skipPaymentMethodsDialogWhenOnlyOnePaymentMethodIsAvailable = builder.skipPaymentMethodsDialogWhenOnlyOnePaymentMethodIsAvailable
     }
 
     constructor(parcel: Parcel) : super(parcel) {
@@ -86,6 +88,7 @@ class DropInConfiguration : Configuration, Parcelable {
         serviceComponentName = parcel.readParcelable(ComponentName::class.java.classLoader)!!
         amount = Amount.CREATOR.createFromParcel(parcel)
         showPreselectedStoredPaymentMethod = ParcelUtils.readBoolean(parcel)
+        skipPaymentMethodsDialogWhenOnlyOnePaymentMethodIsAvailable = ParcelUtils.readBoolean(parcel)
     }
 
     override fun writeToParcel(dest: Parcel, flags: Int) {
@@ -95,6 +98,7 @@ class DropInConfiguration : Configuration, Parcelable {
         dest.writeParcelable(serviceComponentName, flags)
         JsonUtils.writeToParcel(dest, Amount.SERIALIZER.serialize(amount))
         ParcelUtils.writeBoolean(dest, showPreselectedStoredPaymentMethod)
+        ParcelUtils.writeBoolean(dest, skipPaymentMethodsDialogWhenOnlyOnePaymentMethodIsAvailable)
     }
 
     override fun describeContents(): Int {
@@ -152,6 +156,8 @@ class DropInConfiguration : Configuration, Parcelable {
             private set
         var showPreselectedStoredPaymentMethod: Boolean = true
             private set
+        var skipPaymentMethodsDialogWhenOnlyOnePaymentMethodIsAvailable: Boolean = false
+            private set
 
         private val packageName: String
         private val serviceClassName: String
@@ -191,6 +197,7 @@ class DropInConfiguration : Configuration, Parcelable {
             this.amount = dropInConfiguration.amount
             this.clientKey = dropInConfiguration.clientKey
             this.showPreselectedStoredPaymentMethod = dropInConfiguration.showPreselectedStoredPaymentMethod
+            this.skipPaymentMethodsDialogWhenOnlyOnePaymentMethodIsAvailable = dropInConfiguration.skipPaymentMethodsDialogWhenOnlyOnePaymentMethodIsAvailable
         }
 
         fun setServiceComponentName(serviceComponentName: ComponentName): Builder {
@@ -223,6 +230,11 @@ class DropInConfiguration : Configuration, Parcelable {
 
         fun setShowPreselectedStoredPaymentMethod(showStoredPaymentMethod: Boolean): Builder {
             this.showPreselectedStoredPaymentMethod = showStoredPaymentMethod
+            return this
+        }
+
+        fun setSkipPaymentMethodsDialogWhenOnlyOnePaymentMethodIsAvailable(skipPaymentMethodsDialog: Boolean): Builder {
+            this.skipPaymentMethodsDialogWhenOnlyOnePaymentMethodIsAvailable = skipPaymentMethodsDialog
             return this
         }
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/PaymentSelectionHandler.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/PaymentSelectionHandler.kt
@@ -1,0 +1,51 @@
+package com.adyen.checkout.dropin
+
+import com.adyen.checkout.components.GenericComponentState
+import com.adyen.checkout.components.model.payments.request.GenericPaymentMethod
+import com.adyen.checkout.components.model.payments.request.PaymentComponentData
+import com.adyen.checkout.components.model.payments.request.PaymentMethodDetails
+import com.adyen.checkout.components.util.PaymentMethodTypes
+import com.adyen.checkout.core.log.LogUtil
+import com.adyen.checkout.core.log.Logger
+import com.adyen.checkout.dropin.ui.DropInViewModel
+import com.adyen.checkout.dropin.ui.base.DropInBottomSheetDialogFragment
+import com.adyen.checkout.googlepay.GooglePayComponent
+
+private val TAG = LogUtil.getTag()
+
+class PaymentSelectionHandler(
+    private val dropInViewModel: DropInViewModel,
+    private val protocol: DropInBottomSheetDialogFragment.Protocol
+) {
+
+    fun handlePaymentSelection(paymentMethodType: String) {
+        when {
+            GooglePayComponent.PAYMENT_METHOD_TYPES.contains(paymentMethodType) -> {
+                Logger.d(TAG, "onPaymentMethodSelected: starting Google Pay")
+                protocol.startGooglePay(
+                    dropInViewModel.getPaymentMethod(paymentMethodType),
+                    dropInViewModel.dropInConfiguration.getConfigurationForPaymentMethod(paymentMethodType)
+                )
+            }
+            PaymentMethodTypes.SUPPORTED_ACTION_ONLY_PAYMENT_METHODS.contains(paymentMethodType) -> {
+                Logger.d(TAG, "onPaymentMethodSelected: payment method does not need a component, sending payment")
+                sendPayment(paymentMethodType)
+            }
+            PaymentMethodTypes.SUPPORTED_PAYMENT_METHODS.contains(paymentMethodType) -> {
+                Logger.d(TAG, "onPaymentMethodSelected: payment method is supported")
+                protocol.showComponentDialog(dropInViewModel.getPaymentMethod(paymentMethodType))
+            }
+            else -> {
+                Logger.d(TAG, "onPaymentMethodSelected: unidentified payment method, sending payment in case of redirect")
+                sendPayment(paymentMethodType)
+            }
+        }
+    }
+
+    private fun sendPayment(type: String) {
+        val paymentComponentData = PaymentComponentData<PaymentMethodDetails>()
+        paymentComponentData.paymentMethod = GenericPaymentMethod(type)
+        val paymentComponentState = GenericComponentState(paymentComponentData, true, true)
+        protocol.requestPaymentsCall(paymentComponentState)
+    }
+}

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInActivity.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInActivity.kt
@@ -92,7 +92,7 @@ class DropInActivity : AppCompatActivity(), DropInBottomSheetDialogFragment.Prot
 
     private val googlePayErrorObserver: Observer<ComponentError> = Observer {
         Logger.d(TAG, "GooglePay error - ${it?.errorMessage}")
-        if (dropInViewModel.hasOnlyOnePaymentMethod()) {
+        if (dropInViewModel.skipPaymentMethodDialog()) {
             terminateWithError(it.errorMessage)
         } else {
             showPaymentMethodsDialog()
@@ -156,8 +156,8 @@ class DropInActivity : AppCompatActivity(), DropInBottomSheetDialogFragment.Prot
         paymentSelectionHandler = PaymentSelectionHandler(dropInViewModel, this)
 
         if (noDialogPresent()) {
-            if (dropInViewModel.hasOnlyOnePaymentMethod()) {
-                val paymentMethodType = dropInViewModel.getOnlyOnePaymentMethodType()
+            if (dropInViewModel.skipPaymentMethodDialog()) {
+                val paymentMethodType = dropInViewModel.getOneAndOnlyPaymentMethodType()
                 paymentSelectionHandler.handlePaymentSelection(paymentMethodType)
             } else {
                 if (dropInViewModel.showPreselectedStored) {

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInViewModel.kt
@@ -36,13 +36,17 @@ class DropInViewModel(
         return paymentMethodsApiResponse.paymentMethods?.firstOrNull { it.type == type } ?: PaymentMethod()
     }
 
-    fun hasOnlyOnePaymentMethod(): Boolean {
+    fun skipPaymentMethodDialog(): Boolean {
+        return dropInConfiguration.skipPaymentMethodsDialogWhenOnlyOnePaymentMethodIsAvailable && hasOnlyOnePaymentMethod()
+    }
+
+    private fun hasOnlyOnePaymentMethod(): Boolean {
         val paymentMethodsSize = paymentMethodsApiResponse.paymentMethods?.size ?: 0
         val storedPaymentMethodsSize = paymentMethodsApiResponse.storedPaymentMethods?.size ?: 0
         return paymentMethodsSize + storedPaymentMethodsSize == 1
     }
 
-    fun getOnlyOnePaymentMethodType(): String {
+    fun getOneAndOnlyPaymentMethodType(): String {
         if (!hasOnlyOnePaymentMethod()) {
             return ""
         }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInViewModel.kt
@@ -35,4 +35,27 @@ class DropInViewModel(
     fun getPaymentMethod(type: String): PaymentMethod {
         return paymentMethodsApiResponse.paymentMethods?.firstOrNull { it.type == type } ?: PaymentMethod()
     }
+
+    fun hasOnlyOnePaymentMethod(): Boolean {
+        val paymentMethodsSize = paymentMethodsApiResponse.paymentMethods?.size ?: 0
+        val storedPaymentMethodsSize = paymentMethodsApiResponse.storedPaymentMethods?.size ?: 0
+        return paymentMethodsSize + storedPaymentMethodsSize == 1
+    }
+
+    fun getOnlyOnePaymentMethodType(): String {
+        if (!hasOnlyOnePaymentMethod()) {
+            return ""
+        }
+        return when {
+            !paymentMethodsApiResponse.paymentMethods.isNullOrEmpty() -> {
+                paymentMethodsApiResponse.paymentMethods!!.first().type.orEmpty()
+            }
+            !paymentMethodsApiResponse.storedPaymentMethods.isNullOrEmpty() -> {
+                paymentMethodsApiResponse.storedPaymentMethods!!.first().type.orEmpty()
+            }
+            else -> {
+                ""
+            }
+        }
+    }
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
@@ -94,7 +94,11 @@ class ActionComponentDialogFragment : DropInBottomSheetDialogFragment(), Observe
 
     override fun onBackPressed(): Boolean {
         // polling will be canceled by lifecycle event
-        protocol.showPaymentMethodsDialog()
+        if (dropInViewModel.hasOnlyOnePaymentMethod()) {
+            protocol.terminateDropIn()
+        } else {
+            protocol.showPaymentMethodsDialog()
+        }
         return true
     }
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
@@ -94,7 +94,7 @@ class ActionComponentDialogFragment : DropInBottomSheetDialogFragment(), Observe
 
     override fun onBackPressed(): Boolean {
         // polling will be canceled by lifecycle event
-        if (dropInViewModel.hasOnlyOnePaymentMethod()) {
+        if (dropInViewModel.skipPaymentMethodDialog()) {
             protocol.terminateDropIn()
         } else {
             protocol.showPaymentMethodsDialog()

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/base/BaseComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/base/BaseComponentDialogFragment.kt
@@ -138,7 +138,7 @@ abstract class BaseComponentDialogFragment : DropInBottomSheetDialogFragment(), 
 
     override fun onBackPressed(): Boolean {
         Logger.d(TAG, "onBackPressed - $navigatedFromPreselected")
-        if (dropInViewModel.hasOnlyOnePaymentMethod()) {
+        if (dropInViewModel.skipPaymentMethodDialog()) {
             protocol.terminateDropIn()
         } else {
             if (navigatedFromPreselected) {

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/base/BaseComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/base/BaseComponentDialogFragment.kt
@@ -138,10 +138,14 @@ abstract class BaseComponentDialogFragment : DropInBottomSheetDialogFragment(), 
 
     override fun onBackPressed(): Boolean {
         Logger.d(TAG, "onBackPressed - $navigatedFromPreselected")
-        if (navigatedFromPreselected) {
-            protocol.showPreselectedDialog()
+        if (dropInViewModel.hasOnlyOnePaymentMethod()) {
+            protocol.terminateDropIn()
         } else {
-            protocol.showPaymentMethodsDialog()
+            if (navigatedFromPreselected) {
+                protocol.showPreselectedDialog()
+            } else {
+                protocol.showPaymentMethodsDialog()
+            }
         }
         return true
     }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
When there is only one Payment Method available we should skip the PaymentMethodsDialog and go directly to the corresponding input UI for this one Payment Method.

## Tested scenarios
<!-- Description of tested scenarios -->
I mocked the response in the example app of the https://checkout-test.adyen.com/v67/paymentMethods endpoint to return only one payment method. So far it worked with Credit Cards, Google Pay, SEPA and iDEAL. I couldn't test it with a stored payment method.

**Fixed issue**:  <!-- #-prefixed issue number -->
https://github.com/Adyen/adyen-android/issues/205

