### PR TITLE
Remove unnecessary permission

### DIFF
--- a/drop-in/src/main/AndroidManifest.xml
+++ b/drop-in/src/main/AndroidManifest.xml
@@ -3,8 +3,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.adyen.checkout.dropin">
 
-    <uses-permission android:name="android.permission.WAKE_LOCK" />
-
     <application android:supportsRtl="true">
         <activity
             android:name=".ui.DropInActivity"

--- a/drop-in/src/main/AndroidManifest.xml
+++ b/drop-in/src/main/AndroidManifest.xml
@@ -29,7 +29,9 @@
             </intent-filter>
         </activity>
 
-        <service android:name=".service.SessionDropInService" />
+        <service
+            android:name=".service.SessionDropInService"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/example-app/src/main/AndroidManifest.xml
+++ b/example-app/src/main/AndroidManifest.xml
@@ -63,9 +63,15 @@
                 android:value=".ui.main.MainActivity" />
         </activity>
 
-        <service android:name=".service.ExampleDropInService" />
-        <service android:name=".service.ExampleAsyncDropInService" />
-        <service android:name=".service.ExampleFullAsyncDropInService" />
+        <service
+            android:name=".service.ExampleDropInService"
+            android:exported="false" />
+        <service
+            android:name=".service.ExampleAsyncDropInService"
+            android:exported="false" />
+        <service
+            android:name=".service.ExampleFullAsyncDropInService"
+            android:exported="false" />
     </application>
 
 </manifest>


### PR DESCRIPTION
Bonus: mark exported false for all services. Our services shouldn't be started by other applications/processes, so it's better to not export them