### PR TITLE
IntermediateActionScreen: Show payment in progress screen for redirect and 3ds2

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Delegate.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Delegate.kt
@@ -12,12 +12,14 @@ import com.adyen.checkout.components.base.ActionDelegate
 import com.adyen.checkout.components.base.DetailsEmittingDelegate
 import com.adyen.checkout.components.base.IntentHandlingDelegate
 import com.adyen.checkout.components.model.payments.response.BaseThreeds2Action
+import com.adyen.checkout.components.ui.ViewProvidingDelegate
 import com.adyen.threeds2.customization.UiCustomization
 
 interface Adyen3DS2Delegate :
     ActionDelegate<BaseThreeds2Action>,
     DetailsEmittingDelegate,
-    IntentHandlingDelegate {
+    IntentHandlingDelegate,
+    ViewProvidingDelegate {
 
     fun set3DS2UICustomization(uiCustomization: UiCustomization?)
 }

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2ViewProvider.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2ViewProvider.kt
@@ -6,7 +6,7 @@
  * Created by oscars on 23/9/2022.
  */
 
-package com.adyen.checkout.redirect
+package com.adyen.checkout.adyen3ds2
 
 import android.content.Context
 import android.util.AttributeSet
@@ -15,7 +15,7 @@ import com.adyen.checkout.components.ui.PaymentInProgressView
 import com.adyen.checkout.components.ui.ViewProvider
 import com.adyen.checkout.components.ui.view.ComponentViewType
 
-internal object RedirectViewProvider : ViewProvider {
+object Adyen3DS2ViewProvider : ViewProvider {
 
     override fun getView(
         viewType: ComponentViewType,
@@ -24,9 +24,9 @@ internal object RedirectViewProvider : ViewProvider {
         defStyleAttr: Int
     ): ComponentViewNew = when (viewType) {
         // TODO find out why passing attrs crashes
-        RedirectComponentViewType -> PaymentInProgressView(context, null, defStyleAttr)
-        else -> throw IllegalArgumentException("Unsupported view type")
+        Adyen3DS2ComponentViewType -> PaymentInProgressView(context, null, defStyleAttr)
+        else -> throw IllegalStateException("Unsupported view type")
     }
 }
 
-object RedirectComponentViewType : ComponentViewType
+object Adyen3DS2ComponentViewType : ComponentViewType

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2ViewProvider.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2ViewProvider.kt
@@ -23,8 +23,7 @@ object Adyen3DS2ViewProvider : ViewProvider {
         attrs: AttributeSet?,
         defStyleAttr: Int
     ): ComponentViewNew = when (viewType) {
-        // TODO find out why passing attrs crashes
-        Adyen3DS2ComponentViewType -> PaymentInProgressView(context, null, defStyleAttr)
+        Adyen3DS2ComponentViewType -> PaymentInProgressView(context, attrs, defStyleAttr)
         else -> throw IllegalStateException("Unsupported view type")
     }
 }

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/DefaultAdyen3DS2Delegate.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/DefaultAdyen3DS2Delegate.kt
@@ -28,6 +28,8 @@ import com.adyen.checkout.components.model.payments.response.Threeds2Action
 import com.adyen.checkout.components.model.payments.response.Threeds2ChallengeAction
 import com.adyen.checkout.components.model.payments.response.Threeds2FingerprintAction
 import com.adyen.checkout.components.repository.PaymentDataRepository
+import com.adyen.checkout.components.ui.ViewProvider
+import com.adyen.checkout.components.ui.view.ComponentViewType
 import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.core.log.LogUtil
@@ -51,6 +53,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import org.json.JSONException
 import org.json.JSONObject
@@ -75,6 +78,8 @@ internal class DefaultAdyen3DS2Delegate(
 
     private val _exceptionFlow = MutableSingleEventSharedFlow<CheckoutException>()
     override val exceptionFlow: Flow<CheckoutException> = _exceptionFlow
+
+    override val viewFlow: Flow<ComponentViewType?> = MutableStateFlow(Adyen3DS2ComponentViewType)
 
     private var _coroutineScope: CoroutineScope? = null
     private val coroutineScope: CoroutineScope get() = requireNotNull(_coroutineScope)
@@ -406,6 +411,8 @@ internal class DefaultAdyen3DS2Delegate(
             // Safe to ignore
         }
     }
+
+    override fun getViewProvider(): ViewProvider = Adyen3DS2ViewProvider
 
     override fun onCleared() {
         _coroutineScope = null

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/DefaultAdyen3DS2Delegate.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/DefaultAdyen3DS2Delegate.kt
@@ -412,6 +412,10 @@ internal class DefaultAdyen3DS2Delegate(
         }
     }
 
+    override fun onError(e: CheckoutException) {
+        _exceptionFlow.tryEmit(e)
+    }
+
     override fun getViewProvider(): ViewProvider = Adyen3DS2ViewProvider
 
     override fun onCleared() {

--- a/action/src/test/java/com/adyen/checkout/action/TestActionDelegate.kt
+++ b/action/src/test/java/com/adyen/checkout/action/TestActionDelegate.kt
@@ -29,6 +29,7 @@ import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.qrcode.QRCodeOutputData
 import com.adyen.threeds2.customization.UiCustomization
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 
@@ -83,22 +84,30 @@ internal class TestActionDelegate :
 }
 
 internal class Test3DS2Delegate : Adyen3DS2Delegate {
+
+    override val detailsFlow: MutableSharedFlow<ActionComponentData> = MutableSingleEventSharedFlow()
+
+    override val exceptionFlow: Flow<CheckoutException> = MutableSingleEventSharedFlow()
+
+    override val viewFlow: Flow<ComponentViewType?> = MutableSingleEventSharedFlow()
+
     var uiCustomization: UiCustomization? = null
+
+    var handleActionCalled = false
 
     override fun set3DS2UICustomization(uiCustomization: UiCustomization?) {
         this.uiCustomization = uiCustomization
     }
 
-    override val exceptionFlow: MutableSharedFlow<CheckoutException> = MutableSingleEventSharedFlow()
-
-    var handleActionCalled = false
     override fun handleAction(action: BaseThreeds2Action, activity: Activity) {
         handleActionCalled = true
     }
 
-    override val detailsFlow: MutableSharedFlow<ActionComponentData> = MutableSingleEventSharedFlow()
-
     override fun handleIntent(intent: Intent) = Unit
+
+    override fun getViewProvider(): ViewProvider {
+        throw IllegalStateException("This method should not be called from unit tests")
+    }
 }
 
 internal object TestComponentViewType : ComponentViewType

--- a/await/src/main/res/layout/await_view.xml
+++ b/await/src/main/res/layout/await_view.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+
 <!--
   ~ Copyright (c) 2020 Adyen N.V.
   ~
@@ -7,8 +8,7 @@
   ~ Created by caiof on 2/9/2020.
   -->
 
-<merge
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -42,8 +42,7 @@
         <ProgressBar
             android:layout_width="36dp"
             android:layout_height="36dp"
-            android:indeterminateTint="?android:attr/colorPrimary"
-            tools:targetApi="lollipop" />
+            android:indeterminateTint="?android:attr/colorPrimary" />
 
         <TextView
             android:id="@+id/textView_waiting_confirmation"

--- a/checkout-core/src/main/java/com/adyen/checkout/core/exception/CancellationException.kt
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/exception/CancellationException.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 28/9/2022.
+ */
+
+package com.adyen.checkout.core.exception
+
+/**
+ * This exception indicates that the payment flow was manually cancelled by the user.
+ */
+class CancellationException(errorMessage: String) : CheckoutException(errorMessage)

--- a/components-core/src/main/java/com/adyen/checkout/components/base/ActionDelegate.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/base/ActionDelegate.kt
@@ -26,6 +26,11 @@ interface ActionDelegate<ActionT : Action> : ComponentDelegate {
     fun initialize(coroutineScope: CoroutineScope) = Unit
 
     /**
+     * Override this method if you need to emit to the [exceptionFlow] from outside of this class.
+     */
+    fun onError(e: CheckoutException) = Unit
+
+    /**
      * Override this method if you used [initialize] to clear any local reference to [CoroutineScope].
      */
     fun onCleared() = Unit

--- a/components-core/src/test/java/com/adyen/checkout/components/status/DefaultStatusRepositoryTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/status/DefaultStatusRepositoryTest.kt
@@ -13,8 +13,6 @@ import com.adyen.checkout.components.status.api.StatusService
 import com.adyen.checkout.components.status.model.StatusResponse
 import com.adyen.checkout.test.TestDispatcherExtension
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -40,15 +38,12 @@ internal class DefaultStatusRepositoryTest(
     }
 
     @Test
-    fun `when receiving the final result, then it should be emitted and the flow should end`(
-        dispatcher: TestDispatcher
-    ) = runTest(dispatcher) {
+    fun `when receiving the final result, then it should be emitted and the flow should end`() = runTest {
         val response = StatusResponse(resultCode = "final")
         whenever(statusService.checkStatus(any(), any())) doReturn response
 
         statusRepository
             .poll("paymentData")
-            .flowOn(dispatcher)
             .test {
                 val expected = Result.success(response)
                 assertEquals(expected, awaitItem())
@@ -58,9 +53,7 @@ internal class DefaultStatusRepositoryTest(
     }
 
     @Test
-    fun `when refreshing the status, then the result is emitted immediately`(
-        dispatcher: TestDispatcher
-    ) = runTest(dispatcher) {
+    fun `when refreshing the status, then the result is emitted immediately`() = runTest() {
         val refreshResponse = StatusResponse(resultCode = "refresh")
         whenever(statusService.checkStatus(any(), any()))
             // return final result first, so polling stops
@@ -68,7 +61,6 @@ internal class DefaultStatusRepositoryTest(
 
         statusRepository
             .poll("paymentData")
-            .flowOn(dispatcher)
             .test {
                 skipItems(1)
 

--- a/config/gradle/checksums.gradle
+++ b/config/gradle/checksums.gradle
@@ -24,6 +24,7 @@ if (!hasProperty("checksums")) {
 
             // AndroidX
             "androidx.annotation:annotation:1.3.0:a65958ba342e73cd31b9246352ce732a:MD5",
+            "androidx.constraintlayout:constraintlayout:2.0.2:d3275b02544603c93a81397020891052:MD5",
             "androidx.fragment:fragment-ktx:1.5.2:f452192442630a0a8a118fd9ecf14bea:MD5",
             "androidx.lifecycle:lifecycle-runtime-ktx:2.5.1:ddec34e06f4a0f22fd183b94a6772fce:MD5",
             "androidx.lifecycle:lifecycle-livedata-ktx:2.5.1:310579b5e3add440a01fb6ce60097929:MD5",

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/LazyArguments.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/LazyArguments.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 20/9/2022.
+ */
+
+package com.adyen.checkout.dropin.ui
+
+import android.app.Activity
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import kotlin.reflect.KProperty
+
+internal inline fun <reified T> Activity.arguments(key: String): LazyProvider<Fragment, T> =
+    argumentDelegate(key) { intent?.extras }
+
+internal inline fun <reified T> Fragment.arguments(key: String): LazyProvider<Fragment, T> =
+    argumentDelegate(key) { arguments }
+
+internal inline fun <A, reified T> argumentDelegate(
+    key: String,
+    crossinline provideArguments: (A) -> Bundle?
+): LazyProvider<A, T> = object : LazyProvider<A, T> {
+    override fun provideDelegate(argumentsFactory: A, prop: KProperty<*>): Lazy<T> = lazy {
+        provideArguments(argumentsFactory)?.get(key) as T
+    }
+}
+
+internal interface LazyProvider<A, T> {
+    operator fun provideDelegate(argumentsFactory: A, prop: KProperty<*>): Lazy<T>
+}

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
@@ -20,6 +20,7 @@ import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.components.ActionComponentData
 import com.adyen.checkout.components.ComponentError
 import com.adyen.checkout.components.model.payments.response.Action
+import com.adyen.checkout.core.exception.CancellationException
 import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.core.log.LogUtil
 import com.adyen.checkout.core.log.Logger
@@ -116,8 +117,16 @@ class ActionComponentDialogFragment : DropInBottomSheetDialogFragment() {
     }
 
     private fun handleError(componentError: ComponentError) {
-        Logger.e(TAG, componentError.errorMessage)
-        protocol.showError(getString(R.string.action_failed), componentError.errorMessage, true)
+        when (componentError.exception) {
+            is CancellationException -> {
+                Logger.d(TAG, "Flow was cancelled by user")
+                onBackPressed()
+            }
+            else -> {
+                Logger.e(TAG, componentError.errorMessage)
+                protocol.showError(getString(R.string.action_failed), componentError.errorMessage, true)
+            }
+        }
     }
 
     private fun shouldFinishWithAction(): Boolean {

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
@@ -25,6 +25,7 @@ import com.adyen.checkout.core.log.LogUtil
 import com.adyen.checkout.core.log.Logger
 import com.adyen.checkout.dropin.R
 import com.adyen.checkout.dropin.databinding.FragmentGenericActionComponentBinding
+import com.adyen.checkout.dropin.ui.arguments
 import com.adyen.checkout.dropin.ui.base.DropInBottomSheetDialogFragment
 
 @SuppressWarnings("TooManyFunctions")
@@ -33,18 +34,13 @@ class ActionComponentDialogFragment : DropInBottomSheetDialogFragment() {
     private var _binding: FragmentGenericActionComponentBinding? = null
     private val binding: FragmentGenericActionComponentBinding get() = requireNotNull(_binding)
 
-    private lateinit var action: Action
-    private lateinit var actionType: String
-    private lateinit var actionConfiguration: GenericActionConfiguration
+    private val action: Action by arguments(ACTION)
+    private val actionConfiguration: GenericActionConfiguration by arguments(ACTION_CONFIGURATION)
     private lateinit var actionComponent: GenericActionComponent
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         Logger.d(TAG, "onCreate")
-        action = arguments?.getParcelable(ACTION) ?: throw IllegalArgumentException("Action not found")
-        actionType = action.type ?: throw IllegalArgumentException("Action type not found")
-        actionConfiguration =
-            arguments?.getParcelable(ACTION_CONFIGURATION) ?: throw IllegalArgumentException("Configuration not found")
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -68,12 +64,12 @@ class ActionComponentDialogFragment : DropInBottomSheetDialogFragment() {
                 }
             }
 
+            actionComponent.handleAction(requireActivity(), action)
+
             actionComponent.observe(viewLifecycleOwner, ::onActionComponentDataChanged)
             actionComponent.observeErrors(viewLifecycleOwner, ::onError)
 
             binding.componentView.attach(actionComponent, viewLifecycleOwner)
-
-            actionComponent.handleAction(requireActivity(), action)
         } catch (e: CheckoutException) {
             handleError(ComponentError(e))
         }

--- a/redirect/src/main/java/com/adyen/checkout/redirect/DefaultRedirectDelegate.kt
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/DefaultRedirectDelegate.kt
@@ -73,5 +73,9 @@ internal class DefaultRedirectDelegate(
         )
     }
 
+    override fun onError(e: CheckoutException) {
+        _exceptionFlow.tryEmit(e)
+    }
+
     override fun getViewProvider(): ViewProvider = RedirectViewProvider
 }

--- a/redirect/src/main/java/com/adyen/checkout/redirect/DefaultRedirectDelegate.kt
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/DefaultRedirectDelegate.kt
@@ -14,12 +14,15 @@ import com.adyen.checkout.components.ActionComponentData
 import com.adyen.checkout.components.flow.MutableSingleEventSharedFlow
 import com.adyen.checkout.components.model.payments.response.RedirectAction
 import com.adyen.checkout.components.repository.PaymentDataRepository
+import com.adyen.checkout.components.ui.ViewProvider
+import com.adyen.checkout.components.ui.view.ComponentViewType
 import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.core.log.LogUtil
 import com.adyen.checkout.core.log.Logger
 import com.adyen.checkout.redirect.handler.RedirectHandler
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.json.JSONObject
 
 private val TAG = LogUtil.getTag()
@@ -34,6 +37,8 @@ internal class DefaultRedirectDelegate(
 
     private val _exceptionFlow: MutableSharedFlow<CheckoutException> = MutableSingleEventSharedFlow()
     override val exceptionFlow: Flow<CheckoutException> = _exceptionFlow
+
+    override val viewFlow: Flow<ComponentViewType?> = MutableStateFlow(RedirectComponentViewType)
 
     override fun handleAction(action: RedirectAction, activity: Activity) {
         paymentDataRepository.paymentData = action.paymentData
@@ -67,4 +72,6 @@ internal class DefaultRedirectDelegate(
             paymentData = paymentDataRepository.paymentData,
         )
     }
+
+    override fun getViewProvider(): ViewProvider = RedirectViewProvider
 }

--- a/redirect/src/main/java/com/adyen/checkout/redirect/RedirectDelegate.kt
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/RedirectDelegate.kt
@@ -12,5 +12,10 @@ import com.adyen.checkout.components.base.ActionDelegate
 import com.adyen.checkout.components.base.DetailsEmittingDelegate
 import com.adyen.checkout.components.base.IntentHandlingDelegate
 import com.adyen.checkout.components.model.payments.response.RedirectAction
+import com.adyen.checkout.components.ui.ViewProvidingDelegate
 
-interface RedirectDelegate : ActionDelegate<RedirectAction>, DetailsEmittingDelegate, IntentHandlingDelegate
+interface RedirectDelegate :
+    ActionDelegate<RedirectAction>,
+    DetailsEmittingDelegate,
+    IntentHandlingDelegate,
+    ViewProvidingDelegate

--- a/redirect/src/main/java/com/adyen/checkout/redirect/RedirectViewProvider.kt
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/RedirectViewProvider.kt
@@ -23,8 +23,7 @@ internal object RedirectViewProvider : ViewProvider {
         attrs: AttributeSet?,
         defStyleAttr: Int
     ): ComponentViewNew = when (viewType) {
-        // TODO find out why passing attrs crashes
-        RedirectComponentViewType -> PaymentInProgressView(context, null, defStyleAttr)
+        RedirectComponentViewType -> PaymentInProgressView(context, attrs, defStyleAttr)
         else -> throw IllegalArgumentException("Unsupported view type")
     }
 }

--- a/redirect/src/main/java/com/adyen/checkout/redirect/RedirectViewProvider.kt
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/RedirectViewProvider.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 23/9/2022.
+ */
+
+package com.adyen.checkout.redirect
+
+import android.content.Context
+import android.util.AttributeSet
+import com.adyen.checkout.components.ui.ComponentViewNew
+import com.adyen.checkout.components.ui.PaymentInProgressView
+import com.adyen.checkout.components.ui.ViewProvider
+import com.adyen.checkout.components.ui.view.ComponentViewType
+
+internal object RedirectViewProvider : ViewProvider {
+
+    override fun getView(
+        viewType: ComponentViewType,
+        context: Context,
+        attrs: AttributeSet?,
+        defStyleAttr: Int
+    ): ComponentViewNew = when (viewType) {
+        RedirectComponentViewType -> PaymentInProgressView(context, null, defStyleAttr)
+        else -> throw IllegalArgumentException("Unsupported view type")
+    }
+}
+
+object RedirectComponentViewType : ComponentViewType

--- a/ui-core/build.gradle
+++ b/ui-core/build.gradle
@@ -30,6 +30,10 @@ android {
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         consumerProguardFiles "consumer-rules.pro"
     }
+
+    buildFeatures {
+        viewBinding true
+    }
 }
 
 dependencies {
@@ -38,6 +42,7 @@ dependencies {
 
     // Dependencies
     implementation libraries.androidx.appcompat
+    api libraries.androidx.constraintlayout
     implementation libraries.androidx.recyclerview
     implementation libraries.material
 

--- a/ui-core/src/main/java/com/adyen/checkout/components/ui/PaymentInProgressView.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/components/ui/PaymentInProgressView.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 23/9/2022.
+ */
+
+package com.adyen.checkout.components.ui
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
+import androidx.constraintlayout.widget.ConstraintLayout
+import com.adyen.checkout.components.base.ComponentDelegate
+import com.adyen.checkout.components.ui.databinding.ViewPaymentInProgressBinding
+import kotlinx.coroutines.CoroutineScope
+
+class PaymentInProgressView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) :
+    ConstraintLayout(
+        context,
+        attrs,
+        defStyleAttr
+    ),
+    ComponentViewNew {
+
+    private val binding = ViewPaymentInProgressBinding.inflate(LayoutInflater.from(context), this)
+
+    init {
+        layoutParams = LayoutParams(MATCH_PARENT, WRAP_CONTENT)
+    }
+
+    override fun initView(delegate: ComponentDelegate, coroutineScope: CoroutineScope, localizedContext: Context) {
+        initLocalizedStrings(localizedContext)
+
+        binding.buttonPaymentinprogressAbort.setOnClickListener {
+        }
+    }
+
+    @Suppress("SetTextI18n", "UNUSED_PARAMETER")
+    private fun initLocalizedStrings(localizedContext: Context) {
+        with(binding) {
+            // TODO: Use string resources when we have final design
+            textviewPaymentinprogressDescription.text = "Waiting for confirmation"
+            buttonPaymentinprogressAbort.text = "I'm too broke"
+        }
+    }
+
+    override val isConfirmationRequired: Boolean = false
+
+    override fun highlightValidationErrors() = Unit
+
+    override fun getView(): View = this
+}

--- a/ui-core/src/main/java/com/adyen/checkout/components/ui/PaymentInProgressView.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/components/ui/PaymentInProgressView.kt
@@ -12,8 +12,6 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup.LayoutParams.MATCH_PARENT
-import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import androidx.constraintlayout.widget.ConstraintLayout
 import com.adyen.checkout.components.base.ActionDelegate
 import com.adyen.checkout.components.base.ComponentDelegate
@@ -35,16 +33,12 @@ class PaymentInProgressView @JvmOverloads constructor(
 
     private val binding = ViewPaymentInProgressBinding.inflate(LayoutInflater.from(context), this)
 
-    init {
-        layoutParams = LayoutParams(MATCH_PARENT, WRAP_CONTENT)
-    }
-
     override fun initView(delegate: ComponentDelegate, coroutineScope: CoroutineScope, localizedContext: Context) {
         if (delegate !is ActionDelegate<*>) throw IllegalStateException("Unsupported delegate type")
 
         initLocalizedStrings(localizedContext)
 
-        binding.buttonPaymentinprogressAbort.setOnClickListener {
+        binding.buttonPaymentInProgressAbort.setOnClickListener {
             delegate.onError(CancellationException("Payment in progress was cancelled"))
         }
     }
@@ -53,8 +47,8 @@ class PaymentInProgressView @JvmOverloads constructor(
     private fun initLocalizedStrings(localizedContext: Context) {
         with(binding) {
             // TODO: Use string resources when we have final design
-            textviewPaymentinprogressDescription.text = "Waiting for confirmation"
-            buttonPaymentinprogressAbort.text = "I'm too broke"
+            textViewPaymentInProgressDescription.text = "Waiting for confirmation"
+            buttonPaymentInProgressAbort.text = "I'm too broke"
         }
     }
 

--- a/ui-core/src/main/java/com/adyen/checkout/components/ui/PaymentInProgressView.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/components/ui/PaymentInProgressView.kt
@@ -15,8 +15,10 @@ import android.view.View
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import androidx.constraintlayout.widget.ConstraintLayout
+import com.adyen.checkout.components.base.ActionDelegate
 import com.adyen.checkout.components.base.ComponentDelegate
 import com.adyen.checkout.components.ui.databinding.ViewPaymentInProgressBinding
+import com.adyen.checkout.core.exception.CancellationException
 import kotlinx.coroutines.CoroutineScope
 
 class PaymentInProgressView @JvmOverloads constructor(
@@ -38,9 +40,12 @@ class PaymentInProgressView @JvmOverloads constructor(
     }
 
     override fun initView(delegate: ComponentDelegate, coroutineScope: CoroutineScope, localizedContext: Context) {
+        if (delegate !is ActionDelegate<*>) throw IllegalStateException("Unsupported delegate type")
+
         initLocalizedStrings(localizedContext)
 
         binding.buttonPaymentinprogressAbort.setOnClickListener {
+            delegate.onError(CancellationException("Payment in progress was cancelled"))
         }
     }
 

--- a/ui-core/src/main/res/layout/view_payment_in_progress.xml
+++ b/ui-core/src/main/res/layout/view_payment_in_progress.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright (c) 2022 Adyen N.V.
+  ~
+  ~ This file is open source and available under the MIT license. See the LICENSE file for more info.
+  ~
+  ~ Created by oscars on 23/9/2022.
+  -->
+
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
+
+    <ProgressBar
+        android:id="@+id/progressbar_paymentinprogress"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:layout_marginTop="16dp"
+        android:indeterminateTint="?android:attr/colorPrimary"
+        app:layout_constraintEnd_toStartOf="@id/textview_paymentinprogress_description"
+        app:layout_constraintHorizontal_chainStyle="packed"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/textview_paymentinprogress_description"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="8dp"
+        app:layout_constraintBottom_toBottomOf="@id/progressbar_paymentinprogress"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/progressbar_paymentinprogress"
+        app:layout_constraintTop_toTopOf="@id/progressbar_paymentinprogress"
+        tools:text="Waiting for confirmation" />
+
+    <Button
+        android:id="@+id/button_paymentinprogress_abort"
+        style="@style/AdyenCheckout.Button.Secondary"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/progressbar_paymentinprogress"
+        tools:text="Abandon payment" />
+
+</merge>

--- a/ui-core/src/main/res/layout/view_payment_in_progress.xml
+++ b/ui-core/src/main/res/layout/view_payment_in_progress.xml
@@ -16,29 +16,29 @@
     tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
 
     <ProgressBar
-        android:id="@+id/progressbar_paymentinprogress"
+        android:id="@+id/progressBar_paymentInProgress"
         android:layout_width="36dp"
         android:layout_height="36dp"
         android:layout_marginTop="16dp"
         android:indeterminateTint="?android:attr/colorPrimary"
-        app:layout_constraintEnd_toStartOf="@id/textview_paymentinprogress_description"
+        app:layout_constraintEnd_toStartOf="@id/textView_paymentInProgress_description"
         app:layout_constraintHorizontal_chainStyle="packed"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
-        android:id="@+id/textview_paymentinprogress_description"
+        android:id="@+id/textView_paymentInProgress_description"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="8dp"
-        app:layout_constraintBottom_toBottomOf="@id/progressbar_paymentinprogress"
+        app:layout_constraintBottom_toBottomOf="@id/progressBar_paymentInProgress"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/progressbar_paymentinprogress"
-        app:layout_constraintTop_toTopOf="@id/progressbar_paymentinprogress"
+        app:layout_constraintStart_toEndOf="@+id/progressBar_paymentInProgress"
+        app:layout_constraintTop_toTopOf="@id/progressBar_paymentInProgress"
         tools:text="Waiting for confirmation" />
 
     <Button
-        android:id="@+id/button_paymentinprogress_abort"
+        android:id="@+id/button_paymentInProgress_abort"
         style="@style/AdyenCheckout.Button.Secondary"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -46,7 +46,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/progressbar_paymentinprogress"
-        tools:text="Abandon payment" />
+        app:layout_constraintTop_toBottomOf="@+id/progressBar_paymentInProgress"
+        tools:text="I'm too broke" />
 
 </merge>

--- a/wechatpay/build.gradle
+++ b/wechatpay/build.gradle
@@ -38,6 +38,7 @@ android {
 dependencies {
     // Checkout
     api project(':components-core')
+    api project(':ui-core')
 
     // Dependencies
     implementation libraries.wechat

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/DefaultWeChatDelegate.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/DefaultWeChatDelegate.kt
@@ -16,6 +16,8 @@ import com.adyen.checkout.components.flow.MutableSingleEventSharedFlow
 import com.adyen.checkout.components.model.payments.response.SdkAction
 import com.adyen.checkout.components.model.payments.response.WeChatPaySdkData
 import com.adyen.checkout.components.repository.PaymentDataRepository
+import com.adyen.checkout.components.ui.ViewProvider
+import com.adyen.checkout.components.ui.view.ComponentViewType
 import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.core.log.LogUtil
@@ -26,6 +28,7 @@ import com.tencent.mm.opensdk.openapi.IWXAPI
 import com.tencent.mm.opensdk.openapi.IWXAPIEventHandler
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.json.JSONException
 import org.json.JSONObject
 
@@ -40,6 +43,8 @@ internal class DefaultWeChatDelegate(
 
     private val _exceptionFlow: MutableSharedFlow<CheckoutException> = MutableSingleEventSharedFlow()
     override val exceptionFlow: Flow<CheckoutException> = _exceptionFlow
+
+    override val viewFlow: Flow<ComponentViewType?> = MutableStateFlow(WeChatComponentViewType)
 
     private val eventHandler = object : IWXAPIEventHandler {
         override fun onReq(baseReq: BaseReq) = Unit
@@ -111,6 +116,8 @@ internal class DefaultWeChatDelegate(
             paymentData = paymentDataRepository.paymentData,
         )
     }
+
+    override fun getViewProvider(): ViewProvider = WeChatViewProvider
 
     companion object {
         private val TAG = LogUtil.getTag()

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatDelegate.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatDelegate.kt
@@ -13,5 +13,10 @@ import com.adyen.checkout.components.base.DetailsEmittingDelegate
 import com.adyen.checkout.components.base.IntentHandlingDelegate
 import com.adyen.checkout.components.model.payments.response.SdkAction
 import com.adyen.checkout.components.model.payments.response.WeChatPaySdkData
+import com.adyen.checkout.components.ui.ViewProvidingDelegate
 
-interface WeChatDelegate : ActionDelegate<SdkAction<WeChatPaySdkData>>, DetailsEmittingDelegate, IntentHandlingDelegate
+interface WeChatDelegate :
+    ActionDelegate<SdkAction<WeChatPaySdkData>>,
+    DetailsEmittingDelegate,
+    IntentHandlingDelegate,
+    ViewProvidingDelegate

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatViewProvider.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatViewProvider.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 4/10/2022.
+ */
+
+package com.adyen.checkout.wechatpay
+
+import android.content.Context
+import android.util.AttributeSet
+import com.adyen.checkout.components.ui.ComponentViewNew
+import com.adyen.checkout.components.ui.PaymentInProgressView
+import com.adyen.checkout.components.ui.ViewProvider
+import com.adyen.checkout.components.ui.view.ComponentViewType
+
+internal object WeChatViewProvider : ViewProvider {
+
+    override fun getView(
+        viewType: ComponentViewType,
+        context: Context,
+        attrs: AttributeSet?,
+        defStyleAttr: Int
+    ): ComponentViewNew = when (viewType) {
+        WeChatComponentViewType -> PaymentInProgressView(context, attrs, defStyleAttr)
+        else -> throw IllegalArgumentException("Unsupported view type")
+    }
+}
+
+internal object WeChatComponentViewType : ComponentViewType


### PR DESCRIPTION
- Add `PaymentInProgressView`. It looks a bit like the `AwaitView`, but it might change once we have a final design
- Show this new view for redirect and 3ds2 payment flows

Bonus:
- Make `DefaultStatusRepositoryTest` more stable
- Add extension method to lazily initialise arguments:
```Kotlin
class MyFragment : Fragment() {

    // Not so cool way to do it
    private val someArgument: ParcelableClass
        get() = arguments?.getParcelable(ARG_KEY) ?: throw IllegalStateException("OH NO")

    // Cool way to do it 😎 
    private val someArgument: ParcelableClass by arguments(ARG_KEY)

    ...
}
```