### PR TITLE
Add git commit message template

### DIFF
--- a/config/git/commit-template
+++ b/config/git/commit-template
@@ -1,14 +1,8 @@
 # Title: Summary, imperative, start upper case, don't end with a period.
-# No more than 50 chars. #### 50 chars is here: #
 
-# Remember blank line between title and body.
+# Body (optional): Explain what and why (not how).
 
-# Body: Explain what and why (not how).
-# Wrap at 72 chars. ################################## which is here: #
-
-# Another blank line between body and task ID.
-
-# Task ID: Add the YouTrack task ID.
+# COAND-XXX: Add the YouTrack task ID.
 
 # This format is based on this post:
 # https://chris.beams.io/posts/git-commit/

--- a/config/git/commit-template
+++ b/config/git/commit-template
@@ -1,0 +1,26 @@
+# Title: Summary, imperative, start upper case, don't end with a period.
+# No more than 50 chars. #### 50 chars is here: #
+
+# Remember blank line between title and body.
+
+# Body: Explain what and why (not how).
+# Wrap at 72 chars. ################################## which is here: #
+
+# Another blank line between body and task ID.
+
+# Task ID: Add the YouTrack task ID.
+
+# This format is based on this post:
+# https://chris.beams.io/posts/git-commit/
+#
+# Main points in article:
+# 1. Separate subject from body with a blank line
+# 2. Limit the subject line to 50 characters
+# 3. Capitalize the subject line
+# 4. Do not end the subject line with a period
+# 5. Use the imperative mood in the subject line
+# 6. Wrap the body at 72 characters
+# 7. Use the body to explain what and why vs. how
+
+# NOTE: All lines starting with "#" are ignored in your message, so
+# you don't have to worry about deleting them.

--- a/config/git/init.sh
+++ b/config/git/init.sh
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2022 Adyen N.V.
+#
+# This file is open source and available under the MIT license. See the LICENSE file for more info.
+#
+# Created by oscars on 15/11/2022.
+#
+
+#!/bin/sh
+
+git config --global commit.template ./config/git/commit-template


### PR DESCRIPTION
A commit message template will help us to write good, consistent messages. The init.sh file is to easily configure the template. You can run this file with `sh ./config/git/init.sh`.

The template is open for discussion, this is just my preference.

COAND-666
