### PR TITLE
Make DefaultBacsDirectDebitDelegate.paymentMethod private

### DIFF
--- a/bacs/src/main/java/com/adyen/checkout/bacs/DefaultBacsDirectDebitDelegate.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/DefaultBacsDirectDebitDelegate.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 internal class DefaultBacsDirectDebitDelegate(
     private val observerRepository: PaymentObserverRepository,
     override val componentParams: BacsDirectDebitComponentParams,
-    val paymentMethod: PaymentMethod,
+    private val paymentMethod: PaymentMethod,
 ) : BacsDirectDebitDelegate {
 
     private val inputData: BacsDirectDebitInputData = BacsDirectDebitInputData()


### PR DESCRIPTION
Minor fix to make `DefaultBacsDirectDebitDelegate.paymentMethod` private