### PR TITLE
Remove selecting the first card in dual brand flow by default

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/CardInputData.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardInputData.kt
@@ -21,6 +21,6 @@ data class CardInputData(
     var postalCode: String = "",
     var address: AddressInputModel = AddressInputModel(),
     var isStorePaymentSelected: Boolean = false,
-    var selectedCardIndex: Int = 0,
+    var selectedCardIndex: Int = -1,
     var installmentOption: InstallmentModel? = null
 ) : InputData

--- a/card/src/main/java/com/adyen/checkout/card/CardView.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardView.kt
@@ -385,6 +385,7 @@ internal class CardView @JvmOverloads constructor(
 
     private fun initCardBrandLogoViews(selectedIndex: Int) {
         when (selectedIndex) {
+            UNSELECTED_BRAND_INDEX -> deselectBrands()
             PRIMARY_BRAND_INDEX -> selectPrimaryBrand()
             SECONDARY_BRAND_INDEX -> selectSecondaryBrand()
             else -> throw CheckoutException("Illegal brand index selected. Selected index must be either 0 or 1.")
@@ -406,6 +407,11 @@ internal class CardView @JvmOverloads constructor(
     private fun resetBrandSelectionInput() {
         binding.cardBrandLogoContainerPrimary.setOnClickListener(null)
         binding.cardBrandLogoContainerSecondary.setOnClickListener(null)
+    }
+
+    private fun deselectBrands() {
+        binding.cardBrandLogoImageViewPrimary.alpha = UNSELECTED_BRAND_LOGO_ALPHA
+        binding.cardBrandLogoImageViewSecondary.alpha = UNSELECTED_BRAND_LOGO_ALPHA
     }
 
     private fun selectPrimaryBrand() {
@@ -755,6 +761,7 @@ internal class CardView @JvmOverloads constructor(
     companion object {
         private const val UNSELECTED_BRAND_LOGO_ALPHA = 0.2f
         private const val SELECTED_BRAND_LOGO_ALPHA = 1f
+        private const val UNSELECTED_BRAND_INDEX = -1
         private const val PRIMARY_BRAND_INDEX = 0
         private const val SECONDARY_BRAND_INDEX = 1
     }

--- a/card/src/main/java/com/adyen/checkout/card/DefaultCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/DefaultCardDelegate.kt
@@ -235,7 +235,9 @@ internal class DefaultCardDelegate(
             detectedCardTypes,
             inputData.selectedCardIndex
         )
-        val selectedOrFirstCardType = getDetectedCardType(filteredDetectedCardTypes)
+        val selectedOrFirstCardType = DetectedCardTypesUtils.getSelectedOrFirstDetectedCardType(
+            detectedCardTypes = filteredDetectedCardTypes
+        )
 
         val reliableSelectedCard = if (isReliable) selectedOrFirstCardType else null
 
@@ -301,7 +303,9 @@ internal class DefaultCardDelegate(
     ): CardComponentState {
         val cardNumber = outputData.cardNumberState.value
 
-        val firstCardType = getDetectedCardType(outputData.detectedCardTypes)?.cardType
+        val firstCardType = DetectedCardTypesUtils.getSelectedOrFirstDetectedCardType(
+            detectedCardTypes = outputData.detectedCardTypes
+        )?.cardType
 
         val binValue = cardNumber.take(BIN_VALUE_LENGTH)
 
@@ -557,7 +561,9 @@ internal class DefaultCardDelegate(
             }
 
             if (isDualBrandedFlow(stateOutputData.detectedCardTypes)) {
-                brand = getDetectedCardType(stateOutputData.detectedCardTypes)?.cardType?.txVariant
+                brand = DetectedCardTypesUtils.getSelectedCardType(
+                    detectedCardTypes = stateOutputData.detectedCardTypes
+                )?.cardType?.txVariant
             }
 
             fundingSource = getFundingSource()
@@ -583,10 +589,6 @@ internal class DefaultCardDelegate(
             binValue = binValue,
             lastFourDigits = lastFour
         )
-    }
-
-    private fun getDetectedCardType(detectedCardTypes: List<DetectedCardType>): DetectedCardType? {
-        return DetectedCardTypesUtils.getSelectedOrFirstDetectedCardType(detectedCardTypes)
     }
 
     private fun isDualBrandedFlow(detectedCardTypes: List<DetectedCardType>): Boolean {

--- a/card/src/main/java/com/adyen/checkout/card/util/DetectedCardTypesUtils.kt
+++ b/card/src/main/java/com/adyen/checkout/card/util/DetectedCardTypesUtils.kt
@@ -22,7 +22,11 @@ object DetectedCardTypesUtils {
     }
 
     fun getSelectedOrFirstDetectedCardType(detectedCardTypes: List<DetectedCardType>): DetectedCardType? {
-        return detectedCardTypes.firstOrNull { it.isSelected } ?: detectedCardTypes.firstOrNull()
+        return getSelectedCardType(detectedCardTypes) ?: detectedCardTypes.firstOrNull()
+    }
+
+    fun getSelectedCardType(detectedCardTypes: List<DetectedCardType>): DetectedCardType? {
+        return detectedCardTypes.firstOrNull { it.isSelected }
     }
 
     private fun markSelectedCard(cards: List<DetectedCardType>, selectedIndex: Int): List<DetectedCardType> {


### PR DESCRIPTION
By default, no brand will be selected in dual-branded flow. Hence it won't be passed to the PaymentComponentData.

COAND-676
