### PR TITLE
WeChatDelegate: Create WeChatDelegate

### DIFF
--- a/wechatpay/build.gradle
+++ b/wechatpay/build.gradle
@@ -29,7 +29,10 @@ android {
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles "consumer-rules.pro"
     }
-    
+
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
 }
 
 dependencies {
@@ -40,5 +43,8 @@ dependencies {
     implementation libraries.wechat
 
     //Tests
+    testImplementation testLibraries.json
     testImplementation testLibraries.junit5
+    testImplementation testLibraries.mockito
+    testImplementation testLibraries.kotlinCoroutines
 }

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/DefaultWeChatDelegate.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/DefaultWeChatDelegate.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 19/8/2022.
+ */
+
+package com.adyen.checkout.wechatpay
+
+import android.content.Intent
+import com.adyen.checkout.components.model.payments.response.Action
+import com.adyen.checkout.components.model.payments.response.SdkAction
+import com.adyen.checkout.components.model.payments.response.WeChatPaySdkData
+import com.adyen.checkout.core.exception.CheckoutException
+import com.adyen.checkout.core.exception.ComponentException
+import com.adyen.checkout.core.log.LogUtil
+import com.adyen.checkout.core.log.Logger
+import com.tencent.mm.opensdk.modelbase.BaseReq
+import com.tencent.mm.opensdk.modelbase.BaseResp
+import com.tencent.mm.opensdk.openapi.IWXAPI
+import com.tencent.mm.opensdk.openapi.IWXAPIEventHandler
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import org.json.JSONObject
+
+internal class DefaultWeChatDelegate(
+    private val iwxApi: IWXAPI,
+) : WeChatDelegate {
+
+    private val _detailsFlow = MutableSharedFlow<JSONObject>(0, 1, BufferOverflow.DROP_OLDEST)
+    override val detailsFlow: Flow<JSONObject> = _detailsFlow
+
+    private val _exceptionFlow = MutableSharedFlow<CheckoutException>(0, 1, BufferOverflow.DROP_OLDEST)
+    override val exceptionFlow: Flow<CheckoutException> = _exceptionFlow
+
+    private val eventHandler = object : IWXAPIEventHandler {
+        override fun onReq(baseReq: BaseReq) = Unit
+
+        override fun onResp(baseResp: BaseResp) {
+            val response = WeChatPayUtils.parseResult(baseResp)
+            _detailsFlow.tryEmit(response)
+        }
+    }
+
+    override fun handleIntent(intent: Intent) {
+        // TODO check intent identifiers
+        iwxApi.handleIntent(intent, eventHandler)
+    }
+
+    override fun handleAction(action: Action, activityName: String) {
+        Logger.d(TAG, "handleAction: activity - $activityName")
+
+        @Suppress("UNCHECKED_CAST")
+        val sdkData = (action as? SdkAction<WeChatPaySdkData>)?.sdkData ?: run {
+            _exceptionFlow.tryEmit(ComponentException("sdkData is null"))
+            return@handleAction
+        }
+
+        val isWeChatNotInitiated = !initiateWeChatPayRedirect(sdkData, activityName)
+
+        if (isWeChatNotInitiated) {
+            _exceptionFlow.tryEmit(ComponentException("Failed to initialize WeChat app"))
+            return
+        }
+    }
+
+    private fun initiateWeChatPayRedirect(weChatPaySdkData: WeChatPaySdkData, activityName: String): Boolean {
+        Logger.d(TAG, "initiateWeChatPayRedirect")
+        iwxApi.registerApp(weChatPaySdkData.appid)
+        return iwxApi.sendReq(WeChatPayUtils.generatePayRequest(weChatPaySdkData, activityName))
+    }
+
+    companion object {
+        private val TAG = LogUtil.getTag()
+    }
+}

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatDelegate.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatDelegate.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 19/8/2022.
+ */
+
+package com.adyen.checkout.wechatpay
+
+import android.content.Intent
+import com.adyen.checkout.components.model.payments.response.Action
+import com.adyen.checkout.core.exception.CheckoutException
+import kotlinx.coroutines.flow.Flow
+import org.json.JSONObject
+
+interface WeChatDelegate {
+
+    val detailsFlow: Flow<JSONObject>
+
+    val exceptionFlow: Flow<CheckoutException>
+
+    fun handleIntent(intent: Intent)
+
+    fun handleAction(action: Action, activityName: String)
+}

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionComponent.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionComponent.kt
@@ -15,34 +15,15 @@ import com.adyen.checkout.components.ActionComponentProvider
 import com.adyen.checkout.components.base.BaseActionComponent
 import com.adyen.checkout.components.base.IntentHandlingComponent
 import com.adyen.checkout.components.model.payments.response.Action
-import com.adyen.checkout.components.model.payments.response.SdkAction
-import com.adyen.checkout.components.model.payments.response.WeChatPaySdkData
 import com.adyen.checkout.core.exception.ComponentException
-import com.adyen.checkout.core.log.LogUtil.getTag
-import com.adyen.checkout.core.log.Logger
-import com.tencent.mm.opensdk.modelbase.BaseReq
-import com.tencent.mm.opensdk.modelbase.BaseResp
-import com.tencent.mm.opensdk.openapi.IWXAPI
-import com.tencent.mm.opensdk.openapi.IWXAPIEventHandler
-import com.tencent.mm.opensdk.openapi.WXAPIFactory
 
 class WeChatPayActionComponent(
     savedStateHandle: SavedStateHandle,
     application: Application,
-    configuration: WeChatPayActionConfiguration
+    configuration: WeChatPayActionConfiguration,
+    private val weChatDelegate: WeChatDelegate,
 ) : BaseActionComponent<WeChatPayActionConfiguration>(savedStateHandle, application, configuration),
     IntentHandlingComponent {
-
-    private val iwxApi: IWXAPI = WXAPIFactory.createWXAPI(application, null, true)
-    private val eventHandler: IWXAPIEventHandler = object : IWXAPIEventHandler {
-        override fun onReq(baseReq: BaseReq) {
-            // Do nothing.
-        }
-
-        override fun onResp(baseResp: BaseResp) {
-            notifyDetails(WeChatPayUtils.parseResult(baseResp))
-        }
-    }
 
     /**
      * Pass the result Intent from the WeChatPay SDK response on Activity#onNewIntent(Intent).
@@ -51,8 +32,7 @@ class WeChatPayActionComponent(
      * @param intent The intent result from WeChatPay SDK.
      */
     override fun handleIntent(intent: Intent) {
-        // TODO check intent identifiers
-        iwxApi.handleIntent(intent, eventHandler)
+        weChatDelegate.handleIntent(intent)
     }
 
     override fun canHandleAction(action: Action): Boolean {
@@ -61,23 +41,10 @@ class WeChatPayActionComponent(
 
     @Throws(ComponentException::class)
     override fun handleActionInternal(activity: Activity, action: Action) {
-        Logger.d(TAG, "handleActionInternal: activity - " + activity.localClassName)
-        @Suppress("UNCHECKED_CAST")
-        val sdkData = (action as SdkAction<WeChatPaySdkData>).sdkData ?: throw ComponentException("sdkData is null")
-        val weChatInitiated = initiateWeChatPayRedirect(sdkData, activity.javaClass.name)
-        if (!weChatInitiated) {
-            throw ComponentException("Failed to initialize WeChat app.")
-        }
-    }
-
-    private fun initiateWeChatPayRedirect(weChatPaySdkData: WeChatPaySdkData, callbackActivityName: String): Boolean {
-        Logger.d(TAG, "initiateWeChatPayRedirect")
-        iwxApi.registerApp(weChatPaySdkData.appid)
-        return iwxApi.sendReq(WeChatPayUtils.generatePayRequest(weChatPaySdkData, callbackActivityName))
+        weChatDelegate.handleAction(action, activity.javaClass.name)
     }
 
     companion object {
-        private val TAG = getTag()
         val PROVIDER: ActionComponentProvider<WeChatPayActionComponent, WeChatPayActionConfiguration> =
             WeChatPayActionComponentProvider()
     }

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionComponent.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionComponent.kt
@@ -11,11 +11,14 @@ import android.app.Activity
 import android.app.Application
 import android.content.Intent
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
 import com.adyen.checkout.components.ActionComponentProvider
 import com.adyen.checkout.components.base.BaseActionComponent
 import com.adyen.checkout.components.base.IntentHandlingComponent
 import com.adyen.checkout.components.model.payments.response.Action
 import com.adyen.checkout.core.exception.ComponentException
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 class WeChatPayActionComponent(
     savedStateHandle: SavedStateHandle,
@@ -24,6 +27,16 @@ class WeChatPayActionComponent(
     private val weChatDelegate: WeChatDelegate,
 ) : BaseActionComponent<WeChatPayActionConfiguration>(savedStateHandle, application, configuration),
     IntentHandlingComponent {
+
+    init {
+        weChatDelegate.detailsFlow
+            .onEach { notifyDetails(it) }
+            .launchIn(viewModelScope)
+
+        weChatDelegate.exceptionFlow
+            .onEach { notifyException(it) }
+            .launchIn(viewModelScope)
+    }
 
     /**
      * Pass the result Intent from the WeChatPay SDK response on Activity#onNewIntent(Intent).

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionComponentProvider.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionComponentProvider.kt
@@ -42,7 +42,8 @@ class WeChatPayActionComponentProvider :
         defaultArgs: Bundle?
     ): WeChatPayActionComponent {
         val iwxApi: IWXAPI = WXAPIFactory.createWXAPI(application, null, true)
-        val weChatDelegate = DefaultWeChatDelegate(iwxApi)
+        val requestGenerator = WeChatPayRequestGenerator()
+        val weChatDelegate = DefaultWeChatDelegate(iwxApi, requestGenerator)
 
         val weChatFactory = viewModelFactory(savedStateRegistryOwner, defaultArgs) { savedStateHandle ->
             WeChatPayActionComponent(

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionComponentProvider.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionComponentProvider.kt
@@ -18,6 +18,8 @@ import com.adyen.checkout.components.base.lifecycle.viewModelFactory
 import com.adyen.checkout.components.model.payments.response.Action
 import com.adyen.checkout.components.model.payments.response.SdkAction
 import com.adyen.checkout.components.util.PaymentMethodTypes
+import com.tencent.mm.opensdk.openapi.IWXAPI
+import com.tencent.mm.opensdk.openapi.WXAPIFactory
 
 private val PAYMENT_METHODS = listOf(PaymentMethodTypes.WECHAT_PAY_SDK)
 
@@ -39,13 +41,18 @@ class WeChatPayActionComponentProvider :
         configuration: WeChatPayActionConfiguration,
         defaultArgs: Bundle?
     ): WeChatPayActionComponent {
+        val iwxApi: IWXAPI = WXAPIFactory.createWXAPI(application, null, true)
+        val weChatDelegate = DefaultWeChatDelegate(iwxApi)
+
         val weChatFactory = viewModelFactory(savedStateRegistryOwner, defaultArgs) { savedStateHandle ->
             WeChatPayActionComponent(
-                savedStateHandle,
-                application,
-                configuration
+                savedStateHandle = savedStateHandle,
+                application = application,
+                configuration = configuration,
+                weChatDelegate = weChatDelegate,
             )
         }
+
         return ViewModelProvider(viewModelStoreOwner, weChatFactory).get(WeChatPayActionComponent::class.java)
     }
 

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayProvider.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayProvider.kt
@@ -13,6 +13,8 @@ import com.adyen.checkout.components.ComponentAvailableCallback
 import com.adyen.checkout.components.PaymentMethodAvailabilityCheck
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
+import com.tencent.mm.opensdk.constants.Build
+import com.tencent.mm.opensdk.openapi.WXAPIFactory
 
 /**
  * This class is not an actual provider, it only checks whether WeChatPay is available.
@@ -28,6 +30,14 @@ class WeChatPayProvider : PaymentMethodAvailabilityCheck<Configuration> {
         configuration: Configuration?,
         callback: ComponentAvailableCallback<Configuration>
     ) {
-        callback.onAvailabilityResult(WeChatPayUtils.isAvailable(applicationContext), paymentMethod, configuration)
+        callback.onAvailabilityResult(isAvailable(applicationContext), paymentMethod, configuration)
+    }
+
+    private fun isAvailable(applicationContext: Application?): Boolean {
+        val api = WXAPIFactory.createWXAPI(applicationContext, null, true)
+        val isAppInstalled = api.isWXAppInstalled
+        val isSupported = Build.PAY_SUPPORTED_SDK_INT <= api.wxAppSupportAPI
+        api.detach()
+        return isAppInstalled && isSupported
     }
 }

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayRequestGenerator.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayRequestGenerator.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 19/8/2022.
+ */
+
+package com.adyen.checkout.wechatpay
+
+import com.adyen.checkout.components.model.payments.response.WeChatPaySdkData
+import com.tencent.mm.opensdk.modelbase.BaseReq
+import com.tencent.mm.opensdk.modelpay.PayReq
+
+internal interface WeChatRequestGenerator<T : BaseReq> {
+    fun generate(weChatPaySdkData: WeChatPaySdkData, callbackActivityName: String): T
+}
+
+internal class WeChatPayRequestGenerator : WeChatRequestGenerator<PayReq> {
+
+    override fun generate(weChatPaySdkData: WeChatPaySdkData, callbackActivityName: String): PayReq {
+        return PayReq().apply {
+            appId = weChatPaySdkData.appid
+            partnerId = weChatPaySdkData.partnerid
+            prepayId = weChatPaySdkData.prepayid
+            packageValue = weChatPaySdkData.packageValue
+            nonceStr = weChatPaySdkData.noncestr
+            timeStamp = weChatPaySdkData.timestamp
+            sign = weChatPaySdkData.sign
+            options = PayReq.Options()
+            options.callbackClassName = callbackActivityName
+        }
+    }
+}

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayUtils.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayUtils.kt
@@ -7,55 +7,13 @@
  */
 package com.adyen.checkout.wechatpay
 
-import android.app.Application
 import android.content.Intent
-import com.adyen.checkout.components.model.payments.response.WeChatPaySdkData
-import com.adyen.checkout.core.exception.CheckoutException
-import com.tencent.mm.opensdk.constants.Build
-import com.tencent.mm.opensdk.modelbase.BaseResp
-import com.tencent.mm.opensdk.modelpay.PayReq
-import com.tencent.mm.opensdk.openapi.WXAPIFactory
-import org.json.JSONException
-import org.json.JSONObject
 
 object WeChatPayUtils {
 
     private const val RESULT_EXTRA_KEY = "_wxapi_baseresp_errstr"
-    private const val RESULT_CODE = "resultCode"
 
     fun isResultIntent(intent: Intent?): Boolean {
         return intent?.extras?.containsKey(RESULT_EXTRA_KEY) == true
-    }
-
-    fun isAvailable(applicationContext: Application?): Boolean {
-        val api = WXAPIFactory.createWXAPI(applicationContext, null, true)
-        val isAppInstalled = api.isWXAppInstalled
-        val isSupported = Build.PAY_SUPPORTED_SDK_INT <= api.wxAppSupportAPI
-        api.detach()
-        return isAppInstalled && isSupported
-    }
-
-    fun generatePayRequest(weChatPaySdkData: WeChatPaySdkData, callbackActivityName: String): PayReq {
-        return PayReq().apply {
-            appId = weChatPaySdkData.appid
-            partnerId = weChatPaySdkData.partnerid
-            prepayId = weChatPaySdkData.prepayid
-            packageValue = weChatPaySdkData.packageValue
-            nonceStr = weChatPaySdkData.noncestr
-            timeStamp = weChatPaySdkData.timestamp
-            sign = weChatPaySdkData.sign
-            options = PayReq.Options()
-            options.callbackClassName = callbackActivityName
-        }
-    }
-
-    fun parseResult(baseResp: BaseResp): JSONObject {
-        val result = JSONObject()
-        try {
-            result.put(RESULT_CODE, baseResp.errCode)
-        } catch (e: JSONException) {
-            throw CheckoutException("Error parsing result.", e)
-        }
-        return result
     }
 }

--- a/wechatpay/src/test/java/com/adyen/checkout/wechatpay/DefaultWeChatDelegateTest.kt
+++ b/wechatpay/src/test/java/com/adyen/checkout/wechatpay/DefaultWeChatDelegateTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 19/8/2022.
+ */
+
+package com.adyen.checkout.wechatpay
+
+import android.content.Intent
+import app.cash.turbine.test
+import com.adyen.checkout.components.model.payments.response.SdkAction
+import com.adyen.checkout.components.model.payments.response.WeChatPaySdkData
+import com.adyen.checkout.core.exception.ComponentException
+import com.tencent.mm.opensdk.modelpay.PayResp
+import com.tencent.mm.opensdk.openapi.IWXAPI
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.json.JSONObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(MockitoExtension::class)
+internal class DefaultWeChatDelegateTest(
+    @Mock private val iwxApi: IWXAPI,
+    @Mock private val weChatRequestGenerator: WeChatRequestGenerator<*>
+) {
+
+    private lateinit var delegate: DefaultWeChatDelegate
+
+    @BeforeEach
+    fun beforeEach() {
+        delegate = DefaultWeChatDelegate(
+            iwxApi = iwxApi,
+            payRequestGenerator = weChatRequestGenerator,
+        )
+    }
+
+    @Test
+    fun `when handling intent, then delegate it to the IWXAPI`() {
+        delegate.handleIntent(Intent())
+
+        verify(iwxApi).handleIntent(any(), any())
+    }
+
+    @Test
+    fun `when receiving a response from IWXAPI, then details should be emitted`() = runTest {
+        val payResponse = PayResp().apply {
+            prepayId = "somePrepayId"
+            returnKey = "someReturnKey"
+            extData = "someExtData"
+        }
+
+        delegate.detailsFlow.test {
+            delegate.onResponse(payResponse)
+
+            val expected = JSONObject().apply {
+                put("resultCode", 0)
+            }
+            assertEquals(expected.get("resultCode"), awaitItem().get("resultCode"))
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when handling action, then we chat pay is initiated`() {
+        val action = SdkAction(
+            sdkData = WeChatPaySdkData(
+                appid = "appid",
+                noncestr = "noncestr",
+                packageValue = "packageValue",
+                partnerid = "partnerid",
+                prepayid = "prepayid",
+                sign = "sign",
+                timestamp = "timestamp",
+            )
+        )
+
+        delegate.handleAction(action, "name")
+
+        verify(iwxApi).registerApp("appid")
+        verify(iwxApi).sendReq(anyOrNull())
+    }
+
+    @Test
+    fun `when handling action and sdkData is null, then an error is propagated`() = runTest {
+        val action = SdkAction(sdkData = null)
+
+        delegate.exceptionFlow.test {
+            delegate.handleAction(action, "name")
+
+            assertTrue(awaitItem() is ComponentException)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when handling action and sending a request fails, then an error is propagated`() = runTest {
+        whenever(iwxApi.sendReq(any())) doReturn false
+        val action = SdkAction(sdkData = WeChatPaySdkData())
+
+        delegate.exceptionFlow.test {
+            delegate.handleAction(action, "name")
+
+            assertTrue(awaitItem() is ComponentException)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}


### PR DESCRIPTION
- Move logic from component to delegate
- Extract as much logic from `WeChatPayUtils` to classes that use it
- Wrap generation of `PayReq` in a class, so it's testable
