### PR TITLE
Add JUnit extension to make coroutine testing easier

### DIFF
--- a/giftcard/build.gradle
+++ b/giftcard/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     implementation libraries.material
 
     //Tests
+    testImplementation project(':test-core')
     testImplementation testLibraries.junit5
     testImplementation testLibraries.kotlinCoroutines
     testImplementation testLibraries.mockito

--- a/giftcard/src/test/java/com/adyen/checkout/giftcard/DefaultGiftCardDelegateTest.kt
+++ b/giftcard/src/test/java/com/adyen/checkout/giftcard/DefaultGiftCardDelegateTest.kt
@@ -13,13 +13,9 @@ import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.repository.PublicKeyRepository
 import com.adyen.checkout.core.api.Environment
 import com.adyen.checkout.cse.TestCardEncrypter
-import kotlinx.coroutines.Dispatchers
+import com.adyen.checkout.test.TestDispatcherExtension
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -38,7 +34,7 @@ import java.io.IOException
 import java.util.Locale
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@ExtendWith(MockitoExtension::class)
+@ExtendWith(MockitoExtension::class, TestDispatcherExtension::class)
 internal class DefaultGiftCardDelegateTest(
     @Mock private val publicKeyRepository: PublicKeyRepository
 ) {
@@ -58,14 +54,7 @@ internal class DefaultGiftCardDelegateTest(
 
     @BeforeEach
     fun before() {
-        Dispatchers.setMain(UnconfinedTestDispatcher())
-
         cardEncrypter.reset()
-    }
-
-    @AfterEach
-    fun after() {
-        Dispatchers.resetMain()
     }
 
     @Test

--- a/sessions-core/build.gradle
+++ b/sessions-core/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     api libraries.kotlinCoroutines
 
     //Tests
+    testImplementation project(':test-core')
     testImplementation testLibraries.androidx.lifecycle
     testImplementation testLibraries.junit5
     testImplementation testLibraries.kotlinCoroutines

--- a/sessions-core/src/test/java/com/adyen/checkout/sessions/repository/SessionRepositoryTest.kt
+++ b/sessions-core/src/test/java/com/adyen/checkout/sessions/repository/SessionRepositoryTest.kt
@@ -22,13 +22,9 @@ import com.adyen.checkout.sessions.model.orders.SessionOrderResponse
 import com.adyen.checkout.sessions.model.payments.SessionDetailsResponse
 import com.adyen.checkout.sessions.model.payments.SessionPaymentsResponse
 import com.adyen.checkout.sessions.model.setup.SessionSetupResponse
-import kotlinx.coroutines.Dispatchers
+import com.adyen.checkout.test.TestDispatcherExtension
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -42,7 +38,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@ExtendWith(MockitoExtension::class)
+@ExtendWith(MockitoExtension::class, TestDispatcherExtension::class)
 internal class SessionRepositoryTest(
     @Mock private val sessionService: SessionService,
 ) {
@@ -53,13 +49,6 @@ internal class SessionRepositoryTest(
     fun before() {
         val initialSession = Session("id", "sessionData")
         sessionRepository = SessionRepository(sessionService, "someclientkey", initialSession)
-
-        Dispatchers.setMain(UnconfinedTestDispatcher())
-    }
-
-    @AfterEach
-    fun after() {
-        Dispatchers.resetMain()
     }
 
     @Nested

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,6 +23,7 @@ include ':3ds2',
         ':redirect',
         ':sepa',
         ':sessions-core',
+        ':test-core',
         ':ui-core',
         ':voucher',
         ':wechatpay'

--- a/test-core/build.gradle
+++ b/test-core/build.gradle
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 9/8/2022.
+ */
+
+plugins {
+    id 'org.jetbrains.kotlin.jvm'
+}
+
+apply from: "${rootDir}/config/gradle/codeQuality.gradle"
+
+dependencies {
+    implementation testLibraries.junit5
+    implementation testLibraries.kotlinCoroutines
+}
+
+// Disable test tasks, because this module only contains test utils.
+tasks.configureEach { task ->
+    if(task.name.startsWith('test')) {
+        task.enabled = false
+    }
+}

--- a/test-core/src/main/java/com/adyen/checkout/test/TestDispatcherExtension.kt
+++ b/test-core/src/main/java/com/adyen/checkout/test/TestDispatcherExtension.kt
@@ -55,7 +55,8 @@ class TestDispatcherExtension : BeforeEachCallback, AfterEachCallback, Parameter
     @Throws(ParameterResolutionException::class)
     @Suppress("NewApi")
     override fun supportsParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): Boolean =
-        // It's safe to ignore the warning on getType(), because this code is used in JVM unit tests.
+        // It's safe to ignore the warning on getType(), because this code is used in JVM unit tests and not
+        // android related.
         parameterContext.parameter.type.isAssignableFrom(CoroutineDispatcher::class.java) ||
             parameterContext.parameter.type.isAssignableFrom(TestDispatcher::class.java)
 

--- a/test-core/src/main/java/com/adyen/checkout/test/TestDispatcherExtension.kt
+++ b/test-core/src/main/java/com/adyen/checkout/test/TestDispatcherExtension.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 9/8/2022.
+ */
+
+package com.adyen.checkout.test
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.ParameterContext
+import org.junit.jupiter.api.extension.ParameterResolutionException
+import org.junit.jupiter.api.extension.ParameterResolver
+
+/**
+ * JUnit 5 extension that replaces [Dispatchers.Main] with a test dispatcher. This gives control over how the dispatcher
+ * executes it's work.
+ *
+ * Example:
+ * ```
+ * @ExtendWith(TestDispatcherExtension::class)
+ * internal class ExampleTest {
+ *
+ *     @Test
+ *     fun test(dispatcher: CoroutineDispatcher) = runTest(dispatcher) {
+ *         ...
+ *     }
+ * }
+ * ```
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class TestDispatcherExtension : BeforeEachCallback, AfterEachCallback, ParameterResolver {
+
+    override fun beforeEach(context: ExtensionContext) {
+        val testDispatcher = UnconfinedTestDispatcher()
+        Dispatchers.setMain(testDispatcher)
+        context.getStore(NAMESPACE).put(DISPATCHER, testDispatcher)
+    }
+
+    override fun afterEach(context: ExtensionContext) {
+        Dispatchers.resetMain()
+        context.getStore(NAMESPACE).remove(DISPATCHER, TestDispatcher::class.java)
+    }
+
+    @Throws(ParameterResolutionException::class)
+    @Suppress("NewApi")
+    override fun supportsParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): Boolean =
+        // It's safe to ignore the warning on getType(), because this code is used in JVM unit tests.
+        parameterContext.parameter.type.isAssignableFrom(CoroutineDispatcher::class.java) ||
+            parameterContext.parameter.type.isAssignableFrom(TestDispatcher::class.java)
+
+    @Throws(ParameterResolutionException::class)
+    override fun resolveParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): Any =
+        extensionContext.getStore(NAMESPACE).get(DISPATCHER)
+
+    companion object {
+        private val NAMESPACE = ExtensionContext.Namespace.create("com.adyen.checkout")
+        private const val DISPATCHER = "dispatcher"
+    }
+}


### PR DESCRIPTION
- Add `:test-core` module
- Create JUnit extension that replaces the main coroutine dispatcher with a test dispatcher and can provide this dispatchers to tests
- Replace manually replacing the main dispatcher in tests with this new extension