### PR TITLE
Remove spotbugs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,6 @@ apply from: "config/gradle/dependenciesCheck.gradle"
 
 ext {
     checkoutRedirectScheme = "adyencheckout"
-     // This is a quirk in the Spotbugs plugin, the class name isn't findable in the separate spotbugs.gradle file
-     // unless you define classpath "gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.3.0" there.
-    SpotBugsTask = com.github.spotbugs.snom.SpotBugsTask
 }
 
 buildscript {
@@ -21,7 +18,6 @@ buildscript {
         classpath "com.android.tools.build:gradle:$android_gradle_plugin_version"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:$detekt_gradle_plugin_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:$spotbugs_gradle_plugin_version"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokka_version"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
     }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -22,7 +22,6 @@ ext {
     android_gradle_plugin_version = '7.2.0'
     kotlin_version = '1.7.21'
     detekt_gradle_plugin_version = "1.22.0"
-    spotbugs_gradle_plugin_version = "4.5.1"
     dokka_version = "1.6.21"
     hilt_version = "2.43.2"
 


### PR DESCRIPTION
The plugin wasn't configured correctly so it wasn't even working. After enabling it, it flagged errors inside the auto generated view binding classes. Disabling it for now and will investigate later whether it's needed.

COAND-674