### PR TITLE
Release 4.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ If you are upgrading from 3.x.x to a current release, check out our [migration g
 Import the Component module for the Payment Method you want to use by adding it to your `build.gradle` file.
 For example, for the Drop-in solution you should add:
 ```groovy
-implementation "com.adyen.checkout:drop-in:4.7.1"
+implementation "com.adyen.checkout:drop-in:4.8.0"
 ```
 For a Credit Card component you should add:
 ```groovy
-implementation "com.adyen.checkout:card:4.7.1"
+implementation "com.adyen.checkout:card:4.8.0"
 ```
 
 ### Client Key

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,12 @@
 [//]: # ( - DropIn service's package changed from `com.adyen.dropin` to `com.adyen.dropin.services`)
 [//]: # ( # Deprecated)
 [//]: # ( - Configurations public constructor are deprecated, please use each Configuration's builder to make a Configuration object)
+## Added
+- `Online banking Poland` Component
+
+## Changed
+- Update 3DS2 SDK version to `2.2.8`
 
 ## Fixed
-- For BACS Direct Debit, an error message appears under the payment agreement text if the shopper selects the **Continue** button without selecting the toggles to agree.
+- Gracefully terminate drop in without crashing when coming back from a redirect after drop-in was closed
+- Updating 3DS2 SDK version fixed a crash on Android 13

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ allprojects {
     // just for example app, don't need to increment
     ext.version_code = 1
     // The version_name format is "major.minor.patch(-(alpha|beta|rc)[0-9]{2}){0,1}" (e.g. 3.0.0, 3.1.1-alpha04 or 3.1.4-rc01 etc).
-    ext.version_name = "4.7.1"
+    ext.version_name = "4.8.0"
 
     // Code quality
     ext.ktlint_version = '0.40.0'

--- a/example-app/build.gradle
+++ b/example-app/build.gradle
@@ -72,7 +72,7 @@ android {
 dependencies {
     // Checkout
     implementation project(':drop-in')
-//    implementation "com.adyen.checkout:drop-in:4.7.1"
+//    implementation "com.adyen.checkout:drop-in:4.8.0"
 
     // Dependencies
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinx_version"


### PR DESCRIPTION
## Added
- `Online banking Poland` Component

## Changed
- Update 3DS2 SDK version to `2.2.8`

## Fixed
- Gracefully terminate drop in without crashing when coming back from a redirect after drop-in was closed
- Updating 3DS2 SDK version fixed a crash on Android 13