### PR TITLE
Include `LIVE` in Environment values

### DIFF
--- a/checkout-core/src/main/java/com/adyen/checkout/core/api/Environment.java
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/api/Environment.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 public final class Environment implements Parcelable {
 
     public static final Environment TEST;
+    public static final Environment LIVE;
     public static final Environment EUROPE;
     public static final Environment UNITED_STATES;
     public static final Environment AUSTRALIA;
@@ -49,6 +50,7 @@ public final class Environment implements Parcelable {
             EUROPE = new Environment(new URL("https://checkoutshopper-live.adyen.com/checkoutshopper/"));
             UNITED_STATES = new Environment(new URL("https://checkoutshopper-live-us.adyen.com/checkoutshopper/"));
             AUSTRALIA = new Environment(new URL("https://checkoutshopper-live-au.adyen.com/checkoutshopper/"));
+            LIVE = EUROPE;
         } catch (MalformedURLException e) {
             throw new CheckoutException("Failed to parse Environment URL.", e);
         }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

Add `LIVE` value to Environment. 

This is identical to the EUROPE value but makes it clearer that a region specfic endpoint is not necessary. 

Brings the Android SDK in line with the iOS one https://github.com/Adyen/adyen-ios/blob/95f158b88630f023b9f3dc71766b53fe9b17477d/Adyen/Core/APIClient/Environment.swift

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
