### PR TITLE
Fix crash when initializing iDeal.

### DIFF
--- a/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponent.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponent.kt
@@ -25,8 +25,7 @@ class BacsDirectDebitComponent(
     BasePaymentComponent<BacsDirectDebitConfiguration, BacsDirectDebitInputData, BacsDirectDebitOutputData,
         BacsDirectDebitComponentState>(savedStateHandle, paymentMethodDelegate, configuration) {
 
-    override val supportedPaymentMethodTypes: Array<String>
-        get() = PAYMENT_METHOD_TYPES
+    override fun getSupportedPaymentMethodTypes(): Array<String> = PAYMENT_METHOD_TYPES
 
     override fun onInputDataChanged(inputData: BacsDirectDebitInputData): BacsDirectDebitOutputData {
         return BacsDirectDebitOutputData(

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcComponent.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcComponent.kt
@@ -48,18 +48,6 @@ class BcmcComponent(
 ) : BasePaymentComponent<BcmcConfiguration, BcmcInputData, BcmcOutputData,
     PaymentComponentState<CardPaymentMethod>>(savedStateHandle, paymentMethodDelegate, configuration) {
 
-    companion object {
-        private val TAG = LogUtil.getTag()
-
-        private val PAYMENT_METHOD_TYPES = arrayOf(PaymentMethodTypes.BCMC)
-
-        @JvmField
-        val PROVIDER: PaymentComponentProvider<BcmcComponent, BcmcConfiguration> = BcmcComponentProvider()
-
-        @JvmField
-        val SUPPORTED_CARD_TYPE = CardType.BCMC
-    }
-
     private var publicKey: String? = null
 
     init {
@@ -73,8 +61,7 @@ class BcmcComponent(
         }
     }
 
-    override val supportedPaymentMethodTypes: Array<String>
-        get() = PAYMENT_METHOD_TYPES
+    override fun getSupportedPaymentMethodTypes(): Array<String> = PAYMENT_METHOD_TYPES
 
     private suspend fun fetchPublicKey(): String {
         return publicKeyRepository.fetchPublicKey(
@@ -118,7 +105,7 @@ class BcmcComponent(
             CardEncrypter.encryptFields(unencryptedCardBuilder.build(), publicKey)
         } catch (e: EncryptionException) {
             notifyException(e)
-            return PaymentComponentState(paymentComponentData, false, true)
+            return PaymentComponentState(paymentComponentData, isInputValid = false, isReady = true)
         }
 
         // BCMC payment method is scheme type.
@@ -138,7 +125,7 @@ class BcmcComponent(
         paymentComponentData.paymentMethod = cardPaymentMethod
         paymentComponentData.storePaymentMethod = outputData.isStoredPaymentMethodEnabled
         paymentComponentData.shopperReference = configuration.shopperReference
-        return PaymentComponentState(paymentComponentData, true, true)
+        return PaymentComponentState(paymentComponentData, isInputValid = true, isReady = true)
     }
 
     fun isCardNumberSupported(cardNumber: String?): Boolean {
@@ -153,5 +140,17 @@ class BcmcComponent(
 
     private fun validateExpiryDate(expiryDate: ExpiryDate): FieldState<ExpiryDate> {
         return CardValidationUtils.validateExpiryDate(expiryDate, Brand.FieldPolicy.REQUIRED)
+    }
+
+    companion object {
+        private val TAG = LogUtil.getTag()
+
+        private val PAYMENT_METHOD_TYPES = arrayOf(PaymentMethodTypes.BCMC)
+
+        @JvmField
+        val PROVIDER: PaymentComponentProvider<BcmcComponent, BcmcConfiguration> = BcmcComponentProvider()
+
+        @JvmField
+        val SUPPORTED_CARD_TYPE = CardType.BCMC
     }
 }

--- a/blik/src/main/java/com/adyen/checkout/blik/BlikComponent.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/BlikComponent.kt
@@ -32,7 +32,7 @@ class BlikComponent : BasePaymentComponent<BlikConfiguration, BlikInputData, Bli
         paymentDelegate: GenericStoredPaymentDelegate,
         configuration: BlikConfiguration
     ) : super(savedStateHandle, paymentDelegate, configuration) {
-        // TODO: 09/12/2020 move this logic to base component, maybe create the inputdata from the delegate?
+        // TODO: 09/12/2020 move this logic to base component, maybe create the InputData from the delegate?
         inputDataChanged(BlikInputData())
     }
 
@@ -45,8 +45,7 @@ class BlikComponent : BasePaymentComponent<BlikConfiguration, BlikInputData, Bli
         return BlikOutputData(inputData.blikCode)
     }
 
-    override val supportedPaymentMethodTypes: Array<String>
-        get() = arrayOf(PaymentMethodTypes.BLIK)
+    override fun getSupportedPaymentMethodTypes(): Array<String> = PAYMENT_METHOD_TYPES
 
     override fun createComponentState(): PaymentComponentState<BlikPaymentMethod> {
         val blikOutputData = outputData
@@ -74,5 +73,6 @@ class BlikComponent : BasePaymentComponent<BlikConfiguration, BlikInputData, Bli
         @JvmField
         val PROVIDER: StoredPaymentComponentProvider<BlikComponent, BlikConfiguration> =
             GenericStoredPaymentComponentProvider(BlikComponent::class.java)
+        val PAYMENT_METHOD_TYPES = arrayOf(PaymentMethodTypes.BLIK)
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponent.kt
@@ -122,8 +122,7 @@ class CardComponent private constructor(
         cardConfiguration
     )
 
-    override val supportedPaymentMethodTypes: Array<String>
-        get() = PAYMENT_METHOD_TYPES
+    override fun getSupportedPaymentMethodTypes(): Array<String> = PAYMENT_METHOD_TYPES
 
     override fun requiresInput(): Boolean {
         return cardDelegate.requiresInput()

--- a/components-core/src/main/java/com/adyen/checkout/components/PaymentComponent.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/PaymentComponent.kt
@@ -23,7 +23,7 @@ interface PaymentComponent<ComponentStateT : PaymentComponentState<out PaymentMe
     /**
      * @return An array of the supported [com.adyen.checkout.components.util.PaymentMethodTypes]
      */
-    val supportedPaymentMethodTypes: Array<String>
+    fun getSupportedPaymentMethodTypes(): Array<String>
 
     /**
      * @return The last [PaymentComponentState] of this Component.

--- a/components-core/src/main/java/com/adyen/checkout/components/base/BasePaymentComponent.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/base/BasePaymentComponent.kt
@@ -193,7 +193,7 @@ abstract class BasePaymentComponent<
     }
 
     private fun isSupported(paymentMethodType: String): Boolean {
-        for (supportedType in supportedPaymentMethodTypes) {
+        for (supportedType in getSupportedPaymentMethodTypes()) {
             if (supportedType == paymentMethodType) {
                 return true
             }

--- a/components-core/src/test/java/com/adyen/checkout/components/base/BaseComponentTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/base/BaseComponentTest.kt
@@ -72,8 +72,7 @@ class BaseComponentTest {
                 return TestComponentState()
             }
 
-            override val supportedPaymentMethodTypes: Array<String>
-                get() = arrayOf("something")
+            override fun getSupportedPaymentMethodTypes() = arrayOf("something")
         }
     }
 
@@ -112,8 +111,7 @@ class BaseComponentTest {
                 return PaymentComponentState(paymentComponentData, isInputValid = true, isReady = true)
             }
 
-            override val supportedPaymentMethodTypes: Array<String>
-                get() = arrayOf("")
+            override fun getSupportedPaymentMethodTypes() = arrayOf("")
         }
 
     companion object {

--- a/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayComponent.kt
+++ b/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayComponent.kt
@@ -28,10 +28,11 @@ class DotpayComponent(
         return DotpayPaymentMethod()
     }
 
-    override val supportedPaymentMethodTypes: Array<String> = arrayOf(PaymentMethodTypes.DOTPAY)
+    override fun getSupportedPaymentMethodTypes(): Array<String> = PAYMENT_METHOD_TYPES
 
     companion object {
         @JvmField
         val PROVIDER: PaymentComponentProvider<DotpayComponent, DotpayConfiguration> = GenericPaymentComponentProvider(DotpayComponent::class.java)
+        val PAYMENT_METHOD_TYPES = arrayOf(PaymentMethodTypes.DOTPAY)
     }
 }

--- a/entercash/src/main/java/com/adyen/checkout/entercash/EntercashComponent.kt
+++ b/entercash/src/main/java/com/adyen/checkout/entercash/EntercashComponent.kt
@@ -28,12 +28,13 @@ class EntercashComponent(
         return EntercashPaymentMethod()
     }
 
-    override val supportedPaymentMethodTypes: Array<String> = arrayOf(PaymentMethodTypes.ENTERCASH)
+    override fun getSupportedPaymentMethodTypes(): Array<String> = PAYMENT_METHOD_TYPES
 
     companion object {
         @JvmField
         val PROVIDER: PaymentComponentProvider<EntercashComponent, EntercashConfiguration> = GenericPaymentComponentProvider(
             EntercashComponent::class.java
         )
+        val PAYMENT_METHOD_TYPES = arrayOf(PaymentMethodTypes.ENTERCASH)
     }
 }

--- a/eps/src/main/java/com/adyen/checkout/eps/EPSComponent.kt
+++ b/eps/src/main/java/com/adyen/checkout/eps/EPSComponent.kt
@@ -24,7 +24,7 @@ class EPSComponent(
     configuration: EPSConfiguration
 ) : IssuerListComponent<EPSPaymentMethod>(savedStateHandle, paymentMethodDelegate, configuration) {
 
-    override val supportedPaymentMethodTypes: Array<String> = arrayOf(PaymentMethodTypes.EPS)
+    override fun getSupportedPaymentMethodTypes(): Array<String> = PAYMENT_METHOD_TYPES
 
     override fun instantiateTypedPaymentMethod(): EPSPaymentMethod {
         return EPSPaymentMethod()
@@ -34,5 +34,6 @@ class EPSComponent(
         val PROVIDER: PaymentComponentProvider<EPSComponent, EPSConfiguration> = GenericPaymentComponentProvider(
             EPSComponent::class.java
         )
+        val PAYMENT_METHOD_TYPES = arrayOf(PaymentMethodTypes.EPS)
     }
 }

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardComponent.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardComponent.kt
@@ -46,8 +46,7 @@ class GiftCardComponent(
     configuration
 ) {
 
-    override val supportedPaymentMethodTypes: Array<String>
-        get() = PAYMENT_METHOD_TYPES
+    override fun getSupportedPaymentMethodTypes(): Array<String> = PAYMENT_METHOD_TYPES
 
     private var publicKey: String? = null
 

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayComponent.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayComponent.kt
@@ -38,7 +38,7 @@ class GooglePayComponent(
     ),
     ActivityResultHandlingComponent {
 
-    override val supportedPaymentMethodTypes: Array<String> = PAYMENT_METHOD_TYPES
+    override fun getSupportedPaymentMethodTypes() = PAYMENT_METHOD_TYPES
 
     override fun onInputDataChanged(inputData: GooglePayInputData): GooglePayOutputData {
         return GooglePayOutputData(inputData.paymentData ?: throw CheckoutException("paymentData is null"))

--- a/ideal/src/main/java/com/adyen/checkout/ideal/IdealComponent.kt
+++ b/ideal/src/main/java/com/adyen/checkout/ideal/IdealComponent.kt
@@ -24,13 +24,14 @@ class IdealComponent(
     configuration: IdealConfiguration
 ) : IssuerListComponent<IdealPaymentMethod>(savedStateHandle, paymentMethodDelegate, configuration) {
 
-    override val supportedPaymentMethodTypes: Array<String> = arrayOf(PaymentMethodTypes.IDEAL)
+    override fun getSupportedPaymentMethodTypes(): Array<String> = PAYMENT_METHOD_TYPES
 
     override fun instantiateTypedPaymentMethod(): IdealPaymentMethod {
         return IdealPaymentMethod()
     }
 
     companion object {
+        val PAYMENT_METHOD_TYPES = arrayOf(PaymentMethodTypes.IDEAL)
         val PROVIDER: PaymentComponentProvider<IdealComponent, IdealConfiguration> = GenericPaymentComponentProvider(
             IdealComponent::class.java
         )

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/IssuerListComponent.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/IssuerListComponent.kt
@@ -28,6 +28,7 @@ abstract class IssuerListComponent<IssuerListPaymentMethodT : IssuerListPaymentM
     configuration
 ) {
     val issuersLiveData = MutableLiveData<List<IssuerModel>>()
+
     private fun initComponent(paymentMethod: PaymentMethod) {
         val issuersList = paymentMethod.issuers
         if (issuersList != null) {

--- a/mbway/src/main/java/com/adyen/checkout/mbway/MBWayComponent.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/MBWayComponent.kt
@@ -40,8 +40,7 @@ class MBWayComponent(
     BasePaymentComponent<MBWayConfiguration, MBWayInputData, MBWayOutputData,
         PaymentComponentState<MBWayPaymentMethod>>(savedStateHandle, paymentMethodDelegate, configuration) {
 
-    override val supportedPaymentMethodTypes: Array<String>
-        get() = PAYMENT_METHOD_TYPES
+    override fun getSupportedPaymentMethodTypes(): Array<String> = PAYMENT_METHOD_TYPES
 
     companion object {
         @JvmStatic

--- a/molpay/src/main/java/com/adyen/checkout/molpay/MolpayComponent.kt
+++ b/molpay/src/main/java/com/adyen/checkout/molpay/MolpayComponent.kt
@@ -24,11 +24,7 @@ class MolpayComponent(
     configuration: MolpayConfiguration
 ) : IssuerListComponent<MolpayPaymentMethod>(savedStateHandle, paymentMethodDelegate, configuration) {
 
-    override val supportedPaymentMethodTypes: Array<String> = arrayOf(
-        PaymentMethodTypes.MOLPAY_THAILAND,
-        PaymentMethodTypes.MOLPAY_MALAYSIA,
-        PaymentMethodTypes.MOLPAY_VIETNAM
-    )
+    override fun getSupportedPaymentMethodTypes(): Array<String> = PAYMENT_METHOD_TYPES
 
     override fun instantiateTypedPaymentMethod(): MolpayPaymentMethod {
         return MolpayPaymentMethod()
@@ -37,6 +33,11 @@ class MolpayComponent(
     companion object {
         val PROVIDER: PaymentComponentProvider<MolpayComponent, MolpayConfiguration> = GenericPaymentComponentProvider(
             MolpayComponent::class.java
+        )
+        val PAYMENT_METHOD_TYPES = arrayOf(
+            PaymentMethodTypes.MOLPAY_THAILAND,
+            PaymentMethodTypes.MOLPAY_MALAYSIA,
+            PaymentMethodTypes.MOLPAY_VIETNAM
         )
     }
 }

--- a/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingComponent.kt
+++ b/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingComponent.kt
@@ -24,7 +24,7 @@ class OpenBankingComponent(
     configuration: OpenBankingConfiguration
 ) : IssuerListComponent<OpenBankingPaymentMethod>(savedStateHandle, paymentMethodDelegate, configuration) {
 
-    override val supportedPaymentMethodTypes: Array<String> = arrayOf(PaymentMethodTypes.OPEN_BANKING)
+    override fun getSupportedPaymentMethodTypes(): Array<String> = PAYMENT_METHOD_TYPES
 
     override fun instantiateTypedPaymentMethod(): OpenBankingPaymentMethod {
         return OpenBankingPaymentMethod()
@@ -35,5 +35,6 @@ class OpenBankingComponent(
         val PROVIDER: PaymentComponentProvider<OpenBankingComponent, OpenBankingConfiguration> = GenericPaymentComponentProvider(
             OpenBankingComponent::class.java
         )
+        val PAYMENT_METHOD_TYPES = arrayOf(PaymentMethodTypes.OPEN_BANKING)
     }
 }

--- a/sepa/src/main/java/com/adyen/checkout/sepa/SepaComponent.kt
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/SepaComponent.kt
@@ -29,7 +29,7 @@ class SepaComponent(
     configuration
 ) {
 
-    override val supportedPaymentMethodTypes: Array<String> = arrayOf(PaymentMethodTypes.SEPA)
+    override fun getSupportedPaymentMethodTypes(): Array<String> = PAYMENT_METHOD_TYPES
 
     override fun onInputDataChanged(inputData: SepaInputData): SepaOutputData {
         Logger.v(TAG, "onInputDataChanged")
@@ -54,5 +54,6 @@ class SepaComponent(
         val PROVIDER: PaymentComponentProvider<SepaComponent, SepaConfiguration> = GenericPaymentComponentProvider(
             SepaComponent::class.java
         )
+        val PAYMENT_METHOD_TYPES = arrayOf(PaymentMethodTypes.SEPA)
     }
 }


### PR DESCRIPTION
 Fix crash from call to not initialized `supportedPaymentMethodTypes` in BasePaymentComponent when underlying val was not yet assigned.