### PR TITLE
MinCardNumberLength: Set min card number length to 12

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/CardValidationMapper.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardValidationMapper.kt
@@ -20,7 +20,6 @@ class CardValidationMapper {
                 Validation.Invalid(R.string.checkout_card_number_not_valid)
             CardNumberValidation.INVALID_TOO_SHORT -> Validation.Invalid(R.string.checkout_card_number_not_valid)
             CardNumberValidation.INVALID_TOO_LONG -> Validation.Invalid(R.string.checkout_card_number_not_valid)
-            // TODO add string translations
             CardNumberValidation.INVALID_UNSUPPORTED_BRAND -> Validation.Invalid(
                 reason = R.string.checkout_card_brand_not_supported,
                 showErrorWhileEditing = true

--- a/card/src/main/java/com/adyen/checkout/card/util/CardValidationUtils.kt
+++ b/card/src/main/java/com/adyen/checkout/card/util/CardValidationUtils.kt
@@ -25,7 +25,7 @@ object CardValidationUtils {
     private const val FIVE_DIGIT = 5
 
     // Card Number
-    private const val MINIMUM_CARD_NUMBER_LENGTH = 8
+    private const val MINIMUM_CARD_NUMBER_LENGTH = 12
     const val MAXIMUM_CARD_NUMBER_LENGTH = 19
 
     // Security Code


### PR DESCRIPTION
This makes it in line with iOS and web. Credit card numbers range from 13 to 19 digits, so this is safe to do
