### PR TITLE
Remove selecting the first card in dual brand flow by default

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponent.kt
@@ -192,7 +192,8 @@ class CardComponent private constructor(
         val sortedCardTypes = DualBrandedCardUtils.sortBrands(supportedCardTypes)
         val outputCardTypes = markSelectedCard(sortedCardTypes, selectedCardIndex)
 
-        val selectedOrFirstCardType = outputCardTypes.firstOrNull { it.isSelected } ?: outputCardTypes.firstOrNull()
+        val selectedCardType = outputCardTypes.firstOrNull { it.isSelected }
+        val selectedOrFirstCardType = selectedCardType ?: outputCardTypes.firstOrNull()
 
         val reliableSelectedCard = if (isReliable) selectedOrFirstCardType else null
 
@@ -430,7 +431,7 @@ class CardComponent private constructor(
         }
 
         if (isDualBrandedFlow(stateOutputData)) {
-            cardPaymentMethod.brand = stateOutputData.detectedCardTypes.first { it.isSelected }.cardType.txVariant
+            cardPaymentMethod.brand = stateOutputData.detectedCardTypes.firstOrNull { it.isSelected }?.cardType?.txVariant
         }
 
         cardPaymentMethod.fundingSource = cardDelegate.getFundingSource()

--- a/card/src/main/java/com/adyen/checkout/card/CardInputData.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardInputData.kt
@@ -21,6 +21,6 @@ data class CardInputData(
     var postalCode: String = "",
     var address: AddressInputModel = AddressInputModel(),
     var isStorePaymentSelected: Boolean = false,
-    var selectedCardIndex: Int = 0,
+    var selectedCardIndex: Int = -1,
     var installmentOption: InstallmentModel? = null
 ) : InputData

--- a/card/src/main/java/com/adyen/checkout/card/CardView.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardView.kt
@@ -51,6 +51,7 @@ class CardView @JvmOverloads constructor(context: Context, attrs: AttributeSet? 
     companion object {
         private const val UNSELECTED_BRAND_LOGO_ALPHA = 0.2f
         private const val SELECTED_BRAND_LOGO_ALPHA = 1f
+        private const val UNSELECTED_BRAND_INDEX = -1
         private const val PRIMARY_BRAND_INDEX = 0
         private const val SECONDARY_BRAND_INDEX = 1
     }
@@ -360,6 +361,7 @@ class CardView @JvmOverloads constructor(context: Context, attrs: AttributeSet? 
 
     private fun initCardBrandLogoViews(selectedIndex: Int) {
         when (selectedIndex) {
+            UNSELECTED_BRAND_INDEX -> deselectBrands()
             PRIMARY_BRAND_INDEX -> selectPrimaryBrand()
             SECONDARY_BRAND_INDEX -> selectSecondaryBrand()
             else -> throw CheckoutException("Illegal brand index selected. Selected index must be either 0 or 1.")
@@ -383,6 +385,11 @@ class CardView @JvmOverloads constructor(context: Context, attrs: AttributeSet? 
     private fun resetBrandSelectionInput() {
         binding.cardBrandLogoContainerPrimary.setOnClickListener(null)
         binding.cardBrandLogoContainerSecondary.setOnClickListener(null)
+    }
+
+    private fun deselectBrands() {
+        binding.cardBrandLogoImageViewPrimary.alpha = UNSELECTED_BRAND_LOGO_ALPHA
+        binding.cardBrandLogoImageViewSecondary.alpha = UNSELECTED_BRAND_LOGO_ALPHA
     }
 
     private fun selectPrimaryBrand() {


### PR DESCRIPTION
By default, no brand will be selected in dual-branded flow. Hence it won't be passed to the PaymentComponentData.

COAND-676