### PR TITLE
Move configuration defaults to params

### DIFF
--- a/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponentParamsMapper.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponentParamsMapper.kt
@@ -9,6 +9,7 @@
 package com.adyen.checkout.bacs
 
 import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.model.payments.Amount
 
 internal class BacsDirectDebitComponentParamsMapper(
     private val parentConfiguration: Configuration?
@@ -31,7 +32,7 @@ internal class BacsDirectDebitComponentParamsMapper(
             shopperLocale = parentConfiguration.shopperLocale,
             environment = parentConfiguration.environment,
             clientKey = parentConfiguration.clientKey,
-            amount = bacsDirectDebitConfiguration.amount,
+            amount = bacsDirectDebitConfiguration.amount ?: Amount.EMPTY,
         )
     }
 }

--- a/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitConfiguration.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitConfiguration.kt
@@ -25,7 +25,7 @@ class BacsDirectDebitConfiguration private constructor(
     override val shopperLocale: Locale,
     override val environment: Environment,
     override val clientKey: String,
-    override val amount: Amount,
+    override val amount: Amount?,
 ) : Configuration, AmountConfiguration {
 
     private constructor(builder: Builder) : this(
@@ -37,8 +37,7 @@ class BacsDirectDebitConfiguration private constructor(
 
     class Builder : BaseConfigurationBuilder<BacsDirectDebitConfiguration>, AmountConfigurationBuilder {
 
-        internal var amount: Amount = Amount.EMPTY
-            private set
+        internal var amount: Amount? = null
 
         /**
          * Constructor for Builder with default values.

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcComponentParamsMapper.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcComponentParamsMapper.kt
@@ -32,9 +32,9 @@ internal class BcmcComponentParamsMapper(
                 shopperLocale = parentConfiguration.shopperLocale,
                 environment = parentConfiguration.environment,
                 clientKey = parentConfiguration.clientKey,
-                isHolderNameRequired = isHolderNameRequired,
+                isHolderNameRequired = isHolderNameRequired ?: false,
                 shopperReference = shopperReference,
-                isStorePaymentFieldVisible = isStorePaymentFieldVisible,
+                isStorePaymentFieldVisible = isStorePaymentFieldVisible ?: false,
             )
         }
     }

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcConfiguration.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcConfiguration.kt
@@ -22,9 +22,9 @@ class BcmcConfiguration private constructor(
     override val shopperLocale: Locale,
     override val environment: Environment,
     override val clientKey: String,
-    val isHolderNameRequired: Boolean,
+    val isHolderNameRequired: Boolean?,
     val shopperReference: String?,
-    val isStorePaymentFieldVisible: Boolean,
+    val isStorePaymentFieldVisible: Boolean?,
 ) : Configuration {
 
     /**
@@ -32,8 +32,8 @@ class BcmcConfiguration private constructor(
      */
     class Builder : BaseConfigurationBuilder<BcmcConfiguration> {
 
-        private var isHolderNameRequired = false
-        private var showStorePaymentField = false
+        private var isHolderNameRequired: Boolean? = null
+        private var showStorePaymentField: Boolean? = null
         private var shopperReference: String? = null
 
         /**

--- a/card/src/main/java/com/adyen/checkout/card/CardComponentParamsMapper.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponentParamsMapper.kt
@@ -38,7 +38,7 @@ internal class CardComponentParamsMapper(
         return mapToParams(
             parentConfiguration = parentConfiguration ?: cardConfiguration,
             cardConfiguration = cardConfiguration,
-            supportedCardTypes = cardConfiguration.supportedCardTypes
+            supportedCardTypes = cardConfiguration.supportedCardTypes.orEmpty()
         )
     }
 
@@ -52,16 +52,16 @@ internal class CardComponentParamsMapper(
                 shopperLocale = parentConfiguration.shopperLocale,
                 environment = parentConfiguration.environment,
                 clientKey = parentConfiguration.clientKey,
-                isHolderNameRequired = isHolderNameRequired,
+                isHolderNameRequired = isHolderNameRequired ?: false,
                 supportedCardTypes = supportedCardTypes,
                 shopperReference = shopperReference,
-                isStorePaymentFieldVisible = isStorePaymentFieldVisible,
-                isHideCvc = isHideCvc,
-                isHideCvcStoredCard = isHideCvcStoredCard,
-                socialSecurityNumberVisibility = socialSecurityNumberVisibility,
-                kcpAuthVisibility = kcpAuthVisibility,
+                isStorePaymentFieldVisible = isStorePaymentFieldVisible ?: true,
+                isHideCvc = isHideCvc ?: false,
+                isHideCvcStoredCard = isHideCvcStoredCard ?: false,
+                socialSecurityNumberVisibility = socialSecurityNumberVisibility ?: SocialSecurityNumberVisibility.HIDE,
+                kcpAuthVisibility = kcpAuthVisibility ?: KCPAuthVisibility.HIDE,
                 installmentConfiguration = installmentConfiguration,
-                addressConfiguration = addressConfiguration
+                addressConfiguration = addressConfiguration ?: AddressConfiguration.None
             )
         }
     }
@@ -75,7 +75,7 @@ internal class CardComponentParamsMapper(
         paymentMethod: PaymentMethod
     ): List<CardType> {
         return when {
-            cardConfiguration.supportedCardTypes.isNotEmpty() -> {
+            !cardConfiguration.supportedCardTypes.isNullOrEmpty() -> {
                 Logger.v(TAG, "Reading supportedCardTypes from configuration")
                 cardConfiguration.supportedCardTypes
             }

--- a/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
@@ -25,16 +25,16 @@ class CardConfiguration private constructor(
     override val shopperLocale: Locale,
     override val environment: Environment,
     override val clientKey: String,
-    val isHolderNameRequired: Boolean,
-    val supportedCardTypes: List<CardType>,
+    val isHolderNameRequired: Boolean?,
+    val supportedCardTypes: List<CardType>?,
     val shopperReference: String?,
-    val isStorePaymentFieldVisible: Boolean,
-    val isHideCvc: Boolean,
-    val isHideCvcStoredCard: Boolean,
-    val socialSecurityNumberVisibility: SocialSecurityNumberVisibility,
-    val kcpAuthVisibility: KCPAuthVisibility,
+    val isStorePaymentFieldVisible: Boolean?,
+    val isHideCvc: Boolean?,
+    val isHideCvcStoredCard: Boolean?,
+    val socialSecurityNumberVisibility: SocialSecurityNumberVisibility?,
+    val kcpAuthVisibility: KCPAuthVisibility?,
     val installmentConfiguration: InstallmentConfiguration?,
-    val addressConfiguration: AddressConfiguration,
+    val addressConfiguration: AddressConfiguration?,
 ) : Configuration {
 
     /**
@@ -42,17 +42,16 @@ class CardConfiguration private constructor(
      */
     @Suppress("TooManyFunctions")
     class Builder : BaseConfigurationBuilder<CardConfiguration> {
-        private var supportedCardTypes: List<CardType> = emptyList()
-        private var holderNameRequired = false
-        private var isStorePaymentFieldVisible = true
+        private var supportedCardTypes: List<CardType>? = null
+        private var holderNameRequired: Boolean? = null
+        private var isStorePaymentFieldVisible: Boolean? = null
         private var shopperReference: String? = null
-        private var isHideCvc = false
-        private var isHideCvcStoredCard = false
-        private var socialSecurityNumberVisibility: SocialSecurityNumberVisibility =
-            SocialSecurityNumberVisibility.HIDE
-        private var kcpAuthVisibility: KCPAuthVisibility = KCPAuthVisibility.HIDE
+        private var isHideCvc: Boolean? = null
+        private var isHideCvcStoredCard: Boolean? = null
+        private var socialSecurityNumberVisibility: SocialSecurityNumberVisibility? = null
+        private var kcpAuthVisibility: KCPAuthVisibility? = null
         private var installmentConfiguration: InstallmentConfiguration? = null
-        private var addressConfiguration: AddressConfiguration = AddressConfiguration.None
+        private var addressConfiguration: AddressConfiguration? = null
 
         /**
          * Constructor of Card Configuration Builder with instance of CardConfiguration.

--- a/components-core/src/main/java/com/adyen/checkout/components/base/AmountConfiguration.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/base/AmountConfiguration.kt
@@ -14,5 +14,5 @@ import com.adyen.checkout.components.model.payments.Amount
  * Represents a configuration class that contains an amount.
  */
 interface AmountConfiguration {
-    val amount: Amount
+    val amount: Amount?
 }

--- a/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayConfiguration.kt
+++ b/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayConfiguration.kt
@@ -19,8 +19,8 @@ class DotpayConfiguration private constructor(
     override val shopperLocale: Locale,
     override val environment: Environment,
     override val clientKey: String,
-    override val viewType: IssuerListViewType,
-    override val hideIssuerLogos: Boolean,
+    override val viewType: IssuerListViewType?,
+    override val hideIssuerLogos: Boolean?,
 ) : IssuerListConfiguration() {
 
     /**

--- a/entercash/src/main/java/com/adyen/checkout/entercash/EntercashConfiguration.kt
+++ b/entercash/src/main/java/com/adyen/checkout/entercash/EntercashConfiguration.kt
@@ -19,8 +19,8 @@ class EntercashConfiguration private constructor(
     override val shopperLocale: Locale,
     override val environment: Environment,
     override val clientKey: String,
-    override val viewType: IssuerListViewType,
-    override val hideIssuerLogos: Boolean,
+    override val viewType: IssuerListViewType?,
+    override val hideIssuerLogos: Boolean?,
 ) : IssuerListConfiguration() {
 
     /**

--- a/eps/src/main/java/com/adyen/checkout/eps/EPSComponentProvider.kt
+++ b/eps/src/main/java/com/adyen/checkout/eps/EPSComponentProvider.kt
@@ -29,7 +29,10 @@ class EPSComponentProvider(
     parentConfiguration: Configuration? = null,
 ) : PaymentComponentProvider<EPSComponent, EPSConfiguration> {
 
-    private val componentParamsMapper = IssuerListComponentParamsMapper(parentConfiguration)
+    private val componentParamsMapper = IssuerListComponentParamsMapper(
+        parentConfiguration = parentConfiguration,
+        hideIssuerLogosDefaultValue = true
+    )
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/eps/src/main/java/com/adyen/checkout/eps/EPSConfiguration.kt
+++ b/eps/src/main/java/com/adyen/checkout/eps/EPSConfiguration.kt
@@ -19,16 +19,14 @@ class EPSConfiguration private constructor(
     override val shopperLocale: Locale,
     override val environment: Environment,
     override val clientKey: String,
-    override val viewType: IssuerListViewType,
-    override val hideIssuerLogos: Boolean,
+    override val viewType: IssuerListViewType?,
+    override val hideIssuerLogos: Boolean?,
 ) : IssuerListConfiguration() {
 
     /**
      * Builder to create a [EPSConfiguration].
      */
     class Builder : IssuerListBuilder<EPSConfiguration> {
-
-        override var hideIssuerLogos: Boolean = true
 
         /**
          * Constructor for Builder with default values.

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayComponentParamsMapper.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayComponentParamsMapper.kt
@@ -10,6 +10,8 @@ package com.adyen.checkout.googlepay
 
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
+import com.adyen.checkout.components.model.payments.Amount
+import com.adyen.checkout.components.util.CheckoutCurrency
 import com.adyen.checkout.core.api.Environment
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.core.log.LogUtil
@@ -47,16 +49,16 @@ internal class GooglePayComponentParamsMapper(
                 allowedAuthMethods = getAvailableAuthMethods(googlePayConfiguration),
                 allowedCardNetworks = getAvailableCardNetworks(googlePayConfiguration, paymentMethod),
                 googlePayEnvironment = getGooglePayEnvironment(googlePayConfiguration),
-                amount = amount,
-                totalPriceStatus = totalPriceStatus,
+                amount = amount ?: DEFAULT_AMOUNT,
+                totalPriceStatus = totalPriceStatus ?: DEFAULT_TOTAL_PRICE_STATUS,
                 countryCode = countryCode,
                 merchantInfo = merchantInfo,
-                isAllowPrepaidCards = isAllowPrepaidCards,
-                isEmailRequired = isEmailRequired,
-                isExistingPaymentMethodRequired = isExistingPaymentMethodRequired,
-                isShippingAddressRequired = isShippingAddressRequired,
+                isAllowPrepaidCards = isAllowPrepaidCards ?: false,
+                isEmailRequired = isEmailRequired ?: false,
+                isExistingPaymentMethodRequired = isExistingPaymentMethodRequired ?: false,
+                isShippingAddressRequired = isShippingAddressRequired ?: false,
                 shippingAddressParameters = shippingAddressParameters,
-                isBillingAddressRequired = isBillingAddressRequired,
+                isBillingAddressRequired = isBillingAddressRequired ?: false,
                 billingAddressParameters = billingAddressParameters,
             )
         }
@@ -120,5 +122,7 @@ internal class GooglePayComponentParamsMapper(
 
     companion object {
         private val TAG = LogUtil.getTag()
+        private val DEFAULT_AMOUNT = Amount(currency = CheckoutCurrency.USD.name, value = 0)
+        private const val DEFAULT_TOTAL_PRICE_STATUS = "FINAL"
     }
 }

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.kt
@@ -14,6 +14,7 @@ import com.adyen.checkout.components.base.AmountConfiguration
 import com.adyen.checkout.components.base.AmountConfigurationBuilder
 import com.adyen.checkout.components.base.BaseConfigurationBuilder
 import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.model.payments.Amount
 import com.adyen.checkout.components.util.CheckoutCurrency.Companion.isSupported
 import com.adyen.checkout.core.api.Environment
@@ -143,6 +144,10 @@ class GooglePayConfiguration private constructor(
 
         /**
          * Set the merchant account to be put in the payment token from Google to Adyen.
+         *
+         * If not set then [PaymentMethod.configuration.gatewayMerchantId] will be used.
+         * If that value is also not set, an exception will be thrown indicating that you need to update you Adyen API
+         * version or pass this value manually.
          *
          * @param merchantAccount Your merchant account.
          */

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.kt
@@ -15,7 +15,6 @@ import com.adyen.checkout.components.base.AmountConfigurationBuilder
 import com.adyen.checkout.components.base.BaseConfigurationBuilder
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.model.payments.Amount
-import com.adyen.checkout.components.util.CheckoutCurrency
 import com.adyen.checkout.components.util.CheckoutCurrency.Companion.isSupported
 import com.adyen.checkout.core.api.Environment
 import com.adyen.checkout.core.exception.CheckoutException
@@ -34,18 +33,18 @@ class GooglePayConfiguration private constructor(
     override val clientKey: String,
     val merchantAccount: String?,
     val googlePayEnvironment: Int?,
-    override val amount: Amount,
-    val totalPriceStatus: String,
+    override val amount: Amount?,
+    val totalPriceStatus: String?,
     val countryCode: String?,
     val merchantInfo: MerchantInfo?,
     val allowedAuthMethods: List<String>?,
     val allowedCardNetworks: List<String>?,
-    val isAllowPrepaidCards: Boolean,
-    val isEmailRequired: Boolean,
-    val isExistingPaymentMethodRequired: Boolean,
-    val isShippingAddressRequired: Boolean,
+    val isAllowPrepaidCards: Boolean?,
+    val isEmailRequired: Boolean?,
+    val isExistingPaymentMethodRequired: Boolean?,
+    val isShippingAddressRequired: Boolean?,
     val shippingAddressParameters: ShippingAddressParameters?,
-    val isBillingAddressRequired: Boolean,
+    val isBillingAddressRequired: Boolean?,
     val billingAddressParameters: BillingAddressParameters?,
 ) : Configuration, AmountConfiguration {
 
@@ -56,22 +55,19 @@ class GooglePayConfiguration private constructor(
     class Builder : BaseConfigurationBuilder<GooglePayConfiguration>, AmountConfigurationBuilder {
         private var merchantAccount: String? = null
         private var googlePayEnvironment: Int? = null
-        private var amount = Amount(
-            value = 0,
-            currency = CheckoutCurrency.USD.name
-        )
+        private var amount: Amount? = null
         private var merchantInfo: MerchantInfo? = null
         private var countryCode: String? = null
         private var allowedAuthMethods: List<String>? = null
         private var allowedCardNetworks: List<String>? = null
-        private var isAllowPrepaidCards = false
-        private var isEmailRequired = false
-        private var isExistingPaymentMethodRequired = false
-        private var isShippingAddressRequired = false
+        private var isAllowPrepaidCards: Boolean? = null
+        private var isEmailRequired: Boolean? = null
+        private var isExistingPaymentMethodRequired: Boolean? = null
+        private var isShippingAddressRequired: Boolean? = null
         private var shippingAddressParameters: ShippingAddressParameters? = null
-        private var isBillingAddressRequired = false
+        private var isBillingAddressRequired: Boolean? = null
         private var billingAddressParameters: BillingAddressParameters? = null
-        private var totalPriceStatus: String = "FINAL"
+        private var totalPriceStatus: String? = null
 
         /**
          * Constructor for Builder with default values.

--- a/ideal/src/main/java/com/adyen/checkout/ideal/IdealConfiguration.kt
+++ b/ideal/src/main/java/com/adyen/checkout/ideal/IdealConfiguration.kt
@@ -19,8 +19,8 @@ class IdealConfiguration private constructor(
     override val shopperLocale: Locale,
     override val environment: Environment,
     override val clientKey: String,
-    override val viewType: IssuerListViewType,
-    override val hideIssuerLogos: Boolean,
+    override val viewType: IssuerListViewType?,
+    override val hideIssuerLogos: Boolean?,
 ) : IssuerListConfiguration() {
 
     /**

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/IssuerListComponentParamsMapper.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/IssuerListComponentParamsMapper.kt
@@ -13,7 +13,8 @@ import com.adyen.checkout.components.base.Configuration
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class IssuerListComponentParamsMapper(
-    private val parentConfiguration: Configuration?
+    private val parentConfiguration: Configuration?,
+    private val hideIssuerLogosDefaultValue: Boolean = false
 ) {
 
     fun mapToParams(
@@ -34,8 +35,8 @@ class IssuerListComponentParamsMapper(
                 shopperLocale = parentConfiguration.shopperLocale,
                 environment = parentConfiguration.environment,
                 clientKey = parentConfiguration.clientKey,
-                viewType = viewType,
-                hideIssuerLogos = hideIssuerLogos,
+                viewType = viewType ?: IssuerListViewType.RECYCLER_VIEW,
+                hideIssuerLogos = hideIssuerLogos ?: hideIssuerLogosDefaultValue,
             )
         }
     }

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/IssuerListConfiguration.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/IssuerListConfiguration.kt
@@ -15,14 +15,14 @@ import java.util.Locale
 
 abstract class IssuerListConfiguration : Configuration {
 
-    abstract val viewType: IssuerListViewType
-    abstract val hideIssuerLogos: Boolean
+    abstract val viewType: IssuerListViewType?
+    abstract val hideIssuerLogos: Boolean?
 
     abstract class IssuerListBuilder<IssuerListConfigurationT : IssuerListConfiguration> :
         BaseConfigurationBuilder<IssuerListConfigurationT> {
 
-        protected open var viewType: IssuerListViewType = IssuerListViewType.RECYCLER_VIEW
-        protected open var hideIssuerLogos: Boolean = false
+        protected open var viewType: IssuerListViewType? = null
+        protected open var hideIssuerLogos: Boolean? = null
 
         protected constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,

--- a/issuer-list/src/test/java/com/adyen/checkout/issuerlist/utils/TestIssuerListConfiguration.kt
+++ b/issuer-list/src/test/java/com/adyen/checkout/issuerlist/utils/TestIssuerListConfiguration.kt
@@ -20,8 +20,8 @@ class TestIssuerListConfiguration private constructor(
     override val shopperLocale: Locale,
     override val environment: Environment,
     override val clientKey: String,
-    override val viewType: IssuerListViewType,
-    override val hideIssuerLogos: Boolean,
+    override val viewType: IssuerListViewType?,
+    override val hideIssuerLogos: Boolean?,
 ) : IssuerListConfiguration() {
 
     class Builder : IssuerListBuilder<TestIssuerListConfiguration> {

--- a/molpay/src/main/java/com/adyen/checkout/molpay/MolpayConfiguration.kt
+++ b/molpay/src/main/java/com/adyen/checkout/molpay/MolpayConfiguration.kt
@@ -19,8 +19,8 @@ class MolpayConfiguration private constructor(
     override val shopperLocale: Locale,
     override val environment: Environment,
     override val clientKey: String,
-    override val viewType: IssuerListViewType,
-    override val hideIssuerLogos: Boolean,
+    override val viewType: IssuerListViewType?,
+    override val hideIssuerLogos: Boolean?,
 ) : IssuerListConfiguration() {
 
     /**

--- a/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLConfiguration.kt
+++ b/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLConfiguration.kt
@@ -20,8 +20,8 @@ class OnlineBankingPLConfiguration private constructor(
     override val shopperLocale: Locale,
     override val environment: Environment,
     override val clientKey: String,
-    override val viewType: IssuerListViewType,
-    override val hideIssuerLogos: Boolean,
+    override val viewType: IssuerListViewType?,
+    override val hideIssuerLogos: Boolean?,
 ) : IssuerListConfiguration() {
 
     class Builder : IssuerListBuilder<OnlineBankingPLConfiguration> {

--- a/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingConfiguration.kt
+++ b/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingConfiguration.kt
@@ -19,8 +19,8 @@ class OpenBankingConfiguration private constructor(
     override val shopperLocale: Locale,
     override val environment: Environment,
     override val clientKey: String,
-    override val viewType: IssuerListViewType,
-    override val hideIssuerLogos: Boolean,
+    override val viewType: IssuerListViewType?,
+    override val hideIssuerLogos: Boolean?,
 ) : IssuerListConfiguration() {
 
     /**


### PR DESCRIPTION
Moving all the default values from the configuration builders to the mappers means that the mappers become the source of truth for all config values, since we already compute other values in there. And we need to make sure that we keep the config builder docs up to date.

COAND-549