### PR TITLE
Add BaseConfigurationBuilder to itself as a generic type

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Configuration.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Configuration.kt
@@ -21,16 +21,10 @@ class Adyen3DS2Configuration private constructor(
     override val clientKey: String,
 ) : Configuration {
 
-    private constructor(builder: Builder) : this(
-        builder.shopperLocale,
-        builder.environment,
-        builder.clientKey
-    )
-
     /**
      * Builder to create a [Adyen3DS2Configuration].
      */
-    class Builder : BaseConfigurationBuilder<Adyen3DS2Configuration> {
+    class Builder : BaseConfigurationBuilder<Adyen3DS2Configuration, Builder> {
 
         /**
          * Constructor for Builder with default values.
@@ -66,7 +60,11 @@ class Adyen3DS2Configuration private constructor(
         constructor(configuration: Adyen3DS2Configuration) : super(configuration)
 
         override fun buildInternal(): Adyen3DS2Configuration {
-            return Adyen3DS2Configuration(this)
+            return Adyen3DS2Configuration(
+                shopperLocale = shopperLocale,
+                environment = environment,
+                clientKey = clientKey,
+            )
         }
     }
 }

--- a/action/src/main/java/com/adyen/checkout/action/ActionDelegateProvider.kt
+++ b/action/src/main/java/com/adyen/checkout/action/ActionDelegateProvider.kt
@@ -108,7 +108,7 @@ internal class ActionDelegateProvider(
         val environment = configuration.environment
         val clientKey = configuration.clientKey
 
-        val builder: BaseConfigurationBuilder<out Configuration> = when (T::class) {
+        val builder: BaseConfigurationBuilder<*, *> = when (T::class) {
             AwaitConfiguration::class -> AwaitConfiguration.Builder(shopperLocale, environment, clientKey)
             RedirectConfiguration::class -> RedirectConfiguration.Builder(shopperLocale, environment, clientKey)
             QRCodeConfiguration::class -> QRCodeConfiguration.Builder(shopperLocale, environment, clientKey)

--- a/action/src/main/java/com/adyen/checkout/action/GenericActionConfiguration.kt
+++ b/action/src/main/java/com/adyen/checkout/action/GenericActionConfiguration.kt
@@ -39,13 +39,6 @@ class GenericActionConfiguration private constructor(
     private val availableActionConfigs: HashMap<Class<*>, Configuration>,
 ) : Configuration {
 
-    private constructor(builder: Builder) : this(
-        builder.shopperLocale,
-        builder.environment,
-        builder.clientKey,
-        builder.availableActionConfigs
-    )
-
     internal inline fun <reified T : Configuration> getConfigurationForAction(): T? {
         val actionClass = T::class.java
         if (availableActionConfigs.containsKey(actionClass)) {
@@ -59,7 +52,7 @@ class GenericActionConfiguration private constructor(
      * Builder for creating a [GenericActionConfiguration] where you can set specific Configurations for an action
      */
     @Suppress("unused")
-    class Builder : BaseConfigurationBuilder<GenericActionConfiguration> {
+    class Builder : BaseConfigurationBuilder<GenericActionConfiguration, Builder> {
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         val availableActionConfigs = HashMap<Class<*>, Configuration>()
@@ -146,7 +139,12 @@ class GenericActionConfiguration private constructor(
         }
 
         override fun buildInternal(): GenericActionConfiguration {
-            return GenericActionConfiguration(this)
+            return GenericActionConfiguration(
+                shopperLocale = shopperLocale,
+                environment = environment,
+                clientKey = clientKey,
+                availableActionConfigs = availableActionConfigs,
+            )
         }
     }
 }

--- a/await/src/main/java/com/adyen/checkout/await/AwaitConfiguration.kt
+++ b/await/src/main/java/com/adyen/checkout/await/AwaitConfiguration.kt
@@ -21,16 +21,10 @@ class AwaitConfiguration private constructor(
     override val clientKey: String,
 ) : Configuration {
 
-    private constructor(builder: Builder) : this(
-        builder.shopperLocale,
-        builder.environment,
-        builder.clientKey
-    )
-
     /**
      * Builder to create a [AwaitConfiguration].
      */
-    class Builder : BaseConfigurationBuilder<AwaitConfiguration> {
+    class Builder : BaseConfigurationBuilder<AwaitConfiguration, Builder> {
 
         /**
          * Constructor for Builder with default values.
@@ -66,7 +60,11 @@ class AwaitConfiguration private constructor(
         constructor(configuration: AwaitConfiguration) : super(configuration)
 
         override fun buildInternal(): AwaitConfiguration {
-            return AwaitConfiguration(this)
+            return AwaitConfiguration(
+                shopperLocale = shopperLocale,
+                environment = environment,
+                clientKey = clientKey,
+            )
         }
     }
 }

--- a/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitConfiguration.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitConfiguration.kt
@@ -28,14 +28,7 @@ class BacsDirectDebitConfiguration private constructor(
     override val amount: Amount?,
 ) : Configuration, AmountConfiguration {
 
-    private constructor(builder: Builder) : this(
-        builder.shopperLocale,
-        builder.environment,
-        builder.clientKey,
-        builder.amount,
-    )
-
-    class Builder : BaseConfigurationBuilder<BacsDirectDebitConfiguration>, AmountConfigurationBuilder {
+    class Builder : BaseConfigurationBuilder<BacsDirectDebitConfiguration, Builder>, AmountConfigurationBuilder {
 
         internal var amount: Amount? = null
 
@@ -75,7 +68,12 @@ class BacsDirectDebitConfiguration private constructor(
         }
 
         override fun buildInternal(): BacsDirectDebitConfiguration {
-            return BacsDirectDebitConfiguration(this)
+            return BacsDirectDebitConfiguration(
+                shopperLocale = shopperLocale,
+                environment = environment,
+                clientKey = clientKey,
+                amount = amount,
+            )
         }
 
         override fun setAmount(amount: Amount): Builder {

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcConfiguration.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcConfiguration.kt
@@ -30,7 +30,7 @@ class BcmcConfiguration private constructor(
     /**
      * Builder to create a [BcmcConfiguration].
      */
-    class Builder : BaseConfigurationBuilder<BcmcConfiguration> {
+    class Builder : BaseConfigurationBuilder<BcmcConfiguration, Builder> {
 
         private var isHolderNameRequired: Boolean? = null
         private var showStorePaymentField: Boolean? = null

--- a/blik/src/main/java/com/adyen/checkout/blik/BlikConfiguration.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/BlikConfiguration.kt
@@ -21,16 +21,10 @@ class BlikConfiguration private constructor(
     override val clientKey: String,
 ) : Configuration {
 
-    private constructor(builder: Builder) : this(
-        builder.shopperLocale,
-        builder.environment,
-        builder.clientKey
-    )
-
     /**
      * Builder to create a [BlikConfiguration].
      */
-    class Builder : BaseConfigurationBuilder<BlikConfiguration> {
+    class Builder : BaseConfigurationBuilder<BlikConfiguration, Builder> {
 
         /**
          * Constructor for Builder with default values.
@@ -66,7 +60,11 @@ class BlikConfiguration private constructor(
         constructor(configuration: BlikConfiguration) : super(configuration)
 
         override fun buildInternal(): BlikConfiguration {
-            return BlikConfiguration(this)
+            return BlikConfiguration(
+                shopperLocale = shopperLocale,
+                environment = environment,
+                clientKey = clientKey,
+            )
         }
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
@@ -41,7 +41,7 @@ class CardConfiguration private constructor(
      * Builder to create a [CardConfiguration].
      */
     @Suppress("TooManyFunctions")
-    class Builder : BaseConfigurationBuilder<CardConfiguration> {
+    class Builder : BaseConfigurationBuilder<CardConfiguration, Builder> {
         private var supportedCardTypes: List<CardType>? = null
         private var holderNameRequired: Boolean? = null
         private var isStorePaymentFieldVisible: Boolean? = null

--- a/components-core/src/main/java/com/adyen/checkout/components/base/BaseConfigurationBuilder.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/base/BaseConfigurationBuilder.kt
@@ -14,10 +14,13 @@ import java.util.Locale
  * @param environment   The [Environment] to be used for network calls to Adyen.
  * @param clientKey     Your Client Key used for network calls from the SDK to Adyen.
  */
-abstract class BaseConfigurationBuilder<ConfigurationT : Configuration>(
-    var shopperLocale: Locale,
-    var environment: Environment,
-    var clientKey: String
+abstract class BaseConfigurationBuilder<
+    ConfigurationT : Configuration,
+    BuilderT : BaseConfigurationBuilder<ConfigurationT, BuilderT>
+    >(
+    protected var shopperLocale: Locale,
+    protected var environment: Environment,
+    protected var clientKey: String
 ) {
 
     init {

--- a/components-core/src/test/java/com/adyen/checkout/components/models/TestConfiguration.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/models/TestConfiguration.kt
@@ -22,7 +22,7 @@ class TestConfiguration private constructor(
     override val clientKey: String,
 ) : Configuration {
 
-    class Builder : BaseConfigurationBuilder<TestConfiguration> {
+    class Builder : BaseConfigurationBuilder<TestConfiguration, Builder> {
 
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,

--- a/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayConfiguration.kt
+++ b/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayConfiguration.kt
@@ -26,7 +26,7 @@ class DotpayConfiguration private constructor(
     /**
      * Builder to create a [DotpayConfiguration].
      */
-    class Builder : IssuerListBuilder<DotpayConfiguration> {
+    class Builder : IssuerListBuilder<DotpayConfiguration, Builder> {
 
         /**
          * Constructor for Builder with default values.

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
@@ -144,7 +144,7 @@ internal fun <T : Configuration> getDefaultConfigForPaymentMethod(
     val shopperLocale = dropInConfiguration.shopperLocale
     val environment = dropInConfiguration.environment
     val clientKey = dropInConfiguration.clientKey
-    val builder: BaseConfigurationBuilder<out Configuration> = when {
+    val builder: BaseConfigurationBuilder<*, *> = when {
         BlikComponent.PROVIDER.isPaymentMethodSupported(storedPaymentMethod) -> BlikConfiguration.Builder(
             shopperLocale = shopperLocale,
             environment = environment,
@@ -173,7 +173,7 @@ internal fun <T : Configuration> getDefaultConfigForPaymentMethod(
     val clientKey = dropInConfiguration.clientKey
 
     // get default builder for Configuration type
-    val builder: BaseConfigurationBuilder<out Configuration> = when {
+    val builder: BaseConfigurationBuilder<*, *> = when {
         BacsDirectDebitComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) ->
             BacsDirectDebitConfiguration.Builder(
                 shopperLocale = shopperLocale,
@@ -502,7 +502,7 @@ internal fun getComponentFor(
 }
 
 @Suppress("ComplexMethod")
-private fun Configuration.toBuilder(): BaseConfigurationBuilder<out Configuration> {
+private fun Configuration.toBuilder(): BaseConfigurationBuilder<*, *> {
     return when (this) {
         is Adyen3DS2Configuration -> Adyen3DS2Configuration.Builder(this)
         is AwaitConfiguration -> AwaitConfiguration.Builder(this)

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
@@ -66,21 +66,6 @@ class DropInConfiguration private constructor(
     val additionalDataForDropInService: Bundle?,
 ) : Configuration {
 
-    constructor(
-        builder: Builder
-    ) : this(
-        builder.shopperLocale,
-        builder.environment,
-        builder.clientKey,
-        builder.availablePaymentConfigs,
-        builder.availableActionConfigs,
-        builder.amount,
-        builder.showPreselectedStoredPaymentMethod,
-        builder.skipListWhenSinglePaymentMethod,
-        builder.isRemovingStoredPaymentMethodsEnabled,
-        builder.additionalDataForDropInService,
-    )
-
     internal fun <T : Configuration> getConfigurationForPaymentMethod(paymentMethod: String): T? {
         if (availablePaymentConfigs.containsKey(paymentMethod)) {
             @Suppress("UNCHECKED_CAST")
@@ -103,21 +88,16 @@ class DropInConfiguration private constructor(
      * Builder for creating a [DropInConfiguration] where you can set specific Configurations for a Payment Method
      */
     @Suppress("unused", "TooManyFunctions")
-    class Builder : BaseConfigurationBuilder<DropInConfiguration> {
+    class Builder : BaseConfigurationBuilder<DropInConfiguration, Builder> {
 
         internal val availablePaymentConfigs = HashMap<String, Configuration>()
         internal val availableActionConfigs = HashMap<Class<*>, Configuration>()
 
-        var amount: Amount = Amount.EMPTY
-            private set
-        var showPreselectedStoredPaymentMethod: Boolean = true
-            private set
-        var skipListWhenSinglePaymentMethod: Boolean = false
-            private set
-        var isRemovingStoredPaymentMethodsEnabled: Boolean = false
-            private set
-        var additionalDataForDropInService: Bundle? = null
-            private set
+        private var amount: Amount = Amount.EMPTY
+        private var showPreselectedStoredPaymentMethod: Boolean = true
+        private var skipListWhenSinglePaymentMethod: Boolean = false
+        private var isRemovingStoredPaymentMethodsEnabled: Boolean = false
+        private var additionalDataForDropInService: Bundle? = null
 
         /**
          * Create a [DropInConfiguration]
@@ -399,7 +379,18 @@ class DropInConfiguration private constructor(
         }
 
         override fun buildInternal(): DropInConfiguration {
-            return DropInConfiguration(this)
+            return DropInConfiguration(
+                shopperLocale = shopperLocale,
+                environment = environment,
+                clientKey = clientKey,
+                availablePaymentConfigs = availablePaymentConfigs,
+                availableActionConfigs = availableActionConfigs,
+                amount = amount,
+                showPreselectedStoredPaymentMethod = showPreselectedStoredPaymentMethod,
+                skipListWhenSinglePaymentMethod = skipListWhenSinglePaymentMethod,
+                isRemovingStoredPaymentMethodsEnabled = isRemovingStoredPaymentMethodsEnabled,
+                additionalDataForDropInService = additionalDataForDropInService,
+            )
         }
     }
 }

--- a/entercash/src/main/java/com/adyen/checkout/entercash/EntercashConfiguration.kt
+++ b/entercash/src/main/java/com/adyen/checkout/entercash/EntercashConfiguration.kt
@@ -26,7 +26,7 @@ class EntercashConfiguration private constructor(
     /**
      * Builder to create a [EntercashConfiguration].
      */
-    class Builder : IssuerListBuilder<EntercashConfiguration> {
+    class Builder : IssuerListBuilder<EntercashConfiguration, Builder> {
 
         /**
          * Constructor for Builder with default values.

--- a/eps/src/main/java/com/adyen/checkout/eps/EPSConfiguration.kt
+++ b/eps/src/main/java/com/adyen/checkout/eps/EPSConfiguration.kt
@@ -26,7 +26,7 @@ class EPSConfiguration private constructor(
     /**
      * Builder to create a [EPSConfiguration].
      */
-    class Builder : IssuerListBuilder<EPSConfiguration> {
+    class Builder : IssuerListBuilder<EPSConfiguration, Builder> {
 
         /**
          * Constructor for Builder with default values.
@@ -62,17 +62,6 @@ class EPSConfiguration private constructor(
         constructor(configuration: EPSConfiguration) : super(configuration) {
             viewType = configuration.viewType
             hideIssuerLogos = configuration.hideIssuerLogos
-        }
-
-        /**
-         * Sets whether the logos should be shows next to the issuers name.
-         *
-         * Default is true.
-         *
-         * @param hideIssuerLogos if issuer logos should be hidden or not.
-         */
-        override fun setHideIssuerLogos(hideIssuerLogos: Boolean): Builder {
-            return super.setHideIssuerLogos(hideIssuerLogos) as Builder
         }
 
         public override fun buildInternal(): EPSConfiguration {

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardConfiguration.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardConfiguration.kt
@@ -21,16 +21,10 @@ class GiftCardConfiguration private constructor(
     override val clientKey: String
 ) : Configuration {
 
-    private constructor(builder: Builder) : this(
-        builder.shopperLocale,
-        builder.environment,
-        builder.clientKey
-    )
-
     /**
      * Builder to create a [GiftCardConfiguration].
      */
-    class Builder : BaseConfigurationBuilder<GiftCardConfiguration> {
+    class Builder : BaseConfigurationBuilder<GiftCardConfiguration, Builder> {
 
         /**
          * Constructor for Builder with default values.
@@ -66,7 +60,11 @@ class GiftCardConfiguration private constructor(
         constructor(configuration: GiftCardConfiguration) : super(configuration)
 
         override fun buildInternal(): GiftCardConfiguration {
-            return GiftCardConfiguration(this)
+            return GiftCardConfiguration(
+                shopperLocale = shopperLocale,
+                environment = environment,
+                clientKey = clientKey,
+            )
         }
     }
 }

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.kt
@@ -53,7 +53,7 @@ class GooglePayConfiguration private constructor(
      * Builder to create a [GooglePayConfiguration].
      */
     @Suppress("TooManyFunctions")
-    class Builder : BaseConfigurationBuilder<GooglePayConfiguration>, AmountConfigurationBuilder {
+    class Builder : BaseConfigurationBuilder<GooglePayConfiguration, Builder>, AmountConfigurationBuilder {
         private var merchantAccount: String? = null
         private var googlePayEnvironment: Int? = null
         private var amount: Amount? = null
@@ -117,29 +117,6 @@ class GooglePayConfiguration private constructor(
             shippingAddressParameters = configuration.shippingAddressParameters
             isBillingAddressRequired = configuration.isBillingAddressRequired
             billingAddressParameters = configuration.billingAddressParameters
-        }
-
-        override fun buildInternal(): GooglePayConfiguration {
-            return GooglePayConfiguration(
-                shopperLocale = shopperLocale,
-                environment = environment,
-                clientKey = clientKey,
-                merchantAccount = merchantAccount,
-                googlePayEnvironment = googlePayEnvironment,
-                amount = amount,
-                totalPriceStatus = totalPriceStatus,
-                countryCode = countryCode,
-                merchantInfo = merchantInfo,
-                allowedAuthMethods = allowedAuthMethods,
-                allowedCardNetworks = allowedCardNetworks,
-                isAllowPrepaidCards = isAllowPrepaidCards,
-                isEmailRequired = isEmailRequired,
-                isExistingPaymentMethodRequired = isExistingPaymentMethodRequired,
-                isShippingAddressRequired = isShippingAddressRequired,
-                shippingAddressParameters = shippingAddressParameters,
-                isBillingAddressRequired = isBillingAddressRequired,
-                billingAddressParameters = billingAddressParameters,
-            )
         }
 
         /**
@@ -366,6 +343,29 @@ class GooglePayConfiguration private constructor(
         fun setTotalPriceStatus(totalPriceStatus: String): Builder {
             this.totalPriceStatus = totalPriceStatus
             return this
+        }
+
+        override fun buildInternal(): GooglePayConfiguration {
+            return GooglePayConfiguration(
+                shopperLocale = shopperLocale,
+                environment = environment,
+                clientKey = clientKey,
+                merchantAccount = merchantAccount,
+                googlePayEnvironment = googlePayEnvironment,
+                amount = amount,
+                totalPriceStatus = totalPriceStatus,
+                countryCode = countryCode,
+                merchantInfo = merchantInfo,
+                allowedAuthMethods = allowedAuthMethods,
+                allowedCardNetworks = allowedCardNetworks,
+                isAllowPrepaidCards = isAllowPrepaidCards,
+                isEmailRequired = isEmailRequired,
+                isExistingPaymentMethodRequired = isExistingPaymentMethodRequired,
+                isShippingAddressRequired = isShippingAddressRequired,
+                shippingAddressParameters = shippingAddressParameters,
+                isBillingAddressRequired = isBillingAddressRequired,
+                billingAddressParameters = billingAddressParameters,
+            )
         }
     }
 }

--- a/ideal/src/main/java/com/adyen/checkout/ideal/IdealConfiguration.kt
+++ b/ideal/src/main/java/com/adyen/checkout/ideal/IdealConfiguration.kt
@@ -26,7 +26,7 @@ class IdealConfiguration private constructor(
     /**
      * Builder to create a [IdealConfiguration].
      */
-    class Builder : IssuerListBuilder<IdealConfiguration> {
+    class Builder : IssuerListBuilder<IdealConfiguration, Builder> {
 
         /**
          * Constructor for Builder with default values.

--- a/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentConfiguration.kt
+++ b/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentConfiguration.kt
@@ -21,16 +21,11 @@ class InstantPaymentConfiguration private constructor(
     override val environment: Environment,
     override val clientKey: String
 ) : Configuration {
-    private constructor(builder: Builder) : this(
-        builder.shopperLocale,
-        builder.environment,
-        builder.clientKey
-    )
 
     /**
      * Builder to create a [InstantPaymentConfiguration].
      */
-    class Builder : BaseConfigurationBuilder<InstantPaymentConfiguration> {
+    class Builder : BaseConfigurationBuilder<InstantPaymentConfiguration, Builder> {
 
         /**
          * Constructor for Builder with default values.
@@ -66,7 +61,11 @@ class InstantPaymentConfiguration private constructor(
         constructor(configuration: InstantPaymentConfiguration) : super(configuration)
 
         override fun buildInternal(): InstantPaymentConfiguration {
-            return InstantPaymentConfiguration(this)
+            return InstantPaymentConfiguration(
+                shopperLocale = shopperLocale,
+                environment = environment,
+                clientKey = clientKey,
+            )
         }
     }
 }

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/IssuerListConfiguration.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/IssuerListConfiguration.kt
@@ -18,8 +18,10 @@ abstract class IssuerListConfiguration : Configuration {
     abstract val viewType: IssuerListViewType?
     abstract val hideIssuerLogos: Boolean?
 
-    abstract class IssuerListBuilder<IssuerListConfigurationT : IssuerListConfiguration> :
-        BaseConfigurationBuilder<IssuerListConfigurationT> {
+    abstract class IssuerListBuilder<
+        IssuerListConfigurationT : IssuerListConfiguration,
+        IssuerListBuilderT : IssuerListBuilder<IssuerListConfigurationT, IssuerListBuilderT>
+        > : BaseConfigurationBuilder<IssuerListConfigurationT, IssuerListBuilderT> {
 
         protected open var viewType: IssuerListViewType? = null
         protected open var hideIssuerLogos: Boolean? = null
@@ -45,9 +47,10 @@ abstract class IssuerListConfiguration : Configuration {
          *
          * @param viewType an enum with the view type options.
          */
-        open fun setViewType(viewType: IssuerListViewType): IssuerListBuilder<IssuerListConfigurationT> {
+        fun setViewType(viewType: IssuerListViewType): IssuerListBuilderT {
             this.viewType = viewType
-            return this
+            @Suppress("UNCHECKED_CAST")
+            return this as IssuerListBuilderT
         }
 
         /**
@@ -57,9 +60,10 @@ abstract class IssuerListConfiguration : Configuration {
          *
          * @param hideIssuerLogos if issuer logos should be hidden or not.
          */
-        open fun setHideIssuerLogos(hideIssuerLogos: Boolean): IssuerListBuilder<IssuerListConfigurationT> {
+        fun setHideIssuerLogos(hideIssuerLogos: Boolean): IssuerListBuilderT {
             this.hideIssuerLogos = hideIssuerLogos
-            return this
+            @Suppress("UNCHECKED_CAST")
+            return this as IssuerListBuilderT
         }
     }
 }

--- a/issuer-list/src/test/java/com/adyen/checkout/issuerlist/utils/TestIssuerListConfiguration.kt
+++ b/issuer-list/src/test/java/com/adyen/checkout/issuerlist/utils/TestIssuerListConfiguration.kt
@@ -24,7 +24,7 @@ class TestIssuerListConfiguration private constructor(
     override val hideIssuerLogos: Boolean?,
 ) : IssuerListConfiguration() {
 
-    class Builder : IssuerListBuilder<TestIssuerListConfiguration> {
+    class Builder : IssuerListBuilder<TestIssuerListConfiguration, Builder> {
 
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,

--- a/mbway/src/main/java/com/adyen/checkout/mbway/MBWayConfiguration.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/MBWayConfiguration.kt
@@ -21,16 +21,10 @@ class MBWayConfiguration private constructor(
     override val clientKey: String,
 ) : Configuration {
 
-    private constructor(builder: Builder) : this(
-        builder.shopperLocale,
-        builder.environment,
-        builder.clientKey
-    )
-
     /**
      * Builder to create a [MBWayConfiguration].
      */
-    class Builder : BaseConfigurationBuilder<MBWayConfiguration> {
+    class Builder : BaseConfigurationBuilder<MBWayConfiguration, Builder> {
 
         /**
          * Constructor for Builder with default values.
@@ -66,7 +60,11 @@ class MBWayConfiguration private constructor(
         constructor(configuration: MBWayConfiguration) : super(configuration)
 
         override fun buildInternal(): MBWayConfiguration {
-            return MBWayConfiguration(this)
+            return MBWayConfiguration(
+                shopperLocale = shopperLocale,
+                environment = environment,
+                clientKey = clientKey,
+            )
         }
     }
 }

--- a/molpay/src/main/java/com/adyen/checkout/molpay/MolpayConfiguration.kt
+++ b/molpay/src/main/java/com/adyen/checkout/molpay/MolpayConfiguration.kt
@@ -26,7 +26,7 @@ class MolpayConfiguration private constructor(
     /**
      * Builder to create a [MolpayConfiguration].
      */
-    class Builder : IssuerListBuilder<MolpayConfiguration> {
+    class Builder : IssuerListBuilder<MolpayConfiguration, Builder> {
 
         /**
          * Constructor for Builder with default values.

--- a/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/TestOnlineBankingConfiguration.kt
+++ b/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/TestOnlineBankingConfiguration.kt
@@ -22,7 +22,7 @@ class TestOnlineBankingConfiguration private constructor(
     override val clientKey: String,
 ) : Configuration {
 
-    class Builder : BaseConfigurationBuilder<TestOnlineBankingConfiguration> {
+    class Builder : BaseConfigurationBuilder<TestOnlineBankingConfiguration, Builder> {
 
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,

--- a/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZConfiguration.kt
+++ b/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZConfiguration.kt
@@ -22,7 +22,7 @@ class OnlineBankingCZConfiguration private constructor(
     override val clientKey: String,
 ) : Configuration {
 
-    class Builder : BaseConfigurationBuilder<OnlineBankingCZConfiguration> {
+    class Builder : BaseConfigurationBuilder<OnlineBankingCZConfiguration, Builder> {
 
         /**
          * Constructor for Builder with default values.

--- a/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLConfiguration.kt
+++ b/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLConfiguration.kt
@@ -24,7 +24,7 @@ class OnlineBankingPLConfiguration private constructor(
     override val hideIssuerLogos: Boolean?,
 ) : IssuerListConfiguration() {
 
-    class Builder : IssuerListBuilder<OnlineBankingPLConfiguration> {
+    class Builder : IssuerListBuilder<OnlineBankingPLConfiguration, Builder> {
 
         /**
          * Constructor for Builder with default values.

--- a/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKConfiguration.kt
+++ b/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKConfiguration.kt
@@ -22,7 +22,7 @@ class OnlineBankingSKConfiguration private constructor(
     override val clientKey: String,
 ) : Configuration {
 
-    class Builder : BaseConfigurationBuilder<OnlineBankingSKConfiguration> {
+    class Builder : BaseConfigurationBuilder<OnlineBankingSKConfiguration, Builder> {
 
         /**
          * Constructor for Builder with default values.

--- a/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingConfiguration.kt
+++ b/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingConfiguration.kt
@@ -26,7 +26,7 @@ class OpenBankingConfiguration private constructor(
     /**
      * Builder to create a [OpenBankingConfiguration].
      */
-    class Builder : IssuerListBuilder<OpenBankingConfiguration> {
+    class Builder : IssuerListBuilder<OpenBankingConfiguration, Builder> {
 
         /**
          * Constructor for Builder with default values.

--- a/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankConfiguration.kt
+++ b/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankConfiguration.kt
@@ -22,16 +22,10 @@ class PayByBankConfiguration private constructor(
     override val clientKey: String,
 ) : Configuration {
 
-    private constructor(builder: Builder) : this(
-        builder.shopperLocale,
-        builder.environment,
-        builder.clientKey
-    )
-
     /**
      * Builder to create a [PayByBankConfiguration].
      */
-    class Builder : BaseConfigurationBuilder<PayByBankConfiguration> {
+    class Builder : BaseConfigurationBuilder<PayByBankConfiguration, Builder> {
         /**
          * Constructor for Builder with default values.
          *
@@ -66,7 +60,11 @@ class PayByBankConfiguration private constructor(
         constructor(configuration: PayByBankConfiguration) : super(configuration)
 
         override fun buildInternal(): PayByBankConfiguration {
-            return PayByBankConfiguration(this)
+            return PayByBankConfiguration(
+                shopperLocale = shopperLocale,
+                environment = environment,
+                clientKey = clientKey,
+            )
         }
     }
 }

--- a/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeConfiguration.kt
+++ b/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeConfiguration.kt
@@ -11,8 +11,8 @@ import android.content.Context
 import com.adyen.checkout.components.base.BaseConfigurationBuilder
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.core.api.Environment
-import kotlinx.parcelize.Parcelize
 import java.util.Locale
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 class QRCodeConfiguration private constructor(
@@ -21,16 +21,10 @@ class QRCodeConfiguration private constructor(
     override val clientKey: String,
 ) : Configuration {
 
-    internal constructor(builder: Builder) : this(
-        builder.shopperLocale,
-        builder.environment,
-        builder.clientKey
-    )
-
     /**
      * Builder to create a [QRCodeConfiguration].
      */
-    class Builder : BaseConfigurationBuilder<QRCodeConfiguration> {
+    class Builder : BaseConfigurationBuilder<QRCodeConfiguration, Builder> {
 
         /**
          * Constructor for Builder with default values.
@@ -66,7 +60,11 @@ class QRCodeConfiguration private constructor(
         constructor(configuration: QRCodeConfiguration) : super(configuration)
 
         override fun buildInternal(): QRCodeConfiguration {
-            return QRCodeConfiguration(this)
+            return QRCodeConfiguration(
+                shopperLocale = shopperLocale,
+                environment = environment,
+                clientKey = clientKey,
+            )
         }
     }
 }

--- a/redirect/src/main/java/com/adyen/checkout/redirect/RedirectConfiguration.kt
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/RedirectConfiguration.kt
@@ -24,7 +24,7 @@ class RedirectConfiguration private constructor(
     /**
      * Builder to create a [RedirectConfiguration].
      */
-    class Builder : BaseConfigurationBuilder<RedirectConfiguration> {
+    class Builder : BaseConfigurationBuilder<RedirectConfiguration, Builder> {
 
         /**
          * Constructor for Builder with default values.

--- a/sepa/src/main/java/com/adyen/checkout/sepa/SepaConfiguration.kt
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/SepaConfiguration.kt
@@ -24,7 +24,7 @@ class SepaConfiguration private constructor(
     /**
      * Builder to create a [SepaConfiguration].
      */
-    class Builder : BaseConfigurationBuilder<SepaConfiguration> {
+    class Builder : BaseConfigurationBuilder<SepaConfiguration, Builder> {
 
         /**
          * Constructor for Builder with default values.
@@ -63,7 +63,7 @@ class SepaConfiguration private constructor(
             return SepaConfiguration(
                 shopperLocale = shopperLocale,
                 environment = environment,
-                clientKey = clientKey
+                clientKey = clientKey,
             )
         }
     }

--- a/voucher/src/main/java/com/adyen/checkout/voucher/VoucherConfiguration.kt
+++ b/voucher/src/main/java/com/adyen/checkout/voucher/VoucherConfiguration.kt
@@ -22,13 +22,7 @@ class VoucherConfiguration private constructor(
     override val clientKey: String,
 ) : Configuration {
 
-    private constructor(builder: Builder) : this(
-        builder.shopperLocale,
-        builder.environment,
-        builder.clientKey
-    )
-
-    class Builder : BaseConfigurationBuilder<VoucherConfiguration> {
+    class Builder : BaseConfigurationBuilder<VoucherConfiguration, Builder> {
 
         /**
          * Constructor for Builder with default values.
@@ -64,7 +58,11 @@ class VoucherConfiguration private constructor(
         constructor(configuration: VoucherConfiguration) : super(configuration)
 
         override fun buildInternal(): VoucherConfiguration {
-            return VoucherConfiguration(this)
+            return VoucherConfiguration(
+                shopperLocale = shopperLocale,
+                environment = environment,
+                clientKey = clientKey,
+            )
         }
     }
 }

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionConfiguration.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionConfiguration.kt
@@ -24,7 +24,7 @@ class WeChatPayActionConfiguration private constructor(
     /**
      * Builder to create a [WeChatPayActionConfiguration].
      */
-    class Builder : BaseConfigurationBuilder<WeChatPayActionConfiguration> {
+    class Builder : BaseConfigurationBuilder<WeChatPayActionConfiguration, Builder> {
 
         /**
          * Constructor for Builder with default values.


### PR DESCRIPTION
Base methods (setters for common fields) in `BaseConfigurationBuilder` need to be able to return the super type of the builder and not `BaseConfigurationBuilder`, because if we call these methods on a specific builder and they return the base builder, we won't be able to chain any other methods from that specific builder.

Example:
```kotlin
CardConfiguration.Builder()
    .setEnvironment(TEST) // this method used to return BaseConfigurationBuilder
    .setSupportedCardTypes(types) // this method cannot be called because it's defined inside CardConfiguration.Builder not BaseConfigurationBuilder
    .build()
```

We were solving these by re-overriding all of these common methods in all of the builders and returning the super type, but that generates lots of verbose code and we can easily forget to override these methods.

By adding `BuilderT: BaseConfigurationBuilder` as a generic type to itself, the builder can have methods that return the generic type which is the type of the super class we need to return.

COAND-549