### PR TITLE
Remove view binding references when view is destroyed for all fragments

### DIFF
--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/LoadingDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/LoadingDialogFragment.kt
@@ -19,16 +19,19 @@ import com.adyen.checkout.dropin.R
 
 class LoadingDialogFragment : DialogFragment() {
 
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        isCancelable = false
+        return inflater.inflate(R.layout.loading, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        requireDialog().window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+    }
+
     companion object {
         fun newInstance(): LoadingDialogFragment {
             return LoadingDialogFragment()
         }
-    }
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        // TODO: 11/09/2020 code smell
-        dialog!!.window!!.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
-        isCancelable = false
-        return inflater.inflate(R.layout.loading, container, false)
     }
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
@@ -52,7 +52,8 @@ class ActionComponentDialogFragment : DropInBottomSheetDialogFragment(), Observe
         }
     }
 
-    private lateinit var binding: FragmentActionComponentBinding
+    private var _binding: FragmentActionComponentBinding? = null
+    private val binding: FragmentActionComponentBinding get() = requireNotNull(_binding)
     private lateinit var action: Action
     private lateinit var actionType: String
     private lateinit var componentView: ComponentView<in OutputData, ViewableComponent<*, *, ActionComponentData>>
@@ -67,7 +68,7 @@ class ActionComponentDialogFragment : DropInBottomSheetDialogFragment(), Observe
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        binding = FragmentActionComponentBinding.inflate(inflater)
+        _binding = FragmentActionComponentBinding.inflate(inflater)
         return binding.root
     }
 
@@ -190,5 +191,10 @@ class ActionComponentDialogFragment : DropInBottomSheetDialogFragment(), Observe
 
     private fun shouldFinishWithAction(): Boolean {
         return getActionProviderFor(action)?.providesDetails() == false
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
     }
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/BacsDirectDebitDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/BacsDirectDebitDialogFragment.kt
@@ -37,14 +37,15 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 @Suppress("TooManyFunctions")
 class BacsDirectDebitDialogFragment : BaseComponentDialogFragment() {
 
-    private lateinit var binding: FragmentBacsDirectDebitComponentBinding
+    private var _binding: FragmentBacsDirectDebitComponentBinding? = null
+    private val binding: FragmentBacsDirectDebitComponentBinding get() = requireNotNull(_binding)
 
     companion object : BaseCompanion<BacsDirectDebitDialogFragment>(BacsDirectDebitDialogFragment::class.java) {
         private val TAG = LogUtil.getTag()
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        binding = FragmentBacsDirectDebitComponentBinding.inflate(inflater, container, false)
+        _binding = FragmentBacsDirectDebitComponentBinding.inflate(inflater, container, false)
         return binding.root
     }
 
@@ -205,5 +206,10 @@ class BacsDirectDebitDialogFragment : BaseComponentDialogFragment() {
             bottomSheet?.layoutParams = layoutParams
             behavior?.state = BottomSheetBehavior.STATE_EXPANDED
         }
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
     }
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/CardComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/CardComponentDialogFragment.kt
@@ -32,10 +32,11 @@ class CardComponentDialogFragment : BaseComponentDialogFragment() {
         private val TAG = LogUtil.getTag()
     }
 
-    private lateinit var binding: FragmentCardComponentBinding
+    private var _binding: FragmentCardComponentBinding? = null
+    private val binding: FragmentCardComponentBinding get() = requireNotNull(_binding)
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        binding = FragmentCardComponentBinding.inflate(inflater, container, false)
+        _binding = FragmentCardComponentBinding.inflate(inflater, container, false)
         return binding.root
     }
 
@@ -90,5 +91,10 @@ class CardComponentDialogFragment : BaseComponentDialogFragment() {
 
     override fun onChanged(paymentComponentState: PaymentComponentState<in PaymentMethodDetails>?) {
         componentDialogViewModel.componentStateChanged(component.state)
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
     }
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/GenericComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/GenericComponentDialogFragment.kt
@@ -34,14 +34,15 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 class GenericComponentDialogFragment : BaseComponentDialogFragment() {
 
     private lateinit var componentView: ComponentView<in OutputData, ViewableComponent<*, *, *>>
-    private lateinit var binding: FragmentGenericComponentBinding
+    private var _binding: FragmentGenericComponentBinding? = null
+    private val binding: FragmentGenericComponentBinding get() = requireNotNull(_binding)
 
     companion object : BaseCompanion<GenericComponentDialogFragment>(GenericComponentDialogFragment::class.java) {
         private val TAG = LogUtil.getTag()
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        binding = FragmentGenericComponentBinding.inflate(inflater, container, false)
+        _binding = FragmentGenericComponentBinding.inflate(inflater, container, false)
         return binding.root
     }
 
@@ -94,5 +95,10 @@ class GenericComponentDialogFragment : BaseComponentDialogFragment() {
         } else {
             binding.payButton.visibility = View.GONE
         }
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
     }
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/GiftCardComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/GiftCardComponentDialogFragment.kt
@@ -33,14 +33,15 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 class GiftCardComponentDialogFragment : BaseComponentDialogFragment() {
 
     private lateinit var componentView: ComponentView<in OutputData, ViewableComponent<*, *, *>>
-    private lateinit var binding: FragmentGiftcardComponentBinding
+    private var _binding: FragmentGiftcardComponentBinding? = null
+    private val binding: FragmentGiftcardComponentBinding get() = requireNotNull(_binding)
 
     companion object : BaseCompanion<GiftCardComponentDialogFragment>(GiftCardComponentDialogFragment::class.java) {
         private val TAG = LogUtil.getTag()
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        binding = FragmentGiftcardComponentBinding.inflate(inflater, container, false)
+        _binding = FragmentGiftcardComponentBinding.inflate(inflater, container, false)
         return binding.root
     }
 
@@ -94,5 +95,10 @@ class GiftCardComponentDialogFragment : BaseComponentDialogFragment() {
             throw CheckoutException("Unsupported payment method, not a gift card: $componentState")
         }
         protocol.requestBalanceCall(componentState)
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
     }
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/giftcard/GiftCardPaymentConfirmationDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/giftcard/GiftCardPaymentConfirmationDialogFragment.kt
@@ -27,8 +27,8 @@ import com.adyen.checkout.dropin.ui.paymentmethods.PaymentMethodAdapter
 
 class GiftCardPaymentConfirmationDialogFragment : DropInBottomSheetDialogFragment() {
 
-    private lateinit var binding: FragmentGiftCardPaymentConfirmationBinding
-    private lateinit var paymentMethodAdapter: PaymentMethodAdapter
+    private var _binding: FragmentGiftCardPaymentConfirmationBinding? = null
+    private val binding: FragmentGiftCardPaymentConfirmationBinding get() = requireNotNull(_binding)
 
     private lateinit var giftCardPaymentConfirmationData: GiftCardPaymentConfirmationData
 
@@ -45,7 +45,7 @@ class GiftCardPaymentConfirmationDialogFragment : DropInBottomSheetDialogFragmen
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         Logger.d(TAG, "onCreateView")
-        binding = FragmentGiftCardPaymentConfirmationBinding.inflate(inflater, container, false)
+        _binding = FragmentGiftCardPaymentConfirmationBinding.inflate(inflater, container, false)
         return binding.root
     }
 
@@ -101,9 +101,8 @@ class GiftCardPaymentConfirmationDialogFragment : DropInBottomSheetDialogFragmen
             dropInViewModel.dropInConfiguration.environment
         )
 
-        paymentMethodAdapter = PaymentMethodAdapter(paymentMethods, imageLoader)
         binding.recyclerViewGiftCards.layoutManager = LinearLayoutManager(requireContext())
-        binding.recyclerViewGiftCards.adapter = paymentMethodAdapter
+        binding.recyclerViewGiftCards.adapter = PaymentMethodAdapter(paymentMethods, imageLoader)
     }
 
     override fun onCancel(dialog: DialogInterface) {
@@ -123,6 +122,12 @@ class GiftCardPaymentConfirmationDialogFragment : DropInBottomSheetDialogFragmen
             protocol.showPaymentMethodsDialog()
         }
         return true
+    }
+
+    override fun onDestroyView() {
+        binding.recyclerViewGiftCards.adapter = null
+        _binding = null
+        super.onDestroyView()
     }
 
     companion object {

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/stored/PreselectedStoredPaymentMethodFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/stored/PreselectedStoredPaymentMethodFragment.kt
@@ -53,7 +53,8 @@ class PreselectedStoredPaymentMethodFragment : DropInBottomSheetDialogFragment()
             dropInViewModel.dropInConfiguration.isRemovingStoredPaymentMethodsEnabled
         )
     }
-    private lateinit var binding: FragmentStoredPaymentMethodBinding
+    private var _binding: FragmentStoredPaymentMethodBinding? = null
+    private val binding: FragmentStoredPaymentMethodBinding get() = requireNotNull(_binding)
     private lateinit var storedPaymentMethod: StoredPaymentMethod
     private lateinit var imageLoader: ImageLoader
     private lateinit var component: PaymentComponent<PaymentComponentState<in PaymentMethodDetails>, Configuration>
@@ -105,7 +106,7 @@ class PreselectedStoredPaymentMethodFragment : DropInBottomSheetDialogFragment()
         component.observe(viewLifecycleOwner, storedPaymentViewModel::componentStateChanged)
         component.observeErrors(viewLifecycleOwner, storedPaymentViewModel::componentErrorOccurred)
 
-        binding = FragmentStoredPaymentMethodBinding.inflate(inflater, container, false)
+        _binding = FragmentStoredPaymentMethodBinding.inflate(inflater, container, false)
         return binding.root
     }
 
@@ -187,6 +188,11 @@ class PreselectedStoredPaymentMethodFragment : DropInBottomSheetDialogFragment()
                 dialog.dismiss()
             }
             .show()
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
     }
 
     companion object {


### PR DESCRIPTION
Holding a reference to a binding in a fragment will cause a memory leak, because the fragment lives longer than the view. Source: https://developer.android.com/topic/libraries/view-binding#fragments