### PR TITLE
Create card component parameters for internal use

### DIFF
--- a/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponentParams.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponentParams.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 15/11/2022.
+ */
+
+package com.adyen.checkout.bacs
+
+import com.adyen.checkout.components.base.ComponentParams
+import com.adyen.checkout.components.model.payments.Amount
+import com.adyen.checkout.core.api.Environment
+import kotlinx.parcelize.Parcelize
+import java.util.Locale
+
+@Parcelize
+// TODO check if this class is still needed once all params support [Amount]
+internal data class BacsDirectDebitComponentParams(
+    override val shopperLocale: Locale,
+    override val environment: Environment,
+    override val clientKey: String,
+    val amount: Amount,
+) : ComponentParams

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcComponentParams.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcComponentParams.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 15/11/2022.
+ */
+
+package com.adyen.checkout.bcmc
+
+import com.adyen.checkout.components.base.ComponentParams
+import com.adyen.checkout.core.api.Environment
+import kotlinx.parcelize.Parcelize
+import java.util.Locale
+
+@Parcelize
+internal data class BcmcComponentParams(
+    override val shopperLocale: Locale,
+    override val environment: Environment,
+    override val clientKey: String,
+    val isHolderNameRequired: Boolean,
+    val shopperReference: String?,
+    val isStorePaymentFieldVisible: Boolean,
+) : ComponentParams

--- a/card/src/main/java/com/adyen/checkout/card/CardComponentParams.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponentParams.kt
@@ -11,8 +11,8 @@ package com.adyen.checkout.card
 import com.adyen.checkout.card.data.CardType
 import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.core.api.Environment
-import kotlinx.parcelize.Parcelize
 import java.util.Locale
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class CardComponentParams(

--- a/card/src/main/java/com/adyen/checkout/card/CardComponentParams.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponentParams.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 15/11/2022.
+ */
+
+package com.adyen.checkout.card
+
+import com.adyen.checkout.card.data.CardType
+import com.adyen.checkout.components.base.ComponentParams
+import com.adyen.checkout.core.api.Environment
+import kotlinx.parcelize.Parcelize
+import java.util.Locale
+
+@Parcelize
+internal data class CardComponentParams(
+    override val shopperLocale: Locale,
+    override val environment: Environment,
+    override val clientKey: String,
+    val isHolderNameRequired: Boolean,
+    val supportedCardTypes: List<CardType>,
+    val shopperReference: String?,
+    val isStorePaymentFieldVisible: Boolean,
+    val isHideCvc: Boolean,
+    val isHideCvcStoredCard: Boolean,
+    val socialSecurityNumberVisibility: SocialSecurityNumberVisibility?,
+    val kcpAuthVisibility: KCPAuthVisibility?,
+    val installmentConfiguration: InstallmentConfiguration?,
+    val addressConfiguration: AddressConfiguration,
+) : ComponentParams

--- a/card/src/main/java/com/adyen/checkout/card/CardComponentParams.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponentParams.kt
@@ -25,8 +25,8 @@ internal data class CardComponentParams(
     val isStorePaymentFieldVisible: Boolean,
     val isHideCvc: Boolean,
     val isHideCvcStoredCard: Boolean,
-    val socialSecurityNumberVisibility: SocialSecurityNumberVisibility?,
-    val kcpAuthVisibility: KCPAuthVisibility?,
+    val socialSecurityNumberVisibility: SocialSecurityNumberVisibility,
+    val kcpAuthVisibility: KCPAuthVisibility,
     val installmentConfiguration: InstallmentConfiguration?,
     val addressConfiguration: AddressConfiguration,
 ) : ComponentParams

--- a/card/src/main/java/com/adyen/checkout/card/CardComponentParamsMapper.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponentParamsMapper.kt
@@ -9,18 +9,25 @@
 package com.adyen.checkout.card
 
 import com.adyen.checkout.card.data.CardType
+import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.model.paymentmethods.StoredPaymentMethod
 import com.adyen.checkout.core.log.LogUtil
 import com.adyen.checkout.core.log.Logger
 
-internal class CardComponentParamsMapper {
+internal class CardComponentParamsMapper(
+    private val parentConfiguration: Configuration?
+) {
 
     fun mapToParams(
         cardConfiguration: CardConfiguration,
         paymentMethod: PaymentMethod,
     ): CardComponentParams {
-        return mapToParams(cardConfiguration, getSupportedCardTypes(cardConfiguration, paymentMethod))
+        return mapToParams(
+            parentConfiguration = parentConfiguration ?: cardConfiguration,
+            cardConfiguration = cardConfiguration,
+            supportedCardTypes = getSupportedCardTypes(cardConfiguration, paymentMethod)
+        )
     }
 
     fun mapToParams(
@@ -28,18 +35,23 @@ internal class CardComponentParamsMapper {
         // not needed for the actual mapping but indicates that this is the method to use in a stored flow
         storedPaymentMethod: StoredPaymentMethod,
     ): CardComponentParams {
-        return mapToParams(cardConfiguration, cardConfiguration.supportedCardTypes)
+        return mapToParams(
+            parentConfiguration = parentConfiguration ?: cardConfiguration,
+            cardConfiguration = cardConfiguration,
+            supportedCardTypes = cardConfiguration.supportedCardTypes
+        )
     }
 
     private fun mapToParams(
+        parentConfiguration: Configuration,
         cardConfiguration: CardConfiguration,
         supportedCardTypes: List<CardType>,
     ): CardComponentParams {
         with(cardConfiguration) {
             return CardComponentParams(
-                shopperLocale = shopperLocale,
-                environment = environment,
-                clientKey = clientKey,
+                shopperLocale = parentConfiguration.shopperLocale,
+                environment = parentConfiguration.environment,
+                clientKey = parentConfiguration.clientKey,
                 isHolderNameRequired = isHolderNameRequired,
                 supportedCardTypes = supportedCardTypes,
                 shopperReference = shopperReference,

--- a/card/src/main/java/com/adyen/checkout/card/CardComponentParamsMapper.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponentParamsMapper.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 15/11/2022.
+ */
+
+package com.adyen.checkout.card
+
+import com.adyen.checkout.card.data.CardType
+import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
+import com.adyen.checkout.components.model.paymentmethods.StoredPaymentMethod
+import com.adyen.checkout.core.log.LogUtil
+import com.adyen.checkout.core.log.Logger
+
+internal class CardComponentParamsMapper {
+
+    fun mapToParams(
+        cardConfiguration: CardConfiguration,
+        paymentMethod: PaymentMethod,
+    ): CardComponentParams {
+        return mapToParams(cardConfiguration, getSupportedCardTypes(cardConfiguration, paymentMethod))
+    }
+
+    fun mapToParams(
+        cardConfiguration: CardConfiguration,
+        // not needed for the actual mapping but indicates that this is the method to use in a stored flow
+        storedPaymentMethod: StoredPaymentMethod,
+    ): CardComponentParams {
+        return mapToParams(cardConfiguration, cardConfiguration.supportedCardTypes)
+    }
+
+    private fun mapToParams(
+        cardConfiguration: CardConfiguration,
+        supportedCardTypes: List<CardType>,
+    ): CardComponentParams {
+        with(cardConfiguration) {
+            return CardComponentParams(
+                shopperLocale = shopperLocale,
+                environment = environment,
+                clientKey = clientKey,
+                isHolderNameRequired = isHolderNameRequired,
+                supportedCardTypes = supportedCardTypes,
+                shopperReference = shopperReference,
+                isStorePaymentFieldVisible = isStorePaymentFieldVisible,
+                isHideCvc = isHideCvc,
+                isHideCvcStoredCard = isHideCvcStoredCard,
+                socialSecurityNumberVisibility = socialSecurityNumberVisibility,
+                kcpAuthVisibility = kcpAuthVisibility,
+                installmentConfiguration = installmentConfiguration,
+                addressConfiguration = addressConfiguration
+            )
+        }
+    }
+
+    /**
+     * Check which set of supported cards to pass to the component.
+     * Priority is: Custom -> PaymentMethod.brands -> Default
+     */
+    private fun getSupportedCardTypes(
+        cardConfiguration: CardConfiguration,
+        paymentMethod: PaymentMethod
+    ): List<CardType> {
+        return when {
+            cardConfiguration.supportedCardTypes.isNotEmpty() -> {
+                Logger.v(TAG, "Reading supportedCardTypes from configuration")
+                cardConfiguration.supportedCardTypes
+            }
+            paymentMethod.brands.orEmpty().isNotEmpty() -> {
+                Logger.v(TAG, "Reading supportedCardTypes from API brands")
+                paymentMethod.brands.orEmpty().map {
+                    CardType.getByBrandName(it)
+                }
+            }
+            else -> {
+                Logger.v(TAG, "Falling back to CardConfiguration.DEFAULT_SUPPORTED_CARDS_LIST")
+                CardConfiguration.DEFAULT_SUPPORTED_CARDS_LIST
+            }
+        }
+    }
+
+    companion object {
+        private val TAG = LogUtil.getTag()
+    }
+}

--- a/card/src/main/java/com/adyen/checkout/card/CardComponentProvider.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponentProvider.kt
@@ -16,6 +16,7 @@ import com.adyen.checkout.card.data.CardType
 import com.adyen.checkout.card.repository.DefaultAddressRepository
 import com.adyen.checkout.card.repository.DefaultDetectCardTypeRepository
 import com.adyen.checkout.components.StoredPaymentComponentProvider
+import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
@@ -31,9 +32,11 @@ import com.adyen.checkout.cse.DefaultGenericEncrypter
 private val TAG = LogUtil.getTag()
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class CardComponentProvider : StoredPaymentComponentProvider<CardComponent, CardConfiguration> {
+class CardComponentProvider(
+    parentConfiguration: Configuration? = null,
+) : StoredPaymentComponentProvider<CardComponent, CardConfiguration> {
 
-    private val componentParamsMapper = CardComponentParamsMapper()
+    private val componentParamsMapper = CardComponentParamsMapper(parentConfiguration)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/card/src/main/java/com/adyen/checkout/card/CardComponentProvider.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponentProvider.kt
@@ -8,6 +8,7 @@
 package com.adyen.checkout.card
 
 import android.os.Bundle
+import androidx.annotation.RestrictTo
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
@@ -29,7 +30,10 @@ import com.adyen.checkout.cse.DefaultGenericEncrypter
 
 private val TAG = LogUtil.getTag()
 
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class CardComponentProvider : StoredPaymentComponentProvider<CardComponent, CardConfiguration> {
+
+    private val componentParamsMapper = CardComponentParamsMapper()
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,
@@ -41,6 +45,7 @@ class CardComponentProvider : StoredPaymentComponentProvider<CardComponent, Card
     ): CardComponent {
         assertSupported(paymentMethod)
 
+        val componentParams = componentParamsMapper.mapToParams(configuration, paymentMethod)
         val verifiedConfiguration = checkSupportedCardTypes(paymentMethod, configuration)
         val genericEncrypter = DefaultGenericEncrypter()
         val cardEncrypter = DefaultCardEncrypter(genericEncrypter)
@@ -78,6 +83,7 @@ class CardComponentProvider : StoredPaymentComponentProvider<CardComponent, Card
     ): CardComponent {
         assertSupported(storedPaymentMethod)
 
+        val componentParams = componentParamsMapper.mapToParams(configuration, storedPaymentMethod)
         val publicKeyRepository = DefaultPublicKeyRepository()
         val genericEncrypter = DefaultGenericEncrypter()
         val cardEncrypter = DefaultCardEncrypter(genericEncrypter)
@@ -105,6 +111,7 @@ class CardComponentProvider : StoredPaymentComponentProvider<CardComponent, Card
      * @param cardConfiguration The configuration object that will start the component.
      * @return The Configuration object with possibly adjusted values.
      */
+    // TODO remove after replacing configuration with params
     private fun checkSupportedCardTypes(
         paymentMethod: PaymentMethod,
         cardConfiguration: CardConfiguration

--- a/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
@@ -31,8 +31,8 @@ class CardConfiguration private constructor(
     val isStorePaymentFieldVisible: Boolean,
     val isHideCvc: Boolean,
     val isHideCvcStoredCard: Boolean,
-    val socialSecurityNumberVisibility: SocialSecurityNumberVisibility?,
-    val kcpAuthVisibility: KCPAuthVisibility?,
+    val socialSecurityNumberVisibility: SocialSecurityNumberVisibility,
+    val kcpAuthVisibility: KCPAuthVisibility,
     val installmentConfiguration: InstallmentConfiguration?,
     val addressConfiguration: AddressConfiguration,
 ) : Configuration {
@@ -48,9 +48,9 @@ class CardConfiguration private constructor(
         private var shopperReference: String? = null
         private var isHideCvc = false
         private var isHideCvcStoredCard = false
-        private var socialSecurityNumberVisibility: SocialSecurityNumberVisibility? =
+        private var socialSecurityNumberVisibility: SocialSecurityNumberVisibility =
             SocialSecurityNumberVisibility.HIDE
-        private var kcpAuthVisibility: KCPAuthVisibility? = KCPAuthVisibility.HIDE
+        private var kcpAuthVisibility: KCPAuthVisibility = KCPAuthVisibility.HIDE
         private var installmentConfiguration: InstallmentConfiguration? = null
         private var addressConfiguration: AddressConfiguration = AddressConfiguration.None
 

--- a/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
@@ -11,6 +11,7 @@ import android.content.Context
 import com.adyen.checkout.card.data.CardType
 import com.adyen.checkout.components.base.BaseConfigurationBuilder
 import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.core.api.Environment
 import kotlinx.parcelize.Parcelize
 import java.util.Locale
@@ -35,10 +36,6 @@ class CardConfiguration private constructor(
     val installmentConfiguration: InstallmentConfiguration?,
     val addressConfiguration: AddressConfiguration,
 ) : Configuration {
-
-    fun newBuilder(): Builder {
-        return Builder(this)
-    }
 
     /**
      * Builder to create a [CardConfiguration].
@@ -110,6 +107,8 @@ class CardConfiguration private constructor(
         /**
          * Set the supported card types for this payment. Supported types will be shown as user inputs the card number.
          *
+         * Defaults to [PaymentMethod.brands] if it exists, or [DEFAULT_SUPPORTED_CARDS_LIST] otherwise.
+         *
          * @param supportCardTypes array of [CardType]
          * @return [CardConfiguration.Builder]
          */
@@ -121,6 +120,8 @@ class CardConfiguration private constructor(
         /**
          * Set if the holder name is required and should be shown as an input field.
          *
+         * Default is false.
+         *
          * @param holderNameRequired [Boolean]
          * @return [CardConfiguration.Builder]
          */
@@ -131,6 +132,8 @@ class CardConfiguration private constructor(
 
         /**
          * Set if the option to store the card for future payments should be shown as an input field.
+         *
+         * Default is true.
          *
          * @param showStorePaymentField [Boolean]
          * @return [CardConfiguration.Builder]
@@ -159,6 +162,8 @@ class CardConfiguration private constructor(
          * Note that this might have implications for the risk of the transaction. Talk to Adyen Support before enabling
          * this.
          *
+         * Default is false.
+         *
          * @param hideCvc If CVC should be hidden or not.
          * @return [CardConfiguration.Builder]
          */
@@ -172,6 +177,8 @@ class CardConfiguration private constructor(
          * flow.
          * Note that this has implications for the risk of the transaction. Talk to Adyen Support before enabling this.
          *
+         * Default is false.
+         *
          * @param hideCvcStoredCard If CVC should be hidden or not for stored payments.
          * @return [CardConfiguration.Builder]
          */
@@ -183,6 +190,8 @@ class CardConfiguration private constructor(
         /**
          * Set if CPF/CNPJ field for Brazil merchants should be visible or not.
          *
+         * Default is [SocialSecurityNumberVisibility.HIDE].
+         *
          * @param socialSecurityNumberVisibility If CPF/CNPJ field should be visible or not.
          * @return [CardConfiguration.Builder]
          */
@@ -191,6 +200,14 @@ class CardConfiguration private constructor(
             return this
         }
 
+        /**
+         * Set if security fields for Korean cards should be visible or not.
+         *
+         * Default is [KCPAuthVisibility.HIDE].
+         *
+         * @param kcpAuthVisibility If security fields for Korean cards should be visible or not.
+         * @return [CardConfiguration.Builder]
+         */
         fun setKcpAuthVisibility(kcpAuthVisibility: KCPAuthVisibility): Builder {
             this.kcpAuthVisibility = kcpAuthVisibility
             return this
@@ -209,6 +226,8 @@ class CardConfiguration private constructor(
 
         /**
          * Configures the address form to be shown to the shopper.
+         *
+         * Default is [AddressConfiguration.None].
          *
          * @param addressConfiguration The configuration object for address form.
          * @return [CardConfiguration.Builder]

--- a/card/src/main/java/com/adyen/checkout/card/repository/AddressRepository.kt
+++ b/card/src/main/java/com/adyen/checkout/card/repository/AddressRepository.kt
@@ -9,9 +9,10 @@
 package com.adyen.checkout.card.repository
 
 import com.adyen.checkout.card.api.model.AddressItem
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.core.api.Environment
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import java.util.Locale
 
 interface AddressRepository {
 
@@ -20,10 +21,15 @@ interface AddressRepository {
     val countriesFlow: Flow<List<AddressItem>>
 
     fun getStateList(
-        configuration: Configuration,
+        environment: Environment,
+        shopperLocale: Locale,
         countryCode: String?,
         coroutineScope: CoroutineScope
     )
 
-    fun getCountryList(configuration: Configuration, coroutineScope: CoroutineScope)
+    fun getCountryList(
+        environment: Environment,
+        shopperLocale: Locale,
+        coroutineScope: CoroutineScope
+    )
 }

--- a/card/src/main/java/com/adyen/checkout/card/repository/DefaultAddressRepository.kt
+++ b/card/src/main/java/com/adyen/checkout/card/repository/DefaultAddressRepository.kt
@@ -11,7 +11,6 @@ package com.adyen.checkout.card.repository
 import com.adyen.checkout.card.api.AddressService
 import com.adyen.checkout.card.api.model.AddressItem
 import com.adyen.checkout.card.ui.AddressSpecification
-import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.channel.bufferedChannel
 import com.adyen.checkout.core.api.Environment
 import com.adyen.checkout.core.log.LogUtil
@@ -36,7 +35,8 @@ internal class DefaultAddressRepository : AddressRepository {
     private val cache: HashMap<String, List<AddressItem>> = hashMapOf()
 
     override fun getStateList(
-        configuration: Configuration,
+        environment: Environment,
+        shopperLocale: Locale,
         countryCode: String?,
         coroutineScope: CoroutineScope
     ) {
@@ -47,8 +47,8 @@ internal class DefaultAddressRepository : AddressRepository {
                 statesChannel.trySend(it)
             } ?: run {
                 fetchStateList(
-                    configuration.environment,
-                    configuration.shopperLocale,
+                    environment,
+                    shopperLocale,
                     countryCode,
                     coroutineScope
                 )
@@ -82,13 +82,13 @@ internal class DefaultAddressRepository : AddressRepository {
         }
     }
 
-    override fun getCountryList(configuration: Configuration, coroutineScope: CoroutineScope) {
+    override fun getCountryList(environment: Environment, shopperLocale: Locale, coroutineScope: CoroutineScope) {
         cache[COUNTRIES_CACHE_KEY]?.let {
             countriesChannel.trySend(it)
         } ?: run {
             fetchCountryList(
-                configuration.environment,
-                configuration.shopperLocale,
+                environment,
+                shopperLocale,
                 coroutineScope
             )
         }

--- a/card/src/main/java/com/adyen/checkout/card/test/TestAddressRepository.kt
+++ b/card/src/main/java/com/adyen/checkout/card/test/TestAddressRepository.kt
@@ -11,10 +11,11 @@ package com.adyen.checkout.card.test
 import androidx.annotation.RestrictTo
 import com.adyen.checkout.card.api.model.AddressItem
 import com.adyen.checkout.card.repository.AddressRepository
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.core.api.Environment
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import java.util.Locale
 
 /**
  * Test implementation of [AddressRepository]. This class should never be used except in test code.
@@ -32,12 +33,17 @@ class TestAddressRepository : AddressRepository {
     private val _countriesFlow: MutableSharedFlow<List<AddressItem>> = MutableSharedFlow(extraBufferCapacity = 1)
     override val countriesFlow: Flow<List<AddressItem>> = _countriesFlow
 
-    override fun getStateList(configuration: Configuration, countryCode: String?, coroutineScope: CoroutineScope) {
+    override fun getStateList(
+        environment: Environment,
+        shopperLocale: Locale,
+        countryCode: String?,
+        coroutineScope: CoroutineScope
+    ) {
         val states = if (shouldReturnError) emptyList() else STATES
         _statesFlow.tryEmit(states)
     }
 
-    override fun getCountryList(configuration: Configuration, coroutineScope: CoroutineScope) {
+    override fun getCountryList(environment: Environment, shopperLocale: Locale, coroutineScope: CoroutineScope) {
         val countries = if (shouldReturnError) emptyList() else COUNTRIES
         _countriesFlow.tryEmit(countries)
     }

--- a/card/src/test/java/com/adyen/checkout/card/CardComponentParamsMapperTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/CardComponentParamsMapperTest.kt
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 16/11/2022.
+ */
+
+package com.adyen.checkout.card
+
+import com.adyen.checkout.card.data.CardType
+import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
+import com.adyen.checkout.core.api.Environment
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.util.Locale
+
+internal class CardComponentParamsMapperTest {
+
+    @Test
+    fun `when parent configuration is null and custom card configuration fields are null then all fields should match`() {
+        val cardConfiguration = getCardConfigurationBuilder().build()
+
+        val params = CardComponentParamsMapper(null).mapToParams(cardConfiguration, PaymentMethod())
+
+        val expected = getCardComponentParams()
+
+        assertEquals(expected, params)
+    }
+
+    @Test
+    fun `when parent configuration is null and custom card configuration fields are set then all fields should match`() {
+        val shopperReference = "SHOPPER_REFERENCE_1"
+        val installmentConfiguration = InstallmentConfiguration(
+            InstallmentOptions.DefaultInstallmentOptions(
+                maxInstallments = 3,
+                includeRevolving = true
+            )
+        )
+        val addressConfiguration = AddressConfiguration.FullAddress(supportedCountryCodes = listOf("CA", "GB"))
+
+        val cardConfiguration = CardConfiguration.Builder(
+            shopperLocale = Locale.FRANCE,
+            environment = Environment.APSE,
+            clientKey = TEST_CLIENT_KEY_2
+        )
+            .setHolderNameRequired(true)
+            .setSupportedCardTypes(CardType.DINERS, CardType.MAESTRO)
+            .setShopperReference(shopperReference)
+            .setShowStorePaymentField(false)
+            .setHideCvc(true)
+            .setHideCvcStoredCard(true)
+            .setSocialSecurityNumberVisibility(SocialSecurityNumberVisibility.SHOW)
+            .setKcpAuthVisibility(KCPAuthVisibility.SHOW)
+            .setInstallmentConfigurations(installmentConfiguration)
+            .setAddressConfiguration(addressConfiguration)
+            .build()
+
+        val params = CardComponentParamsMapper(null).mapToParams(cardConfiguration, PaymentMethod())
+
+        val expected = getCardComponentParams(
+            shopperLocale = Locale.FRANCE,
+            environment = Environment.APSE,
+            clientKey = TEST_CLIENT_KEY_2,
+            isHolderNameRequired = true,
+            supportedCardTypes = listOf(CardType.DINERS, CardType.MAESTRO),
+            shopperReference = shopperReference,
+            isStorePaymentFieldVisible = false,
+            isHideCvc = true,
+            isHideCvcStoredCard = true,
+            socialSecurityNumberVisibility = SocialSecurityNumberVisibility.SHOW,
+            kcpAuthVisibility = KCPAuthVisibility.SHOW,
+            installmentConfiguration = installmentConfiguration,
+            addressConfiguration = addressConfiguration
+        )
+
+        assertEquals(expected, params)
+    }
+
+    @Test
+    fun `when parent configuration is set then parent configuration fields should override card configuration fields`() {
+        val cardConfiguration = getCardConfigurationBuilder().build()
+
+        // this is in practice DropInConfiguration, but we don't have access to it in this module and any Configuration
+        // class can work
+        val parentConfiguration = CardConfiguration.Builder(
+            Locale.GERMAN,
+            Environment.EUROPE,
+            TEST_CLIENT_KEY_2
+        ).build()
+
+        val params = CardComponentParamsMapper(parentConfiguration).mapToParams(cardConfiguration, PaymentMethod())
+
+        val expected = getCardComponentParams(
+            shopperLocale = Locale.GERMAN,
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+        )
+
+        assertEquals(expected, params)
+    }
+
+    @Test
+    fun `when supported card types are set in the card configuration then they should be used in the params`() {
+        val cardConfiguration = getCardConfigurationBuilder()
+            .setSupportedCardTypes(CardType.MAESTRO, CardType.BCMC)
+            .build()
+
+        val paymentMethod = PaymentMethod(brands = listOf(CardType.VISA.txVariant, CardType.MASTERCARD.txVariant))
+
+        val params = CardComponentParamsMapper(null).mapToParams(cardConfiguration, paymentMethod)
+
+        val expected = getCardComponentParams(
+            supportedCardTypes = listOf(CardType.MAESTRO, CardType.BCMC)
+        )
+
+        assertEquals(expected, params)
+    }
+
+    @Test
+    fun `when supported card types are not set in the card configuration and payment method brands exist then brands should be used in the params`() {
+        val cardConfiguration = getCardConfigurationBuilder()
+            .build()
+
+        val paymentMethod = PaymentMethod(brands = listOf(CardType.VISA.txVariant, CardType.MASTERCARD.txVariant))
+
+        val params = CardComponentParamsMapper(null).mapToParams(cardConfiguration, paymentMethod)
+
+        val expected = getCardComponentParams(
+            supportedCardTypes = listOf(CardType.VISA, CardType.MASTERCARD)
+        )
+
+        assertEquals(expected, params)
+    }
+
+    @Test
+    fun `when supported card types are not set in the card configuration and payment method brands do not exist then the default card types should be used in the params`() {
+        val cardConfiguration = getCardConfigurationBuilder()
+            .build()
+
+        val params = CardComponentParamsMapper(null).mapToParams(cardConfiguration, PaymentMethod())
+
+        val expected = getCardComponentParams(
+            supportedCardTypes = CardConfiguration.DEFAULT_SUPPORTED_CARDS_LIST
+        )
+
+        assertEquals(expected, params)
+    }
+
+    private fun getCardConfigurationBuilder() = CardConfiguration.Builder(
+        shopperLocale = Locale.US,
+        environment = Environment.TEST,
+        clientKey = TEST_CLIENT_KEY_1
+    )
+
+    private fun getCardComponentParams(
+        shopperLocale: Locale = Locale.US,
+        environment: Environment = Environment.TEST,
+        clientKey: String = TEST_CLIENT_KEY_1,
+        isHolderNameRequired: Boolean = false,
+        supportedCardTypes: List<CardType> = CardConfiguration.DEFAULT_SUPPORTED_CARDS_LIST,
+        shopperReference: String? = null,
+        isStorePaymentFieldVisible: Boolean = true,
+        isHideCvc: Boolean = false,
+        isHideCvcStoredCard: Boolean = false,
+        socialSecurityNumberVisibility: SocialSecurityNumberVisibility? = SocialSecurityNumberVisibility.HIDE,
+        kcpAuthVisibility: KCPAuthVisibility? = KCPAuthVisibility.HIDE,
+        installmentConfiguration: InstallmentConfiguration? = null,
+        addressConfiguration: AddressConfiguration = AddressConfiguration.None,
+    ) = CardComponentParams(
+        shopperLocale = shopperLocale,
+        environment = environment,
+        clientKey = clientKey,
+        isHolderNameRequired = isHolderNameRequired,
+        supportedCardTypes = supportedCardTypes,
+        shopperReference = shopperReference,
+        isStorePaymentFieldVisible = isStorePaymentFieldVisible,
+        isHideCvc = isHideCvc,
+        isHideCvcStoredCard = isHideCvcStoredCard,
+        socialSecurityNumberVisibility = socialSecurityNumberVisibility,
+        kcpAuthVisibility = kcpAuthVisibility,
+        installmentConfiguration = installmentConfiguration,
+        addressConfiguration = addressConfiguration
+    )
+
+    companion object {
+        private const val TEST_CLIENT_KEY_1 = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
+        private const val TEST_CLIENT_KEY_2 = "live_qwertyui34566776787zxcvbnmqwerty"
+    }
+}

--- a/card/src/test/java/com/adyen/checkout/card/CardComponentParamsMapperTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/CardComponentParamsMapperTest.kt
@@ -163,8 +163,8 @@ internal class CardComponentParamsMapperTest {
         isStorePaymentFieldVisible: Boolean = true,
         isHideCvc: Boolean = false,
         isHideCvcStoredCard: Boolean = false,
-        socialSecurityNumberVisibility: SocialSecurityNumberVisibility? = SocialSecurityNumberVisibility.HIDE,
-        kcpAuthVisibility: KCPAuthVisibility? = KCPAuthVisibility.HIDE,
+        socialSecurityNumberVisibility: SocialSecurityNumberVisibility = SocialSecurityNumberVisibility.HIDE,
+        kcpAuthVisibility: KCPAuthVisibility = KCPAuthVisibility.HIDE,
         installmentConfiguration: InstallmentConfiguration? = null,
         addressConfiguration: AddressConfiguration = AddressConfiguration.None,
     ) = CardComponentParams(

--- a/card/src/test/java/com/adyen/checkout/card/DefaultCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/DefaultCardDelegateTest.kt
@@ -709,6 +709,7 @@ internal class DefaultCardDelegateTest {
             paymentMethod = paymentMethod,
             publicKeyRepository = publicKeyRepository,
             configuration = configuration,
+            componentParams = CardComponentParamsMapper(null).mapToParams(configuration, paymentMethod),
             cardEncrypter = cardEncrypter,
             addressRepository = addressRepository,
             detectCardTypeRepository = detectCardTypeRepository,

--- a/card/src/test/java/com/adyen/checkout/card/StoredCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/StoredCardDelegateTest.kt
@@ -297,7 +297,8 @@ internal class StoredCardDelegateTest {
             observerRepository = PaymentObserverRepository(),
             storedPaymentMethod = storedPaymentMethod,
             publicKeyRepository = publicKeyRepository,
-            configuration = configuration,
+            configuration  =configuration,
+            componentParams = CardComponentParamsMapper(null).mapToParams(configuration, storedPaymentMethod),
             cardEncrypter = cardEncrypter,
         )
     }

--- a/card/src/test/java/com/adyen/checkout/card/StoredCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/StoredCardDelegateTest.kt
@@ -297,7 +297,7 @@ internal class StoredCardDelegateTest {
             observerRepository = PaymentObserverRepository(),
             storedPaymentMethod = storedPaymentMethod,
             publicKeyRepository = publicKeyRepository,
-            configuration  =configuration,
+            configuration = configuration,
             componentParams = CardComponentParamsMapper(null).mapToParams(configuration, storedPaymentMethod),
             cardEncrypter = cardEncrypter,
         )

--- a/components-core/src/main/java/com/adyen/checkout/components/base/ComponentParams.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/base/ComponentParams.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 15/11/2022.
+ */
+
+package com.adyen.checkout.components.base
+
+import android.os.Parcelable
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.core.api.Environment
+import java.util.Locale
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+interface ComponentParams : Parcelable {
+    val shopperLocale: Locale
+    val environment: Environment
+    val clientKey: String
+}

--- a/components-core/src/main/java/com/adyen/checkout/components/base/GenericComponentParams.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/base/GenericComponentParams.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 15/11/2022.
+ */
+
+package com.adyen.checkout.components.base
+
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.core.api.Environment
+import kotlinx.parcelize.Parcelize
+import java.util.Locale
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Parcelize
+data class GenericComponentParams(
+    override val shopperLocale: Locale,
+    override val environment: Environment,
+    override val clientKey: String,
+) : ComponentParams

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
@@ -22,6 +22,7 @@ import com.adyen.checkout.bcmc.BcmcConfiguration
 import com.adyen.checkout.blik.BlikComponent
 import com.adyen.checkout.blik.BlikConfiguration
 import com.adyen.checkout.card.CardComponent
+import com.adyen.checkout.card.CardComponentProvider
 import com.adyen.checkout.card.CardConfiguration
 import com.adyen.checkout.components.AlwaysAvailablePaymentMethod
 import com.adyen.checkout.components.ComponentAvailableCallback
@@ -341,7 +342,7 @@ internal fun getComponentFor(
         CardComponent.PROVIDER.isPaymentMethodSupported(storedPaymentMethod) -> {
             val cardConfig: CardConfiguration =
                 getConfigurationForPaymentMethod(storedPaymentMethod, dropInConfiguration, amount)
-            CardComponent.PROVIDER.get(fragment, storedPaymentMethod, cardConfig)
+            CardComponentProvider(dropInConfiguration).get(fragment, storedPaymentMethod, cardConfig)
         }
         BlikComponent.PROVIDER.isPaymentMethodSupported(storedPaymentMethod) -> {
             val blikConfig: BlikConfiguration =
@@ -391,7 +392,7 @@ internal fun getComponentFor(
         CardComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) -> {
             val cardConfig: CardConfiguration =
                 getConfigurationForPaymentMethod(paymentMethod, dropInConfiguration, amount)
-            CardComponent.PROVIDER.get(fragment, paymentMethod, cardConfig)
+            CardComponentProvider(dropInConfiguration).get(fragment, paymentMethod, cardConfig)
         }
         DotpayComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) -> {
             val dotpayConfig: DotpayConfiguration =

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropInComponentParams.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropInComponentParams.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 15/11/2022.
+ */
+
+package com.adyen.checkout.dropin
+
+import android.os.Bundle
+import com.adyen.checkout.components.base.ComponentParams
+import com.adyen.checkout.components.model.payments.Amount
+import com.adyen.checkout.core.api.Environment
+import kotlinx.parcelize.Parcelize
+import java.util.Locale
+
+@Parcelize
+internal data class DropInComponentParams(
+    override val shopperLocale: Locale,
+    override val environment: Environment,
+    override val clientKey: String,
+    val amount: Amount,
+    val showPreselectedStoredPaymentMethod: Boolean,
+    val skipListWhenSinglePaymentMethod: Boolean,
+    val isRemovingStoredPaymentMethodsEnabled: Boolean,
+    val additionalDataForDropInService: Bundle?,
+) : ComponentParams

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayComponentParams.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayComponentParams.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 15/11/2022.
+ */
+
+package com.adyen.checkout.googlepay
+
+import com.adyen.checkout.components.base.ComponentParams
+import com.adyen.checkout.components.model.payments.Amount
+import com.adyen.checkout.core.api.Environment
+import com.adyen.checkout.googlepay.model.BillingAddressParameters
+import com.adyen.checkout.googlepay.model.MerchantInfo
+import com.adyen.checkout.googlepay.model.ShippingAddressParameters
+import java.util.Locale
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+internal data class GooglePayComponentParams(
+    override val shopperLocale: Locale,
+    override val environment: Environment,
+    override val clientKey: String,
+    val gatewayMerchantId: String,
+    val googlePayEnvironment: Int,
+    val amount: Amount,
+    val totalPriceStatus: String,
+    val countryCode: String?,
+    val merchantInfo: MerchantInfo?,
+    val allowedAuthMethods: List<String>,
+    val allowedCardNetworks: List<String>,
+    val isAllowPrepaidCards: Boolean,
+    val isEmailRequired: Boolean,
+    val isExistingPaymentMethodRequired: Boolean,
+    val isShippingAddressRequired: Boolean,
+    val shippingAddressParameters: ShippingAddressParameters?,
+    val isBillingAddressRequired: Boolean,
+    val billingAddressParameters: BillingAddressParameters?,
+) : ComponentParams

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/model/GooglePayParams.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/model/GooglePayParams.kt
@@ -21,6 +21,7 @@ private val TAG = LogUtil.getTag()
 /**
  * Model class holding the parameters required to build requests for GooglePay
  */
+// TODO remove in favor of [GooglePayComponentParams]
 data class GooglePayParams(
     private val googlePayConfiguration: GooglePayConfiguration,
     private val serverGatewayMerchantId: String?,

--- a/issuer-list/build.gradle
+++ b/issuer-list/build.gradle
@@ -9,6 +9,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
+    id 'kotlin-parcelize'
 }
 
 // Maven artifact

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/IssuerListComponentParams.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/IssuerListComponentParams.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 15/11/2022.
+ */
+
+package com.adyen.checkout.issuerlist
+
+import com.adyen.checkout.components.base.ComponentParams
+import com.adyen.checkout.core.api.Environment
+import kotlinx.parcelize.Parcelize
+import java.util.Locale
+
+@Parcelize
+internal data class IssuerListComponentParams(
+    override val shopperLocale: Locale,
+    override val environment: Environment,
+    override val clientKey: String,
+    val viewType: IssuerListViewType,
+    val hideIssuerLogos: Boolean,
+) : ComponentParams


### PR DESCRIPTION
Our configuration classes are built directly by the developers and they are immutable. We need to be able to inject some values into them from drop-in or from the API responses.

In this PR we create a data class for the card component that shadows the card configuration and includes any extra parameters we need.

COAND-549