### PR TITLE
Reload Google Pay component in drop-in

### DIFF
--- a/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponent.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponent.kt
@@ -17,8 +17,6 @@ import com.adyen.checkout.components.model.payments.request.BacsDirectDebitPayme
 import com.adyen.checkout.components.model.payments.request.PaymentComponentData
 import com.adyen.checkout.components.util.PaymentMethodTypes
 
-private val PAYMENT_METHOD_TYPES = arrayOf(PaymentMethodTypes.BACS)
-
 class BacsDirectDebitComponent(
     savedStateHandle: SavedStateHandle,
     paymentMethodDelegate: GenericPaymentMethodDelegate,
@@ -76,5 +74,6 @@ class BacsDirectDebitComponent(
         @JvmStatic
         val PROVIDER: PaymentComponentProvider<BacsDirectDebitComponent, BacsDirectDebitConfiguration> =
             GenericPaymentComponentProvider(BacsDirectDebitComponent::class.java)
+        val PAYMENT_METHOD_TYPES = arrayOf(PaymentMethodTypes.BACS)
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponent.kt
@@ -39,7 +39,7 @@ import kotlinx.coroutines.launch
 
 private val TAG = LogUtil.getTag()
 
-private val PAYMENT_METHOD_TYPES = arrayOf(PaymentMethodTypes.SCHEME)
+
 private const val BIN_VALUE_LENGTH = 6
 private const val LAST_FOUR_LENGTH = 4
 private const val SINGLE_CARD_LIST_SIZE = 1
@@ -434,5 +434,6 @@ class CardComponent private constructor(
     companion object {
         @JvmStatic
         val PROVIDER: StoredPaymentComponentProvider<CardComponent, CardConfiguration> = CardComponentProvider()
+        val PAYMENT_METHOD_TYPES = arrayOf(PaymentMethodTypes.SCHEME)
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponent.kt
@@ -39,7 +39,6 @@ import kotlinx.coroutines.launch
 
 private val TAG = LogUtil.getTag()
 
-
 private const val BIN_VALUE_LENGTH = 6
 private const val LAST_FOUR_LENGTH = 4
 private const val SINGLE_CARD_LIST_SIZE = 1

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInActivity.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInActivity.kt
@@ -63,6 +63,9 @@ import com.adyen.checkout.dropin.ui.giftcard.GiftCardPaymentConfirmationData
 import com.adyen.checkout.dropin.ui.giftcard.GiftCardPaymentConfirmationDialogFragment
 import com.adyen.checkout.dropin.ui.paymentmethods.PaymentMethodListDialogFragment
 import com.adyen.checkout.dropin.ui.stored.PreselectedStoredPaymentMethodFragment
+import com.adyen.checkout.dropin.ui.viewmodel.DropInActivityEvent
+import com.adyen.checkout.dropin.ui.viewmodel.DropInViewModel
+import com.adyen.checkout.dropin.ui.viewmodel.DropInViewModelFactory
 import com.adyen.checkout.giftcard.GiftCardComponent
 import com.adyen.checkout.giftcard.GiftCardComponentState
 import com.adyen.checkout.googlepay.GooglePayComponent

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInActivity.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInActivity.kt
@@ -22,6 +22,8 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.lifecycleScope
+import com.adyen.checkout.bacs.BacsDirectDebitComponent
+import com.adyen.checkout.card.CardComponent
 import com.adyen.checkout.components.ActionComponentData
 import com.adyen.checkout.components.ComponentError
 import com.adyen.checkout.components.PaymentComponentState
@@ -34,7 +36,6 @@ import com.adyen.checkout.components.model.payments.request.OrderRequest
 import com.adyen.checkout.components.model.payments.response.Action
 import com.adyen.checkout.components.model.payments.response.BalanceResult
 import com.adyen.checkout.components.model.payments.response.OrderResponse
-import com.adyen.checkout.components.util.PaymentMethodTypes
 import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.core.log.LogUtil
 import com.adyen.checkout.core.log.Logger
@@ -62,6 +63,7 @@ import com.adyen.checkout.dropin.ui.giftcard.GiftCardPaymentConfirmationData
 import com.adyen.checkout.dropin.ui.giftcard.GiftCardPaymentConfirmationDialogFragment
 import com.adyen.checkout.dropin.ui.paymentmethods.PaymentMethodListDialogFragment
 import com.adyen.checkout.dropin.ui.stored.PreselectedStoredPaymentMethodFragment
+import com.adyen.checkout.giftcard.GiftCardComponent
 import com.adyen.checkout.giftcard.GiftCardComponentState
 import com.adyen.checkout.googlepay.GooglePayComponent
 import com.adyen.checkout.googlepay.GooglePayComponentState
@@ -370,10 +372,10 @@ class DropInActivity : AppCompatActivity(), DropInBottomSheetDialogFragment.Prot
     override fun showStoredComponentDialog(storedPaymentMethod: StoredPaymentMethod, fromPreselected: Boolean) {
         Logger.d(TAG, "showStoredComponentDialog")
         hideAllScreens()
-        val dialogFragment = when (storedPaymentMethod.type) {
-            PaymentMethodTypes.SCHEME -> CardComponentDialogFragment
+        val dialogFragment = when {
+            CardComponent.PAYMENT_METHOD_TYPES.contains(storedPaymentMethod.type) -> CardComponentDialogFragment
             else -> GenericComponentDialogFragment
-        }.newInstance(storedPaymentMethod, dropInViewModel.dropInConfiguration, fromPreselected)
+        }.newInstance(storedPaymentMethod, fromPreselected)
 
         dialogFragment.show(supportFragmentManager, COMPONENT_FRAGMENT_TAG)
     }
@@ -381,12 +383,12 @@ class DropInActivity : AppCompatActivity(), DropInBottomSheetDialogFragment.Prot
     override fun showComponentDialog(paymentMethod: PaymentMethod) {
         Logger.d(TAG, "showComponentDialog")
         hideAllScreens()
-        val dialogFragment = when (paymentMethod.type) {
-            PaymentMethodTypes.SCHEME -> CardComponentDialogFragment
-            PaymentMethodTypes.BACS -> BacsDirectDebitDialogFragment
-            PaymentMethodTypes.GIFTCARD -> GiftCardComponentDialogFragment
-            else -> GenericComponentDialogFragment
-        }.newInstance(paymentMethod, dropInViewModel.dropInConfiguration)
+        val dialogFragment = when {
+            CardComponent.PAYMENT_METHOD_TYPES.contains(paymentMethod.type) -> CardComponentDialogFragment.newInstance(paymentMethod)
+            BacsDirectDebitComponent.PAYMENT_METHOD_TYPES.contains(paymentMethod.type) -> BacsDirectDebitDialogFragment.newInstance(paymentMethod)
+            GiftCardComponent.PAYMENT_METHOD_TYPES.contains(paymentMethod.type) -> GiftCardComponentDialogFragment.newInstance(paymentMethod)
+            else -> GenericComponentDialogFragment.newInstance(paymentMethod)
+        }
 
         dialogFragment.show(supportFragmentManager, COMPONENT_FRAGMENT_TAG)
     }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/base/BaseComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/base/BaseComponentDialogFragment.kt
@@ -27,8 +27,8 @@ import com.adyen.checkout.core.log.LogUtil
 import com.adyen.checkout.core.log.Logger
 import com.adyen.checkout.dropin.R
 import com.adyen.checkout.dropin.getComponentFor
-import com.adyen.checkout.dropin.ui.ComponentDialogViewModel
-import com.adyen.checkout.dropin.ui.ComponentFragmentState
+import com.adyen.checkout.dropin.ui.viewmodel.ComponentDialogViewModel
+import com.adyen.checkout.dropin.ui.viewmodel.ComponentFragmentState
 
 private const val STORED_PAYMENT_METHOD = "STORED_PAYMENT_METHOD"
 private const val NAVIGATED_FROM_PRESELECTED = "NAVIGATED_FROM_PRESELECTED"

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/base/DropInBottomSheetDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/base/DropInBottomSheetDialogFragment.kt
@@ -23,7 +23,6 @@ import com.adyen.checkout.core.log.Logger
 import com.adyen.checkout.dropin.R
 import com.adyen.checkout.dropin.ui.viewmodel.DropInViewModel
 import com.adyen.checkout.giftcard.GiftCardComponentState
-import com.adyen.checkout.googlepay.GooglePayConfiguration
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/base/DropInBottomSheetDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/base/DropInBottomSheetDialogFragment.kt
@@ -101,7 +101,6 @@ abstract class DropInBottomSheetDialogFragment : BottomSheetDialogFragment() {
         fun requestDetailsCall(actionComponentData: ActionComponentData)
         fun showError(errorMessage: String, reason: String, terminate: Boolean)
         fun terminateDropIn()
-        fun startGooglePay(paymentMethod: PaymentMethod, googlePayConfiguration: GooglePayConfiguration)
         fun requestBalanceCall(giftCardComponentState: GiftCardComponentState)
         fun requestPartialPayment()
         fun requestOrderCancellation()

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/base/DropInBottomSheetDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/base/DropInBottomSheetDialogFragment.kt
@@ -21,7 +21,7 @@ import com.adyen.checkout.components.model.paymentmethods.StoredPaymentMethod
 import com.adyen.checkout.core.log.LogUtil
 import com.adyen.checkout.core.log.Logger
 import com.adyen.checkout.dropin.R
-import com.adyen.checkout.dropin.ui.DropInViewModel
+import com.adyen.checkout.dropin.ui.viewmodel.DropInViewModel
 import com.adyen.checkout.giftcard.GiftCardComponentState
 import com.adyen.checkout.googlepay.GooglePayConfiguration
 import com.google.android.material.bottomsheet.BottomSheetBehavior

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/CardComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/CardComponentDialogFragment.kt
@@ -69,7 +69,7 @@ class CardComponentDialogFragment : BaseComponentDialogFragment() {
         val cardComponent = component as CardComponent
 
         if (!dropInViewModel.amount.isEmpty) {
-            val value = CurrencyUtils.formatAmount(dropInViewModel.amount, dropInConfiguration.shopperLocale)
+            val value = CurrencyUtils.formatAmount(dropInViewModel.amount, dropInViewModel.dropInConfiguration.shopperLocale)
             binding.payButton.text = String.format(resources.getString(R.string.pay_button_with_value), value)
         }
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/GenericComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/GenericComponentDialogFragment.kt
@@ -61,7 +61,7 @@ class GenericComponentDialogFragment : BaseComponentDialogFragment() {
         binding.header.text = paymentMethod.name
 
         if (!dropInViewModel.amount.isEmpty) {
-            val value = CurrencyUtils.formatAmount(dropInViewModel.amount, dropInConfiguration.shopperLocale)
+            val value = CurrencyUtils.formatAmount(dropInViewModel.amount, dropInViewModel.dropInConfiguration.shopperLocale)
             binding.payButton.text = String.format(resources.getString(R.string.pay_button_with_value), value)
         }
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/GooglePayComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/GooglePayComponentDialogFragment.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.flow.collect
 private const val NAVIGATED_FROM_PRESELECTED = "NAVIGATED_FROM_PRESELECTED"
 private const val PAYMENT_METHOD = "PAYMENT_METHOD"
 
+@Suppress("TooManyFunctions")
 class GooglePayComponentDialogFragment : DropInBottomSheetDialogFragment(), Observer<GooglePayComponentState> {
 
     companion object {

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/GooglePayComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/GooglePayComponentDialogFragment.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 11/1/2022.
+ */
+
+package com.adyen.checkout.dropin.ui.component
+
+import android.content.DialogInterface
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Observer
+import androidx.lifecycle.lifecycleScope
+import com.adyen.checkout.components.ComponentError
+import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
+import com.adyen.checkout.core.exception.CheckoutException
+import com.adyen.checkout.core.log.LogUtil
+import com.adyen.checkout.core.log.Logger
+import com.adyen.checkout.dropin.R
+import com.adyen.checkout.dropin.getComponentFor
+import com.adyen.checkout.dropin.ui.GOOGLE_PAY_REQUEST_CODE
+import com.adyen.checkout.dropin.ui.base.DropInBottomSheetDialogFragment
+import com.adyen.checkout.dropin.ui.viewmodel.GooglePayFragmentEvent
+import com.adyen.checkout.dropin.ui.viewmodel.GooglePayViewModel
+import com.adyen.checkout.googlepay.GooglePayComponent
+import com.adyen.checkout.googlepay.GooglePayComponentState
+import kotlinx.coroutines.flow.collect
+
+private const val NAVIGATED_FROM_PRESELECTED = "NAVIGATED_FROM_PRESELECTED"
+private const val PAYMENT_METHOD = "PAYMENT_METHOD"
+
+class GooglePayComponentDialogFragment : DropInBottomSheetDialogFragment(), Observer<GooglePayComponentState> {
+
+    companion object {
+        private val TAG = LogUtil.getTag()
+
+        fun newInstance(
+            paymentMethod: PaymentMethod
+        ): GooglePayComponentDialogFragment {
+            val args = Bundle()
+            args.putParcelable(PAYMENT_METHOD, paymentMethod)
+
+            return GooglePayComponentDialogFragment().apply {
+                arguments = args
+            }
+        }
+    }
+
+    private val googlePayViewModel: GooglePayViewModel by viewModels()
+
+    private lateinit var paymentMethod: PaymentMethod
+    private lateinit var component: GooglePayComponent
+    private var navigatedFromPreselected = false
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        Logger.d(TAG, "onCreateView")
+        return inflater.inflate(R.layout.fragment_google_pay_component, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        Logger.d(TAG, "onViewCreated")
+        component.observe(viewLifecycleOwner, this)
+        component.observeErrors(viewLifecycleOwner, createErrorHandlerObserver())
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        Logger.d(TAG, "onCreate")
+        super.onCreate(savedInstanceState)
+        arguments?.let {
+            paymentMethod = it.getParcelable(PAYMENT_METHOD) ?: throw IllegalArgumentException("Payment method is null")
+            navigatedFromPreselected = it.getBoolean(NAVIGATED_FROM_PRESELECTED, false)
+        }
+
+        try {
+            component = getComponentFor(this, paymentMethod, dropInViewModel.dropInConfiguration, dropInViewModel.amount) as GooglePayComponent
+        } catch (e: CheckoutException) {
+            handleError(ComponentError(e))
+            return
+        } catch (e: ClassCastException) {
+            throw CheckoutException("Component is not GooglePayComponent")
+        }
+        lifecycleScope.launchWhenStarted {
+            googlePayViewModel.fragmentLoaded()
+            googlePayViewModel.eventsFlow.collect { handleEvent(it) }
+        }
+    }
+
+    private fun handleEvent(event: GooglePayFragmentEvent) {
+        when (event) {
+            is GooglePayFragmentEvent.StartGooglePay -> {
+                component.startGooglePayScreen(requireActivity(), GOOGLE_PAY_REQUEST_CODE)
+            }
+        }
+    }
+
+    override fun onBackPressed(): Boolean {
+        Logger.d(TAG, "onBackPressed - $navigatedFromPreselected")
+        return performBackAction()
+    }
+
+    override fun onCancel(dialog: DialogInterface) {
+        super.onCancel(dialog)
+        Logger.d(TAG, "onCancel")
+        protocol.terminateDropIn()
+    }
+
+    private fun createErrorHandlerObserver(): Observer<ComponentError> {
+        return Observer {
+            if (it != null) {
+                Logger.e(TAG, "ComponentError", it.exception)
+                handleError(it)
+            }
+        }
+    }
+
+    private fun handleError(componentError: ComponentError) {
+        Logger.e(TAG, componentError.errorMessage)
+        // TODO find a way to show an error dialog unless the payment is cancelled by the user
+        //  then move back to the payment methods screen afterwards
+        performBackAction()
+    }
+
+    private fun performBackAction(): Boolean {
+        when {
+            navigatedFromPreselected -> protocol.showPreselectedDialog()
+            dropInViewModel.shouldSkipToSinglePaymentMethod() -> protocol.terminateDropIn()
+            else -> protocol.showPaymentMethodsDialog()
+        }
+        return true
+    }
+
+    override fun onChanged(state: GooglePayComponentState?) {
+        if (state?.isValid == true) {
+            protocol.requestPaymentsCall(state)
+        }
+    }
+
+    fun handleActivityResult(resultCode: Int, data: Intent?) {
+        component.handleActivityResult(resultCode, data)
+    }
+}

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/paymentmethods/PaymentMethodListDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/paymentmethods/PaymentMethodListDialogFragment.kt
@@ -34,6 +34,7 @@ import com.adyen.checkout.dropin.R
 import com.adyen.checkout.dropin.getConfigurationForPaymentMethod
 import com.adyen.checkout.dropin.ui.base.DropInBottomSheetDialogFragment
 import com.adyen.checkout.dropin.ui.getViewModel
+import com.adyen.checkout.dropin.ui.viewmodel.PaymentMethodsListViewModel
 import com.adyen.checkout.googlepay.GooglePayComponent
 
 private val TAG = LogUtil.getTag()

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/paymentmethods/PaymentMethodListDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/paymentmethods/PaymentMethodListDialogFragment.kt
@@ -31,11 +31,9 @@ import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.core.log.LogUtil
 import com.adyen.checkout.core.log.Logger
 import com.adyen.checkout.dropin.R
-import com.adyen.checkout.dropin.getConfigurationForPaymentMethod
 import com.adyen.checkout.dropin.ui.base.DropInBottomSheetDialogFragment
 import com.adyen.checkout.dropin.ui.getViewModel
 import com.adyen.checkout.dropin.ui.viewmodel.PaymentMethodsListViewModel
-import com.adyen.checkout.googlepay.GooglePayComponent
 
 private val TAG = LogUtil.getTag()
 
@@ -127,13 +125,6 @@ class PaymentMethodListDialogFragment :
 
         // Check some specific payment methods that don't need to show a view
         when {
-            GooglePayComponent.PAYMENT_METHOD_TYPES.contains(paymentMethod.type) -> {
-                Logger.d(TAG, "onPaymentMethodSelected: starting Google Pay")
-                protocol.startGooglePay(
-                    paymentMethodsListViewModel.getPaymentMethod(paymentMethod),
-                    getConfigurationForPaymentMethod(paymentMethod.type, dropInViewModel.dropInConfiguration, dropInViewModel.amount)
-                )
-            }
             PaymentMethodTypes.SUPPORTED_ACTION_ONLY_PAYMENT_METHODS.contains(paymentMethod.type) -> {
                 Logger.d(TAG, "onPaymentMethodSelected: payment method does not need a component, sending payment")
                 sendPayment(paymentMethod.type)

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/stored/PreselectedStoredPaymentMethodFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/stored/PreselectedStoredPaymentMethodFragment.kt
@@ -34,11 +34,12 @@ import com.adyen.checkout.dropin.getComponentFor
 import com.adyen.checkout.dropin.ui.base.DropInBottomSheetDialogFragment
 import com.adyen.checkout.dropin.ui.paymentmethods.GenericStoredModel
 import com.adyen.checkout.dropin.ui.paymentmethods.StoredCardModel
-import com.adyen.checkout.dropin.ui.stored.PreselectedStoredState.AwaitingComponentInitialization
-import com.adyen.checkout.dropin.ui.stored.PreselectedStoredState.PaymentError
-import com.adyen.checkout.dropin.ui.stored.PreselectedStoredState.RequestPayment
-import com.adyen.checkout.dropin.ui.stored.PreselectedStoredState.ShowStoredPaymentDialog
+import com.adyen.checkout.dropin.ui.viewmodel.PreselectedStoredState.AwaitingComponentInitialization
+import com.adyen.checkout.dropin.ui.viewmodel.PreselectedStoredState.PaymentError
+import com.adyen.checkout.dropin.ui.viewmodel.PreselectedStoredState.RequestPayment
+import com.adyen.checkout.dropin.ui.viewmodel.PreselectedStoredState.ShowStoredPaymentDialog
 import com.adyen.checkout.dropin.ui.viewModelsFactory
+import com.adyen.checkout.dropin.ui.viewmodel.PreselectedStoredPaymentViewModel
 
 private val TAG = LogUtil.getTag()
 private const val STORED_PAYMENT_KEY = "STORED_PAYMENT"

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/viewmodel/ComponentDialogViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/viewmodel/ComponentDialogViewModel.kt
@@ -6,7 +6,7 @@
  * Created by josephj on 18/3/2021.
  */
 
-package com.adyen.checkout.dropin.ui
+package com.adyen.checkout.dropin.ui.viewmodel
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.SavedStateHandle

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/viewmodel/DropInActivityEvent.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/viewmodel/DropInActivityEvent.kt
@@ -6,7 +6,7 @@
  * Created by josephj on 29/11/2021.
  */
 
-package com.adyen.checkout.dropin.ui
+package com.adyen.checkout.dropin.ui.viewmodel
 
 import com.adyen.checkout.components.PaymentComponentState
 import com.adyen.checkout.components.model.payments.request.OrderRequest

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/viewmodel/DropInViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/viewmodel/DropInViewModel.kt
@@ -6,7 +6,7 @@
  * Created by arman on 2/7/2019.
  */
 
-package com.adyen.checkout.dropin.ui
+package com.adyen.checkout.dropin.ui.viewmodel
 
 import android.content.Intent
 import androidx.lifecycle.SavedStateHandle
@@ -30,7 +30,6 @@ import com.adyen.checkout.dropin.R
 import com.adyen.checkout.dropin.ui.giftcard.GiftCardBalanceResult
 import com.adyen.checkout.dropin.ui.giftcard.GiftCardPaymentConfirmationData
 import com.adyen.checkout.dropin.ui.order.OrderModel
-import com.adyen.checkout.dropin.ui.paymentmethods.PaymentMethodsListViewModel
 import com.adyen.checkout.giftcard.GiftCardComponentState
 import com.adyen.checkout.giftcard.util.GiftCardBalanceStatus
 import com.adyen.checkout.giftcard.util.GiftCardBalanceUtils

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/viewmodel/DropInViewModelFactory.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/viewmodel/DropInViewModelFactory.kt
@@ -6,7 +6,7 @@
  * Created by josephj on 29/11/2021.
  */
 
-package com.adyen.checkout.dropin.ui
+package com.adyen.checkout.dropin.ui.viewmodel
 
 import android.os.Bundle
 import androidx.lifecycle.AbstractSavedStateViewModelFactory

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/viewmodel/GooglePayViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/viewmodel/GooglePayViewModel.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 17/1/2022.
+ */
+
+package com.adyen.checkout.dropin.ui.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.adyen.checkout.core.log.LogUtil
+import com.adyen.checkout.core.log.Logger
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+
+class GooglePayViewModel(private val savedStateHandle: SavedStateHandle) : ViewModel() {
+    companion object {
+        private val TAG = LogUtil.getTag()
+        private const val IS_GOOGLE_PAY_STARTED = "IS_GOOGLE_PAY_STARTED"
+    }
+
+    private val eventChannel = Channel<GooglePayFragmentEvent>(Channel.BUFFERED)
+    internal val eventsFlow = eventChannel.receiveAsFlow()
+
+    private var isGooglePayStarted: Boolean
+        get() {
+            return savedStateHandle[IS_GOOGLE_PAY_STARTED] ?: false
+        }
+        set(value) {
+            savedStateHandle[IS_GOOGLE_PAY_STARTED] = value
+        }
+
+    fun fragmentLoaded() {
+        if (isGooglePayStarted) return
+        isGooglePayStarted = true
+        viewModelScope.launch {
+            Logger.d(TAG, "Sending start GooglePay event")
+            eventChannel.send(GooglePayFragmentEvent.StartGooglePay)
+        }
+    }
+}
+
+sealed class GooglePayFragmentEvent {
+    object StartGooglePay : GooglePayFragmentEvent()
+}

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/viewmodel/PaymentMethodsListViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/viewmodel/PaymentMethodsListViewModel.kt
@@ -6,7 +6,7 @@
  * Created by caiof on 30/11/2020.
  */
 
-package com.adyen.checkout.dropin.ui.paymentmethods
+package com.adyen.checkout.dropin.ui.viewmodel
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
@@ -26,6 +26,12 @@ import com.adyen.checkout.dropin.DropInConfiguration
 import com.adyen.checkout.dropin.R
 import com.adyen.checkout.dropin.checkPaymentMethodAvailability
 import com.adyen.checkout.dropin.ui.order.OrderModel
+import com.adyen.checkout.dropin.ui.paymentmethods.GiftCardPaymentMethodModel
+import com.adyen.checkout.dropin.ui.paymentmethods.PaymentMethodHeader
+import com.adyen.checkout.dropin.ui.paymentmethods.PaymentMethodListItem
+import com.adyen.checkout.dropin.ui.paymentmethods.PaymentMethodModel
+import com.adyen.checkout.dropin.ui.paymentmethods.PaymentMethodNote
+import com.adyen.checkout.dropin.ui.paymentmethods.StoredPaymentMethodModel
 import com.adyen.checkout.dropin.ui.stored.makeStoredModel
 
 class PaymentMethodsListViewModel(

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/viewmodel/PreselectedStoredPaymentViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/viewmodel/PreselectedStoredPaymentViewModel.kt
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2020 Adyen N.V.
+ * Copyright (c) 2021 Adyen N.V.
  *
  * This file is open source and available under the MIT license. See the LICENSE file for more info.
  *
- * Created by caiof on 2/12/2020.
+ * Created by josephj on 14/1/2022.
  */
 
-package com.adyen.checkout.dropin.ui.stored
+package com.adyen.checkout.dropin.ui.viewmodel
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -18,11 +18,12 @@ import com.adyen.checkout.components.model.payments.request.PaymentMethodDetails
 import com.adyen.checkout.core.log.LogUtil
 import com.adyen.checkout.core.log.Logger
 import com.adyen.checkout.dropin.ui.paymentmethods.StoredPaymentMethodModel
-import com.adyen.checkout.dropin.ui.stored.PreselectedStoredState.AwaitingComponentInitialization
-import com.adyen.checkout.dropin.ui.stored.PreselectedStoredState.Idle
-import com.adyen.checkout.dropin.ui.stored.PreselectedStoredState.PaymentError
-import com.adyen.checkout.dropin.ui.stored.PreselectedStoredState.RequestPayment
-import com.adyen.checkout.dropin.ui.stored.PreselectedStoredState.ShowStoredPaymentDialog
+import com.adyen.checkout.dropin.ui.stored.makeStoredModel
+import com.adyen.checkout.dropin.ui.viewmodel.PreselectedStoredState.AwaitingComponentInitialization
+import com.adyen.checkout.dropin.ui.viewmodel.PreselectedStoredState.Idle
+import com.adyen.checkout.dropin.ui.viewmodel.PreselectedStoredState.PaymentError
+import com.adyen.checkout.dropin.ui.viewmodel.PreselectedStoredState.RequestPayment
+import com.adyen.checkout.dropin.ui.viewmodel.PreselectedStoredState.ShowStoredPaymentDialog
 
 class PreselectedStoredPaymentViewModel(
     storedPaymentMethod: StoredPaymentMethod,

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/viewmodel/PreselectedStoredPaymentViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/viewmodel/PreselectedStoredPaymentViewModel.kt
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2021 Adyen N.V.
+ * Copyright (c) 2020 Adyen N.V.
  *
  * This file is open source and available under the MIT license. See the LICENSE file for more info.
  *
- * Created by josephj on 14/1/2022.
+ * Created by caiof on 2/12/2020.
  */
 
 package com.adyen.checkout.dropin.ui.viewmodel

--- a/drop-in/src/main/res/layout/fragment_google_pay_component.xml
+++ b/drop-in/src/main/res/layout/fragment_google_pay_component.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2022 Adyen N.V.
+  ~
+  ~ This file is open source and available under the MIT license. See the LICENSE file for more info.
+  ~
+  ~ Created by josephj on 14/1/2022.
+  -->
+
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content" />

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardComponent.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardComponent.kt
@@ -27,8 +27,6 @@ import kotlinx.coroutines.launch
 
 private val TAG = LogUtil.getTag()
 
-private val PAYMENT_METHOD_TYPES = arrayOf(PaymentMethodTypes.GIFTCARD)
-
 private const val LAST_FOUR_LENGTH = 4
 
 /**
@@ -52,6 +50,7 @@ class GiftCardComponent(
     companion object {
         @JvmStatic
         val PROVIDER: PaymentComponentProvider<GiftCardComponent, GiftCardConfiguration> = GiftCardComponentProvider()
+        val PAYMENT_METHOD_TYPES = arrayOf(PaymentMethodTypes.GIFTCARD)
     }
 
     private var publicKey: String? = null


### PR DESCRIPTION
Add the ability to reload the GooglePayComponent with a different configuration in the same drop-in session (e.g. in the gift card flow).
