### PR TITLE
Fix crash in GooglePayComponentProvider (develop)

### DIFF
--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayComponentProvider.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayComponentProvider.kt
@@ -74,8 +74,8 @@ class GooglePayComponentProvider :
             Wallet.getPaymentsClient(applicationContext, GooglePayUtils.createWalletOptions(params))
         val readyToPayRequest: IsReadyToPayRequest = GooglePayUtils.createIsReadyToPayRequest(params)
         val readyToPayTask: Task<Boolean> = paymentsClient.isReadyToPay(readyToPayRequest)
-        readyToPayTask.addOnCompleteListener { task ->
-            callbackWeakReference.get()?.onAvailabilityResult(task.result == true, paymentMethod, configuration)
+        readyToPayTask.addOnSuccessListener { result ->
+            callbackWeakReference.get()?.onAvailabilityResult(result == true, paymentMethod, configuration)
         }
         readyToPayTask.addOnCanceledListener {
             Logger.e(TAG, "GooglePay readyToPay task is cancelled.")


### PR DESCRIPTION
`onComplete` will always be called even when the task fails. Since we already have `onFailed` and `onCancelled` listeners, we only have to change `onComplete` with `onSuccess`