### PR TITLE
Fix bottom sheets in landscape

### DIFF
--- a/config/gradle/checksums.gradle
+++ b/config/gradle/checksums.gradle
@@ -34,7 +34,7 @@ if (!hasProperty("checksums")) {
             "androidx.browser:browser:1.3.0:f4bd0b4782e1a25c4c3fae304aa982c2:MD5",
 
             // Google
-            "com.google.android.material:material:1.4.0:78381e0a7541f6480b22b202d1ba2fbd:MD5",
+            "com.google.android.material:material:1.6.1:def6680e132be7fd5f84d3caca354c92:MD5",
             "com.google.android.gms:play-services-wallet:18.1.3:2314339d19e7fe101ae793085ed08863:MD5",
 
             // WeChatPay

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -37,7 +37,7 @@ ext {
     coroutines_version = "1.6.3"
     fragment_version = "1.5.2"
     lifecycle_version = "2.5.1"
-    material_version = "1.4.0"
+    material_version = "1.6.1"
     recyclerview_version = "1.2.1"
 
     // Adyen Dependencies

--- a/example-app/src/main/res/values-land/styles_bottom_sheet.xml
+++ b/example-app/src/main/res/values-land/styles_bottom_sheet.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="Widget.Adyen.BottomSheetDialogTheme" parent="@style/ThemeOverlay.MaterialComponents.BottomSheetDialog">
+        <item name="android:windowIsFloating">false</item>
+        <item name="bottomSheetStyle">@style/Widget.Adyen.BottomSheet</item>
+        <item name="android:windowSoftInputMode">adjustResize</item>
+
+        <!-- If the navigation bar color is not fully opaque the window insets are not taken into
+             account. This causes it to appear not centered in landscape. -->
+        <item name="android:navigationBarColor">@color/color_background</item>
+    </style>
+
+</resources>

--- a/ui-core/src/main/java/com/adyen/checkout/components/ui/view/AdyenSwipeToRevealLayout.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/components/ui/view/AdyenSwipeToRevealLayout.kt
@@ -28,7 +28,7 @@ import kotlin.math.min
 
 private const val CHILD_COUNT = 2
 
-private const val ELEVATION_CORRECTION = 56f
+private const val ELEVATION_CORRECTION = 44f
 
 /**
  * A swipeable view that contains two child views which are:

--- a/ui-core/src/main/res/values-land/styles_bottom_sheet.xml
+++ b/ui-core/src/main/res/values-land/styles_bottom_sheet.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="AdyenCheckout.BottomSheetDialogTheme" parent="@style/ThemeOverlay.MaterialComponents.BottomSheetDialog">
+        <item name="android:windowIsFloating">false</item>
+        <item name="bottomSheetStyle">@style/AdyenCheckout.BottomSheet</item>
+        <item name="android:windowSoftInputMode">adjustResize</item>
+
+        <!-- If the navigation bar color is not fully opaque the window insets are not taken into
+             account. This causes it to appear not centered in landscape. -->
+        <item name="android:navigationBarColor">?android:colorBackground</item>
+    </style>
+
+</resources>


### PR DESCRIPTION
- Setting the navigation bar color to an opaque color fixed the positioning
- Updating the Material library fixed an issue with the sizing of AdyenSwipeToRevealLayout
- Noticed that the background color of AdyenSwipeToRevealLayout was slightly off in dark mode, so adjusted it to better match