### PR TITLE
Pass Bundle with additional information to the drop in service

### DIFF
--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropIn.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropIn.kt
@@ -11,6 +11,7 @@ package com.adyen.checkout.dropin
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.os.Bundle
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import androidx.fragment.app.Fragment
@@ -86,11 +87,16 @@ object DropIn {
      * [getDropInResultFromIntent] helper method to get it or you can find it in the intent
      * extras with key [RESULT_KEY].
      *
+     * When additional data is needed in the DropInService use the [additionalDataForDropInService]
+     * bundle. This bundle will be passed to the DropInService methods onPaymentsCallRequested and
+     * onDetailsCallRequested.
+     *
      * @param activity An activity to start the Checkout flow.
      * @param dropInLauncher A launcher to start Drop-in, obtained with [registerForDropInResult].
      * @param paymentMethodsApiResponse The result from the paymentMethods/ endpoint.
      * @param dropInConfiguration Additional required configuration data.
      * @param resultHandlerIntent Intent to be called after Drop-in has finished.
+     * @param additionalDataForDropInService Bundle which will passed to the DropInService
      *
      */
     @JvmStatic
@@ -99,7 +105,8 @@ object DropIn {
         dropInLauncher: ActivityResultLauncher<Intent>,
         paymentMethodsApiResponse: PaymentMethodsApiResponse,
         dropInConfiguration: DropInConfiguration,
-        resultHandlerIntent: Intent? = null
+        resultHandlerIntent: Intent? = null,
+        additionalDataForDropInService: Bundle? = null
     ) {
         updateDefaultLogcatLevel(activity)
         Logger.d(TAG, "startPayment from Activity")
@@ -108,7 +115,8 @@ object DropIn {
             activity,
             paymentMethodsApiResponse,
             dropInConfiguration,
-            resultHandlerIntent
+            resultHandlerIntent,
+            additionalDataForDropInService
         )
         dropInLauncher.launch(intent)
     }
@@ -141,11 +149,16 @@ object DropIn {
      * [getDropInResultFromIntent] helper method to get it or you can find it in the intent
      * extras with key [RESULT_KEY].
      *
+     * When additional data is needed in the DropInService use the [additionalDataForDropInService]
+     * bundle. This bundle will be passed to the DropInService methods onPaymentsCallRequested and
+     * onDetailsCallRequested.
+     *
      * @param fragment A fragment to start the Checkout flow.
      * @param dropInLauncher A launcher to start Drop-in, obtained with [registerForDropInResult].
      * @param paymentMethodsApiResponse The result from the paymentMethods/ endpoint.
      * @param dropInConfiguration Additional required configuration data.
      * @param resultHandlerIntent Intent to be called after Drop-in has finished.
+     * @param additionalDataForDropInService Bundle which will passed to the DropInService
      *
      */
     @JvmStatic
@@ -154,7 +167,8 @@ object DropIn {
         dropInLauncher: ActivityResultLauncher<Intent>,
         paymentMethodsApiResponse: PaymentMethodsApiResponse,
         dropInConfiguration: DropInConfiguration,
-        resultHandlerIntent: Intent? = null
+        resultHandlerIntent: Intent? = null,
+        additionalDataForDropInService: Bundle? = null
     ) {
         updateDefaultLogcatLevel(fragment.requireContext())
         Logger.d(TAG, "startPayment from Fragment")
@@ -163,7 +177,8 @@ object DropIn {
             fragment.requireContext(),
             paymentMethodsApiResponse,
             dropInConfiguration,
-            resultHandlerIntent
+            resultHandlerIntent,
+            additionalDataForDropInService
         )
         dropInLauncher.launch(intent)
     }
@@ -203,10 +218,15 @@ object DropIn {
      * [getDropInResultFromIntent] helper method to get it or you can find it in the intent
      * extras with key [RESULT_KEY].
      *
+     * When additional data is needed in the DropInService use the [additionalDataForDropInService]
+     * bundle. This bundle will be passed to the DropInService methods onPaymentsCallRequested and
+     * onDetailsCallRequested.
+     *
      * @param activity An activity to start the Checkout flow.
      * @param paymentMethodsApiResponse The result from the paymentMethods/ endpoint.
      * @param dropInConfiguration Additional required configuration data.
      * @param resultHandlerIntent Intent to be called after Drop-in has finished.
+     * @param additionalDataForDropInService Bundle which will passed to the DropInService
      *
      */
     @JvmStatic
@@ -214,7 +234,8 @@ object DropIn {
         activity: Activity,
         paymentMethodsApiResponse: PaymentMethodsApiResponse,
         dropInConfiguration: DropInConfiguration,
-        resultHandlerIntent: Intent? = null
+        resultHandlerIntent: Intent? = null,
+        additionalDataForDropInService: Bundle? = null
     ) {
         updateDefaultLogcatLevel(activity)
         Logger.d(TAG, "startPayment from Activity")
@@ -223,7 +244,8 @@ object DropIn {
             activity,
             paymentMethodsApiResponse,
             dropInConfiguration,
-            resultHandlerIntent
+            resultHandlerIntent,
+            additionalDataForDropInService
         )
         activity.startActivityForResult(intent, DROP_IN_REQUEST_CODE)
     }
@@ -263,10 +285,15 @@ object DropIn {
      * [getDropInResultFromIntent] helper method to get it or you can find it in the intent
      * extras with key [RESULT_KEY].
      *
+     * When additional data is needed in the DropInService use the [additionalDataForDropInService]
+     * bundle. This bundle will be passed to the DropInService methods onPaymentsCallRequested and
+     * onDetailsCallRequested.
+     *
      * @param fragment A fragment to start the Checkout flow.
      * @param paymentMethodsApiResponse The result from the paymentMethods/ endpoint.
      * @param dropInConfiguration Additional required configuration data.
      * @param resultHandlerIntent Intent to be called after Drop-in has finished.
+     * @param additionalDataForDropInService Bundle which will passed to the DropInService
      *
      */
     @JvmStatic
@@ -274,7 +301,8 @@ object DropIn {
         fragment: Fragment,
         paymentMethodsApiResponse: PaymentMethodsApiResponse,
         dropInConfiguration: DropInConfiguration,
-        resultHandlerIntent: Intent? = null
+        resultHandlerIntent: Intent? = null,
+        additionalDataForDropInService: Bundle? = null
     ) {
         updateDefaultLogcatLevel(fragment.requireContext())
         Logger.d(TAG, "startPayment from Fragment")
@@ -283,7 +311,8 @@ object DropIn {
             fragment.requireContext(),
             paymentMethodsApiResponse,
             dropInConfiguration,
-            resultHandlerIntent
+            resultHandlerIntent,
+            additionalDataForDropInService
         )
         fragment.startActivityForResult(intent, DROP_IN_REQUEST_CODE)
     }
@@ -292,7 +321,8 @@ object DropIn {
         context: Context,
         paymentMethodsApiResponse: PaymentMethodsApiResponse,
         dropInConfiguration: DropInConfiguration,
-        resultHandlerIntent: Intent?
+        resultHandlerIntent: Intent?,
+        additionalDataForDropInService: Bundle?
     ): Intent {
         // Add locale to prefs
         DropInPrefs.setShopperLocale(context, dropInConfiguration.shopperLocale)
@@ -301,7 +331,8 @@ object DropIn {
             context,
             dropInConfiguration,
             paymentMethodsApiResponse,
-            resultHandlerIntent
+            resultHandlerIntent,
+            additionalDataForDropInService
         )
     }
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/service/DropInService.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/service/DropInService.kt
@@ -14,6 +14,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
 import android.os.Binder
+import android.os.Bundle
 import android.os.IBinder
 import com.adyen.checkout.components.ActionComponentData
 import com.adyen.checkout.components.PaymentComponentState
@@ -80,10 +81,10 @@ abstract class DropInService : Service(), CoroutineScope, DropInServiceInterface
         super.onDestroy()
     }
 
-    override fun requestPaymentsCall(paymentComponentState: PaymentComponentState<*>) {
+    override fun requestPaymentsCall(paymentComponentState: PaymentComponentState<*>, additionalDataForDropInService: Bundle?) {
         Logger.d(TAG, "requestPaymentsCall")
         val json = PaymentComponentData.SERIALIZER.serialize(paymentComponentState.data)
-        onPaymentsCallRequested(paymentComponentState, json)
+        onPaymentsCallRequested(paymentComponentState, json, additionalDataForDropInService)
     }
 
     /**
@@ -129,10 +130,12 @@ abstract class DropInService : Service(), CoroutineScope, DropInServiceInterface
      * submits the payment.
      * @param paymentComponentJson The serialized data from the [PaymentComponent] to compose your
      * call.
+     * @param additionalDataForDropInService The bundle data which was passed to the DropIn SDK
      */
     protected open fun onPaymentsCallRequested(
         paymentComponentState: PaymentComponentState<*>,
-        paymentComponentJson: JSONObject
+        paymentComponentJson: JSONObject,
+        additionalDataForDropInService: Bundle?
     ) {
         launch(Dispatchers.IO) {
             // Merchant makes network call
@@ -141,10 +144,10 @@ abstract class DropInService : Service(), CoroutineScope, DropInServiceInterface
         }
     }
 
-    override fun requestDetailsCall(actionComponentData: ActionComponentData) {
+    override fun requestDetailsCall(actionComponentData: ActionComponentData, additionalDataForDropInService: Bundle?) {
         Logger.d(TAG, "requestDetailsCall")
         val json = ActionComponentData.SERIALIZER.serialize(actionComponentData)
-        onDetailsCallRequested(actionComponentData, json)
+        onDetailsCallRequested(actionComponentData, json, additionalDataForDropInService)
     }
 
     /**
@@ -187,7 +190,8 @@ abstract class DropInService : Service(), CoroutineScope, DropInServiceInterface
      */
     protected open fun onDetailsCallRequested(
         actionComponentData: ActionComponentData,
-        actionComponentJson: JSONObject
+        actionComponentJson: JSONObject,
+        additionalDataForDropInService: Bundle?
     ) {
         launch(Dispatchers.IO) {
             // Merchant makes network call
@@ -438,8 +442,8 @@ abstract class DropInService : Service(), CoroutineScope, DropInServiceInterface
 
 internal interface DropInServiceInterface {
     suspend fun observeResult(callback: (BaseDropInServiceResult) -> Unit)
-    fun requestPaymentsCall(paymentComponentState: PaymentComponentState<*>)
-    fun requestDetailsCall(actionComponentData: ActionComponentData)
+    fun requestPaymentsCall(paymentComponentState: PaymentComponentState<*>, additionalDataForDropInService: Bundle?)
+    fun requestDetailsCall(actionComponentData: ActionComponentData, additionalDataForDropInService: Bundle?)
     fun requestBalanceCall(paymentMethodData: PaymentMethodDetails)
     fun requestOrdersCall()
     fun requestCancelOrder(order: OrderRequest, isDropInCancelledByUser: Boolean)

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInActivity.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInActivity.kt
@@ -290,7 +290,7 @@ class DropInActivity : AppCompatActivity(), DropInBottomSheetDialogFragment.Prot
         dropInViewModel.isWaitingResult = true
         setLoading(true)
         dropInViewModel.updatePaymentComponentStateForPaymentsCall(paymentComponentState)
-        dropInService?.requestPaymentsCall(paymentComponentState)
+        dropInService?.requestPaymentsCall(paymentComponentState, dropInViewModel.additionalDataForDropInService)
     }
 
     override fun requestDetailsCall(actionComponentData: ActionComponentData) {
@@ -302,7 +302,7 @@ class DropInActivity : AppCompatActivity(), DropInBottomSheetDialogFragment.Prot
         }
         dropInViewModel.isWaitingResult = true
         setLoading(true)
-        dropInService?.requestDetailsCall(actionComponentData)
+        dropInService?.requestDetailsCall(actionComponentData, dropInViewModel.additionalDataForDropInService)
     }
 
     override fun showError(errorMessage: String, reason: String, terminate: Boolean) {
@@ -661,10 +661,11 @@ class DropInActivity : AppCompatActivity(), DropInBottomSheetDialogFragment.Prot
             context: Context,
             dropInConfiguration: DropInConfiguration,
             paymentMethodsApiResponse: PaymentMethodsApiResponse,
-            resultHandlerIntent: Intent?
+            resultHandlerIntent: Intent?,
+            additionalDataForDropInService: Bundle?
         ): Intent {
             val intent = Intent(context, DropInActivity::class.java)
-            DropInViewModel.putIntentExtras(intent, dropInConfiguration, paymentMethodsApiResponse, resultHandlerIntent)
+            DropInViewModel.putIntentExtras(intent, dropInConfiguration, paymentMethodsApiResponse, resultHandlerIntent, additionalDataForDropInService)
             return intent
         }
     }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInViewModel.kt
@@ -9,6 +9,7 @@
 package com.adyen.checkout.dropin.ui
 
 import android.content.Intent
+import android.os.Bundle
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -46,6 +47,7 @@ private const val PAYMENT_METHODS_RESPONSE_KEY = "PAYMENT_METHODS_RESPONSE_KEY"
 private const val DROP_IN_CONFIGURATION_KEY = "DROP_IN_CONFIGURATION_KEY"
 private const val DROP_IN_RESULT_INTENT_KEY = "DROP_IN_RESULT_INTENT_KEY"
 private const val IS_WAITING_FOR_RESULT_KEY = "IS_WAITING_FOR_RESULT_KEY"
+private const val ADDITIONAL_DATA_FOR_DROP_IN_SERVICE_KEY = "ADDITIONAL_DATA_FOR_DROP_IN_SERVICE_KEY"
 private const val CACHED_GIFT_CARD = "CACHED_GIFT_CARD"
 private const val CURRENT_ORDER = "CURRENT_ORDER"
 private const val PARTIAL_PAYMENT_AMOUNT = "PARTIAL_PAYMENT_AMOUNT"
@@ -62,6 +64,7 @@ class DropInViewModel(
 
     val dropInConfiguration: DropInConfiguration = getStateValueOrFail(DROP_IN_CONFIGURATION_KEY)
     val resultHandlerIntent: Intent? = savedStateHandle[DROP_IN_RESULT_INTENT_KEY]
+    val additionalDataForDropInService: Bundle? = savedStateHandle[ADDITIONAL_DATA_FOR_DROP_IN_SERVICE_KEY]
 
     var amount: Amount
         get() {
@@ -327,12 +330,14 @@ class DropInViewModel(
             intent: Intent,
             dropInConfiguration: DropInConfiguration,
             paymentMethodsApiResponse: PaymentMethodsApiResponse,
-            resultHandlerIntent: Intent?
+            resultHandlerIntent: Intent?,
+            additionalDataForDropInService: Bundle?
         ) {
             intent.apply {
                 putExtra(PAYMENT_METHODS_RESPONSE_KEY, paymentMethodsApiResponse)
                 putExtra(DROP_IN_CONFIGURATION_KEY, dropInConfiguration)
                 putExtra(DROP_IN_RESULT_INTENT_KEY, resultHandlerIntent)
+                putExtra(ADDITIONAL_DATA_FOR_DROP_IN_SERVICE_KEY, additionalDataForDropInService)
             }
         }
     }

--- a/example-app/src/main/java/com/adyen/checkout/example/service/ExampleAsyncDropInService.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/service/ExampleAsyncDropInService.kt
@@ -8,6 +8,7 @@
 
 package com.adyen.checkout.example.service
 
+import android.os.Bundle
 import com.adyen.checkout.card.CardComponentState
 import com.adyen.checkout.components.ActionComponentData
 import com.adyen.checkout.components.PaymentComponentState
@@ -52,7 +53,11 @@ class ExampleAsyncDropInService : DropInService() {
     @Inject
     lateinit var keyValueStorage: KeyValueStorage
 
-    override fun onPaymentsCallRequested(paymentComponentState: PaymentComponentState<*>, paymentComponentJson: JSONObject) {
+    override fun onPaymentsCallRequested(
+        paymentComponentState: PaymentComponentState<*>,
+        paymentComponentJson: JSONObject,
+        additionalDataForDropInService: Bundle?
+    ) {
         launch(Dispatchers.IO) {
             Logger.d(TAG, "onPaymentsCallRequested")
 
@@ -91,7 +96,11 @@ class ExampleAsyncDropInService : DropInService() {
         }
     }
 
-    override fun onDetailsCallRequested(actionComponentData: ActionComponentData, actionComponentJson: JSONObject) {
+    override fun onDetailsCallRequested(
+        actionComponentData: ActionComponentData,
+        actionComponentJson: JSONObject,
+        additionalDataForDropInService: Bundle?
+    ) {
         launch(Dispatchers.IO) {
             Logger.d(TAG, "onDetailsCallRequested")
 

--- a/example-app/src/main/java/com/adyen/checkout/example/service/ExampleFullAsyncDropInService.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/service/ExampleFullAsyncDropInService.kt
@@ -8,6 +8,7 @@
 
 package com.adyen.checkout.example.service
 
+import android.os.Bundle
 import com.adyen.checkout.card.CardComponentState
 import com.adyen.checkout.components.ActionComponentData
 import com.adyen.checkout.components.PaymentComponentState
@@ -63,7 +64,11 @@ class ExampleFullAsyncDropInService : DropInService() {
     @Inject
     lateinit var keyValueStorage: KeyValueStorage
 
-    override fun onPaymentsCallRequested(paymentComponentState: PaymentComponentState<*>, paymentComponentJson: JSONObject) {
+    override fun onPaymentsCallRequested(
+        paymentComponentState: PaymentComponentState<*>,
+        paymentComponentJson: JSONObject,
+        additionalDataForDropInService: Bundle?
+    ) {
         launch(Dispatchers.IO) {
             Logger.d(TAG, "onPaymentsCallRequested")
 
@@ -102,7 +107,11 @@ class ExampleFullAsyncDropInService : DropInService() {
         }
     }
 
-    override fun onDetailsCallRequested(actionComponentData: ActionComponentData, actionComponentJson: JSONObject) {
+    override fun onDetailsCallRequested(
+        actionComponentData: ActionComponentData,
+        actionComponentJson: JSONObject,
+        additionalDataForDropInService: Bundle?
+    ) {
         launch(Dispatchers.IO) {
             Logger.d(TAG, "onDetailsCallRequested")
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
When making a payment request to our backend, I need additional data in the `onPaymentsCallRequested` and `onDetailsCallRequested` method. I didn't want to use shared prefs (what you are doing in the example app) or something else (e.g. inject a "data holder" class). So I added this functionality into my fork and now I want to show you what I did.
So you can merge this if you think it could be helpful or close it if this is not useful.


## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**: 
- https://github.com/Adyen/adyen-android/issues/180
