### PR TITLE
Fix screen rotation issues with action handling in payment components

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponent.kt
@@ -19,6 +19,7 @@ import com.adyen.checkout.components.PaymentComponentEvent
 import com.adyen.checkout.components.StoredPaymentComponentProvider
 import com.adyen.checkout.components.base.BasePaymentComponent
 import com.adyen.checkout.components.base.ComponentDelegate
+import com.adyen.checkout.components.extensions.mergeViewFlows
 import com.adyen.checkout.components.toActionCallback
 import com.adyen.checkout.components.ui.ViewableComponent
 import com.adyen.checkout.components.ui.view.ComponentViewType
@@ -26,7 +27,6 @@ import com.adyen.checkout.components.util.PaymentMethodTypes
 import com.adyen.checkout.core.log.LogUtil
 import com.adyen.checkout.core.log.Logger
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.merge
 
 /**
  * Component should not be instantiated directly. Instead use the [PROVIDER] object.
@@ -48,11 +48,11 @@ class CardComponent internal constructor(
 
     override val delegate: ComponentDelegate get() = actionHandlingComponent.activeDelegate
 
-    override val viewFlow: Flow<ComponentViewType?>
-        get() = merge(
-            cardDelegate.viewFlow,
-            genericActionDelegate.viewFlow,
-        )
+    override val viewFlow: Flow<ComponentViewType?> = mergeViewFlows(
+        viewModelScope,
+        cardDelegate.viewFlow,
+        genericActionDelegate.viewFlow,
+    )
 
     init {
         cardDelegate.initialize(viewModelScope)

--- a/components-core/src/main/java/com/adyen/checkout/components/flow/FlowExtensions.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/flow/FlowExtensions.kt
@@ -8,13 +8,18 @@
 
 package com.adyen.checkout.components.flow
 
+import androidx.annotation.RestrictTo
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.flowWithLifecycle
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
 
 internal fun <T> Flow<T>.mapToCallbackWithLifeCycle(
     lifecycleOwner: LifecycleOwner,
@@ -25,3 +30,12 @@ internal fun <T> Flow<T>.mapToCallbackWithLifeCycle(
         .onEach { callback(it) }
         .launchIn(coroutineScope)
 }
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun <T> mergeStateFlows(
+    scope: CoroutineScope,
+    started: SharingStarted,
+    initialValue: T,
+    vararg flows: Flow<T>
+): StateFlow<T> = merge(*flows)
+    .stateIn(scope, started, initialValue)

--- a/ui-core/build.gradle
+++ b/ui-core/build.gradle
@@ -50,5 +50,6 @@ dependencies {
     //Tests
     testImplementation testLibraries.json
     testImplementation testLibraries.junit5
+    testImplementation testLibraries.kotlinCoroutines
     testImplementation testLibraries.robolectric
 }

--- a/ui-core/src/main/java/com/adyen/checkout/components/extensions/FlowExtensions.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/components/extensions/FlowExtensions.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 30/11/2022.
+ */
+
+package com.adyen.checkout.components.extensions
+
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.components.flow.mergeStateFlows
+import com.adyen.checkout.components.ui.view.ComponentViewType
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.drop
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun mergeViewFlows(
+    scope: CoroutineScope,
+    paymentMethodViewFlow: Flow<ComponentViewType?>,
+    genericActionViewFlow: Flow<ComponentViewType?>,
+    initialValue: ComponentViewType? = null,
+    // Lazily is the default, because WhileSubscribed re-emits initial values when f.e. rotating the phone.
+    started: SharingStarted = SharingStarted.Lazily,
+): StateFlow<ComponentViewType?> = mergeStateFlows(
+    scope = scope,
+    initialValue = initialValue,
+    started = started,
+    // genericActionViewFlow's initial value is null. We don't need this value as it breaks the desired behaviour.
+    flows = arrayOf(paymentMethodViewFlow, genericActionViewFlow.drop(1)),
+)

--- a/ui-core/src/main/java/com/adyen/checkout/components/ui/view/AdyenComponentView.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/components/ui/view/AdyenComponentView.kt
@@ -20,13 +20,11 @@ import com.adyen.checkout.components.base.ComponentDelegate
 import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.extensions.createLocalizedContext
 import com.adyen.checkout.components.ui.ComponentView
-import com.adyen.checkout.components.ui.ViewProvider
 import com.adyen.checkout.components.ui.ViewProvidingDelegate
 import com.adyen.checkout.components.ui.ViewableComponent
 import com.adyen.checkout.core.log.LogUtil
 import com.adyen.checkout.core.log.Logger
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
@@ -57,17 +55,18 @@ class AdyenComponentView @JvmOverloads constructor(
         lifecycleOwner: LifecycleOwner
     ) where T : ViewableComponent, T : Component<*, *> {
         component.viewFlow
-            .filterNotNull()
             .onEach { componentViewType ->
+                removeAllViews()
+
                 val delegate = component.delegate
                 if (delegate !is ViewProvidingDelegate) {
                     Logger.i(TAG, "View attached to non viewable component, ignoring.")
                     return@onEach
                 }
+
                 loadView(
                     viewType = componentViewType,
                     delegate = delegate,
-                    viewProvider = componentViewType.viewProvider,
                     componentParams = delegate.componentParams,
                     coroutineScope = lifecycleOwner.lifecycleScope,
                 )
@@ -82,14 +81,12 @@ class AdyenComponentView @JvmOverloads constructor(
     private fun loadView(
         viewType: ComponentViewType?,
         delegate: ComponentDelegate,
-        viewProvider: ViewProvider,
         componentParams: ComponentParams,
         coroutineScope: CoroutineScope,
     ) {
-        removeAllViews()
         viewType ?: return
 
-        val componentView = viewProvider.getView(viewType, context, attrs, defStyleAttr)
+        val componentView = viewType.viewProvider.getView(viewType, context, attrs, defStyleAttr)
         this.componentView = componentView
 
         val localizedContext = context.createLocalizedContext(componentParams.shopperLocale)

--- a/ui-core/src/test/java/com/adyen/checkout/components/extensions/FlowExtensionsTest.kt
+++ b/ui-core/src/test/java/com/adyen/checkout/components/extensions/FlowExtensionsTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 5/12/2022.
+ */
+
+package com.adyen.checkout.components.extensions
+
+import app.cash.turbine.test
+import com.adyen.checkout.components.ui.ViewProvider
+import com.adyen.checkout.components.ui.view.ComponentViewType
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class FlowExtensionsTest {
+
+    @Test
+    fun `when merging view flows, then initial value of action view flow should be ignored`() = runTest {
+        mergeViewFlows(
+            scope = this,
+            paymentMethodViewFlow = flowOf(TestComponentViewType("test")),
+            genericActionViewFlow = flowOf(null),
+        ).test {
+            // Initial value of merged flow
+            assertNull(awaitItem())
+
+            // Initial value of paymentMethodViewFlow
+            assertEquals(TestComponentViewType("test"), awaitItem())
+
+            // Assert initial value of genericActionViewFlow is not emitted
+            ensureAllEventsConsumed()
+        }
+    }
+
+    @Test
+    fun `when merging view flows, then subsequent values should be emitted`() = runTest {
+        mergeViewFlows(
+            scope = this,
+            paymentMethodViewFlow = flowOf(TestComponentViewType("view 1"), TestComponentViewType("view 2")),
+            genericActionViewFlow = flowOf(null, TestComponentViewType("action 1")),
+        ).test {
+            // Initial value of merged flow
+            assertNull(awaitItem())
+
+            assertEquals(TestComponentViewType("view 1"), awaitItem())
+            assertEquals(TestComponentViewType("view 2"), awaitItem())
+            assertEquals(TestComponentViewType("action 1"), awaitItem())
+        }
+    }
+
+    private data class TestComponentViewType(val name: String) : ComponentViewType {
+        override val viewProvider: ViewProvider
+            get() = throw IllegalStateException("This should not be called from unit tests")
+    }
+}


### PR DESCRIPTION
## Description
Steps to reproduce:
1. Open card implementation example
2. Enter credit card details to open native 3ds2 flow
3. Rotate device
4. Complete 3ds2 flow
5. 💥

The issue was that Kotlin's `merge(flows)` function doesn't keep state and the flows in question that are merged are `StateFlow`s. When (re)subscribing to the merged flow, the last values from the `StateFlow`s were emitted again. With `mergeStateFlows` and `mergeViewFlows` added in this PR, it is possible to merge multiple flows into a `StateFlow`. `mergeViewFlows` is tailored to our special needs

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-660