### PR TITLE
Update dependencies

### DIFF
--- a/config/gradle/checksums.gradle
+++ b/config/gradle/checksums.gradle
@@ -36,7 +36,7 @@ if (!hasProperty("checksums")) {
         "androidx.browser:browser:1.4.0:8b6dfac591dd4b320351218bae97040e:MD5",
 
         // Google
-        "com.google.android.material:material:1.6.1:def6680e132be7fd5f84d3caca354c92:MD5",
+        "com.google.android.material:material:1.7.0:038a5afbf1e535e60c58d19ff296a283:MD5",
         "com.google.android.gms:play-services-wallet:18.1.3:2314339d19e7fe101ae793085ed08863:MD5",
 
         // WeChatPay

--- a/config/gradle/checksums.gradle
+++ b/config/gradle/checksums.gradle
@@ -43,7 +43,7 @@ if (!hasProperty("checksums")) {
         "com.tencent.mm.opensdk:wechat-sdk-android-without-mta:6.6.4:8ae40b8665f98587e716b4593401aef2:MD5",
 
         // OkHttp
-        "com.squareup.okhttp3:okhttp:4.9.3:3b3373ecaff75d5804764ad301807d10:MD5"
+        "com.squareup.okhttp3:okhttp:4.10.0:9a229b2af8b8ffcc41508f82ef5e3e72:MD5"
     ]
 
     ext.checksums = checksums

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -58,7 +58,7 @@ ext {
 
     // Tests
     arch_core_testing_version = "2.1.0"
-    espresso_version = "3.4.0"
+    espresso_version = "3.5.0"
     json_version = '20220320'
     junit_version = '4.13.2'
     junit_jupiter_version = "5.8.2"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -63,7 +63,7 @@ ext {
     junit_version = '4.13.2'
     junit_jupiter_version = "5.9.1"
     mockito_kotlin_version = "4.0.0"
-    mockito_version = "4.6.1"
+    mockito_version = "4.9.0"
     robolectric_version = "4.9"
     test_ext_version = "1.1.4"
     test_rules_version = "1.5.0"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -52,7 +52,7 @@ ext {
     leak_canary_version = '2.10'
     moshi_adapters_version = '1.14.0'
     moshi_kotlin_adapter_version = '1.14.0'
-    okhttp_logging_version = "4.9.0"
+    okhttp_logging_version = "4.10.0"
     preference_version = "1.2.0"
     retrofit2_version = '2.9.0'
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -64,7 +64,7 @@ ext {
     junit_jupiter_version = "5.8.2"
     mockito_kotlin_version = "4.0.0"
     mockito_version = "4.6.1"
-    robolectric_version = "4.8.2"
+    robolectric_version = "4.9"
     test_ext_version = "1.1.4"
     test_rules_version = "1.5.0"
     turbine_version = "0.12.1"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -61,7 +61,7 @@ ext {
     espresso_version = "3.5.0"
     json_version = '20220320'
     junit_version = '4.13.2'
-    junit_jupiter_version = "5.8.2"
+    junit_jupiter_version = "5.9.1"
     mockito_kotlin_version = "4.0.0"
     mockito_version = "4.6.1"
     robolectric_version = "4.9"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -43,7 +43,7 @@ ext {
     adyen3ds2_version = "2.2.10"
 
     // External Dependencies
-    okhttp_version = "4.9.3"
+    okhttp_version = "4.10.0"
     play_services_wallet_version = '18.1.3'
     wechat_pay_version = "6.6.4"
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -49,7 +49,7 @@ ext {
 
     // Example app
     constraintlayout_version = '2.1.4'
-    leak_canary_version = '2.9.1'
+    leak_canary_version = '2.10'
     moshi_adapters_version = '1.11.0'
     moshi_kotlin_adapter_version = '1.13.0'
     okhttp_logging_version = "4.9.0"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -36,7 +36,7 @@ ext {
     coroutines_version = "1.6.4"
     fragment_version = "1.5.4"
     lifecycle_version = "2.5.1"
-    material_version = "1.6.1"
+    material_version = "1.7.0"
     recyclerview_version = "1.2.1"
 
     // Adyen Dependencies

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -50,7 +50,7 @@ ext {
     // Example app
     constraintlayout_version = '2.1.4'
     leak_canary_version = '2.10'
-    moshi_adapters_version = '1.11.0'
+    moshi_adapters_version = '1.14.0'
     moshi_kotlin_adapter_version = '1.13.0'
     okhttp_logging_version = "4.9.0"
     preference_version = "1.2.0"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -51,7 +51,7 @@ ext {
     constraintlayout_version = '2.1.4'
     leak_canary_version = '2.10'
     moshi_adapters_version = '1.14.0'
-    moshi_kotlin_adapter_version = '1.13.0'
+    moshi_kotlin_adapter_version = '1.14.0'
     okhttp_logging_version = "4.9.0"
     preference_version = "1.2.0"
     retrofit2_version = '2.9.0'

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -23,7 +23,7 @@ ext {
     kotlin_version = '1.7.21'
     detekt_gradle_plugin_version = "1.22.0"
     dokka_version = "1.7.20"
-    hilt_version = "2.43.2"
+    hilt_version = "2.44.2"
 
     // Code quality
     detekt_version = "1.22.0"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -22,7 +22,7 @@ ext {
     android_gradle_plugin_version = '7.3.1'
     kotlin_version = '1.7.21'
     detekt_gradle_plugin_version = "1.22.0"
-    dokka_version = "1.6.21"
+    dokka_version = "1.7.20"
     hilt_version = "2.43.2"
 
     // Code quality


### PR DESCRIPTION
Enabling Renovate caused tens of PRs to be opened which is cumbersome to fix and rebase.

In this PR we update the first batch of dependencies:

- Update dependency com.google.android.material:material to v1.7.0
- Update dependency com.squareup.leakcanary:leakcanary-android to v2.10
- Update dependency com.squareup.moshi:moshi-adapters to v1.14.0
- Update dependency com.squareup.moshi:moshi-kotlin to v1.14.0
- Update dependency com.squareup.okhttp3:logging-interceptor to v4.10.0
- Update dependency com.squareup.okhttp3:okhttp to v4.10.0
- Update dependency org.jetbrains.dokka:dokka-gradle-plugin to v1.7.20
- Update dependency org.robolectric:robolectric to v4.9
- Update espresso_version to v3.5.0
- Update dependency com.google.dagger:hilt-android to v2.44.2
- Update dependency org.junit.jupiter:junit-jupiter to v5.9.1
- Update dependency org.mockito:mockito-android to v4.9.0