### PR TITLE
UpdateAndroidXLifecycle: Update AndroidX Lifecycle dependencies to 2.5.1

### DIFF
--- a/config/gradle/checksums.gradle
+++ b/config/gradle/checksums.gradle
@@ -24,9 +24,10 @@ if (!hasProperty("checksums")) {
 
             // AndroidX
             "androidx.annotation:annotation:1.3.0:a65958ba342e73cd31b9246352ce732a:MD5",
-            "androidx.fragment:fragment-ktx:1.4.1:89baa4e2b70ec7639074ac644a6163cf:MD5",
-            "androidx.lifecycle:lifecycle-runtime-ktx:2.4.1:10397b0b421aeb3d9031fd418378a5c4:MD5",
-            "androidx.lifecycle:lifecycle-livedata-ktx:2.4.1:a0a4d0121a45df158367a9d88e365ca0:MD5",
+            "androidx.fragment:fragment-ktx:1.5.2:f452192442630a0a8a118fd9ecf14bea:MD5",
+            "androidx.lifecycle:lifecycle-runtime-ktx:2.5.1:ddec34e06f4a0f22fd183b94a6772fce:MD5",
+            "androidx.lifecycle:lifecycle-livedata-ktx:2.5.1:310579b5e3add440a01fb6ce60097929:MD5",
+            "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1:4167b1a439be9f530c5cbf26b590e5cb:MD5",
             "androidx.appcompat:appcompat:1.3.1:19cb8c81e85229a2d43fc770278b7dbe:MD5",
             "androidx.recyclerview:recyclerview:1.2.1:4c7c87151df88efe8e3b25d634874896:MD5",
             "androidx.browser:browser:1.3.0:f4bd0b4782e1a25c4c3fae304aa982c2:MD5",

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -35,8 +35,8 @@ ext {
     appcompat_version = "1.3.1"
     browser_version = "1.3.0"
     coroutines_version = "1.6.3"
-    fragment_version = "1.4.1"
-    lifecycle_version = "2.4.1"
+    fragment_version = "1.5.2"
+    lifecycle_version = "2.5.1"
     material_version = "1.4.0"
     recyclerview_version = "1.2.1"
 
@@ -80,7 +80,8 @@ ext {
             fragment        : "androidx.fragment:fragment-ktx:$fragment_version",
             lifecycle       : [
                 "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_version",
-                "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
+                "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version",
+                "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
             ],
             preference      : "androidx.preference:preference-ktx:$preference_version",
             recyclerview    : "androidx.recyclerview:recyclerview:$recyclerview_version"


### PR DESCRIPTION
Also needed to update AndroidX Fragment to fix the issues caused by the latest Hilt version