### PR TITLE
Skip to Component screen if only 1 available

### DIFF
--- a/checkout-core/src/main/java/com/adyen/checkout/core/api/Environment.java
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/api/Environment.java
@@ -14,7 +14,6 @@ import android.os.Parcelable;
 import androidx.annotation.NonNull;
 
 import com.adyen.checkout.core.exception.CheckoutException;
-import com.adyen.checkout.core.util.ParcelUtils;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -73,7 +72,7 @@ public final class Environment implements Parcelable {
 
     @Override
     public int describeContents() {
-        return ParcelUtils.NO_FILE_DESCRIPTOR;
+        return Parcelable.CONTENTS_FILE_DESCRIPTOR;
     }
 
     @NonNull

--- a/checkout-core/src/main/java/com/adyen/checkout/core/model/ModelObject.java
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/model/ModelObject.java
@@ -14,7 +14,6 @@ import android.os.Parcelable;
 import androidx.annotation.NonNull;
 
 import com.adyen.checkout.core.exception.CheckoutException;
-import com.adyen.checkout.core.util.ParcelUtils;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -34,7 +33,7 @@ public abstract class ModelObject implements Parcelable {
     @SuppressWarnings("PMD.EmptyMethodInAbstractClassShouldBeAbstract")
     @Override
     public final int describeContents() {
-        return ParcelUtils.NO_FILE_DESCRIPTOR;
+        return Parcelable.CONTENTS_FILE_DESCRIPTOR;
     }
 
     /**

--- a/checkout-core/src/main/java/com/adyen/checkout/core/util/ParcelUtils.java
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/util/ParcelUtils.java
@@ -16,8 +16,6 @@ import com.adyen.checkout.core.exception.NoConstructorException;
 
 public final class ParcelUtils {
 
-    public static final int NO_FILE_DESCRIPTOR = 0;
-
     private static final int BOOLEAN_TRUE_VALUE = 1;
     private static final int BOOLEAN_FALSE_VALUE = 0;
 

--- a/components-core/src/main/java/com/adyen/checkout/components/analytics/AnalyticEvent.java
+++ b/components-core/src/main/java/com/adyen/checkout/components/analytics/AnalyticEvent.java
@@ -20,7 +20,6 @@ import androidx.annotation.NonNull;
 import com.adyen.checkout.components.BuildConfig;
 import com.adyen.checkout.core.exception.CheckoutException;
 import com.adyen.checkout.core.util.LocaleUtil;
-import com.adyen.checkout.core.util.ParcelUtils;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -152,7 +151,7 @@ public class AnalyticEvent implements Parcelable {
 
     @Override
     public int describeContents() {
-        return ParcelUtils.NO_FILE_DESCRIPTOR;
+        return Parcelable.CONTENTS_FILE_DESCRIPTOR;
     }
 
     @Override

--- a/components-core/src/main/java/com/adyen/checkout/components/api/LogoApi.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/api/LogoApi.kt
@@ -15,8 +15,7 @@ import com.adyen.checkout.core.api.Environment
 import com.adyen.checkout.core.api.ThreadManager
 import com.adyen.checkout.core.log.LogUtil
 import com.adyen.checkout.core.log.Logger
-import java.util.HashMap
-import java.util.Locale
+import java.util.*
 
 class LogoApi(host: String, displayMetrics: DisplayMetrics) {
     companion object {
@@ -194,7 +193,7 @@ class LogoApi(host: String, displayMetrics: DisplayMetrics) {
         LARGE;
 
         override fun toString(): String {
-            return name.toLowerCase(Locale.ROOT)
+            return name.lowercase()
         }
     }
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/base/Configuration.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/base/Configuration.kt
@@ -3,7 +3,6 @@ package com.adyen.checkout.components.base
 import android.os.Parcel
 import android.os.Parcelable
 import com.adyen.checkout.core.api.Environment
-import com.adyen.checkout.core.util.ParcelUtils
 import java.util.*
 
 abstract class Configuration protected constructor(
@@ -25,6 +24,6 @@ abstract class Configuration protected constructor(
     }
 
     override fun describeContents(): Int {
-        return ParcelUtils.NO_FILE_DESCRIPTOR
+        return Parcelable.CONTENTS_FILE_DESCRIPTOR
     }
 }

--- a/cse/src/main/java/com/adyen/checkout/cse/EncryptedCard.java
+++ b/cse/src/main/java/com/adyen/checkout/cse/EncryptedCard.java
@@ -14,8 +14,6 @@ import android.os.Parcelable;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.adyen.checkout.core.util.ParcelUtils;
-
 public final class EncryptedCard implements Parcelable {
 
     @NonNull
@@ -57,7 +55,7 @@ public final class EncryptedCard implements Parcelable {
 
     @Override
     public int describeContents() {
-        return ParcelUtils.NO_FILE_DESCRIPTOR;
+        return Parcelable.CONTENTS_FILE_DESCRIPTOR;
     }
 
     @Override

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
@@ -58,6 +58,7 @@ class DropInConfiguration : Configuration, Parcelable {
     val serviceComponentName: ComponentName
     val amount: Amount
     val showPreselectedStoredPaymentMethod: Boolean
+    val skipListWhenSinglePaymentMethod: Boolean
 
     companion object {
         @JvmField
@@ -76,6 +77,7 @@ class DropInConfiguration : Configuration, Parcelable {
         this.serviceComponentName = builder.serviceComponentName
         this.amount = builder.amount
         this.showPreselectedStoredPaymentMethod = builder.showPreselectedStoredPaymentMethod
+        this.skipListWhenSinglePaymentMethod = builder.skipListWhenSinglePaymentMethod
     }
 
     constructor(parcel: Parcel) : super(parcel) {
@@ -86,6 +88,7 @@ class DropInConfiguration : Configuration, Parcelable {
         serviceComponentName = parcel.readParcelable(ComponentName::class.java.classLoader)!!
         amount = Amount.CREATOR.createFromParcel(parcel)
         showPreselectedStoredPaymentMethod = ParcelUtils.readBoolean(parcel)
+        skipListWhenSinglePaymentMethod = ParcelUtils.readBoolean(parcel)
     }
 
     override fun writeToParcel(dest: Parcel, flags: Int) {
@@ -95,6 +98,7 @@ class DropInConfiguration : Configuration, Parcelable {
         dest.writeParcelable(serviceComponentName, flags)
         JsonUtils.writeToParcel(dest, Amount.SERIALIZER.serialize(amount))
         ParcelUtils.writeBoolean(dest, showPreselectedStoredPaymentMethod)
+        ParcelUtils.writeBoolean(dest, skipListWhenSinglePaymentMethod)
     }
 
     override fun describeContents(): Int {
@@ -151,6 +155,8 @@ class DropInConfiguration : Configuration, Parcelable {
         var amount: Amount = Amount.EMPTY
             private set
         var showPreselectedStoredPaymentMethod: Boolean = true
+            private set
+        var skipListWhenSinglePaymentMethod: Boolean = true
             private set
 
         private val packageName: String
@@ -221,8 +227,19 @@ class DropInConfiguration : Configuration, Parcelable {
             return this
         }
 
+        /**
+         * When set to false, Drop-in will skip the preselected screen and go straight to the payment methods list.
+         */
         fun setShowPreselectedStoredPaymentMethod(showStoredPaymentMethod: Boolean): Builder {
             this.showPreselectedStoredPaymentMethod = showStoredPaymentMethod
+            return this
+        }
+
+        /**
+         * When set to false, Drop-in will show the payment methods list even when there is only one payment method available.
+         */
+        fun setSkipListWhenSinglePaymentMethod(skipListWhenSinglePaymentMethod: Boolean): Builder {
+            this.skipListWhenSinglePaymentMethod = skipListWhenSinglePaymentMethod
             return this
         }
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
@@ -101,10 +101,6 @@ class DropInConfiguration : Configuration, Parcelable {
         ParcelUtils.writeBoolean(dest, skipListWhenSinglePaymentMethod)
     }
 
-    override fun describeContents(): Int {
-        return ParcelUtils.NO_FILE_DESCRIPTOR
-    }
-
     internal fun <T : Configuration> getConfigurationForPaymentMethodOrNull(paymentMethod: String): T? {
         return try {
             getConfigurationForPaymentMethod(paymentMethod)

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInActivity.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInActivity.kt
@@ -151,10 +151,15 @@ class DropInActivity : AppCompatActivity(), DropInBottomSheetDialogFragment.Prot
         }
 
         if (noDialogPresent()) {
-            if (dropInViewModel.showPreselectedStored) {
-                showPreselectedDialog()
-            } else {
-                showPaymentMethodsDialog()
+            when {
+                dropInViewModel.shouldSkipToSinglePaymentMethod() -> {
+                    val firstPaymentMethod = dropInViewModel.paymentMethodsApiResponse.paymentMethods?.get(0)
+                    if (firstPaymentMethod != null) {
+                        showComponentDialog(firstPaymentMethod)
+                    }
+                }
+                dropInViewModel.showPreselectedStored -> showPreselectedDialog()
+                else -> showPaymentMethodsDialog()
             }
         }
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInActivity.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInActivity.kt
@@ -30,6 +30,7 @@ import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.model.paymentmethods.StoredPaymentMethod
 import com.adyen.checkout.components.model.payments.response.Action
 import com.adyen.checkout.components.util.PaymentMethodTypes
+import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.core.log.LogUtil
 import com.adyen.checkout.core.log.Logger
 import com.adyen.checkout.core.util.LocaleUtil
@@ -153,9 +154,11 @@ class DropInActivity : AppCompatActivity(), DropInBottomSheetDialogFragment.Prot
         if (noDialogPresent()) {
             when {
                 dropInViewModel.shouldSkipToSinglePaymentMethod() -> {
-                    val firstPaymentMethod = dropInViewModel.paymentMethodsApiResponse.paymentMethods?.get(0)
+                    val firstPaymentMethod = dropInViewModel.paymentMethodsApiResponse.paymentMethods?.firstOrNull()
                     if (firstPaymentMethod != null) {
                         showComponentDialog(firstPaymentMethod)
+                    } else {
+                        throw CheckoutException("First payment method is null")
                     }
                 }
                 dropInViewModel.showPreselectedStored -> showPreselectedDialog()

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInViewModel.kt
@@ -14,6 +14,7 @@ import com.adyen.checkout.components.model.PaymentMethodsApiResponse
 import com.adyen.checkout.components.model.paymentmethods.StoredPaymentMethod
 import com.adyen.checkout.components.util.PaymentMethodTypes
 import com.adyen.checkout.dropin.DropInConfiguration
+import com.adyen.checkout.googlepay.GooglePayComponent
 
 class DropInViewModel(
     val paymentMethodsApiResponse: PaymentMethodsApiResponse,
@@ -29,5 +30,16 @@ class DropInViewModel(
 
     fun getStoredPaymentMethod(id: String): StoredPaymentMethod {
         return paymentMethodsApiResponse.storedPaymentMethods?.firstOrNull { it.id == id } ?: StoredPaymentMethod()
+    }
+
+    fun shouldSkipToSinglePaymentMethod(): Boolean {
+        val noStored = paymentMethodsApiResponse.storedPaymentMethods.isNullOrEmpty()
+        val singlePm = paymentMethodsApiResponse.paymentMethods?.size == 1
+
+        val firstPaymentMethod = paymentMethodsApiResponse.paymentMethods?.get(0)
+        val paymentMethodHasComponent = PaymentMethodTypes.SUPPORTED_PAYMENT_METHODS.contains(firstPaymentMethod?.type) &&
+                !GooglePayComponent.PAYMENT_METHOD_TYPES.contains(firstPaymentMethod?.type)
+
+        return noStored && singlePm && paymentMethodHasComponent
     }
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInViewModel.kt
@@ -40,6 +40,6 @@ class DropInViewModel(
         val paymentMethodHasComponent = PaymentMethodTypes.SUPPORTED_PAYMENT_METHODS.contains(firstPaymentMethod?.type) &&
                 !GooglePayComponent.PAYMENT_METHOD_TYPES.contains(firstPaymentMethod?.type)
 
-        return noStored && singlePm && paymentMethodHasComponent
+        return noStored && singlePm && paymentMethodHasComponent && dropInConfiguration.skipListWhenSinglePaymentMethod
     }
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInViewModel.kt
@@ -38,7 +38,7 @@ class DropInViewModel(
 
         val firstPaymentMethod = paymentMethodsApiResponse.paymentMethods?.get(0)
         val paymentMethodHasComponent = PaymentMethodTypes.SUPPORTED_PAYMENT_METHODS.contains(firstPaymentMethod?.type) &&
-                !GooglePayComponent.PAYMENT_METHOD_TYPES.contains(firstPaymentMethod?.type)
+            !GooglePayComponent.PAYMENT_METHOD_TYPES.contains(firstPaymentMethod?.type)
 
         return noStored && singlePm && paymentMethodHasComponent && dropInConfiguration.skipListWhenSinglePaymentMethod
     }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInViewModel.kt
@@ -36,9 +36,10 @@ class DropInViewModel(
         val noStored = paymentMethodsApiResponse.storedPaymentMethods.isNullOrEmpty()
         val singlePm = paymentMethodsApiResponse.paymentMethods?.size == 1
 
-        val firstPaymentMethod = paymentMethodsApiResponse.paymentMethods?.get(0)
+        val firstPaymentMethod = paymentMethodsApiResponse.paymentMethods?.firstOrNull()
         val paymentMethodHasComponent = PaymentMethodTypes.SUPPORTED_PAYMENT_METHODS.contains(firstPaymentMethod?.type) &&
-            !GooglePayComponent.PAYMENT_METHOD_TYPES.contains(firstPaymentMethod?.type)
+            !GooglePayComponent.PAYMENT_METHOD_TYPES.contains(firstPaymentMethod?.type) &&
+            !PaymentMethodTypes.SUPPORTED_ACTION_ONLY_PAYMENT_METHODS.contains(firstPaymentMethod?.type)
 
         return noStored && singlePm && paymentMethodHasComponent && dropInConfiguration.skipListWhenSinglePaymentMethod
     }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
@@ -94,7 +94,11 @@ class ActionComponentDialogFragment : DropInBottomSheetDialogFragment(), Observe
 
     override fun onBackPressed(): Boolean {
         // polling will be canceled by lifecycle event
-        protocol.showPaymentMethodsDialog()
+        if (dropInViewModel.shouldSkipToSinglePaymentMethod()) {
+            protocol.terminateDropIn()
+        } else {
+            protocol.showPaymentMethodsDialog()
+        }
         return true
     }
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/base/BaseComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/base/BaseComponentDialogFragment.kt
@@ -138,10 +138,11 @@ abstract class BaseComponentDialogFragment : DropInBottomSheetDialogFragment(), 
 
     override fun onBackPressed(): Boolean {
         Logger.d(TAG, "onBackPressed - $navigatedFromPreselected")
-        if (navigatedFromPreselected) {
-            protocol.showPreselectedDialog()
-        } else {
-            protocol.showPaymentMethodsDialog()
+
+        when {
+            navigatedFromPreselected -> protocol.showPreselectedDialog()
+            dropInViewModel.shouldSkipToSinglePaymentMethod() -> protocol.terminateDropIn()
+            else -> protocol.showPaymentMethodsDialog()
         }
         return true
     }


### PR DESCRIPTION
If there is only 1 available payment method, and it has a Component, the Drop-in will skip to the Component screen instead of showing the payment methods list.

Merchant can choose to disable this behavior in the DropInConfiguration