### PR TITLE
3DS2Delegate: Create 3DS2Delegate

### DIFF
--- a/3ds2/build.gradle
+++ b/3ds2/build.gradle
@@ -30,6 +30,10 @@ android {
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles "consumer-rules.pro"
     }
+
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
 }
 
 dependencies {
@@ -41,5 +45,9 @@ dependencies {
     api libraries.adyen3ds2
 
     //Tests
+    testImplementation project(':test-core')
+    testImplementation testLibraries.json
     testImplementation testLibraries.junit5
+    testImplementation testLibraries.mockito
+    testImplementation testLibraries.kotlinCoroutines
 }

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
@@ -9,88 +9,65 @@ package com.adyen.checkout.adyen3ds2
 
 import android.app.Activity
 import android.app.Application
-import android.content.Context
 import android.content.Intent
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.Observer
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
-import com.adyen.checkout.adyen3ds2.exception.Authentication3DS2Exception
-import com.adyen.checkout.adyen3ds2.exception.Cancelled3DS2Exception
-import com.adyen.checkout.adyen3ds2.model.ChallengeToken
-import com.adyen.checkout.adyen3ds2.model.FingerprintToken
-import com.adyen.checkout.adyen3ds2.repository.SubmitFingerprintRepository
-import com.adyen.checkout.adyen3ds2.repository.SubmitFingerprintResult
 import com.adyen.checkout.components.ActionComponentData
 import com.adyen.checkout.components.ActionComponentProvider
 import com.adyen.checkout.components.base.BaseActionComponent
 import com.adyen.checkout.components.base.IntentHandlingComponent
-import com.adyen.checkout.components.encoding.Base64Encoder
 import com.adyen.checkout.components.model.payments.response.Action
-import com.adyen.checkout.components.model.payments.response.RedirectAction
-import com.adyen.checkout.components.model.payments.response.Threeds2Action
-import com.adyen.checkout.components.model.payments.response.Threeds2Action.SubType
-import com.adyen.checkout.components.model.payments.response.Threeds2ChallengeAction
-import com.adyen.checkout.components.model.payments.response.Threeds2FingerprintAction
-import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.core.log.LogUtil
 import com.adyen.checkout.core.log.Logger
-import com.adyen.checkout.redirect.handler.RedirectHandler
-import com.adyen.threeds2.AuthenticationRequestParameters
-import com.adyen.threeds2.ChallengeStatusReceiver
-import com.adyen.threeds2.CompletionEvent
-import com.adyen.threeds2.ProtocolErrorEvent
-import com.adyen.threeds2.RuntimeErrorEvent
 import com.adyen.threeds2.ThreeDS2Service
-import com.adyen.threeds2.Transaction
 import com.adyen.threeds2.customization.UiCustomization
-import com.adyen.threeds2.exception.InvalidInputException
-import com.adyen.threeds2.exception.SDKAlreadyInitializedException
 import com.adyen.threeds2.exception.SDKNotInitializedException
-import com.adyen.threeds2.exception.SDKRuntimeException
-import com.adyen.threeds2.parameters.ChallengeParameters
-import com.adyen.threeds2.util.AdyenConfigParameters
-import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import org.json.JSONException
-import org.json.JSONObject
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
-@Suppress("TooManyFunctions")
 class Adyen3DS2Component(
     savedStateHandle: SavedStateHandle,
     application: Application,
     configuration: Adyen3DS2Configuration,
-    private val submitFingerprintRepository: SubmitFingerprintRepository,
-    private val adyen3DS2Serializer: Adyen3DS2Serializer,
-    private val redirectHandler: RedirectHandler,
+    private val adyen3DS2Delegate: Adyen3DS2Delegate,
 ) : BaseActionComponent<Adyen3DS2Configuration>(savedStateHandle, application, configuration),
-    ChallengeStatusReceiver,
     IntentHandlingComponent {
 
-    private var mTransaction: Transaction? = null
-    private var mUiCustomization: UiCustomization? = null
-    private var authorizationToken: String?
-        get() {
-            return savedStateHandle[AUTHORIZATION_TOKEN_KEY]
-        }
-        set(value) {
-            savedStateHandle[AUTHORIZATION_TOKEN_KEY] = value
-        }
+    init {
+        adyen3DS2Delegate.detailsFlow
+            .onEach { notifyDetails(it) }
+            .launchIn(viewModelScope)
 
-    override fun onCleared() {
-        super.onCleared()
-        Logger.d(TAG, "onCleared")
-        if (mTransaction != null) {
-            // We don't save the mTransaction reference if the ViewModel gets cleared.
-            sGotDestroyedWhileChallenging = true
+        adyen3DS2Delegate.exceptionFlow
+            .onEach { notifyException(it) }
+            .launchIn(viewModelScope)
+
+        adyen3DS2Delegate.eventFlow
+            .onEach { onEvent(it) }
+            .launchIn(viewModelScope)
+    }
+
+    private fun onEvent(event: Adyen3DS2Event) {
+        when (event) {
+            Adyen3DS2Event.CleanUp3DS2 -> {
+                try {
+                    ThreeDS2Service.INSTANCE.cleanup(getApplication())
+                } catch (e: SDKNotInitializedException) {
+                    // no problem
+                }
+            }
+            Adyen3DS2Event.ClearPaymentData -> {
+                paymentData = null
+            }
         }
     }
 
     override fun observe(lifecycleOwner: LifecycleOwner, observer: Observer<ActionComponentData>) {
         super.observe(lifecycleOwner, observer)
-        if (sGotDestroyedWhileChallenging) {
+        if (adyen3DS2Delegate.gotDestroyedWhileChallenging) {
             // This is OK if the user goes back and starts a new payment.
             // TODO notify error to activity?
             Logger.e(TAG, "Lost challenge result reference.")
@@ -104,269 +81,12 @@ class Adyen3DS2Component(
      * @param uiCustomization The customization object.
      */
     fun setUiCustomization(uiCustomization: UiCustomization?) {
-        mUiCustomization = uiCustomization
-    }
-
-    override fun canHandleAction(action: Action): Boolean {
-        return PROVIDER.canHandleAction(action)
+        adyen3DS2Delegate.uiCustomization = uiCustomization
     }
 
     @Throws(ComponentException::class)
     override fun handleActionInternal(activity: Activity, action: Action) {
-        when (action) {
-            is Threeds2FingerprintAction -> {
-                if (action.token.isNullOrEmpty()) {
-                    throw ComponentException("Fingerprint token not found.")
-                }
-                identifyShopper(activity, action.token.orEmpty(), submitFingerprintAutomatically = false)
-            }
-            is Threeds2ChallengeAction -> {
-                if (action.token.isNullOrEmpty()) {
-                    throw ComponentException("Challenge token not found.")
-                }
-                challengeShopper(activity, action.token.orEmpty())
-            }
-            is Threeds2Action -> {
-                if (action.token.isNullOrEmpty()) {
-                    throw ComponentException("3DS2 token not found.")
-                }
-                if (action.subtype == null) {
-                    throw ComponentException("3DS2 Action subtype not found.")
-                }
-                val subtype = SubType.parse(action.subtype.orEmpty())
-                // We need to keep authorizationToken in memory to access it later when the 3DS2 challenge is done
-                authorizationToken = action.authorisationToken
-                handleActionSubtype(activity, subtype, action.token.orEmpty())
-            }
-        }
-    }
-
-    private fun handleActionSubtype(activity: Activity, subtype: SubType, token: String) {
-        when (subtype) {
-            SubType.FINGERPRINT -> identifyShopper(activity, token, submitFingerprintAutomatically = true)
-            SubType.CHALLENGE -> challengeShopper(activity, token)
-        }
-    }
-
-    override fun completed(completionEvent: CompletionEvent) {
-        Logger.d(TAG, "challenge completed")
-        try {
-            // Check whether authorizationToken was set and create the corresponding details object
-            val token = authorizationToken
-            val details =
-                if (token == null) adyen3DS2Serializer.createChallengeDetails(completionEvent)
-                else adyen3DS2Serializer.createThreeDsResultDetails(completionEvent, token)
-            notifyDetails(details)
-        } catch (e: CheckoutException) {
-            notifyException(e)
-        } finally {
-            closeTransaction(getApplication())
-        }
-    }
-
-    override fun cancelled() {
-        Logger.d(TAG, "challenge cancelled")
-        notifyException(Cancelled3DS2Exception("Challenge canceled."))
-        closeTransaction(getApplication())
-    }
-
-    override fun timedout() {
-        Logger.d(TAG, "challenge timed out")
-        notifyException(Authentication3DS2Exception("Challenge timed out."))
-        closeTransaction(getApplication())
-    }
-
-    override fun protocolError(protocolErrorEvent: ProtocolErrorEvent) {
-        with(protocolErrorEvent.errorMessage) {
-            Logger.e(TAG, "protocolError - $errorCode - $errorDescription - $errorDetails")
-            notifyException(Authentication3DS2Exception("Protocol Error - $this"))
-        }
-        closeTransaction(getApplication())
-    }
-
-    override fun runtimeError(runtimeErrorEvent: RuntimeErrorEvent) {
-        Logger.d(TAG, "runtimeError")
-        notifyException(Authentication3DS2Exception("Runtime Error - " + runtimeErrorEvent.errorMessage))
-        closeTransaction(getApplication())
-    }
-
-    @Suppress("LongMethod")
-    @Throws(ComponentException::class)
-    private fun identifyShopper(
-        activity: Activity,
-        encodedFingerprintToken: String,
-        submitFingerprintAutomatically: Boolean
-    ) {
-        Logger.d(TAG, "identifyShopper - submitFingerprintAutomatically: $submitFingerprintAutomatically")
-        val decodedFingerprintToken = Base64Encoder.decode(encodedFingerprintToken)
-
-        val fingerprintJson: JSONObject = try {
-            JSONObject(decodedFingerprintToken)
-        } catch (e: JSONException) {
-            throw ComponentException("JSON parsing of FingerprintToken failed", e)
-        }
-
-        val fingerprintToken = FingerprintToken.SERIALIZER.deserialize(fingerprintJson)
-        val configParameters = AdyenConfigParameters.Builder(
-            fingerprintToken.directoryServerId,
-            fingerprintToken.directoryServerPublicKey
-        ).build()
-
-        val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
-            Logger.e(TAG, "Unexpected uncaught 3DS2 Exception", throwable)
-            notifyException(CheckoutException("Unexpected 3DS2 exception.", throwable))
-        }
-        viewModelScope.launch(Dispatchers.Default + coroutineExceptionHandler) {
-            try {
-                Logger.d(TAG, "initialize 3DS2 SDK")
-                ThreeDS2Service.INSTANCE.initialize(activity, configParameters, null, mUiCustomization)
-            } catch (e: SDKRuntimeException) {
-                notifyException(ComponentException("Failed to initialize 3DS2 SDK", e))
-                return@launch
-            } catch (e: SDKAlreadyInitializedException) {
-                // This shouldn't cause any side effect.
-                Logger.w(TAG, "3DS2 Service already initialized.")
-            }
-
-            mTransaction = try {
-                Logger.d(TAG, "create transaction")
-                if (fingerprintToken.threeDSMessageVersion != null) {
-                    ThreeDS2Service.INSTANCE.createTransaction(null, fingerprintToken.threeDSMessageVersion)
-                } else {
-                    notifyException(
-                        ComponentException(
-                            "Failed to create 3DS2 Transaction. Missing " +
-                                "threeDSMessageVersion inside fingerprintToken."
-                        )
-                    )
-                    return@launch
-                }
-            } catch (e: SDKNotInitializedException) {
-                notifyException(ComponentException("Failed to create 3DS2 Transaction", e))
-                return@launch
-            } catch (e: SDKRuntimeException) {
-                notifyException(ComponentException("Failed to create 3DS2 Transaction", e))
-                return@launch
-            }
-
-            val authenticationRequestParameters = mTransaction?.authenticationRequestParameters
-            if (authenticationRequestParameters == null) {
-                notifyException(ComponentException("Failed to retrieve 3DS2 authentication parameters"))
-                return@launch
-            }
-            val encodedFingerprint = createEncodedFingerprint(authenticationRequestParameters)
-            if (submitFingerprintAutomatically) {
-                submitFingerprintAutomatically(activity, encodedFingerprint)
-            } else {
-                launch(Dispatchers.Main) {
-                    notifyDetails(adyen3DS2Serializer.createFingerprintDetails(encodedFingerprint))
-                }
-            }
-        }
-    }
-
-    private suspend fun submitFingerprintAutomatically(activity: Activity, encodedFingerprint: String) {
-        submitFingerprintRepository.submitFingerprint(encodedFingerprint, configuration, paymentData)
-            .fold(
-                onSuccess = { result -> onSubmitFingerprintResult(result, activity) },
-                onFailure = { e -> notifyException(ComponentException("Unable to submit fingerprint", e)) }
-            )
-    }
-
-    private fun onSubmitFingerprintResult(result: SubmitFingerprintResult, activity: Activity) {
-        // This flow (calling the internal submitFingerprint endpoint) requires that we do not send paymentData
-        // back to the merchant. Setting it to null ensures that when the flow ends and notifyDetails is called,
-        // paymentData will not be included in the response.
-        paymentData = null
-
-        when (result) {
-            is SubmitFingerprintResult.Completed -> {
-                viewModelScope.launch(Dispatchers.Main) {
-                    notifyDetails(result.details)
-                }
-            }
-            is SubmitFingerprintResult.Redirect -> {
-                makeRedirect(activity, result.action)
-            }
-            is SubmitFingerprintResult.Threeds2 -> {
-                handleAction(activity, result.action)
-            }
-        }
-    }
-
-    private fun makeRedirect(activity: Activity, action: RedirectAction) {
-        val url = action.url
-        try {
-            Logger.d(TAG, "makeRedirect - $url")
-            redirectHandler.launchUriRedirect(activity, url)
-        } catch (ex: CheckoutException) {
-            notifyException(ex)
-        }
-    }
-
-    @Throws(ComponentException::class)
-    private fun challengeShopper(activity: Activity, encodedChallengeToken: String) {
-        Logger.d(TAG, "challengeShopper")
-        if (mTransaction == null) {
-            notifyException(
-                Authentication3DS2Exception("Failed to make challenge, missing reference to initial transaction.")
-            )
-            return
-        }
-        val decodedChallengeToken = Base64Encoder.decode(encodedChallengeToken)
-        val challengeTokenJson: JSONObject = try {
-            JSONObject(decodedChallengeToken)
-        } catch (e: JSONException) {
-            throw ComponentException("JSON parsing of FingerprintToken failed", e)
-        }
-        val challengeToken = ChallengeToken.SERIALIZER.deserialize(challengeTokenJson)
-        val challengeParameters = createChallengeParameters(challengeToken)
-        try {
-            mTransaction?.doChallenge(activity, challengeParameters, this, DEFAULT_CHALLENGE_TIME_OUT)
-        } catch (e: InvalidInputException) {
-            notifyException(CheckoutException("Error starting challenge", e))
-        }
-    }
-
-    @Throws(ComponentException::class)
-    fun createEncodedFingerprint(authenticationRequestParameters: AuthenticationRequestParameters): String {
-        val fingerprintJson = JSONObject()
-        try {
-            with(authenticationRequestParameters) {
-                fingerprintJson.put("sdkAppID", sdkAppID)
-                fingerprintJson.put("sdkEncData", deviceData)
-                fingerprintJson.put("sdkEphemPubKey", JSONObject(sdkEphemeralPublicKey))
-                fingerprintJson.put("sdkReferenceNumber", sdkReferenceNumber)
-                fingerprintJson.put("sdkTransID", sdkTransactionID)
-                fingerprintJson.put("messageVersion", messageVersion)
-            }
-        } catch (e: JSONException) {
-            throw ComponentException("Failed to create encoded fingerprint", e)
-        }
-        return Base64Encoder.encode(fingerprintJson.toString())
-    }
-
-    private fun createChallengeParameters(challenge: ChallengeToken): ChallengeParameters {
-        return ChallengeParameters().apply {
-            set3DSServerTransactionID(challenge.threeDSServerTransID)
-            acsTransactionID = challenge.acsTransID
-            acsRefNumber = challenge.acsReferenceNumber
-            acsSignedContent = challenge.acsSignedContent
-            // This field was introduced in version 2.2.0 so older protocols don't expect it to be present and might throw an error.
-            if (challenge.messageVersion != PROTOCOL_VERSION_2_1_0) {
-                threeDSRequestorAppURL = ChallengeParameters.getEmbeddedRequestorAppURL(getApplication())
-            }
-        }
-    }
-
-    private fun closeTransaction(context: Context) {
-        mTransaction?.close()
-        mTransaction = null
-        try {
-            ThreeDS2Service.INSTANCE.cleanup(context)
-        } catch (e: SDKNotInitializedException) {
-            // no problem
-        }
+        adyen3DS2Delegate.handleAction(action, activity, paymentData)
     }
 
     /**
@@ -376,25 +96,23 @@ class Adyen3DS2Component(
      * @param intent The received [Intent].
      */
     override fun handleIntent(intent: Intent) {
-        try {
-            val parsedResult = redirectHandler.parseRedirectResult(intent.data)
-            notifyDetails(parsedResult)
-        } catch (e: CheckoutException) {
-            notifyException(e)
-        }
+        adyen3DS2Delegate.handleIntent(intent)
+    }
+
+    override fun canHandleAction(action: Action): Boolean {
+        return PROVIDER.canHandleAction(action)
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        Logger.d(TAG, "onCleared")
+        adyen3DS2Delegate.onCleared()
     }
 
     companion object {
         private val TAG = LogUtil.getTag()
 
-        private const val AUTHORIZATION_TOKEN_KEY = "authorization_token"
-
         @JvmField
         val PROVIDER: ActionComponentProvider<Adyen3DS2Component, Adyen3DS2Configuration> = Adyen3DS2ComponentProvider()
-
-        private const val DEFAULT_CHALLENGE_TIME_OUT = 10
-        private const val PROTOCOL_VERSION_2_1_0 = "2.1.0"
-
-        private var sGotDestroyedWhileChallenging = false
     }
 }

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
@@ -10,11 +10,8 @@ package com.adyen.checkout.adyen3ds2
 import android.app.Activity
 import android.app.Application
 import android.content.Intent
-import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.Observer
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
-import com.adyen.checkout.components.ActionComponentData
 import com.adyen.checkout.components.ActionComponentProvider
 import com.adyen.checkout.components.base.BaseActionComponent
 import com.adyen.checkout.components.base.IntentHandlingComponent
@@ -62,15 +59,6 @@ class Adyen3DS2Component(
             Adyen3DS2Event.ClearPaymentData -> {
                 paymentData = null
             }
-        }
-    }
-
-    override fun observe(lifecycleOwner: LifecycleOwner, observer: Observer<ActionComponentData>) {
-        super.observe(lifecycleOwner, observer)
-        if (adyen3DS2Delegate.gotDestroyedWhileChallenging) {
-            // This is OK if the user goes back and starts a new payment.
-            // TODO notify error to activity?
-            Logger.e(TAG, "Lost challenge result reference.")
         }
     }
 

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
@@ -19,9 +19,7 @@ import com.adyen.checkout.components.model.payments.response.Action
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.core.log.LogUtil
 import com.adyen.checkout.core.log.Logger
-import com.adyen.threeds2.ThreeDS2Service
 import com.adyen.threeds2.customization.UiCustomization
-import com.adyen.threeds2.exception.SDKNotInitializedException
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
@@ -49,13 +47,6 @@ class Adyen3DS2Component(
 
     private fun onEvent(event: Adyen3DS2Event) {
         when (event) {
-            Adyen3DS2Event.CleanUp3DS2 -> {
-                try {
-                    ThreeDS2Service.INSTANCE.cleanup(getApplication())
-                } catch (e: SDKNotInitializedException) {
-                    // no problem
-                }
-            }
             // TODO: Remove when generic action component is ready
             Adyen3DS2Event.ClearPaymentData -> {
                 paymentData = null

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
@@ -56,6 +56,7 @@ class Adyen3DS2Component(
                     // no problem
                 }
             }
+            // TODO: Remove when generic action component is ready
             Adyen3DS2Event.ClearPaymentData -> {
                 paymentData = null
             }

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2ComponentProvider.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2ComponentProvider.kt
@@ -17,11 +17,15 @@ import com.adyen.checkout.adyen3ds2.connection.SubmitFingerprintService
 import com.adyen.checkout.adyen3ds2.repository.SubmitFingerprintRepository
 import com.adyen.checkout.components.ActionComponentProvider
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
+import com.adyen.checkout.components.encoding.AndroidBase64Encoder
 import com.adyen.checkout.components.model.payments.response.Action
 import com.adyen.checkout.components.model.payments.response.Threeds2Action
 import com.adyen.checkout.components.model.payments.response.Threeds2ChallengeAction
 import com.adyen.checkout.components.model.payments.response.Threeds2FingerprintAction
 import com.adyen.checkout.redirect.handler.DefaultRedirectHandler
+import com.adyen.threeds2.ThreeDS2Service
+import com.adyen.threeds2.parameters.ChallengeParameters
+import kotlinx.coroutines.Dispatchers
 
 class Adyen3DS2ComponentProvider : ActionComponentProvider<Adyen3DS2Component, Adyen3DS2Configuration> {
 
@@ -44,6 +48,7 @@ class Adyen3DS2ComponentProvider : ActionComponentProvider<Adyen3DS2Component, A
         val submitFingerprintRepository = SubmitFingerprintRepository(submitFingerprintService)
         val adyen3DS2DetailsParser = Adyen3DS2Serializer()
         val redirectHandler = DefaultRedirectHandler()
+        val embeddedRequestorAppUrl = ChallengeParameters.getEmbeddedRequestorAppURL(application)
 
         val threeDS2Factory = viewModelFactory(savedStateRegistryOwner, defaultArgs) { savedStateHandle ->
             val adyen3DS2Delegate = DefaultAdyen3DS2Delegate(
@@ -52,6 +57,10 @@ class Adyen3DS2ComponentProvider : ActionComponentProvider<Adyen3DS2Component, A
                 submitFingerprintRepository = submitFingerprintRepository,
                 adyen3DS2Serializer = adyen3DS2DetailsParser,
                 redirectHandler = redirectHandler,
+                threeDS2Service = ThreeDS2Service.INSTANCE,
+                defaultDispatcher = Dispatchers.Default,
+                embeddedRequestorAppUrl = embeddedRequestorAppUrl,
+                base64Encoder = AndroidBase64Encoder(),
             )
 
             Adyen3DS2Component(

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2ComponentProvider.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2ComponentProvider.kt
@@ -61,6 +61,7 @@ class Adyen3DS2ComponentProvider : ActionComponentProvider<Adyen3DS2Component, A
                 defaultDispatcher = Dispatchers.Default,
                 embeddedRequestorAppUrl = embeddedRequestorAppUrl,
                 base64Encoder = AndroidBase64Encoder(),
+                application = application,
             )
 
             Adyen3DS2Component(

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Delegate.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Delegate.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 22/8/2022.
+ */
+
+package com.adyen.checkout.adyen3ds2
+
+import android.app.Activity
+import android.content.Intent
+import com.adyen.checkout.components.model.payments.response.Action
+import com.adyen.checkout.core.exception.CheckoutException
+import com.adyen.threeds2.customization.UiCustomization
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import org.json.JSONObject
+
+interface Adyen3DS2Delegate {
+
+    val detailsFlow: Flow<JSONObject>
+
+    val exceptionFlow: Flow<CheckoutException>
+
+    val eventFlow: Flow<Adyen3DS2Event>
+
+    var uiCustomization: UiCustomization?
+
+    val gotDestroyedWhileChallenging: Boolean
+
+    fun initialize(coroutineScope: CoroutineScope)
+
+    fun handleAction(action: Action, activity: Activity, paymentData: String?)
+
+    fun handleIntent(intent: Intent)
+
+    fun onCleared()
+}

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Delegate.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Delegate.kt
@@ -27,8 +27,6 @@ interface Adyen3DS2Delegate {
 
     var uiCustomization: UiCustomization?
 
-    val gotDestroyedWhileChallenging: Boolean
-
     fun initialize(coroutineScope: CoroutineScope)
 
     fun handleAction(action: Action, activity: Activity, paymentData: String?)

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Event.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Event.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 23/8/2022.
+ */
+
+package com.adyen.checkout.adyen3ds2
+
+sealed class Adyen3DS2Event {
+
+    object CleanUp3DS2 : Adyen3DS2Event()
+
+    object ClearPaymentData : Adyen3DS2Event()
+}

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Event.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Event.kt
@@ -10,7 +10,5 @@ package com.adyen.checkout.adyen3ds2
 
 sealed class Adyen3DS2Event {
 
-    object CleanUp3DS2 : Adyen3DS2Event()
-
     object ClearPaymentData : Adyen3DS2Event()
 }

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/DefaultAdyen3DS2Delegate.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/DefaultAdyen3DS2Delegate.kt
@@ -76,9 +76,6 @@ internal class DefaultAdyen3DS2Delegate(
 
     override var uiCustomization: UiCustomization? = null
 
-    @Volatile
-    override var gotDestroyedWhileChallenging: Boolean = false
-
     private var _coroutineScope: CoroutineScope? = null
     private val coroutineScope: CoroutineScope get() = requireNotNull(_coroutineScope)
 
@@ -388,10 +385,6 @@ internal class DefaultAdyen3DS2Delegate(
     }
 
     override fun onCleared() {
-        if (currentTransaction != null) {
-            gotDestroyedWhileChallenging = true
-        }
-
         _coroutineScope = null
     }
 

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/DefaultAdyen3DS2Delegate.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/DefaultAdyen3DS2Delegate.kt
@@ -1,0 +1,383 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 22/8/2022.
+ */
+
+package com.adyen.checkout.adyen3ds2
+
+import android.app.Activity
+import android.content.Intent
+import androidx.lifecycle.SavedStateHandle
+import com.adyen.checkout.adyen3ds2.exception.Authentication3DS2Exception
+import com.adyen.checkout.adyen3ds2.exception.Cancelled3DS2Exception
+import com.adyen.checkout.adyen3ds2.model.ChallengeToken
+import com.adyen.checkout.adyen3ds2.model.FingerprintToken
+import com.adyen.checkout.adyen3ds2.repository.SubmitFingerprintRepository
+import com.adyen.checkout.adyen3ds2.repository.SubmitFingerprintResult
+import com.adyen.checkout.components.encoding.Base64Encoder
+import com.adyen.checkout.components.model.payments.response.Action
+import com.adyen.checkout.components.model.payments.response.RedirectAction
+import com.adyen.checkout.components.model.payments.response.Threeds2Action
+import com.adyen.checkout.components.model.payments.response.Threeds2ChallengeAction
+import com.adyen.checkout.components.model.payments.response.Threeds2FingerprintAction
+import com.adyen.checkout.core.exception.CheckoutException
+import com.adyen.checkout.core.exception.ComponentException
+import com.adyen.checkout.core.log.LogUtil
+import com.adyen.checkout.core.log.Logger
+import com.adyen.checkout.redirect.handler.RedirectHandler
+import com.adyen.threeds2.AuthenticationRequestParameters
+import com.adyen.threeds2.ChallengeStatusReceiver
+import com.adyen.threeds2.CompletionEvent
+import com.adyen.threeds2.ProtocolErrorEvent
+import com.adyen.threeds2.RuntimeErrorEvent
+import com.adyen.threeds2.ThreeDS2Service
+import com.adyen.threeds2.Transaction
+import com.adyen.threeds2.customization.UiCustomization
+import com.adyen.threeds2.exception.InvalidInputException
+import com.adyen.threeds2.exception.SDKAlreadyInitializedException
+import com.adyen.threeds2.exception.SDKNotInitializedException
+import com.adyen.threeds2.exception.SDKRuntimeException
+import com.adyen.threeds2.parameters.ChallengeParameters
+import com.adyen.threeds2.util.AdyenConfigParameters
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import org.json.JSONException
+import org.json.JSONObject
+
+@Suppress("TooManyFunctions")
+internal class DefaultAdyen3DS2Delegate(
+    private val savedStateHandle: SavedStateHandle,
+    private val configuration: Adyen3DS2Configuration,
+    private val submitFingerprintRepository: SubmitFingerprintRepository,
+    private val adyen3DS2Serializer: Adyen3DS2Serializer,
+    private val redirectHandler: RedirectHandler,
+) : Adyen3DS2Delegate, ChallengeStatusReceiver {
+
+    private val _detailsFlow = MutableSharedFlow<JSONObject>(1, 1, BufferOverflow.DROP_OLDEST)
+    override val detailsFlow: Flow<JSONObject> = _detailsFlow
+
+    private val _exceptionFlow = MutableSharedFlow<CheckoutException>(1, 1, BufferOverflow.DROP_OLDEST)
+    override val exceptionFlow: Flow<CheckoutException> = _exceptionFlow
+
+    private val _eventFlow = MutableSharedFlow<Adyen3DS2Event>(1, 1, BufferOverflow.DROP_OLDEST)
+    override val eventFlow: Flow<Adyen3DS2Event> = _eventFlow
+
+    override var uiCustomization: UiCustomization? = null
+
+    @Volatile
+    override var gotDestroyedWhileChallenging: Boolean = false
+
+    private var _coroutineScope: CoroutineScope? = null
+    private val coroutineScope: CoroutineScope get() = requireNotNull(_coroutineScope)
+
+    private var currentTransaction: Transaction? = null
+
+    private var authorizationToken: String?
+        get() = savedStateHandle[AUTHORIZATION_TOKEN_KEY]
+        set(value) {
+            savedStateHandle[AUTHORIZATION_TOKEN_KEY] = value
+        }
+
+    override fun initialize(coroutineScope: CoroutineScope) {
+        _coroutineScope = coroutineScope
+    }
+
+    override fun handleAction(action: Action, activity: Activity, paymentData: String?) {
+        when (action) {
+            is Threeds2FingerprintAction -> {
+                if (action.token.isNullOrEmpty()) {
+                    throw ComponentException("Fingerprint token not found.")
+                }
+                identifyShopper(activity, action.token.orEmpty(), submitFingerprintAutomatically = false, paymentData)
+            }
+            is Threeds2ChallengeAction -> {
+                if (action.token.isNullOrEmpty()) {
+                    throw ComponentException("Challenge token not found.")
+                }
+                challengeShopper(activity, action.token.orEmpty())
+            }
+            is Threeds2Action -> {
+                if (action.token.isNullOrEmpty()) {
+                    throw ComponentException("3DS2 token not found.")
+                }
+                if (action.subtype == null) {
+                    throw ComponentException("3DS2 Action subtype not found.")
+                }
+                val subtype = Threeds2Action.SubType.parse(action.subtype.orEmpty())
+                // We need to keep authorizationToken in memory to access it later when the 3DS2 challenge is done
+                authorizationToken = action.authorisationToken
+                handleActionSubtype(activity, subtype, action.token.orEmpty(), paymentData)
+            }
+        }
+    }
+
+    private fun handleActionSubtype(
+        activity: Activity,
+        subtype: Threeds2Action.SubType,
+        token: String,
+        paymentData: String?,
+    ) {
+        when (subtype) {
+            Threeds2Action.SubType.FINGERPRINT -> identifyShopper(
+                activity = activity,
+                encodedFingerprintToken = token,
+                submitFingerprintAutomatically = true,
+                paymentData = paymentData,
+            )
+            Threeds2Action.SubType.CHALLENGE -> challengeShopper(activity, token)
+        }
+    }
+
+    @Suppress("LongMethod")
+    @Throws(ComponentException::class)
+    private fun identifyShopper(
+        activity: Activity,
+        encodedFingerprintToken: String,
+        submitFingerprintAutomatically: Boolean,
+        paymentData: String?,
+    ) {
+        Logger.d(TAG, "identifyShopper - submitFingerprintAutomatically: $submitFingerprintAutomatically")
+        val decodedFingerprintToken = Base64Encoder.decode(encodedFingerprintToken)
+
+        val fingerprintJson: JSONObject = try {
+            JSONObject(decodedFingerprintToken)
+        } catch (e: JSONException) {
+            throw ComponentException("JSON parsing of FingerprintToken failed", e)
+        }
+
+        val fingerprintToken = FingerprintToken.SERIALIZER.deserialize(fingerprintJson)
+        val configParameters = AdyenConfigParameters.Builder(
+            fingerprintToken.directoryServerId,
+            fingerprintToken.directoryServerPublicKey
+        ).build()
+
+        val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
+            Logger.e(TAG, "Unexpected uncaught 3DS2 Exception", throwable)
+            _exceptionFlow.tryEmit(CheckoutException("Unexpected 3DS2 exception.", throwable))
+        }
+
+        coroutineScope.launch(Dispatchers.Default + coroutineExceptionHandler) {
+            try {
+                Logger.d(TAG, "initialize 3DS2 SDK")
+                ThreeDS2Service.INSTANCE.initialize(activity, configParameters, null, uiCustomization)
+            } catch (e: SDKRuntimeException) {
+                _exceptionFlow.tryEmit(ComponentException("Failed to initialize 3DS2 SDK", e))
+                return@launch
+            } catch (e: SDKAlreadyInitializedException) {
+                // This shouldn't cause any side effect.
+                Logger.w(TAG, "3DS2 Service already initialized.")
+            }
+
+            currentTransaction = try {
+                Logger.d(TAG, "create transaction")
+                if (fingerprintToken.threeDSMessageVersion != null) {
+                    ThreeDS2Service.INSTANCE.createTransaction(null, fingerprintToken.threeDSMessageVersion)
+                } else {
+                    _exceptionFlow.tryEmit(
+                        ComponentException(
+                            "Failed to create 3DS2 Transaction. Missing " +
+                                "threeDSMessageVersion inside fingerprintToken."
+                        )
+                    )
+                    return@launch
+                }
+            } catch (e: SDKNotInitializedException) {
+                _exceptionFlow.tryEmit(ComponentException("Failed to create 3DS2 Transaction", e))
+                return@launch
+            } catch (e: SDKRuntimeException) {
+                _exceptionFlow.tryEmit(ComponentException("Failed to create 3DS2 Transaction", e))
+                return@launch
+            }
+
+            val authenticationRequestParameters = currentTransaction?.authenticationRequestParameters
+            if (authenticationRequestParameters == null) {
+                _exceptionFlow.tryEmit(ComponentException("Failed to retrieve 3DS2 authentication parameters"))
+                return@launch
+            }
+            val encodedFingerprint = createEncodedFingerprint(authenticationRequestParameters)
+            if (submitFingerprintAutomatically) {
+                submitFingerprintAutomatically(activity, encodedFingerprint, paymentData)
+            } else {
+                _detailsFlow.tryEmit(adyen3DS2Serializer.createFingerprintDetails(encodedFingerprint))
+            }
+        }
+    }
+
+    @Throws(ComponentException::class)
+    private fun createEncodedFingerprint(authenticationRequestParameters: AuthenticationRequestParameters): String {
+        val fingerprintJson = JSONObject()
+        try {
+            with(authenticationRequestParameters) {
+                fingerprintJson.put("sdkAppID", sdkAppID)
+                fingerprintJson.put("sdkEncData", deviceData)
+                fingerprintJson.put("sdkEphemPubKey", JSONObject(sdkEphemeralPublicKey))
+                fingerprintJson.put("sdkReferenceNumber", sdkReferenceNumber)
+                fingerprintJson.put("sdkTransID", sdkTransactionID)
+                fingerprintJson.put("messageVersion", messageVersion)
+            }
+        } catch (e: JSONException) {
+            throw ComponentException("Failed to create encoded fingerprint", e)
+        }
+        return Base64Encoder.encode(fingerprintJson.toString())
+    }
+
+    private suspend fun submitFingerprintAutomatically(
+        activity: Activity,
+        encodedFingerprint: String,
+        paymentData: String?
+    ) {
+        submitFingerprintRepository.submitFingerprint(encodedFingerprint, configuration.clientKey, paymentData)
+            .fold(
+                onSuccess = { result -> onSubmitFingerprintResult(result, activity, paymentData) },
+                onFailure = { e -> _exceptionFlow.tryEmit(ComponentException("Unable to submit fingerprint", e)) }
+            )
+    }
+
+    private fun onSubmitFingerprintResult(result: SubmitFingerprintResult, activity: Activity, paymentData: String?) {
+        // This flow (calling the internal submitFingerprint endpoint) requires that we do not send paymentData
+        // back to the merchant. Setting it to null ensures that when the flow ends and notifyDetails is called,
+        // paymentData will not be included in the response.
+        _eventFlow.tryEmit(Adyen3DS2Event.ClearPaymentData)
+
+        when (result) {
+            is SubmitFingerprintResult.Completed -> {
+                _detailsFlow.tryEmit(result.details)
+            }
+            is SubmitFingerprintResult.Redirect -> {
+                makeRedirect(activity, result.action)
+            }
+            is SubmitFingerprintResult.Threeds2 -> {
+                handleAction(result.action, activity, paymentData)
+            }
+        }
+    }
+
+    private fun makeRedirect(activity: Activity, action: RedirectAction) {
+        val url = action.url
+        try {
+            Logger.d(TAG, "makeRedirect - $url")
+            redirectHandler.launchUriRedirect(activity, url)
+        } catch (e: CheckoutException) {
+            _exceptionFlow.tryEmit(e)
+        }
+    }
+
+    @Throws(ComponentException::class)
+    private fun challengeShopper(activity: Activity, encodedChallengeToken: String) {
+        Logger.d(TAG, "challengeShopper")
+        if (currentTransaction == null) {
+            _exceptionFlow.tryEmit(
+                Authentication3DS2Exception("Failed to make challenge, missing reference to initial transaction.")
+            )
+            return
+        }
+        val decodedChallengeToken = Base64Encoder.decode(encodedChallengeToken)
+        val challengeTokenJson: JSONObject = try {
+            JSONObject(decodedChallengeToken)
+        } catch (e: JSONException) {
+            throw ComponentException("JSON parsing of FingerprintToken failed", e)
+        }
+        val challengeToken = ChallengeToken.SERIALIZER.deserialize(challengeTokenJson)
+        val challengeParameters = createChallengeParameters(challengeToken, activity)
+        try {
+            currentTransaction?.doChallenge(activity, challengeParameters, this, DEFAULT_CHALLENGE_TIME_OUT)
+        } catch (e: InvalidInputException) {
+            _exceptionFlow.tryEmit(CheckoutException("Error starting challenge", e))
+        }
+    }
+
+    private fun createChallengeParameters(challenge: ChallengeToken, activity: Activity): ChallengeParameters {
+        return ChallengeParameters().apply {
+            set3DSServerTransactionID(challenge.threeDSServerTransID)
+            acsTransactionID = challenge.acsTransID
+            acsRefNumber = challenge.acsReferenceNumber
+            acsSignedContent = challenge.acsSignedContent
+            // This field was introduced in version 2.2.0 so older protocols don't expect it to be present and might
+            // throw an error.
+            if (challenge.messageVersion != PROTOCOL_VERSION_2_1_0) {
+                threeDSRequestorAppURL = ChallengeParameters.getEmbeddedRequestorAppURL(activity.applicationContext)
+            }
+        }
+    }
+
+    override fun handleIntent(intent: Intent) {
+        try {
+            val parsedResult = redirectHandler.parseRedirectResult(intent.data)
+            _detailsFlow.tryEmit(parsedResult)
+        } catch (e: CheckoutException) {
+            _exceptionFlow.tryEmit(e)
+        }
+    }
+
+    override fun completed(completionEvent: CompletionEvent) {
+        Logger.d(TAG, "challenge completed")
+        try {
+            // Check whether authorizationToken was set and create the corresponding details object
+            val token = authorizationToken
+            val details =
+                if (token == null) adyen3DS2Serializer.createChallengeDetails(completionEvent)
+                else adyen3DS2Serializer.createThreeDsResultDetails(completionEvent, token)
+            _detailsFlow.tryEmit(details)
+        } catch (e: CheckoutException) {
+            _exceptionFlow.tryEmit(e)
+        } finally {
+            closeTransaction()
+        }
+    }
+
+    override fun cancelled() {
+        Logger.d(TAG, "challenge cancelled")
+        _exceptionFlow.tryEmit(Cancelled3DS2Exception("Challenge canceled."))
+        closeTransaction()
+    }
+
+    override fun timedout() {
+        Logger.d(TAG, "challenge timed out")
+        _exceptionFlow.tryEmit(Authentication3DS2Exception("Challenge timed out."))
+        closeTransaction()
+    }
+
+    override fun protocolError(protocolErrorEvent: ProtocolErrorEvent) {
+        with(protocolErrorEvent.errorMessage) {
+            Logger.e(TAG, "protocolError - $errorCode - $errorDescription - $errorDetails")
+            _exceptionFlow.tryEmit(Authentication3DS2Exception("Protocol Error - $this"))
+        }
+        closeTransaction()
+    }
+
+    override fun runtimeError(runtimeErrorEvent: RuntimeErrorEvent) {
+        Logger.d(TAG, "runtimeError")
+        _exceptionFlow.tryEmit(Authentication3DS2Exception("Runtime Error - " + runtimeErrorEvent.errorMessage))
+        closeTransaction()
+    }
+
+    private fun closeTransaction() {
+        currentTransaction?.close()
+        currentTransaction = null
+        _eventFlow.tryEmit(Adyen3DS2Event.CleanUp3DS2)
+    }
+
+    override fun onCleared() {
+        if (currentTransaction != null) {
+            gotDestroyedWhileChallenging = true
+        }
+
+        _coroutineScope = null
+    }
+
+    companion object {
+        private val TAG = LogUtil.getTag()
+
+        private const val AUTHORIZATION_TOKEN_KEY = "authorization_token"
+        private const val DEFAULT_CHALLENGE_TIME_OUT = 10
+        private const val PROTOCOL_VERSION_2_1_0 = "2.1.0"
+    }
+}

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/model/ChallengeResult.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/model/ChallengeResult.kt
@@ -7,7 +7,7 @@
  */
 package com.adyen.checkout.adyen3ds2.model
 
-import com.adyen.checkout.components.encoding.Base64Encoder
+import com.adyen.checkout.components.encoding.AndroidBase64Encoder
 import com.adyen.threeds2.CompletionEvent
 import org.json.JSONException
 import org.json.JSONObject
@@ -34,7 +34,7 @@ class ChallengeResult private constructor(val isAuthenticated: Boolean, val payl
             val jsonObject = JSONObject()
             jsonObject.put(KEY_TRANSACTION_STATUS, transactionStatus)
             jsonObject.putOpt(KEY_AUTHORISATION_TOKEN, authorisationToken)
-            val payload = Base64Encoder.encode(jsonObject.toString())
+            val payload = AndroidBase64Encoder().encode(jsonObject.toString())
             return ChallengeResult(isAuthenticated, payload)
         }
     }

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/repository/SubmitFingerprintRepository.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/repository/SubmitFingerprintRepository.kt
@@ -8,7 +8,6 @@
 
 package com.adyen.checkout.adyen3ds2.repository
 
-import com.adyen.checkout.adyen3ds2.Adyen3DS2Configuration
 import com.adyen.checkout.adyen3ds2.connection.SubmitFingerprintService
 import com.adyen.checkout.adyen3ds2.model.SubmitFingerprintRequest
 import com.adyen.checkout.components.model.payments.response.RedirectAction
@@ -18,11 +17,13 @@ import com.adyen.checkout.core.log.Logger
 import com.adyen.checkout.core.util.runSuspendCatching
 import org.json.JSONObject
 
-class SubmitFingerprintRepository {
+class SubmitFingerprintRepository internal constructor(
+    private val submitFingerprintService: SubmitFingerprintService
+) {
 
     suspend fun submitFingerprint(
         encodedFingerprint: String,
-        configuration: Adyen3DS2Configuration,
+        clientKey: String,
         paymentData: String?
     ): Result<SubmitFingerprintResult> = runSuspendCatching {
         Logger.d(TAG, "Submitting fingerprint automatically")
@@ -32,10 +33,7 @@ class SubmitFingerprintRepository {
             paymentData = paymentData
         )
 
-        val response = SubmitFingerprintService(configuration.environment).submitFingerprint(
-            request,
-            configuration.clientKey
-        )
+        val response = submitFingerprintService.submitFingerprint(request, clientKey)
 
         when {
             response.type == RESPONSE_TYPE_COMPLETED && response.details != null -> {

--- a/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/DefaultAdyen3DS2DelegateTest.kt
+++ b/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/DefaultAdyen3DS2DelegateTest.kt
@@ -1,0 +1,571 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 24/8/2022.
+ */
+
+package com.adyen.checkout.adyen3ds2
+
+import android.app.Activity
+import android.content.Intent
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import app.cash.turbine.testIn
+import com.adyen.checkout.adyen3ds2.exception.Authentication3DS2Exception
+import com.adyen.checkout.adyen3ds2.exception.Cancelled3DS2Exception
+import com.adyen.checkout.adyen3ds2.repository.SubmitFingerprintRepository
+import com.adyen.checkout.adyen3ds2.repository.SubmitFingerprintResult
+import com.adyen.checkout.components.encoding.JavaBase64Encoder
+import com.adyen.checkout.components.model.payments.response.RedirectAction
+import com.adyen.checkout.components.model.payments.response.Threeds2Action
+import com.adyen.checkout.components.model.payments.response.Threeds2ChallengeAction
+import com.adyen.checkout.components.model.payments.response.Threeds2FingerprintAction
+import com.adyen.checkout.core.api.Environment
+import com.adyen.checkout.core.exception.ComponentException
+import com.adyen.checkout.redirect.test.TestRedirectHandler
+import com.adyen.checkout.test.TestDispatcherExtension
+import com.adyen.threeds2.AuthenticationRequestParameters
+import com.adyen.threeds2.ChallengeStatusReceiver
+import com.adyen.threeds2.CompletionEvent
+import com.adyen.threeds2.ErrorMessage
+import com.adyen.threeds2.ProgressDialog
+import com.adyen.threeds2.ProtocolErrorEvent
+import com.adyen.threeds2.RuntimeErrorEvent
+import com.adyen.threeds2.ThreeDS2Service
+import com.adyen.threeds2.Transaction
+import com.adyen.threeds2.exception.InvalidInputException
+import com.adyen.threeds2.exception.SDKRuntimeException
+import com.adyen.threeds2.parameters.ChallengeParameters
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.json.JSONException
+import org.json.JSONObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
+import java.io.IOException
+import java.util.Locale
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(MockitoExtension::class, TestDispatcherExtension::class)
+internal class DefaultAdyen3DS2DelegateTest(
+    @Mock private val submitFingerprintRepository: SubmitFingerprintRepository,
+    @Mock private val adyen3DS2Serializer: Adyen3DS2Serializer,
+    @Mock private val threeDS2Service: ThreeDS2Service,
+) {
+
+    private lateinit var redirectHandler: TestRedirectHandler
+    private lateinit var delegate: DefaultAdyen3DS2Delegate
+
+    private val base64Encoder = JavaBase64Encoder()
+
+    @BeforeEach
+    fun beforeEach(dispatcher: TestDispatcher) {
+        redirectHandler = TestRedirectHandler()
+        delegate = DefaultAdyen3DS2Delegate(
+            savedStateHandle = SavedStateHandle(),
+            configuration = Adyen3DS2Configuration.Builder(Locale.US, Environment.TEST, TEST_CLIENT_KEY).build(),
+            submitFingerprintRepository = submitFingerprintRepository,
+            adyen3DS2Serializer = adyen3DS2Serializer,
+            redirectHandler = redirectHandler,
+            threeDS2Service = threeDS2Service,
+            defaultDispatcher = dispatcher,
+            embeddedRequestorAppUrl = "embeddedRequestorAppUrl",
+            base64Encoder = base64Encoder,
+        )
+    }
+
+    @Nested
+    @DisplayName("when handling")
+    inner class HandleActionTest {
+
+        @Test
+        fun `Threeds2FingerprintAction and token is null, then an exception is thrown`(
+            dispatcher: TestDispatcher
+        ) = runTest {
+            delegate.initialize(CoroutineScope(dispatcher))
+
+            delegate.exceptionFlow.test {
+                delegate.handleAction(Threeds2FingerprintAction(token = null), Activity(), null)
+
+                assertTrue(awaitItem() is ComponentException)
+            }
+        }
+
+        @Test
+        fun `Threeds2ChallengeAction and token is null, then an exception is thrown`(
+            dispatcher: TestDispatcher
+        ) = runTest {
+            delegate.initialize(CoroutineScope(dispatcher))
+
+            delegate.exceptionFlow.test {
+                delegate.handleAction(Threeds2ChallengeAction(token = null), Activity(), null)
+
+                assertTrue(awaitItem() is ComponentException)
+            }
+        }
+
+        @Test
+        fun `Threeds2Action and token is null, then an exception is thrown`(
+            dispatcher: TestDispatcher
+        ) = runTest {
+            delegate.initialize(CoroutineScope(dispatcher))
+
+            delegate.exceptionFlow.test {
+                delegate.handleAction(Threeds2Action(token = null), Activity(), null)
+
+                assertTrue(awaitItem() is ComponentException)
+            }
+        }
+
+        @Test
+        fun `Threeds2Action and sub type is null, then an exception is thrown`(
+            dispatcher: TestDispatcher
+        ) = runTest {
+            delegate.initialize(CoroutineScope(dispatcher))
+
+            delegate.exceptionFlow.test {
+                delegate.handleAction(Threeds2Action(token = "sometoken", subtype = null), Activity(), null)
+
+                assertTrue(awaitItem() is ComponentException)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("when identifying shopper and")
+    inner class IdentifyShopperTest {
+
+        @Test
+        fun `fingerprint is malformed, then an exception is thrown`(dispatcher: TestDispatcher) = runTest {
+            delegate.initialize(CoroutineScope(dispatcher))
+
+            assertThrows<ComponentException> {
+                val encodedJson = base64Encoder.encode("{incorrectJson}")
+                delegate.identifyShopper(Activity(), encodedJson, false, null)
+            }
+        }
+
+        @Test
+        fun `3ds2 sdk throws an exception while initializing, then an exception emitted`(dispatcher: TestDispatcher) =
+            runTest {
+                val error = SDKRuntimeException("test", "test", null)
+                whenever(threeDS2Service.initialize(any(), any(), anyOrNull(), anyOrNull())) doAnswer {
+                    throw error
+                }
+                delegate.initialize(CoroutineScope(dispatcher))
+
+                delegate.exceptionFlow.test {
+                    val encodedJson = base64Encoder.encode(
+                        "{\"directoryServerId\": \"id\", \"directoryServerPublicKey\": \"key\"}"
+                    )
+                    delegate.identifyShopper(Activity(), encodedJson, false, null)
+
+                    assertEquals(error, awaitItem().cause)
+                }
+            }
+
+        @Test
+        fun `creating 3ds2 transaction fails, then an exception emitted`(dispatcher: TestDispatcher) = runTest {
+            val error = SDKRuntimeException("test", "test", null)
+            whenever(threeDS2Service.createTransaction(anyOrNull(), any())) doAnswer {
+                throw error
+            }
+            delegate.initialize(CoroutineScope(dispatcher))
+
+            delegate.exceptionFlow.test {
+                val encodedJson = base64Encoder.encode(
+                    "{\"directoryServerId\": \"id\", \"directoryServerPublicKey\": \"key\", \"threeDSMessageVersion\":\"2.1.0\"}"
+                )
+                delegate.identifyShopper(Activity(), encodedJson, false, null)
+
+                assertEquals(error, awaitItem().cause)
+            }
+        }
+
+        @Test
+        fun `transaction parameters are null, then an exception emitted`(dispatcher: TestDispatcher) = runTest {
+            whenever(threeDS2Service.createTransaction(anyOrNull(), any())) doReturn TestTransaction()
+            delegate.initialize(CoroutineScope(dispatcher))
+
+            delegate.exceptionFlow.test {
+                val encodedJson = base64Encoder.encode(
+                    "{\"directoryServerId\": \"id\", \"directoryServerPublicKey\": \"key\", \"threeDSMessageVersion\":\"2.1.0\"}"
+                )
+                delegate.identifyShopper(Activity(), encodedJson, false, null)
+
+                assertTrue(awaitItem() is ComponentException)
+            }
+        }
+
+        @Test
+        fun `fingerprint is submitted automatically and result is completed, then details are emitted`(dispatcher: TestDispatcher) =
+            runTest {
+                val authReqParams = TestAuthenticationRequestParameters(
+                    deviceData = "deviceData",
+                    sdkTransactionID = "sdkTransactionID",
+                    sdkAppID = "sdkAppID",
+                    sdkReferenceNumber = "sdkReferenceNumber",
+                    sdkEphemeralPublicKey = "{}",
+                    messageVersion = "messageVersion",
+                )
+                whenever(threeDS2Service.createTransaction(anyOrNull(), any())) doReturn TestTransaction(authReqParams)
+                val submitFingerprintResult = SubmitFingerprintResult.Completed(JSONObject())
+                whenever(submitFingerprintRepository.submitFingerprint(any(), any(), anyOrNull())) doReturn
+                    Result.success(submitFingerprintResult)
+
+                delegate.initialize(CoroutineScope(dispatcher))
+
+                val encodedJson = base64Encoder.encode(
+                    "{\"directoryServerId\": \"id\", \"directoryServerPublicKey\": \"key\", \"threeDSMessageVersion\":\"2.1.0\"}"
+                )
+                delegate.identifyShopper(Activity(), encodedJson, true, null)
+
+                val eventFlowTest = delegate.eventFlow.testIn(this)
+                val detailsFlowTest = delegate.detailsFlow.testIn(this)
+
+                assertEquals(eventFlowTest.awaitItem(), Adyen3DS2Event.ClearPaymentData)
+                assertEquals(detailsFlowTest.awaitItem(), submitFingerprintResult.details)
+
+                eventFlowTest.cancel()
+                detailsFlowTest.cancel()
+            }
+
+        @Test
+        fun `fingerprint is submitted automatically and result is redirect, then redirect should be handled`(dispatcher: TestDispatcher) =
+            runTest {
+                val authReqParams = TestAuthenticationRequestParameters(
+                    deviceData = "deviceData",
+                    sdkTransactionID = "sdkTransactionID",
+                    sdkAppID = "sdkAppID",
+                    sdkReferenceNumber = "sdkReferenceNumber",
+                    sdkEphemeralPublicKey = "{}",
+                    messageVersion = "messageVersion",
+                )
+                whenever(threeDS2Service.createTransaction(anyOrNull(), any())) doReturn TestTransaction(authReqParams)
+                val submitFingerprintResult = SubmitFingerprintResult.Redirect(RedirectAction())
+                whenever(submitFingerprintRepository.submitFingerprint(any(), any(), anyOrNull())) doReturn
+                    Result.success(submitFingerprintResult)
+
+                delegate.initialize(CoroutineScope(dispatcher))
+
+                val encodedJson = base64Encoder.encode(
+                    "{\"directoryServerId\": \"id\", \"directoryServerPublicKey\": \"key\", \"threeDSMessageVersion\":\"2.1.0\"}"
+                )
+                delegate.identifyShopper(Activity(), encodedJson, true, null)
+
+                redirectHandler.assertLaunchRedirectCalled()
+            }
+
+        @Test
+        fun `fingerprint is submitted automatically and it fails, then an exception is emitted`(dispatcher: TestDispatcher) =
+            runTest {
+                val authReqParams = TestAuthenticationRequestParameters(
+                    deviceData = "deviceData",
+                    sdkTransactionID = "sdkTransactionID",
+                    sdkAppID = "sdkAppID",
+                    sdkReferenceNumber = "sdkReferenceNumber",
+                    sdkEphemeralPublicKey = "{}",
+                    messageVersion = "messageVersion",
+                )
+                whenever(threeDS2Service.createTransaction(anyOrNull(), any())) doReturn TestTransaction(authReqParams)
+                val error = IOException("test")
+                whenever(submitFingerprintRepository.submitFingerprint(any(), any(), anyOrNull())) doReturn
+                    Result.failure(error)
+
+                delegate.initialize(CoroutineScope(dispatcher))
+
+                delegate.exceptionFlow.test {
+                    val encodedJson = base64Encoder.encode(
+                        "{\"directoryServerId\": \"id\", \"directoryServerPublicKey\": \"key\", \"threeDSMessageVersion\":\"2.1.0\"}"
+                    )
+                    delegate.identifyShopper(Activity(), encodedJson, true, null)
+                    assertEquals(error, awaitItem().cause)
+                }
+            }
+
+        @Test
+        fun `fingerprint is not submitted automatically, then details are emitted`(dispatcher: TestDispatcher) =
+            runTest {
+                val authReqParams = TestAuthenticationRequestParameters(
+                    deviceData = "deviceData",
+                    sdkTransactionID = "sdkTransactionID",
+                    sdkAppID = "sdkAppID",
+                    sdkReferenceNumber = "sdkReferenceNumber",
+                    sdkEphemeralPublicKey = "{}",
+                    messageVersion = "messageVersion",
+                )
+                whenever(threeDS2Service.createTransaction(anyOrNull(), any())) doReturn TestTransaction(authReqParams)
+                val fingerprintDetails = JSONObject("{\"finger\":\"print\"}")
+                whenever(adyen3DS2Serializer.createFingerprintDetails(any())) doReturn fingerprintDetails
+
+                delegate.initialize(CoroutineScope(dispatcher))
+
+                delegate.detailsFlow.test {
+                    val encodedJson = base64Encoder.encode(
+                        "{\"directoryServerId\": \"id\", \"directoryServerPublicKey\": \"key\", \"threeDSMessageVersion\":\"2.1.0\"}"
+                    )
+                    delegate.identifyShopper(Activity(), encodedJson, false, null)
+
+                    assertEquals(fingerprintDetails, awaitItem())
+                }
+            }
+    }
+
+    @Nested
+    @DisplayName("when challenging shopper and")
+    inner class ChallengeShopperTest {
+
+        @Test
+        fun `transaction is null, then an exception is emitted`() = runTest {
+            delegate.exceptionFlow.test {
+                delegate.challengeShopper(Activity(), "token")
+
+                assertTrue(awaitItem() is Authentication3DS2Exception)
+            }
+        }
+
+        @Test
+        fun `token can't be decoded, then an exception is emitted`(dispatcher: TestDispatcher) = runTest {
+            initializeTransaction(dispatcher)
+
+            delegate.exceptionFlow.test {
+                delegate.challengeShopper(Activity(), base64Encoder.encode("token"))
+
+                assertTrue(awaitItem().cause is JSONException)
+            }
+        }
+
+        @Test
+        fun `everything is good, then challenge should be executed`(dispatcher: TestDispatcher) = runTest {
+            val transaction = initializeTransaction(dispatcher)
+
+            delegate.challengeShopper(Activity(), base64Encoder.encode("{}"))
+
+            transaction.assertDoChallengeCalled()
+        }
+
+        @Test
+        fun `challenge fails, then an exception is emitted`(dispatcher: TestDispatcher) = runTest {
+            initializeTransaction(dispatcher).apply {
+                shouldThrowError = true
+            }
+
+            delegate.exceptionFlow.test {
+                delegate.challengeShopper(Activity(), base64Encoder.encode("{}"))
+
+                assertTrue(awaitItem().cause is InvalidInputException)
+            }
+
+        }
+
+        private fun initializeTransaction(dispatcher: TestDispatcher): TestTransaction {
+            val authReqParams = TestAuthenticationRequestParameters(
+                deviceData = "deviceData",
+                sdkTransactionID = "sdkTransactionID",
+                sdkAppID = "sdkAppID",
+                sdkReferenceNumber = "sdkReferenceNumber",
+                sdkEphemeralPublicKey = "{}",
+                messageVersion = "messageVersion",
+            )
+            val transaction = TestTransaction(authReqParams)
+            whenever(threeDS2Service.createTransaction(anyOrNull(), any())) doReturn transaction
+
+            delegate.initialize(CoroutineScope(dispatcher))
+
+            val encodedJson = base64Encoder.encode(
+                "{\"directoryServerId\": \"id\", \"directoryServerPublicKey\": \"key\", \"threeDSMessageVersion\":\"2.1.0\"}"
+            )
+            delegate.identifyShopper(Activity(), encodedJson, false, null)
+
+            return transaction
+        }
+    }
+
+    @Nested
+    @DisplayName("when handling intent and")
+    inner class HandleIntentTest {
+
+        @Test
+        fun `result is parsed, then details are emitted`() = runTest {
+            delegate.detailsFlow.test {
+                delegate.handleIntent(Intent())
+
+                assertEquals(TestRedirectHandler.REDIRECT_RESULT, awaitItem())
+            }
+        }
+
+        @Test
+        fun `parsing fails, then an exception is emitted`() = runTest {
+            val error = ComponentException("yes")
+            redirectHandler.exception = error
+
+            delegate.exceptionFlow.test {
+                delegate.handleIntent(Intent())
+
+                assertEquals(error, awaitItem())
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("when transaction is")
+    inner class TransactionTest {
+
+        @Test
+        fun `completed, then details are emitted`() = runTest {
+            val details = JSONObject("{}")
+            whenever(adyen3DS2Serializer.createChallengeDetails(any())) doReturn details
+
+            delegate.detailsFlow.test {
+                delegate.completed(TestCompletionEvent())
+
+                assertEquals(details, awaitItem())
+            }
+        }
+
+        @Test
+        fun `completed and creating details fails, then an error is emitted`() = runTest {
+            val error = ComponentException("test")
+            whenever(adyen3DS2Serializer.createChallengeDetails(any())) doAnswer { throw error }
+
+            delegate.exceptionFlow.test {
+                delegate.completed(TestCompletionEvent())
+
+                assertEquals(error, awaitItem())
+            }
+        }
+
+        @Test
+        fun `cancelled, then an error is emitted`() = runTest {
+            delegate.exceptionFlow.test {
+                delegate.cancelled()
+
+                assertTrue(awaitItem() is Cancelled3DS2Exception)
+            }
+        }
+
+        @Test
+        fun `timedout, then an error is emitted`() = runTest {
+            delegate.exceptionFlow.test {
+                delegate.timedout()
+
+                assertTrue(awaitItem() is Authentication3DS2Exception)
+            }
+        }
+
+        @Test
+        fun `protocolError, then an error is emitted`() = runTest {
+            delegate.exceptionFlow.test {
+                delegate.protocolError(TestProtocolErrorEvent())
+
+                assertTrue(awaitItem() is Authentication3DS2Exception)
+            }
+        }
+
+        @Test
+        fun `runtimeError, then an error is emitted`() = runTest {
+            delegate.exceptionFlow.test {
+                delegate.runtimeError(TestRuntimeErrorEvent())
+
+                assertTrue(awaitItem() is Authentication3DS2Exception)
+            }
+        }
+    }
+
+    private class TestTransaction(
+        val authReqParameters: AuthenticationRequestParameters? = null
+    ) : Transaction {
+
+        var shouldThrowError: Boolean = false
+
+        private var timesDoChallengeCalled = 0
+
+        override fun getAuthenticationRequestParameters(): AuthenticationRequestParameters? = authReqParameters
+
+        override fun doChallenge(p0: Activity?, p1: ChallengeParameters?, p2: ChallengeStatusReceiver?, p3: Int) {
+            timesDoChallengeCalled++
+            if (shouldThrowError) {
+                throw InvalidInputException("test", null)
+            }
+        }
+
+        override fun getProgressView(p0: Activity?): ProgressDialog {
+            throw IllegalStateException("This method should not be used")
+        }
+
+        override fun close() = Unit
+
+        fun assertDoChallengeCalled() {
+            assert(timesDoChallengeCalled > 0)
+        }
+    }
+
+    private class TestAuthenticationRequestParameters(
+        private val deviceData: String? = null,
+        private val sdkTransactionID: String? = null,
+        private val sdkAppID: String? = null,
+        private val sdkReferenceNumber: String? = null,
+        private val sdkEphemeralPublicKey: String? = null,
+        private val messageVersion: String? = null,
+    ) : AuthenticationRequestParameters {
+
+        override fun getDeviceData(): String? = deviceData
+
+        override fun getSDKTransactionID(): String? = sdkTransactionID
+
+        override fun getSDKAppID(): String? = sdkAppID
+
+        override fun getSDKReferenceNumber(): String? = sdkReferenceNumber
+
+        override fun getSDKEphemeralPublicKey(): String? = sdkEphemeralPublicKey
+
+        override fun getMessageVersion(): String? = messageVersion
+    }
+
+    private class TestCompletionEvent : CompletionEvent {
+        override fun getSDKTransactionID(): String = "transactionId"
+
+        override fun getTransactionStatus(): String = "status"
+    }
+
+    private class TestProtocolErrorEvent : ProtocolErrorEvent {
+        override fun getErrorMessage(): ErrorMessage = object : ErrorMessage {
+            override fun getErrorCode(): String = ""
+
+            override fun getErrorDescription(): String = ""
+
+            override fun getErrorDetails(): String = ""
+
+            override fun getTransactionID(): String = ""
+        }
+
+        override fun getSDKTransactionID(): String = "transactionId"
+    }
+
+    private class TestRuntimeErrorEvent : RuntimeErrorEvent {
+        override fun getErrorCode(): String = ""
+
+        override fun getErrorMessage(): String = ""
+    }
+
+    companion object {
+        private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
+    }
+}

--- a/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/DefaultAdyen3DS2DelegateTest.kt
+++ b/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/DefaultAdyen3DS2DelegateTest.kt
@@ -9,6 +9,7 @@
 package com.adyen.checkout.adyen3ds2
 
 import android.app.Activity
+import android.app.Application
 import android.content.Intent
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
@@ -88,6 +89,7 @@ internal class DefaultAdyen3DS2DelegateTest(
             defaultDispatcher = dispatcher,
             embeddedRequestorAppUrl = "embeddedRequestorAppUrl",
             base64Encoder = base64Encoder,
+            application = Application(),
         )
     }
 

--- a/components-core/src/main/java/com/adyen/checkout/components/encoding/Base64Encoder.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/encoding/Base64Encoder.kt
@@ -9,21 +9,57 @@ package com.adyen.checkout.components.encoding
 
 import android.util.Base64
 import java.nio.charset.Charset
+import java.util.Base64 as JavaBase64
 
-object Base64Encoder {
+interface Base64Encoder {
 
-    private const val UTF_8 = "UTF-8"
-    private val DEFAULT_CHARSET = if (Charset.isSupported(UTF_8)) Charset.forName(UTF_8) else Charset.defaultCharset()
+    fun encode(decodedData: String, flags: Int = Base64.DEFAULT): String
 
-    @JvmOverloads
-    fun encode(decodedData: String, flags: Int = Base64.DEFAULT): String {
+    fun decode(encodedData: String, flags: Int = Base64.DEFAULT): String
+}
+
+/**
+ * Use this encoder to base64 encode and decode strings
+ */
+class AndroidBase64Encoder : Base64Encoder {
+
+    override fun encode(decodedData: String, flags: Int): String {
         val decodedBytes = decodedData.toByteArray(DEFAULT_CHARSET)
         return Base64.encodeToString(decodedBytes, flags)
     }
 
-    @JvmOverloads
-    fun decode(encodedData: String, flags: Int = Base64.DEFAULT): String {
+    override fun decode(encodedData: String, flags: Int): String {
         val decodedBytes = Base64.decode(encodedData, flags)
         return String(decodedBytes, DEFAULT_CHARSET)
+    }
+
+    companion object {
+        private const val UTF_8 = "UTF-8"
+        private val DEFAULT_CHARSET =
+            if (Charset.isSupported(UTF_8)) Charset.forName(UTF_8) else Charset.defaultCharset()
+    }
+}
+
+/**
+ * Java implementation of [AndroidBase64Encoder]. This implementations can only be used from API 26+ and is mainly used
+ * for testing.
+ */
+@Suppress("NewApi")
+class JavaBase64Encoder : Base64Encoder {
+
+    override fun encode(decodedData: String, flags: Int): String {
+        val decodedBytes = decodedData.toByteArray(DEFAULT_CHARSET)
+        return JavaBase64.getEncoder().encodeToString(decodedBytes)
+    }
+
+    override fun decode(encodedData: String, flags: Int): String {
+        val decodedBytes = JavaBase64.getDecoder().decode(encodedData)
+        return String(decodedBytes, DEFAULT_CHARSET)
+    }
+
+    companion object {
+        private const val UTF_8 = "UTF-8"
+        private val DEFAULT_CHARSET =
+            if (Charset.isSupported(UTF_8)) Charset.forName(UTF_8) else Charset.defaultCharset()
     }
 }

--- a/redirect/src/main/java/com/adyen/checkout/redirect/test/TestRedirectHandler.kt
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/test/TestRedirectHandler.kt
@@ -24,14 +24,20 @@ class TestRedirectHandler : RedirectHandler {
 
     var exception: ComponentException? = null
 
+    private var timesLaunchRedirectCalled = 0
+
     override fun parseRedirectResult(data: Uri?): JSONObject {
         exception?.let { throw it }
         return REDIRECT_RESULT
     }
 
     override fun launchUriRedirect(context: Context, url: String?) {
+        timesLaunchRedirectCalled++
         exception?.let { throw it }
     }
+
+    fun assertLaunchRedirectCalled() =
+        assert(timesLaunchRedirectCalled > 0)
 
     companion object {
         val REDIRECT_RESULT = JSONObject().apply { put("redirect", "successful") }


### PR DESCRIPTION
- Move logic from component to delegate
- Split `Base64Encoder` into an interface and two implementations (for testing)
- Small tweaks to make testing easier
