### PR TITLE
Do not override configurations

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2ComponentProvider.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2ComponentProvider.kt
@@ -18,7 +18,7 @@ import androidx.savedstate.SavedStateRegistryOwner
 import com.adyen.checkout.adyen3ds2.connection.SubmitFingerprintService
 import com.adyen.checkout.adyen3ds2.repository.SubmitFingerprintRepository
 import com.adyen.checkout.components.ActionComponentProvider
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.base.GenericComponentParamsMapper
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
@@ -37,11 +37,10 @@ import kotlinx.coroutines.Dispatchers
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class Adyen3DS2ComponentProvider(
-    parentConfiguration: Configuration? = null,
-    isCreatedByDropIn: Boolean = false,
+    overrideComponentParams: ComponentParams? = null,
 ) : ActionComponentProvider<Adyen3DS2Component, Adyen3DS2Configuration, Adyen3DS2Delegate> {
 
-    private val componentParamsMapper = GenericComponentParamsMapper(parentConfiguration, isCreatedByDropIn)
+    private val componentParamsMapper = GenericComponentParamsMapper(overrideComponentParams)
 
     override fun <T> get(
         owner: T,

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Configuration.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Configuration.kt
@@ -53,13 +53,6 @@ class Adyen3DS2Configuration private constructor(
             clientKey
         )
 
-        /**
-         * Constructor that copies an existing configuration.
-         *
-         * @param configuration A configuration to initialize the builder.
-         */
-        constructor(configuration: Adyen3DS2Configuration) : super(configuration)
-
         override fun buildInternal(): Adyen3DS2Configuration {
             return Adyen3DS2Configuration(
                 shopperLocale = shopperLocale,

--- a/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/DefaultAdyen3DS2DelegateTest.kt
+++ b/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/DefaultAdyen3DS2DelegateTest.kt
@@ -88,10 +88,7 @@ internal class DefaultAdyen3DS2DelegateTest(
         delegate = DefaultAdyen3DS2Delegate(
             observerRepository = ActionObserverRepository(),
             savedStateHandle = SavedStateHandle(),
-            componentParams = GenericComponentParamsMapper(
-                parentConfiguration = null,
-                isCreatedByDropIn = false
-            ).mapToParams(configuration),
+            componentParams = GenericComponentParamsMapper(null).mapToParams(configuration),
             submitFingerprintRepository = submitFingerprintRepository,
             paymentDataRepository = paymentDataRepository,
             adyen3DS2Serializer = adyen3DS2Serializer,

--- a/action/src/main/java/com/adyen/checkout/action/ActionDelegateProvider.kt
+++ b/action/src/main/java/com/adyen/checkout/action/ActionDelegateProvider.kt
@@ -16,6 +16,7 @@ import com.adyen.checkout.await.AwaitComponentProvider
 import com.adyen.checkout.await.AwaitConfiguration
 import com.adyen.checkout.components.base.ActionDelegate
 import com.adyen.checkout.components.base.BaseConfigurationBuilder
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.model.payments.response.Action
 import com.adyen.checkout.components.model.payments.response.AwaitAction
@@ -35,8 +36,7 @@ import com.adyen.checkout.wechatpay.WeChatPayActionComponentProvider
 import com.adyen.checkout.wechatpay.WeChatPayActionConfiguration
 
 internal class ActionDelegateProvider(
-    private val parentConfiguration: Configuration,
-    private val isCreatedByDropIn: Boolean,
+    private val overrideComponentParams: ComponentParams?
 ) {
 
     fun getDelegate(
@@ -47,42 +47,42 @@ internal class ActionDelegateProvider(
     ): ActionDelegate {
         val delegate = when (action) {
             is AwaitAction -> {
-                AwaitComponentProvider(parentConfiguration, isCreatedByDropIn).getDelegate(
+                AwaitComponentProvider(overrideComponentParams).getDelegate(
                     getConfigurationForAction(configuration),
                     savedStateHandle,
                     application
                 )
             }
             is QrCodeAction -> {
-                QRCodeComponentProvider(parentConfiguration, isCreatedByDropIn).getDelegate(
+                QRCodeComponentProvider(overrideComponentParams).getDelegate(
                     getConfigurationForAction(configuration),
                     savedStateHandle,
                     application
                 )
             }
             is RedirectAction -> {
-                RedirectComponentProvider(parentConfiguration, isCreatedByDropIn).getDelegate(
+                RedirectComponentProvider(overrideComponentParams).getDelegate(
                     getConfigurationForAction(configuration),
                     savedStateHandle,
                     application
                 )
             }
             is BaseThreeds2Action -> {
-                Adyen3DS2ComponentProvider(parentConfiguration).getDelegate(
+                Adyen3DS2ComponentProvider(overrideComponentParams).getDelegate(
                     getConfigurationForAction(configuration),
                     savedStateHandle,
                     application
                 )
             }
             is VoucherAction -> {
-                VoucherComponentProvider(parentConfiguration, isCreatedByDropIn).getDelegate(
+                VoucherComponentProvider(overrideComponentParams).getDelegate(
                     getConfigurationForAction(configuration),
                     savedStateHandle,
                     application
                 )
             }
             is SdkAction<*> -> {
-                WeChatPayActionComponentProvider(parentConfiguration, isCreatedByDropIn).getDelegate(
+                WeChatPayActionComponentProvider(overrideComponentParams).getDelegate(
                     getConfigurationForAction(configuration),
                     savedStateHandle,
                     application

--- a/action/src/main/java/com/adyen/checkout/action/GenericActionComponentProvider.kt
+++ b/action/src/main/java/com/adyen/checkout/action/GenericActionComponentProvider.kt
@@ -15,7 +15,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
 import com.adyen.checkout.components.ActionComponentProvider
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.base.GenericComponentParamsMapper
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
@@ -31,11 +31,10 @@ import com.adyen.checkout.components.model.payments.response.VoucherAction
 import com.adyen.checkout.components.repository.ActionObserverRepository
 
 class GenericActionComponentProvider(
-    parentConfiguration: Configuration? = null,
-    private val isCreatedByDropIn: Boolean = false,
+    overrideComponentParams: ComponentParams? = null
 ) : ActionComponentProvider<GenericActionComponent, GenericActionConfiguration, GenericActionDelegate> {
 
-    private val componentParamsMapper = GenericComponentParamsMapper(parentConfiguration, isCreatedByDropIn)
+    private val componentParamsMapper = GenericComponentParamsMapper(overrideComponentParams)
 
     override fun <T> get(
         owner: T,
@@ -76,7 +75,7 @@ class GenericActionComponentProvider(
             savedStateHandle = savedStateHandle,
             configuration = configuration,
             componentParams = componentParams,
-            actionDelegateProvider = ActionDelegateProvider(configuration, isCreatedByDropIn)
+            actionDelegateProvider = ActionDelegateProvider(componentParams)
         )
     }
 

--- a/action/src/main/java/com/adyen/checkout/action/GenericActionConfiguration.kt
+++ b/action/src/main/java/com/adyen/checkout/action/GenericActionConfiguration.kt
@@ -85,13 +85,6 @@ class GenericActionConfiguration private constructor(
         )
 
         /**
-         * Constructor that copies an existing configuration.
-         *
-         * @param configuration A configuration to initialize the builder.
-         */
-        constructor(configuration: GenericActionConfiguration) : super(configuration)
-
-        /**
          * Add configuration for 3DS2 action.
          */
         fun add3ds2ActionConfiguration(configuration: Adyen3DS2Configuration): Builder {

--- a/action/src/test/java/com/adyen/checkout/action/DefaultGenericActionDelegateTest.kt
+++ b/action/src/test/java/com/adyen/checkout/action/DefaultGenericActionDelegateTest.kt
@@ -63,10 +63,7 @@ internal class DefaultGenericActionDelegateTest(
             ActionObserverRepository(),
             SavedStateHandle(),
             configuration,
-            GenericComponentParamsMapper(
-                parentConfiguration = null,
-                isCreatedByDropIn = false
-            ).mapToParams(configuration),
+            GenericComponentParamsMapper(null).mapToParams(configuration),
             actionDelegateProvider
         )
         whenever(activity.application) doReturn Application()

--- a/action/src/test/java/com/adyen/checkout/action/TestActionDelegate.kt
+++ b/action/src/test/java/com/adyen/checkout/action/TestActionDelegate.kt
@@ -80,10 +80,7 @@ internal class TestActionDelegate :
             throw NotImplementedError("This method shouldn't be used in tests")
         }
     }
-    override val componentParams: ComponentParams = GenericComponentParamsMapper(
-        parentConfiguration = null,
-        isCreatedByDropIn = false
-    ).mapToParams(configuration)
+    override val componentParams: ComponentParams = GenericComponentParamsMapper(null).mapToParams(configuration)
 
     var initializeCalled = false
     override fun initialize(coroutineScope: CoroutineScope) {
@@ -124,10 +121,7 @@ internal class Test3DS2Delegate : Adyen3DS2Delegate {
     private val configuration: Adyen3DS2Configuration =
         Adyen3DS2Configuration.Builder(Locale.US, Environment.TEST, TEST_CLIENT_KEY).build()
 
-    override val componentParams: ComponentParams = GenericComponentParamsMapper(
-        parentConfiguration = null,
-        isCreatedByDropIn = false
-    ).mapToParams(configuration)
+    override val componentParams: ComponentParams = GenericComponentParamsMapper(null).mapToParams(configuration)
 
     override val detailsFlow: MutableSharedFlow<ActionComponentData> = MutableSharedFlow(extraBufferCapacity = 1)
 

--- a/await/src/main/java/com/adyen/checkout/await/AwaitComponentProvider.kt
+++ b/await/src/main/java/com/adyen/checkout/await/AwaitComponentProvider.kt
@@ -16,7 +16,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
 import com.adyen.checkout.components.ActionComponentProvider
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.base.GenericComponentParamsMapper
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
@@ -31,11 +31,10 @@ import com.adyen.checkout.core.api.HttpClientFactory
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class AwaitComponentProvider(
-    parentConfiguration: Configuration? = null,
-    isCreatedByDropIn: Boolean = false,
+    overrideComponentParams: ComponentParams? = null
 ) : ActionComponentProvider<AwaitComponent, AwaitConfiguration, AwaitDelegate> {
 
-    private val componentParamsMapper = GenericComponentParamsMapper(parentConfiguration, isCreatedByDropIn)
+    private val componentParamsMapper = GenericComponentParamsMapper(overrideComponentParams)
 
     override val supportedActionTypes: List<String>
         get() = listOf(AwaitAction.ACTION_TYPE)

--- a/await/src/main/java/com/adyen/checkout/await/AwaitConfiguration.kt
+++ b/await/src/main/java/com/adyen/checkout/await/AwaitConfiguration.kt
@@ -53,13 +53,6 @@ class AwaitConfiguration private constructor(
             clientKey
         )
 
-        /**
-         * Constructor that copies an existing configuration.
-         *
-         * @param configuration A configuration to initialize the builder.
-         */
-        constructor(configuration: AwaitConfiguration) : super(configuration)
-
         override fun buildInternal(): AwaitConfiguration {
             return AwaitConfiguration(
                 shopperLocale = shopperLocale,

--- a/await/src/test/java/com/adyen/checkout/await/DefaultAwaitDelegateTest.kt
+++ b/await/src/test/java/com/adyen/checkout/await/DefaultAwaitDelegateTest.kt
@@ -52,10 +52,7 @@ internal class DefaultAwaitDelegateTest {
         ).build()
         delegate = DefaultAwaitDelegate(
             ActionObserverRepository(),
-            GenericComponentParamsMapper(
-                parentConfiguration = null,
-                isCreatedByDropIn = false
-            ).mapToParams(configuration),
+            GenericComponentParamsMapper(null).mapToParams(configuration),
             statusRepository,
             paymentDataRepository
         )

--- a/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponentParams.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponentParams.kt
@@ -9,11 +9,12 @@
 package com.adyen.checkout.bacs
 
 import androidx.annotation.RestrictTo
+import com.adyen.checkout.components.base.AmountComponentParams
 import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.model.payments.Amount
 import com.adyen.checkout.core.api.Environment
-import java.util.Locale
 import kotlinx.parcelize.Parcelize
+import java.util.Locale
 
 @Parcelize
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -24,5 +25,5 @@ data class BacsDirectDebitComponentParams(
     override val clientKey: String,
     override val isAnalyticsEnabled: Boolean,
     override val isCreatedByDropIn: Boolean,
-    val amount: Amount,
-) : ComponentParams
+    override val amount: Amount,
+) : ComponentParams, AmountComponentParams

--- a/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponentParamsMapper.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponentParamsMapper.kt
@@ -8,6 +8,7 @@
 
 package com.adyen.checkout.bacs
 
+import com.adyen.checkout.components.base.AmountComponentParams
 import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.model.payments.Amount
 
@@ -38,12 +39,14 @@ internal class BacsDirectDebitComponentParamsMapper(
         overrideComponentParams: ComponentParams?
     ): BacsDirectDebitComponentParams {
         if (overrideComponentParams == null) return this
+        val amount = (overrideComponentParams as? AmountComponentParams)?.amount ?: amount
         return copy(
             shopperLocale = overrideComponentParams.shopperLocale,
             environment = overrideComponentParams.environment,
             clientKey = overrideComponentParams.clientKey,
             isAnalyticsEnabled = overrideComponentParams.isAnalyticsEnabled,
             isCreatedByDropIn = overrideComponentParams.isCreatedByDropIn,
+            amount = amount,
         )
     }
 }

--- a/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponentParamsMapper.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponentParamsMapper.kt
@@ -8,34 +8,42 @@
 
 package com.adyen.checkout.bacs
 
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.model.payments.Amount
 
 internal class BacsDirectDebitComponentParamsMapper(
-    private val parentConfiguration: Configuration?,
-    private val isCreatedByDropIn: Boolean,
+    private val overrideComponentParams: ComponentParams?,
 ) {
 
     fun mapToParams(
         bacsDirectDebitConfiguration: BacsDirectDebitConfiguration,
     ): BacsDirectDebitComponentParams {
-        return mapToParams(
-            parentConfiguration = parentConfiguration ?: bacsDirectDebitConfiguration,
-            bacsDirectDebitConfiguration = bacsDirectDebitConfiguration,
+        return bacsDirectDebitConfiguration
+            .mapToParamsInternal()
+            .override(overrideComponentParams)
+    }
+
+    private fun BacsDirectDebitConfiguration.mapToParamsInternal(): BacsDirectDebitComponentParams {
+        return BacsDirectDebitComponentParams(
+            shopperLocale = shopperLocale,
+            environment = environment,
+            clientKey = clientKey,
+            isAnalyticsEnabled = isAnalyticsEnabled ?: true,
+            isCreatedByDropIn = false,
+            amount = amount ?: Amount.EMPTY,
         )
     }
 
-    private fun mapToParams(
-        parentConfiguration: Configuration,
-        bacsDirectDebitConfiguration: BacsDirectDebitConfiguration,
+    private fun BacsDirectDebitComponentParams.override(
+        overrideComponentParams: ComponentParams?
     ): BacsDirectDebitComponentParams {
-        return BacsDirectDebitComponentParams(
-            shopperLocale = parentConfiguration.shopperLocale,
-            environment = parentConfiguration.environment,
-            clientKey = parentConfiguration.clientKey,
-            isAnalyticsEnabled = parentConfiguration.isAnalyticsEnabled ?: true,
-            isCreatedByDropIn = isCreatedByDropIn,
-            amount = bacsDirectDebitConfiguration.amount ?: Amount.EMPTY,
+        if (overrideComponentParams == null) return this
+        return copy(
+            shopperLocale = overrideComponentParams.shopperLocale,
+            environment = overrideComponentParams.environment,
+            clientKey = overrideComponentParams.clientKey,
+            isAnalyticsEnabled = overrideComponentParams.isAnalyticsEnabled,
+            isCreatedByDropIn = overrideComponentParams.isCreatedByDropIn,
         )
     }
 }

--- a/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponentProvider.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponentProvider.kt
@@ -18,7 +18,7 @@ import com.adyen.checkout.components.analytics.AnalyticsMapper
 import com.adyen.checkout.components.analytics.AnalyticsSource
 import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
 import com.adyen.checkout.components.api.AnalyticsService
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
@@ -27,11 +27,10 @@ import com.adyen.checkout.core.api.HttpClientFactory
 import com.adyen.checkout.core.exception.ComponentException
 
 class BacsDirectDebitComponentProvider(
-    parentConfiguration: Configuration? = null,
-    isCreatedByDropIn: Boolean = false,
+    overrideComponentParams: ComponentParams? = null,
 ) : PaymentComponentProvider<BacsDirectDebitComponent, BacsDirectDebitConfiguration> {
 
-    private val componentParamsMapper = BacsDirectDebitComponentParamsMapper(parentConfiguration, isCreatedByDropIn)
+    private val componentParamsMapper = BacsDirectDebitComponentParamsMapper(overrideComponentParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitConfiguration.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitConfiguration.kt
@@ -59,15 +59,6 @@ class BacsDirectDebitConfiguration private constructor(
             clientKey
         )
 
-        /**
-         * Constructor that copies an existing configuration.
-         *
-         * @param configuration A configuration to initialize the builder.
-         */
-        constructor(configuration: BacsDirectDebitConfiguration) : super(configuration) {
-            amount = configuration.amount
-        }
-
         override fun buildInternal(): BacsDirectDebitConfiguration {
             return BacsDirectDebitConfiguration(
                 shopperLocale = shopperLocale,

--- a/bacs/src/test/java/com/adyen/checkout/bacs/BacsDirectDebitComponentParamsMapperTest.kt
+++ b/bacs/src/test/java/com/adyen/checkout/bacs/BacsDirectDebitComponentParamsMapperTest.kt
@@ -8,6 +8,7 @@
 
 package com.adyen.checkout.bacs
 
+import com.adyen.checkout.components.base.GenericComponentParams
 import com.adyen.checkout.components.model.payments.Amount
 import com.adyen.checkout.core.api.Environment
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -25,10 +26,7 @@ internal class BacsDirectDebitComponentParamsMapperTest {
         )
             .build()
 
-        val params = BacsDirectDebitComponentParamsMapper(
-            parentConfiguration = null,
-            isCreatedByDropIn = false
-        ).mapToParams(bacsDirectDebitConfiguration)
+        val params = BacsDirectDebitComponentParamsMapper(null).mapToParams(bacsDirectDebitConfiguration)
 
         val expected = BacsDirectDebitComponentParams(
             shopperLocale = Locale.US,
@@ -53,10 +51,7 @@ internal class BacsDirectDebitComponentParamsMapperTest {
             .setAmount(amount)
             .build()
 
-        val params = BacsDirectDebitComponentParamsMapper(
-            parentConfiguration = null,
-            isCreatedByDropIn = false
-        ).mapToParams(bacsDirectDebitConfiguration)
+        val params = BacsDirectDebitComponentParamsMapper(null).mapToParams(bacsDirectDebitConfiguration)
 
         val expected = BacsDirectDebitComponentParams(
             shopperLocale = Locale.US,
@@ -81,20 +76,17 @@ internal class BacsDirectDebitComponentParamsMapperTest {
             .setAmount(amount)
             .build()
 
-        // this is in practice DropInConfiguration, but we don't have access to it in this module and any Configuration
-        // class can work
-        val parentConfiguration = BacsDirectDebitConfiguration.Builder(
+        // this is in practice DropInComponentParams, but we don't have access to it in this module and any
+        // ComponentParams class can work
+        val overrideParams = GenericComponentParams(
             shopperLocale = Locale.GERMAN,
             environment = Environment.EUROPE,
             clientKey = TEST_CLIENT_KEY_2,
+            isAnalyticsEnabled = false,
+            isCreatedByDropIn = true,
         )
-            .setAnalyticsEnabled(false)
-            .build()
 
-        val params = BacsDirectDebitComponentParamsMapper(
-            parentConfiguration = parentConfiguration,
-            isCreatedByDropIn = true
-        ).mapToParams(bacsDirectDebitConfiguration)
+        val params = BacsDirectDebitComponentParamsMapper(overrideParams).mapToParams(bacsDirectDebitConfiguration)
 
         val expected = BacsDirectDebitComponentParams(
             shopperLocale = Locale.GERMAN,

--- a/bacs/src/test/java/com/adyen/checkout/bacs/DefaultBacsDirectDebitDelegateTest.kt
+++ b/bacs/src/test/java/com/adyen/checkout/bacs/DefaultBacsDirectDebitDelegateTest.kt
@@ -50,10 +50,7 @@ internal class DefaultBacsDirectDebitDelegateTest(
         ).build()
         delegate = DefaultBacsDirectDebitDelegate(
             observerRepository = PaymentObserverRepository(),
-            componentParams = BacsDirectDebitComponentParamsMapper(
-                parentConfiguration = null,
-                isCreatedByDropIn = false
-            ).mapToParams(configuration),
+            componentParams = BacsDirectDebitComponentParamsMapper(null).mapToParams(configuration),
             paymentMethod = PaymentMethod(),
             analyticsRepository = analyticsRepository,
         )

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcComponentParamsMapper.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcComponentParamsMapper.kt
@@ -8,39 +8,43 @@
 
 package com.adyen.checkout.bcmc
 
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 
 internal class BcmcComponentParamsMapper(
-    private val parentConfiguration: Configuration?,
-    private val isCreatedByDropIn: Boolean,
+    private val overrideComponentParams: ComponentParams?,
 ) {
 
     fun mapToParams(
         bcmcConfiguration: BcmcConfiguration,
     ): BcmcComponentParams {
-        return mapToParams(
-            parentConfiguration = parentConfiguration ?: bcmcConfiguration,
-            bcmcConfiguration = bcmcConfiguration,
-            isCreatedByDropIn = isCreatedByDropIn,
+        return bcmcConfiguration
+            .mapToParamsInternal()
+            .override(overrideComponentParams)
+    }
+
+    private fun BcmcConfiguration.mapToParamsInternal(): BcmcComponentParams {
+        return BcmcComponentParams(
+            shopperLocale = shopperLocale,
+            environment = environment,
+            clientKey = clientKey,
+            isAnalyticsEnabled = isAnalyticsEnabled ?: true,
+            isCreatedByDropIn = false,
+            isHolderNameRequired = isHolderNameRequired ?: false,
+            shopperReference = shopperReference,
+            isStorePaymentFieldVisible = isStorePaymentFieldVisible ?: false,
         )
     }
 
-    private fun mapToParams(
-        parentConfiguration: Configuration,
-        bcmcConfiguration: BcmcConfiguration,
-        isCreatedByDropIn: Boolean,
+    private fun BcmcComponentParams.override(
+        overrideComponentParams: ComponentParams?
     ): BcmcComponentParams {
-        with(bcmcConfiguration) {
-            return BcmcComponentParams(
-                shopperLocale = parentConfiguration.shopperLocale,
-                environment = parentConfiguration.environment,
-                clientKey = parentConfiguration.clientKey,
-                isAnalyticsEnabled = parentConfiguration.isAnalyticsEnabled ?: true,
-                isCreatedByDropIn = isCreatedByDropIn,
-                isHolderNameRequired = isHolderNameRequired ?: false,
-                shopperReference = shopperReference,
-                isStorePaymentFieldVisible = isStorePaymentFieldVisible ?: false,
-            )
-        }
+        if (overrideComponentParams == null) return this
+        return copy(
+            shopperLocale = overrideComponentParams.shopperLocale,
+            environment = overrideComponentParams.environment,
+            clientKey = overrideComponentParams.clientKey,
+            isAnalyticsEnabled = overrideComponentParams.isAnalyticsEnabled,
+            isCreatedByDropIn = overrideComponentParams.isCreatedByDropIn,
+        )
     }
 }

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcComponentProvider.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcComponentProvider.kt
@@ -20,7 +20,7 @@ import com.adyen.checkout.components.analytics.AnalyticsSource
 import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
 import com.adyen.checkout.components.api.AnalyticsService
 import com.adyen.checkout.components.api.PublicKeyService
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
@@ -33,11 +33,10 @@ import com.adyen.checkout.cse.DefaultGenericEncrypter
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class BcmcComponentProvider(
-    parentConfiguration: Configuration? = null,
-    isCreatedByDropIn: Boolean = false,
+    overrideComponentParams: ComponentParams? = null,
 ) : PaymentComponentProvider<BcmcComponent, BcmcConfiguration> {
 
-    private val componentParamsMapper = BcmcComponentParamsMapper(parentConfiguration, isCreatedByDropIn)
+    private val componentParamsMapper = BcmcComponentParamsMapper(overrideComponentParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcConfiguration.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcConfiguration.kt
@@ -65,16 +65,6 @@ class BcmcConfiguration private constructor(
         ) : super(shopperLocale, environment, clientKey)
 
         /**
-         * Constructor that copies an existing configuration.
-         *
-         * @param configuration A configuration to initialize the builder.
-         */
-        constructor(configuration: BcmcConfiguration) : super(configuration) {
-            shopperReference = configuration.shopperReference
-            showStorePaymentField = configuration.isStorePaymentFieldVisible
-        }
-
-        /**
          * Set if the holder name is required and should be shown as an input field.
          *
          * Default is false.

--- a/bcmc/src/test/java/com/adyen/checkout/bcmc/BcmcComponentParamsMapperTest.kt
+++ b/bcmc/src/test/java/com/adyen/checkout/bcmc/BcmcComponentParamsMapperTest.kt
@@ -8,6 +8,7 @@
 
 package com.adyen.checkout.bcmc
 
+import com.adyen.checkout.components.base.GenericComponentParams
 import com.adyen.checkout.core.api.Environment
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -24,10 +25,7 @@ internal class BcmcComponentParamsMapperTest {
         )
             .build()
 
-        val params = BcmcComponentParamsMapper(
-            parentConfiguration = null,
-            isCreatedByDropIn = false
-        ).mapToParams(bcmcConfiguration)
+        val params = BcmcComponentParamsMapper(null).mapToParams(bcmcConfiguration)
 
         val expected = BcmcComponentParams(
             shopperLocale = Locale.US,
@@ -57,10 +55,7 @@ internal class BcmcComponentParamsMapperTest {
             .setShowStorePaymentField(true)
             .build()
 
-        val params = BcmcComponentParamsMapper(
-            parentConfiguration = null,
-            isCreatedByDropIn = false
-        ).mapToParams(bcmcConfiguration)
+        val params = BcmcComponentParamsMapper(null).mapToParams(bcmcConfiguration)
 
         val expected = BcmcComponentParams(
             shopperLocale = Locale.US,
@@ -85,21 +80,17 @@ internal class BcmcComponentParamsMapperTest {
         )
             .build()
 
-        // this is in practice DropInConfiguration, but we don't have access to it in this module and any Configuration
-        // class can work
-        val parentConfiguration = BcmcConfiguration.Builder(
-            Locale.GERMAN,
-            Environment.EUROPE,
-            TEST_CLIENT_KEY_2
+        // this is in practice DropInComponentParams, but we don't have access to it in this module and any
+        // ComponentParams class can work
+        val overrideParams = GenericComponentParams(
+            shopperLocale = Locale.GERMAN,
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+            isAnalyticsEnabled = false,
+            isCreatedByDropIn = true,
         )
-            .setAnalyticsEnabled(false)
-            .build()
 
-        val params =
-            BcmcComponentParamsMapper(
-                parentConfiguration = parentConfiguration,
-                isCreatedByDropIn = true
-            ).mapToParams(bcmcConfiguration)
+        val params = BcmcComponentParamsMapper(overrideParams).mapToParams(bcmcConfiguration)
 
         val expected = BcmcComponentParams(
             shopperLocale = Locale.GERMAN,

--- a/bcmc/src/test/java/com/adyen/checkout/bcmc/DefaultBcmcDelegateTest.kt
+++ b/bcmc/src/test/java/com/adyen/checkout/bcmc/DefaultBcmcDelegateTest.kt
@@ -64,10 +64,7 @@ internal class DefaultBcmcDelegateTest(
             observerRepository = PaymentObserverRepository(),
             paymentMethod = PaymentMethod(),
             publicKeyRepository = testPublicKeyRepository,
-            componentParams = BcmcComponentParamsMapper(
-                parentConfiguration = null,
-                isCreatedByDropIn = false
-            ).mapToParams(configuration),
+            componentParams = BcmcComponentParamsMapper(null).mapToParams(configuration),
             cardValidationMapper = cardValidationMapper,
             cardEncrypter = cardEncrypter,
             analyticsRepository = analyticsRepository,

--- a/blik/src/main/java/com/adyen/checkout/blik/BlikComponentProvider.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/BlikComponentProvider.kt
@@ -19,7 +19,7 @@ import com.adyen.checkout.components.analytics.AnalyticsMapper
 import com.adyen.checkout.components.analytics.AnalyticsSource
 import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
 import com.adyen.checkout.components.api.AnalyticsService
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.base.GenericComponentParamsMapper
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
@@ -31,11 +31,10 @@ import com.adyen.checkout.core.exception.ComponentException
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class BlikComponentProvider(
-    parentConfiguration: Configuration? = null,
-    isCreatedByDropIn: Boolean = false,
+    overrideComponentParams: ComponentParams? = null
 ) : StoredPaymentComponentProvider<BlikComponent, BlikConfiguration> {
 
-    private val componentParamsMapper = GenericComponentParamsMapper(parentConfiguration, isCreatedByDropIn)
+    private val componentParamsMapper = GenericComponentParamsMapper(overrideComponentParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/blik/src/main/java/com/adyen/checkout/blik/BlikConfiguration.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/BlikConfiguration.kt
@@ -53,13 +53,6 @@ class BlikConfiguration private constructor(
             clientKey
         )
 
-        /**
-         * Constructor that copies an existing configuration.
-         *
-         * @param configuration A configuration to initialize the builder.
-         */
-        constructor(configuration: BlikConfiguration) : super(configuration)
-
         override fun buildInternal(): BlikConfiguration {
             return BlikConfiguration(
                 shopperLocale = shopperLocale,

--- a/blik/src/test/java/com/adyen/checkout/blik/DefaultBlikDelegateTest.kt
+++ b/blik/src/test/java/com/adyen/checkout/blik/DefaultBlikDelegateTest.kt
@@ -49,10 +49,7 @@ internal class DefaultBlikDelegateTest(
         ).build()
         delegate = DefaultBlikDelegate(
             observerRepository = PaymentObserverRepository(),
-            componentParams = GenericComponentParamsMapper(
-                parentConfiguration = null,
-                isCreatedByDropIn = false
-            ).mapToParams(configuration),
+            componentParams = GenericComponentParamsMapper(null).mapToParams(configuration),
             paymentMethod = PaymentMethod(),
             analyticsRepository = analyticsRepository,
         )

--- a/card/src/main/java/com/adyen/checkout/card/CardComponentParamsMapper.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponentParamsMapper.kt
@@ -11,7 +11,6 @@ package com.adyen.checkout.card
 import com.adyen.checkout.card.data.CardType
 import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
-import com.adyen.checkout.components.model.paymentmethods.StoredPaymentMethod
 import com.adyen.checkout.core.log.LogUtil
 import com.adyen.checkout.core.log.Logger
 
@@ -19,7 +18,7 @@ internal class CardComponentParamsMapper(
     private val overrideComponentParams: ComponentParams?,
 ) {
 
-    fun mapToParams(
+    fun mapToParamsDefault(
         cardConfiguration: CardConfiguration,
         paymentMethod: PaymentMethod,
     ): CardComponentParams {
@@ -29,11 +28,10 @@ internal class CardComponentParamsMapper(
             .override(overrideComponentParams)
     }
 
-    fun mapToParams(
+    fun mapToParamsStored(
         cardConfiguration: CardConfiguration,
-        storedPaymentMethod: StoredPaymentMethod,
     ): CardComponentParams {
-        val supportedCardTypes = cardConfiguration.getSupportedCardTypes(storedPaymentMethod)
+        val supportedCardTypes = cardConfiguration.getSupportedCardTypesStored()
         return cardConfiguration
             .mapToParamsInternal(supportedCardTypes)
             .override(overrideComponentParams)
@@ -86,10 +84,7 @@ internal class CardComponentParamsMapper(
         }
     }
 
-    private fun CardConfiguration.getSupportedCardTypes(
-        // not needed for the actual mapping but indicates that this is the method to use in a stored flow
-        storedPaymentMethod: StoredPaymentMethod,
-    ): List<CardType> {
+    private fun CardConfiguration.getSupportedCardTypesStored(): List<CardType> {
         return supportedCardTypes.orEmpty()
     }
 

--- a/card/src/main/java/com/adyen/checkout/card/CardComponentProvider.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponentProvider.kt
@@ -56,7 +56,7 @@ class CardComponentProvider(
     ): CardComponent {
         assertSupported(paymentMethod)
 
-        val componentParams = componentParamsMapper.mapToParams(configuration, paymentMethod)
+        val componentParams = componentParamsMapper.mapToParamsDefault(configuration, paymentMethod)
         val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
         val genericEncrypter = DefaultGenericEncrypter()
         val cardEncrypter = DefaultCardEncrypter(genericEncrypter)
@@ -124,7 +124,7 @@ class CardComponentProvider(
     ): CardComponent {
         assertSupported(storedPaymentMethod)
 
-        val componentParams = componentParamsMapper.mapToParams(configuration, storedPaymentMethod)
+        val componentParams = componentParamsMapper.mapToParamsStored(configuration)
         val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
         val publicKeyService = PublicKeyService(httpClient)
         val publicKeyRepository = DefaultPublicKeyRepository(publicKeyService)

--- a/card/src/main/java/com/adyen/checkout/card/CardComponentProvider.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponentProvider.kt
@@ -26,7 +26,7 @@ import com.adyen.checkout.components.analytics.AnalyticsSource
 import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
 import com.adyen.checkout.components.api.AnalyticsService
 import com.adyen.checkout.components.api.PublicKeyService
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
@@ -40,11 +40,10 @@ import com.adyen.checkout.cse.DefaultGenericEncrypter
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class CardComponentProvider(
-    parentConfiguration: Configuration? = null,
-    isCreatedByDropIn: Boolean = false,
+    overrideComponentParams: ComponentParams? = null,
 ) : StoredPaymentComponentProvider<CardComponent, CardConfiguration> {
 
-    private val componentParamsMapper = CardComponentParamsMapper(parentConfiguration, isCreatedByDropIn)
+    private val componentParamsMapper = CardComponentParamsMapper(overrideComponentParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
@@ -55,22 +55,6 @@ class CardConfiguration private constructor(
         private var addressConfiguration: AddressConfiguration? = null
 
         /**
-         * Constructor of Card Configuration Builder with instance of CardConfiguration.
-         */
-        constructor(cardConfiguration: CardConfiguration) : super(cardConfiguration) {
-            supportedCardTypes = cardConfiguration.supportedCardTypes
-            holderNameRequired = cardConfiguration.isHolderNameRequired
-            isStorePaymentFieldVisible = cardConfiguration.isStorePaymentFieldVisible
-            shopperReference = cardConfiguration.shopperReference
-            isHideCvc = cardConfiguration.isHideCvc
-            isHideCvcStoredCard = cardConfiguration.isHideCvcStoredCard
-            socialSecurityNumberVisibility = cardConfiguration.socialSecurityNumberVisibility
-            kcpAuthVisibility = cardConfiguration.kcpAuthVisibility
-            installmentConfiguration = cardConfiguration.installmentConfiguration
-            addressConfiguration = cardConfiguration.addressConfiguration
-        }
-
-        /**
          * Constructor for Builder with default values.
          *
          * @param context   A context

--- a/card/src/test/java/com/adyen/checkout/card/CardComponentParamsMapperTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/CardComponentParamsMapperTest.kt
@@ -22,7 +22,7 @@ internal class CardComponentParamsMapperTest {
     fun `when parent configuration is null and custom card configuration fields are null then all fields should match`() {
         val cardConfiguration = getCardConfigurationBuilder().build()
 
-        val params = CardComponentParamsMapper(null).mapToParams(cardConfiguration, PaymentMethod())
+        val params = CardComponentParamsMapper(null).mapToParamsDefault(cardConfiguration, PaymentMethod())
 
         val expected = getCardComponentParams()
 
@@ -57,7 +57,7 @@ internal class CardComponentParamsMapperTest {
             .setAddressConfiguration(addressConfiguration)
             .build()
 
-        val params = CardComponentParamsMapper(null).mapToParams(cardConfiguration, PaymentMethod())
+        val params = CardComponentParamsMapper(null).mapToParamsDefault(cardConfiguration, PaymentMethod())
 
         val expected = getCardComponentParams(
             shopperLocale = Locale.FRANCE,
@@ -92,7 +92,7 @@ internal class CardComponentParamsMapperTest {
             isCreatedByDropIn = true,
         )
 
-        val params = CardComponentParamsMapper(overrideParams).mapToParams(cardConfiguration, PaymentMethod())
+        val params = CardComponentParamsMapper(overrideParams).mapToParamsDefault(cardConfiguration, PaymentMethod())
 
         val expected = getCardComponentParams(
             shopperLocale = Locale.GERMAN,
@@ -113,7 +113,7 @@ internal class CardComponentParamsMapperTest {
 
         val paymentMethod = PaymentMethod(brands = listOf(CardType.VISA.txVariant, CardType.MASTERCARD.txVariant))
 
-        val params = CardComponentParamsMapper(null).mapToParams(cardConfiguration, paymentMethod)
+        val params = CardComponentParamsMapper(null).mapToParamsDefault(cardConfiguration, paymentMethod)
 
         val expected = getCardComponentParams(
             supportedCardTypes = listOf(CardType.MAESTRO, CardType.BCMC)
@@ -129,7 +129,7 @@ internal class CardComponentParamsMapperTest {
 
         val paymentMethod = PaymentMethod(brands = listOf(CardType.VISA.txVariant, CardType.MASTERCARD.txVariant))
 
-        val params = CardComponentParamsMapper(null).mapToParams(cardConfiguration, paymentMethod)
+        val params = CardComponentParamsMapper(null).mapToParamsDefault(cardConfiguration, paymentMethod)
 
         val expected = getCardComponentParams(
             supportedCardTypes = listOf(CardType.VISA, CardType.MASTERCARD)
@@ -143,7 +143,7 @@ internal class CardComponentParamsMapperTest {
         val cardConfiguration = getCardConfigurationBuilder()
             .build()
 
-        val params = CardComponentParamsMapper(null).mapToParams(cardConfiguration, PaymentMethod())
+        val params = CardComponentParamsMapper(null).mapToParamsDefault(cardConfiguration, PaymentMethod())
 
         val expected = getCardComponentParams(
             supportedCardTypes = CardConfiguration.DEFAULT_SUPPORTED_CARDS_LIST

--- a/card/src/test/java/com/adyen/checkout/card/CardComponentParamsMapperTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/CardComponentParamsMapperTest.kt
@@ -9,6 +9,7 @@
 package com.adyen.checkout.card
 
 import com.adyen.checkout.card.data.CardType
+import com.adyen.checkout.components.base.GenericComponentParams
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.core.api.Environment
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -21,10 +22,7 @@ internal class CardComponentParamsMapperTest {
     fun `when parent configuration is null and custom card configuration fields are null then all fields should match`() {
         val cardConfiguration = getCardConfigurationBuilder().build()
 
-        val params = CardComponentParamsMapper(
-            parentConfiguration = null,
-            isCreatedByDropIn = false
-        ).mapToParams(cardConfiguration, PaymentMethod())
+        val params = CardComponentParamsMapper(null).mapToParams(cardConfiguration, PaymentMethod())
 
         val expected = getCardComponentParams()
 
@@ -59,10 +57,7 @@ internal class CardComponentParamsMapperTest {
             .setAddressConfiguration(addressConfiguration)
             .build()
 
-        val params = CardComponentParamsMapper(
-            parentConfiguration = null,
-            isCreatedByDropIn = false
-        ).mapToParams(cardConfiguration, PaymentMethod())
+        val params = CardComponentParamsMapper(null).mapToParams(cardConfiguration, PaymentMethod())
 
         val expected = getCardComponentParams(
             shopperLocale = Locale.FRANCE,
@@ -87,20 +82,17 @@ internal class CardComponentParamsMapperTest {
     fun `when parent configuration is set then parent configuration fields should override card configuration fields`() {
         val cardConfiguration = getCardConfigurationBuilder().build()
 
-        // this is in practice DropInConfiguration, but we don't have access to it in this module and any Configuration
-        // class can work
-        val parentConfiguration = CardConfiguration.Builder(
-            Locale.GERMAN,
-            Environment.EUROPE,
-            TEST_CLIENT_KEY_2
+        // this is in practice DropInComponentParams, but we don't have access to it in this module and any
+        // ComponentParams class can work
+        val overrideParams = GenericComponentParams(
+            shopperLocale = Locale.GERMAN,
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+            isAnalyticsEnabled = false,
+            isCreatedByDropIn = true,
         )
-            .setAnalyticsEnabled(false)
-            .build()
 
-        val params = CardComponentParamsMapper(
-            parentConfiguration = parentConfiguration,
-            isCreatedByDropIn = true
-        ).mapToParams(cardConfiguration, PaymentMethod())
+        val params = CardComponentParamsMapper(overrideParams).mapToParams(cardConfiguration, PaymentMethod())
 
         val expected = getCardComponentParams(
             shopperLocale = Locale.GERMAN,
@@ -121,10 +113,7 @@ internal class CardComponentParamsMapperTest {
 
         val paymentMethod = PaymentMethod(brands = listOf(CardType.VISA.txVariant, CardType.MASTERCARD.txVariant))
 
-        val params = CardComponentParamsMapper(
-            parentConfiguration = null,
-            isCreatedByDropIn = false
-        ).mapToParams(cardConfiguration, paymentMethod)
+        val params = CardComponentParamsMapper(null).mapToParams(cardConfiguration, paymentMethod)
 
         val expected = getCardComponentParams(
             supportedCardTypes = listOf(CardType.MAESTRO, CardType.BCMC)
@@ -140,10 +129,7 @@ internal class CardComponentParamsMapperTest {
 
         val paymentMethod = PaymentMethod(brands = listOf(CardType.VISA.txVariant, CardType.MASTERCARD.txVariant))
 
-        val params = CardComponentParamsMapper(
-            parentConfiguration = null,
-            isCreatedByDropIn = false
-        ).mapToParams(cardConfiguration, paymentMethod)
+        val params = CardComponentParamsMapper(null).mapToParams(cardConfiguration, paymentMethod)
 
         val expected = getCardComponentParams(
             supportedCardTypes = listOf(CardType.VISA, CardType.MASTERCARD)
@@ -157,10 +143,7 @@ internal class CardComponentParamsMapperTest {
         val cardConfiguration = getCardConfigurationBuilder()
             .build()
 
-        val params = CardComponentParamsMapper(
-            parentConfiguration = null,
-            isCreatedByDropIn = false
-        ).mapToParams(cardConfiguration, PaymentMethod())
+        val params = CardComponentParamsMapper(null).mapToParams(cardConfiguration, PaymentMethod())
 
         val expected = getCardComponentParams(
             supportedCardTypes = CardConfiguration.DEFAULT_SUPPORTED_CARDS_LIST

--- a/card/src/test/java/com/adyen/checkout/card/DefaultCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/DefaultCardDelegateTest.kt
@@ -720,7 +720,7 @@ internal class DefaultCardDelegateTest(
             observerRepository = PaymentObserverRepository(),
             paymentMethod = paymentMethod,
             publicKeyRepository = publicKeyRepository,
-            componentParams = CardComponentParamsMapper(null).mapToParams(configuration, paymentMethod),
+            componentParams = CardComponentParamsMapper(null).mapToParamsDefault(configuration, paymentMethod),
             cardEncrypter = cardEncrypter,
             addressRepository = addressRepository,
             detectCardTypeRepository = detectCardTypeRepository,

--- a/card/src/test/java/com/adyen/checkout/card/DefaultCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/DefaultCardDelegateTest.kt
@@ -720,10 +720,7 @@ internal class DefaultCardDelegateTest(
             observerRepository = PaymentObserverRepository(),
             paymentMethod = paymentMethod,
             publicKeyRepository = publicKeyRepository,
-            componentParams = CardComponentParamsMapper(
-                parentConfiguration = null,
-                isCreatedByDropIn = false
-            ).mapToParams(configuration, paymentMethod),
+            componentParams = CardComponentParamsMapper(null).mapToParams(configuration, paymentMethod),
             cardEncrypter = cardEncrypter,
             addressRepository = addressRepository,
             detectCardTypeRepository = detectCardTypeRepository,

--- a/card/src/test/java/com/adyen/checkout/card/StoredCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/StoredCardDelegateTest.kt
@@ -303,10 +303,7 @@ internal class StoredCardDelegateTest(
             observerRepository = PaymentObserverRepository(),
             storedPaymentMethod = storedPaymentMethod,
             publicKeyRepository = publicKeyRepository,
-            componentParams = CardComponentParamsMapper(
-                parentConfiguration = null,
-                isCreatedByDropIn = false
-            ).mapToParams(configuration, storedPaymentMethod),
+            componentParams = CardComponentParamsMapper(null).mapToParams(configuration, storedPaymentMethod),
             cardEncrypter = cardEncrypter,
             analyticsRepository = analyticsRepository,
         )

--- a/card/src/test/java/com/adyen/checkout/card/StoredCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/StoredCardDelegateTest.kt
@@ -303,7 +303,7 @@ internal class StoredCardDelegateTest(
             observerRepository = PaymentObserverRepository(),
             storedPaymentMethod = storedPaymentMethod,
             publicKeyRepository = publicKeyRepository,
-            componentParams = CardComponentParamsMapper(null).mapToParams(configuration, storedPaymentMethod),
+            componentParams = CardComponentParamsMapper(null).mapToParamsStored(configuration),
             cardEncrypter = cardEncrypter,
             analyticsRepository = analyticsRepository,
         )

--- a/components-core/src/main/java/com/adyen/checkout/components/AlwaysAvailablePaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/AlwaysAvailablePaymentMethod.kt
@@ -18,8 +18,8 @@ class AlwaysAvailablePaymentMethod : PaymentMethodAvailabilityCheck<Configuratio
         applicationContext: Application,
         paymentMethod: PaymentMethod,
         configuration: Configuration?,
-        callback: ComponentAvailableCallback<Configuration>
+        callback: ComponentAvailableCallback
     ) {
-        callback.onAvailabilityResult(true, paymentMethod, configuration)
+        callback.onAvailabilityResult(true, paymentMethod)
     }
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/ComponentAvailableCallback.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/ComponentAvailableCallback.kt
@@ -7,9 +7,8 @@
  */
 package com.adyen.checkout.components
 
-import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 
-interface ComponentAvailableCallback<ConfigurationT : Configuration> {
-    fun onAvailabilityResult(isAvailable: Boolean, paymentMethod: PaymentMethod, config: ConfigurationT?)
+interface ComponentAvailableCallback {
+    fun onAvailabilityResult(isAvailable: Boolean, paymentMethod: PaymentMethod)
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/PaymentMethodAvailabilityCheck.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/PaymentMethodAvailabilityCheck.kt
@@ -22,6 +22,6 @@ interface PaymentMethodAvailabilityCheck<ConfigurationT : Configuration> {
         applicationContext: Application,
         paymentMethod: PaymentMethod,
         configuration: ConfigurationT?,
-        callback: ComponentAvailableCallback<ConfigurationT>
+        callback: ComponentAvailableCallback
     )
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/base/AmountComponentParams.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/base/AmountComponentParams.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 30/11/2022.
+ */
+
+package com.adyen.checkout.components.base
+
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.components.model.payments.Amount
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+interface AmountComponentParams {
+    val amount: Amount
+}

--- a/components-core/src/main/java/com/adyen/checkout/components/base/BaseConfigurationBuilder.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/base/BaseConfigurationBuilder.kt
@@ -49,17 +49,6 @@ abstract class BaseConfigurationBuilder<
     )
 
     /**
-     * Constructor that copies an existing configuration.
-     *
-     * @param configuration A configuration to initialize the builder.
-     */
-    constructor(configuration: ConfigurationT) : this(
-        configuration.shopperLocale,
-        configuration.environment,
-        configuration.clientKey
-    )
-
-    /**
      * Sets if components can send analytics events.
      *
      * Default is True.

--- a/components-core/src/main/java/com/adyen/checkout/components/base/GenericComponentParamsMapper.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/base/GenericComponentParamsMapper.kt
@@ -12,21 +12,37 @@ import androidx.annotation.RestrictTo
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class GenericComponentParamsMapper(
-    private val parentConfiguration: Configuration?,
-    private val isCreatedByDropIn: Boolean,
+    private val overrideComponentParams: ComponentParams?,
 ) {
 
     fun mapToParams(
         configuration: Configuration,
     ): GenericComponentParams {
-        with(parentConfiguration ?: configuration) {
-            return GenericComponentParams(
-                shopperLocale = shopperLocale,
-                environment = environment,
-                clientKey = clientKey,
-                isAnalyticsEnabled = isAnalyticsEnabled ?: true,
-                isCreatedByDropIn = isCreatedByDropIn,
-            )
-        }
+        return configuration
+            .mapToParamsInternal()
+            .override(overrideComponentParams)
+    }
+
+    private fun Configuration.mapToParamsInternal(): GenericComponentParams {
+        return GenericComponentParams(
+            shopperLocale = shopperLocale,
+            environment = environment,
+            clientKey = clientKey,
+            isAnalyticsEnabled = isAnalyticsEnabled ?: true,
+            isCreatedByDropIn = false,
+        )
+    }
+
+    private fun GenericComponentParams.override(
+        overrideComponentParams: ComponentParams?
+    ): GenericComponentParams {
+        if (overrideComponentParams == null) return this
+        return copy(
+            shopperLocale = overrideComponentParams.shopperLocale,
+            environment = overrideComponentParams.environment,
+            clientKey = overrideComponentParams.clientKey,
+            isAnalyticsEnabled = overrideComponentParams.isAnalyticsEnabled,
+            isCreatedByDropIn = overrideComponentParams.isCreatedByDropIn,
+        )
     }
 }

--- a/components-core/src/test/java/com/adyen/checkout/components/GenericComponentParamsMapperTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/GenericComponentParamsMapperTest.kt
@@ -26,10 +26,7 @@ internal class GenericComponentParamsMapperTest {
             clientKey = TEST_CLIENT_KEY_1
         ).build()
 
-        val params = GenericComponentParamsMapper(
-            parentConfiguration = null,
-            isCreatedByDropIn = false
-        ).mapToParams(componentConfiguration)
+        val params = GenericComponentParamsMapper(null).mapToParams(componentConfiguration)
 
         val expected = GenericComponentParams(
             shopperLocale = Locale.US,
@@ -50,20 +47,17 @@ internal class GenericComponentParamsMapperTest {
             clientKey = TEST_CLIENT_KEY_1
         ).build()
 
-        // this is in practice DropInConfiguration, but we don't have access to it in this module and any Configuration
-        // class can work
-        val parentConfiguration = TestConfiguration.Builder(
+        // this is in practice DropInComponentParams, but we don't have access to it in this module and any
+        // ComponentParams class can work
+        val overrideParams = GenericComponentParams(
             shopperLocale = Locale.GERMAN,
             environment = Environment.EUROPE,
             clientKey = TEST_CLIENT_KEY_2,
+            isAnalyticsEnabled = false,
+            isCreatedByDropIn = true,
         )
-            .setAnalyticsEnabled(false)
-            .build()
 
-        val params = GenericComponentParamsMapper(
-            parentConfiguration = parentConfiguration,
-            isCreatedByDropIn = true
-        ).mapToParams(
+        val params = GenericComponentParamsMapper(overrideParams).mapToParams(
             componentConfiguration
         )
 

--- a/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayComponentProvider.kt
+++ b/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayComponentProvider.kt
@@ -19,7 +19,7 @@ import com.adyen.checkout.components.analytics.AnalyticsMapper
 import com.adyen.checkout.components.analytics.AnalyticsSource
 import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
 import com.adyen.checkout.components.api.AnalyticsService
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
@@ -32,11 +32,10 @@ import com.adyen.checkout.issuerlist.IssuerListComponentParamsMapper
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class DotpayComponentProvider(
-    parentConfiguration: Configuration? = null,
-    isCreatedByDropIn: Boolean = false,
+    overrideComponentParams: ComponentParams? = null,
 ) : PaymentComponentProvider<DotpayComponent, DotpayConfiguration> {
 
-    private val componentParamsMapper = IssuerListComponentParamsMapper(parentConfiguration, isCreatedByDropIn)
+    private val componentParamsMapper = IssuerListComponentParamsMapper(overrideComponentParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayConfiguration.kt
+++ b/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayConfiguration.kt
@@ -55,16 +55,6 @@ class DotpayConfiguration private constructor(
             clientKey: String
         ) : super(shopperLocale, environment, clientKey)
 
-        /**
-         * Constructor that copies an existing configuration.
-         *
-         * @param configuration A configuration to initialize the builder.
-         */
-        constructor(configuration: DotpayConfiguration) : super(configuration) {
-            viewType = configuration.viewType
-            hideIssuerLogos = configuration.hideIssuerLogos
-        }
-
         override fun buildInternal(): DotpayConfiguration {
             return DotpayConfiguration(
                 shopperLocale = shopperLocale,

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
@@ -406,7 +406,7 @@ internal fun getComponentFor(
         BacsDirectDebitComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) -> {
             val bacsConfiguration: BacsDirectDebitConfiguration =
                 getConfigurationForPaymentMethod(paymentMethod, dropInConfiguration, amount)
-            BacsDirectDebitComponentProvider(dropInConfiguration, isCreatedByDropIn = true).get(
+            BacsDirectDebitComponentProvider(dropInParams).get(
                 owner = fragment,
                 paymentMethod = paymentMethod,
                 configuration = bacsConfiguration,

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
@@ -401,6 +401,7 @@ internal fun getComponentFor(
     dropInConfiguration: DropInConfiguration,
     amount: Amount
 ): PaymentComponent<PaymentComponentState<in PaymentMethodDetails>, Configuration> {
+    val dropInParams = dropInConfiguration.mapToParams(amount)
     val component = when {
         BacsDirectDebitComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) -> {
             val bacsConfiguration: BacsDirectDebitConfiguration =
@@ -485,7 +486,7 @@ internal fun getComponentFor(
         GooglePayComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) -> {
             val googlePayConfiguration: GooglePayConfiguration =
                 getConfigurationForPaymentMethod(paymentMethod, dropInConfiguration, amount)
-            GooglePayComponentProvider(dropInConfiguration, isCreatedByDropIn = true).get(
+            GooglePayComponentProvider(dropInParams).get(
                 owner = fragment,
                 paymentMethod = paymentMethod,
                 configuration = googlePayConfiguration,
@@ -600,6 +601,10 @@ internal fun getComponentFor(
     component.setCreatedForDropIn()
 
     return component as PaymentComponent<PaymentComponentState<in PaymentMethodDetails>, Configuration>
+}
+
+private fun DropInConfiguration.mapToParams(amount: Amount): DropInComponentParams {
+    return DropInComponentParamsMapper().mapToParams(this, amount)
 }
 
 @Suppress("ComplexMethod")

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
@@ -447,7 +447,7 @@ internal fun getComponentFor(
         DotpayComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) -> {
             val dotpayConfig: DotpayConfiguration =
                 getConfigurationForPaymentMethod(paymentMethod, dropInConfiguration, amount)
-            DotpayComponentProvider(dropInConfiguration, isCreatedByDropIn = true).get(
+            DotpayComponentProvider(dropInParams).get(
                 owner = fragment,
                 paymentMethod = paymentMethod,
                 configuration = dotpayConfig,
@@ -457,7 +457,7 @@ internal fun getComponentFor(
         EntercashComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) -> {
             val entercashConfig: EntercashConfiguration =
                 getConfigurationForPaymentMethod(paymentMethod, dropInConfiguration, amount)
-            EntercashComponentProvider(dropInConfiguration, isCreatedByDropIn = true).get(
+            EntercashComponentProvider(dropInParams).get(
                 owner = fragment,
                 paymentMethod = paymentMethod,
                 configuration = entercashConfig,
@@ -467,7 +467,7 @@ internal fun getComponentFor(
         EPSComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) -> {
             val epsConfig: EPSConfiguration =
                 getConfigurationForPaymentMethod(paymentMethod, dropInConfiguration, amount)
-            EPSComponentProvider(dropInConfiguration, isCreatedByDropIn = true).get(
+            EPSComponentProvider(dropInParams).get(
                 owner = fragment,
                 paymentMethod = paymentMethod,
                 configuration = epsConfig,
@@ -497,7 +497,7 @@ internal fun getComponentFor(
         IdealComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) -> {
             val idealConfig: IdealConfiguration =
                 getConfigurationForPaymentMethod(paymentMethod, dropInConfiguration, amount)
-            IdealComponentProvider(dropInConfiguration, isCreatedByDropIn = true).get(
+            IdealComponentProvider(dropInParams).get(
                 owner = fragment,
                 paymentMethod = paymentMethod,
                 configuration = idealConfig,
@@ -527,7 +527,7 @@ internal fun getComponentFor(
         MolpayComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) -> {
             val molpayConfig: MolpayConfiguration =
                 getConfigurationForPaymentMethod(paymentMethod, dropInConfiguration, amount)
-            MolpayComponentProvider(dropInConfiguration, isCreatedByDropIn = true).get(
+            MolpayComponentProvider(dropInParams).get(
                 owner = fragment,
                 paymentMethod = paymentMethod,
                 configuration = molpayConfig,
@@ -547,7 +547,7 @@ internal fun getComponentFor(
         OnlineBankingPLComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) -> {
             val onlineBankingPLConfig: OnlineBankingPLConfiguration =
                 getConfigurationForPaymentMethod(paymentMethod, dropInConfiguration, amount)
-            OnlineBankingPLComponentProvider(dropInConfiguration, isCreatedByDropIn = true).get(
+            OnlineBankingPLComponentProvider(dropInParams).get(
                 owner = fragment,
                 paymentMethod = paymentMethod,
                 configuration = onlineBankingPLConfig,
@@ -567,7 +567,7 @@ internal fun getComponentFor(
         OpenBankingComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) -> {
             val openBankingConfig: OpenBankingConfiguration =
                 getConfigurationForPaymentMethod(paymentMethod, dropInConfiguration, amount)
-            OpenBankingComponentProvider(dropInConfiguration, isCreatedByDropIn = true).get(
+            OpenBankingComponentProvider(dropInParams).get(
                 owner = fragment,
                 paymentMethod = paymentMethod,
                 configuration = openBankingConfig,

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
@@ -371,7 +371,7 @@ internal fun getComponentFor(
         BlikComponent.PROVIDER.isPaymentMethodSupported(storedPaymentMethod) -> {
             val blikConfig: BlikConfiguration =
                 getConfigurationForPaymentMethod(storedPaymentMethod, dropInConfiguration, amount)
-            BlikComponentProvider(dropInConfiguration, isCreatedByDropIn = true).get(
+            BlikComponentProvider(dropInParams).get(
                 owner = fragment,
                 storedPaymentMethod = storedPaymentMethod,
                 configuration = blikConfig,
@@ -427,7 +427,7 @@ internal fun getComponentFor(
         BlikComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) -> {
             val blikConfiguration: BlikConfiguration =
                 getConfigurationForPaymentMethod(paymentMethod, dropInConfiguration, amount)
-            BlikComponentProvider(dropInConfiguration, isCreatedByDropIn = true).get(
+            BlikComponentProvider(dropInParams).get(
                 owner = fragment,
                 paymentMethod = paymentMethod,
                 configuration = blikConfiguration,
@@ -477,7 +477,7 @@ internal fun getComponentFor(
         GiftCardComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) -> {
             val giftcardConfiguration: GiftCardConfiguration =
                 getConfigurationForPaymentMethod(paymentMethod, dropInConfiguration, amount)
-            GiftCardComponentProvider(dropInConfiguration, isCreatedByDropIn = true).get(
+            GiftCardComponentProvider(dropInParams).get(
                 owner = fragment,
                 paymentMethod = paymentMethod,
                 configuration = giftcardConfiguration,
@@ -507,7 +507,7 @@ internal fun getComponentFor(
         InstantPaymentComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) -> {
             val instantPaymentConfiguration: InstantPaymentConfiguration =
                 getConfigurationForPaymentMethod(paymentMethod, dropInConfiguration, amount)
-            InstantPaymentComponentProvider(dropInConfiguration, isCreatedByDropIn = true).get(
+            InstantPaymentComponentProvider(dropInParams).get(
                 owner = fragment,
                 paymentMethod = paymentMethod,
                 configuration = instantPaymentConfiguration,
@@ -517,7 +517,7 @@ internal fun getComponentFor(
         MBWayComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) -> {
             val mbWayConfiguration: MBWayConfiguration =
                 getConfigurationForPaymentMethod(paymentMethod, dropInConfiguration, amount)
-            MBWayComponentProvider(dropInConfiguration, isCreatedByDropIn = true).get(
+            MBWayComponentProvider(dropInParams).get(
                 owner = fragment,
                 paymentMethod = paymentMethod,
                 configuration = mbWayConfiguration,
@@ -537,7 +537,7 @@ internal fun getComponentFor(
         OnlineBankingCZComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) -> {
             val onlineBankingCZConfig: OnlineBankingCZConfiguration =
                 getConfigurationForPaymentMethod(paymentMethod, dropInConfiguration, amount)
-            OnlineBankingCZComponentProvider(dropInConfiguration, isCreatedByDropIn = true).get(
+            OnlineBankingCZComponentProvider(dropInParams).get(
                 owner = fragment,
                 paymentMethod = paymentMethod,
                 configuration = onlineBankingCZConfig,
@@ -557,7 +557,7 @@ internal fun getComponentFor(
         OnlineBankingSKComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) -> {
             val onlineBankingSKConfig: OnlineBankingSKConfiguration =
                 getConfigurationForPaymentMethod(paymentMethod, dropInConfiguration, amount)
-            OnlineBankingSKComponentProvider(dropInConfiguration, isCreatedByDropIn = true).get(
+            OnlineBankingSKComponentProvider(dropInParams).get(
                 owner = fragment,
                 paymentMethod = paymentMethod,
                 configuration = onlineBankingSKConfig,
@@ -577,7 +577,7 @@ internal fun getComponentFor(
         PayByBankComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) -> {
             val payByBankConfig: PayByBankConfiguration =
                 getConfigurationForPaymentMethod(paymentMethod, dropInConfiguration, amount)
-            PayByBankComponentProvider(dropInConfiguration, isCreatedByDropIn = true).get(
+            PayByBankComponentProvider(dropInParams).get(
                 owner = fragment,
                 paymentMethod = paymentMethod,
                 configuration = payByBankConfig,
@@ -587,7 +587,7 @@ internal fun getComponentFor(
         SepaComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) -> {
             val sepaConfiguration: SepaConfiguration =
                 getConfigurationForPaymentMethod(paymentMethod, dropInConfiguration, amount)
-            SepaComponentProvider(dropInConfiguration, isCreatedByDropIn = true).get(
+            SepaComponentProvider(dropInParams).get(
                 owner = fragment,
                 paymentMethod = paymentMethod,
                 configuration = sepaConfiguration,
@@ -604,7 +604,7 @@ internal fun getComponentFor(
     return component as PaymentComponent<PaymentComponentState<in PaymentMethodDetails>, Configuration>
 }
 
-private fun DropInConfiguration.mapToParams(amount: Amount): DropInComponentParams {
+internal fun DropInConfiguration.mapToParams(amount: Amount): DropInComponentParams {
     return DropInComponentParamsMapper().mapToParams(this, amount)
 }
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
@@ -416,7 +416,7 @@ internal fun getComponentFor(
         BcmcComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) -> {
             val bcmcConfiguration: BcmcConfiguration =
                 getConfigurationForPaymentMethod(paymentMethod, dropInConfiguration, amount)
-            BcmcComponentProvider(dropInConfiguration, isCreatedByDropIn = true).get(
+            BcmcComponentProvider(dropInParams).get(
                 owner = fragment,
                 paymentMethod = paymentMethod,
                 configuration = bcmcConfiguration,

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
@@ -356,11 +356,12 @@ internal fun getComponentFor(
     dropInConfiguration: DropInConfiguration,
     amount: Amount
 ): PaymentComponent<PaymentComponentState<in PaymentMethodDetails>, Configuration> {
+    val dropInParams = dropInConfiguration.mapToParams(amount)
     val component = when {
         CardComponent.PROVIDER.isPaymentMethodSupported(storedPaymentMethod) -> {
             val cardConfig: CardConfiguration =
                 getConfigurationForPaymentMethod(storedPaymentMethod, dropInConfiguration, amount)
-            CardComponentProvider(dropInConfiguration, isCreatedByDropIn = true).get(
+            CardComponentProvider(dropInParams).get(
                 owner = fragment,
                 storedPaymentMethod = storedPaymentMethod,
                 configuration = cardConfig,
@@ -436,7 +437,7 @@ internal fun getComponentFor(
         CardComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) -> {
             val cardConfig: CardConfiguration =
                 getConfigurationForPaymentMethod(paymentMethod, dropInConfiguration, amount)
-            CardComponentProvider(dropInConfiguration, isCreatedByDropIn = true).get(
+            CardComponentProvider(dropInParams).get(
                 owner = fragment,
                 paymentMethod = paymentMethod,
                 configuration = cardConfig,

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropInComponentParams.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropInComponentParams.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 30/11/2022.
+ */
+
+package com.adyen.checkout.dropin
+
+import android.os.Bundle
+import com.adyen.checkout.components.base.ComponentParams
+import com.adyen.checkout.components.model.payments.Amount
+import com.adyen.checkout.core.api.Environment
+import kotlinx.parcelize.Parcelize
+import java.util.Locale
+
+@Parcelize
+internal data class DropInComponentParams(
+    override val shopperLocale: Locale,
+    override val environment: Environment,
+    override val clientKey: String,
+    override val isAnalyticsEnabled: Boolean,
+    override val isCreatedByDropIn: Boolean,
+    val amount: Amount,
+    val showPreselectedStoredPaymentMethod: Boolean,
+    val skipListWhenSinglePaymentMethod: Boolean,
+    val isRemovingStoredPaymentMethodsEnabled: Boolean,
+    val additionalDataForDropInService: Bundle?,
+) : ComponentParams

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropInComponentParams.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropInComponentParams.kt
@@ -9,6 +9,7 @@
 package com.adyen.checkout.dropin
 
 import android.os.Bundle
+import com.adyen.checkout.components.base.AmountComponentParams
 import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.model.payments.Amount
 import com.adyen.checkout.core.api.Environment
@@ -22,9 +23,9 @@ internal data class DropInComponentParams(
     override val clientKey: String,
     override val isAnalyticsEnabled: Boolean,
     override val isCreatedByDropIn: Boolean,
-    val amount: Amount,
+    override val amount: Amount,
     val showPreselectedStoredPaymentMethod: Boolean,
     val skipListWhenSinglePaymentMethod: Boolean,
     val isRemovingStoredPaymentMethodsEnabled: Boolean,
     val additionalDataForDropInService: Bundle?,
-) : ComponentParams
+) : ComponentParams, AmountComponentParams

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropInComponentParamsMapper.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropInComponentParamsMapper.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 30/11/2022.
+ */
+
+package com.adyen.checkout.dropin
+
+import com.adyen.checkout.components.model.payments.Amount
+
+internal class DropInComponentParamsMapper {
+
+    fun mapToParams(
+        dropInConfiguration: DropInConfiguration,
+        overrideAmount: Amount,
+    ): DropInComponentParams {
+        with(dropInConfiguration) {
+            return DropInComponentParams(
+                shopperLocale = shopperLocale,
+                environment = environment,
+                clientKey = clientKey,
+                isAnalyticsEnabled = isAnalyticsEnabled ?: true,
+                isCreatedByDropIn = true,
+                amount = overrideAmount,
+                showPreselectedStoredPaymentMethod = showPreselectedStoredPaymentMethod,
+                skipListWhenSinglePaymentMethod = skipListWhenSinglePaymentMethod,
+                isRemovingStoredPaymentMethodsEnabled = isRemovingStoredPaymentMethodsEnabled,
+                additionalDataForDropInService = additionalDataForDropInService,
+            )
+        }
+    }
+}

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
@@ -128,17 +128,6 @@ class DropInConfiguration private constructor(
             clientKey
         )
 
-        /**
-         * Create a Builder with the same values of an existing Configuration object.
-         */
-        constructor(dropInConfiguration: DropInConfiguration) : super(dropInConfiguration) {
-            amount = dropInConfiguration.amount
-            showPreselectedStoredPaymentMethod = dropInConfiguration.showPreselectedStoredPaymentMethod
-            skipListWhenSinglePaymentMethod = dropInConfiguration.skipListWhenSinglePaymentMethod
-            isRemovingStoredPaymentMethodsEnabled = dropInConfiguration.isRemovingStoredPaymentMethodsEnabled
-            additionalDataForDropInService = dropInConfiguration.additionalDataForDropInService
-        }
-
         override fun setAmount(amount: Amount): Builder {
             if (!CheckoutCurrency.isSupported(amount.currency) || amount.value < 0) {
                 throw CheckoutException("Currency is not valid.")

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
@@ -16,6 +16,8 @@ import com.adyen.checkout.bacs.BacsDirectDebitConfiguration
 import com.adyen.checkout.bcmc.BcmcConfiguration
 import com.adyen.checkout.blik.BlikConfiguration
 import com.adyen.checkout.card.CardConfiguration
+import com.adyen.checkout.components.base.AmountConfiguration
+import com.adyen.checkout.components.base.AmountConfigurationBuilder
 import com.adyen.checkout.components.base.BaseConfigurationBuilder
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.model.payments.Amount
@@ -58,14 +60,14 @@ class DropInConfiguration private constructor(
     override val environment: Environment,
     override val clientKey: String,
     override val isAnalyticsEnabled: Boolean?,
+    override val amount: Amount,
     private val availablePaymentConfigs: HashMap<String, Configuration>,
     internal val availableActionConfigs: HashMap<Class<*>, Configuration>,
-    val amount: Amount,
     val showPreselectedStoredPaymentMethod: Boolean,
     val skipListWhenSinglePaymentMethod: Boolean,
     val isRemovingStoredPaymentMethodsEnabled: Boolean,
     val additionalDataForDropInService: Bundle?,
-) : Configuration {
+) : Configuration, AmountConfiguration {
 
     internal fun <T : Configuration> getConfigurationForPaymentMethod(paymentMethod: String): T? {
         if (availablePaymentConfigs.containsKey(paymentMethod)) {
@@ -89,7 +91,7 @@ class DropInConfiguration private constructor(
      * Builder for creating a [DropInConfiguration] where you can set specific Configurations for a Payment Method
      */
     @Suppress("unused", "TooManyFunctions")
-    class Builder : BaseConfigurationBuilder<DropInConfiguration, Builder> {
+    class Builder : BaseConfigurationBuilder<DropInConfiguration, Builder>, AmountConfigurationBuilder {
 
         internal val availablePaymentConfigs = HashMap<String, Configuration>()
         internal val availableActionConfigs = HashMap<Class<*>, Configuration>()
@@ -137,7 +139,7 @@ class DropInConfiguration private constructor(
             additionalDataForDropInService = dropInConfiguration.additionalDataForDropInService
         }
 
-        fun setAmount(amount: Amount): Builder {
+        override fun setAmount(amount: Amount): Builder {
             if (!CheckoutCurrency.isSupported(amount.currency) || amount.value < 0) {
                 throw CheckoutException("Currency is not valid.")
             }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
@@ -31,6 +31,7 @@ import com.adyen.checkout.core.log.LogUtil
 import com.adyen.checkout.core.log.Logger
 import com.adyen.checkout.dropin.R
 import com.adyen.checkout.dropin.databinding.FragmentGenericActionComponentBinding
+import com.adyen.checkout.dropin.mapToParams
 import com.adyen.checkout.dropin.ui.arguments
 import com.adyen.checkout.dropin.ui.base.DropInBottomSheetDialogFragment
 import com.adyen.checkout.dropin.ui.viewmodel.ActionComponentFragmentEvent
@@ -67,9 +68,8 @@ internal class ActionComponentDialogFragment : DropInBottomSheetDialogFragment()
         binding.header.isVisible = false
 
         try {
-            // We don't need to pass dropInConfiguration as parentConfiguration because actionConfiguration is built
-            // using dropInConfiguration.
-            actionComponent = GenericActionComponentProvider(isCreatedByDropIn = true).get(
+            val componentParams = dropInViewModel.dropInConfiguration.mapToParams(dropInViewModel.amount)
+            actionComponent = GenericActionComponentProvider(componentParams).get(
                 this,
                 requireActivity().application,
                 actionConfiguration

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/viewmodel/PaymentMethodsListViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/viewmodel/PaymentMethodsListViewModel.kt
@@ -11,7 +11,6 @@ package com.adyen.checkout.dropin.ui.viewmodel
 import android.app.Application
 import androidx.lifecycle.ViewModel
 import com.adyen.checkout.components.ComponentAvailableCallback
-import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.model.connection.OrderPaymentMethod
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.model.paymentmethods.StoredPaymentMethod
@@ -43,7 +42,7 @@ internal class PaymentMethodsListViewModel(
     private val order: OrderModel?,
     private val dropInConfiguration: DropInConfiguration,
     private val amount: Amount
-) : ViewModel(), ComponentAvailableCallback<Configuration> {
+) : ViewModel(), ComponentAvailableCallback {
 
     private val _paymentMethodsFlow = MutableStateFlow<List<PaymentMethodListItem>>(emptyList())
     internal val paymentMethodsFlow: StateFlow<List<PaymentMethodListItem>> = _paymentMethodsFlow
@@ -82,7 +81,7 @@ internal class PaymentMethodsListViewModel(
         checkIfListReady()
     }
 
-    override fun onAvailabilityResult(isAvailable: Boolean, paymentMethod: PaymentMethod, config: Configuration?) {
+    override fun onAvailabilityResult(isAvailable: Boolean, paymentMethod: PaymentMethod) {
         Logger.d(TAG, "onAvailabilityResult - ${paymentMethod.type}: $isAvailable")
         paymentMethodsAvailabilityMap[paymentMethod] = isAvailable
         checkIfListReady()

--- a/entercash/src/main/java/com/adyen/checkout/entercash/EntercashComponentProvider.kt
+++ b/entercash/src/main/java/com/adyen/checkout/entercash/EntercashComponentProvider.kt
@@ -19,7 +19,7 @@ import com.adyen.checkout.components.analytics.AnalyticsMapper
 import com.adyen.checkout.components.analytics.AnalyticsSource
 import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
 import com.adyen.checkout.components.api.AnalyticsService
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
@@ -32,11 +32,10 @@ import com.adyen.checkout.issuerlist.IssuerListComponentParamsMapper
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class EntercashComponentProvider(
-    parentConfiguration: Configuration? = null,
-    isCreatedByDropIn: Boolean = false,
+    overrideComponentParams: ComponentParams? = null,
 ) : PaymentComponentProvider<EntercashComponent, EntercashConfiguration> {
 
-    private val componentParamsMapper = IssuerListComponentParamsMapper(parentConfiguration, isCreatedByDropIn)
+    private val componentParamsMapper = IssuerListComponentParamsMapper(overrideComponentParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/entercash/src/main/java/com/adyen/checkout/entercash/EntercashConfiguration.kt
+++ b/entercash/src/main/java/com/adyen/checkout/entercash/EntercashConfiguration.kt
@@ -55,16 +55,6 @@ class EntercashConfiguration private constructor(
             clientKey: String
         ) : super(shopperLocale, environment, clientKey)
 
-        /**
-         * Constructor that copies an existing configuration.
-         *
-         * @param configuration A configuration to initialize the builder.
-         */
-        constructor(configuration: EntercashConfiguration) : super(configuration) {
-            viewType = configuration.viewType
-            hideIssuerLogos = configuration.hideIssuerLogos
-        }
-
         override fun buildInternal(): EntercashConfiguration {
             return EntercashConfiguration(
                 shopperLocale = shopperLocale,

--- a/eps/src/main/java/com/adyen/checkout/eps/EPSComponentProvider.kt
+++ b/eps/src/main/java/com/adyen/checkout/eps/EPSComponentProvider.kt
@@ -19,7 +19,7 @@ import com.adyen.checkout.components.analytics.AnalyticsMapper
 import com.adyen.checkout.components.analytics.AnalyticsSource
 import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
 import com.adyen.checkout.components.api.AnalyticsService
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
@@ -32,13 +32,11 @@ import com.adyen.checkout.issuerlist.IssuerListComponentParamsMapper
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class EPSComponentProvider(
-    parentConfiguration: Configuration? = null,
-    isCreatedByDropIn: Boolean = false,
+    overrideComponentParams: ComponentParams? = null,
 ) : PaymentComponentProvider<EPSComponent, EPSConfiguration> {
 
     private val componentParamsMapper = IssuerListComponentParamsMapper(
-        parentConfiguration = parentConfiguration,
-        isCreatedByDropIn = isCreatedByDropIn,
+        overrideComponentParams = overrideComponentParams,
         hideIssuerLogosDefaultValue = true,
     )
 

--- a/eps/src/main/java/com/adyen/checkout/eps/EPSConfiguration.kt
+++ b/eps/src/main/java/com/adyen/checkout/eps/EPSConfiguration.kt
@@ -55,16 +55,6 @@ class EPSConfiguration private constructor(
             clientKey: String
         ) : super(shopperLocale, environment, clientKey)
 
-        /**
-         * Constructor that copies an existing configuration.
-         *
-         * @param configuration A configuration to initialize the builder.
-         */
-        constructor(configuration: EPSConfiguration) : super(configuration) {
-            viewType = configuration.viewType
-            hideIssuerLogos = configuration.hideIssuerLogos
-        }
-
         public override fun buildInternal(): EPSConfiguration {
             return EPSConfiguration(
                 shopperLocale = shopperLocale,

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/configuration/CheckoutConfigurationProvider.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/configuration/CheckoutConfigurationProvider.kt
@@ -45,6 +45,7 @@ internal class CheckoutConfigurationProvider @Inject constructor(
             .addBcmcConfiguration(getBcmcConfiguration())
             .addGooglePayConfiguration(getGooglePayConfiguration())
             .add3ds2ActionConfiguration(get3DS2Configuration())
+            .addRedirectActionConfiguration(getRedirectConfiguration())
             .setEnableRemovingStoredPaymentMethods(true)
 
         try {
@@ -86,11 +87,11 @@ internal class CheckoutConfigurationProvider @Inject constructor(
             .setAmount(amount)
             .build()
 
-    fun get3DS2Configuration(): Adyen3DS2Configuration =
+    private fun get3DS2Configuration(): Adyen3DS2Configuration =
         Adyen3DS2Configuration.Builder(shopperLocale, environment, clientKey)
             .build()
 
-    fun getRedirectConfiguration(): RedirectConfiguration =
+    private fun getRedirectConfiguration(): RedirectConfiguration =
         RedirectConfiguration.Builder(shopperLocale, environment, clientKey)
             .build()
 

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardComponentProvider.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardComponentProvider.kt
@@ -19,7 +19,7 @@ import com.adyen.checkout.components.analytics.AnalyticsSource
 import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
 import com.adyen.checkout.components.api.AnalyticsService
 import com.adyen.checkout.components.api.PublicKeyService
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.base.GenericComponentParamsMapper
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
@@ -33,11 +33,10 @@ import com.adyen.checkout.cse.DefaultGenericEncrypter
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class GiftCardComponentProvider(
-    parentConfiguration: Configuration? = null,
-    isCreatedByDropIn: Boolean = false,
+    overrideComponentParams: ComponentParams? = null
 ) : PaymentComponentProvider<GiftCardComponent, GiftCardConfiguration> {
 
-    private val componentParamsMapper = GenericComponentParamsMapper(parentConfiguration, isCreatedByDropIn)
+    private val componentParamsMapper = GenericComponentParamsMapper(overrideComponentParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardConfiguration.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardConfiguration.kt
@@ -53,13 +53,6 @@ class GiftCardConfiguration private constructor(
             clientKey
         )
 
-        /**
-         * Constructor that copies an existing configuration.
-         *
-         * @param configuration A configuration to initialize the builder.
-         */
-        constructor(configuration: GiftCardConfiguration) : super(configuration)
-
         override fun buildInternal(): GiftCardConfiguration {
             return GiftCardConfiguration(
                 shopperLocale = shopperLocale,

--- a/giftcard/src/test/java/com/adyen/checkout/giftcard/DefaultGiftCardDelegateTest.kt
+++ b/giftcard/src/test/java/com/adyen/checkout/giftcard/DefaultGiftCardDelegateTest.kt
@@ -58,10 +58,7 @@ internal class DefaultGiftCardDelegateTest(
             observerRepository = PaymentObserverRepository(),
             paymentMethod = PaymentMethod(),
             publicKeyRepository = publicKeyRepository,
-            componentParams = GenericComponentParamsMapper(
-                parentConfiguration = null,
-                isCreatedByDropIn = false
-            ).mapToParams(configuration),
+            componentParams = GenericComponentParamsMapper(null).mapToParams(configuration),
             cardEncrypter = cardEncrypter,
             analyticsRepository = analyticsRepository,
         )

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayComponentParams.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayComponentParams.kt
@@ -8,14 +8,15 @@
 
 package com.adyen.checkout.googlepay
 
+import com.adyen.checkout.components.base.AmountComponentParams
 import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.model.payments.Amount
 import com.adyen.checkout.core.api.Environment
 import com.adyen.checkout.googlepay.model.BillingAddressParameters
 import com.adyen.checkout.googlepay.model.MerchantInfo
 import com.adyen.checkout.googlepay.model.ShippingAddressParameters
-import java.util.Locale
 import kotlinx.parcelize.Parcelize
+import java.util.Locale
 
 @Parcelize
 internal data class GooglePayComponentParams(
@@ -24,9 +25,9 @@ internal data class GooglePayComponentParams(
     override val clientKey: String,
     override val isAnalyticsEnabled: Boolean,
     override val isCreatedByDropIn: Boolean,
+    override val amount: Amount,
     val gatewayMerchantId: String,
     val googlePayEnvironment: Int,
-    val amount: Amount,
     val totalPriceStatus: String,
     val countryCode: String?,
     val merchantInfo: MerchantInfo?,
@@ -39,4 +40,4 @@ internal data class GooglePayComponentParams(
     val shippingAddressParameters: ShippingAddressParameters?,
     val isBillingAddressRequired: Boolean,
     val billingAddressParameters: BillingAddressParameters?,
-) : ComponentParams
+) : ComponentParams, AmountComponentParams

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayComponentParamsMapper.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayComponentParamsMapper.kt
@@ -8,7 +8,7 @@
 
 package com.adyen.checkout.googlepay
 
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.model.payments.Amount
 import com.adyen.checkout.components.util.CheckoutCurrency
@@ -21,61 +21,53 @@ import com.adyen.checkout.googlepay.util.AllowedCardNetworks
 import com.google.android.gms.wallet.WalletConstants
 
 internal class GooglePayComponentParamsMapper(
-    private val parentConfiguration: Configuration?,
-    private val isCreatedByDropIn: Boolean,
+    private val overrideComponentParams: ComponentParams?,
 ) {
 
     fun mapToParams(
         googlePayConfiguration: GooglePayConfiguration,
         paymentMethod: PaymentMethod,
     ): GooglePayComponentParams {
-        return mapToParams(
-            parentConfiguration = parentConfiguration ?: googlePayConfiguration,
-            googlePayConfiguration = googlePayConfiguration,
-            paymentMethod = paymentMethod,
-        )
+        return googlePayConfiguration
+            .mapToParamsInternal(paymentMethod)
+            .override(overrideComponentParams)
     }
 
-    private fun mapToParams(
-        parentConfiguration: Configuration,
-        googlePayConfiguration: GooglePayConfiguration,
+    private fun GooglePayConfiguration.mapToParamsInternal(
         paymentMethod: PaymentMethod,
     ): GooglePayComponentParams {
-        with(googlePayConfiguration) {
-            return GooglePayComponentParams(
-                shopperLocale = parentConfiguration.shopperLocale,
-                environment = parentConfiguration.environment,
-                clientKey = parentConfiguration.clientKey,
-                isAnalyticsEnabled = parentConfiguration.isAnalyticsEnabled ?: true,
-                isCreatedByDropIn = isCreatedByDropIn,
-                gatewayMerchantId = getPreferredGatewayMerchantId(googlePayConfiguration, paymentMethod),
-                allowedAuthMethods = getAvailableAuthMethods(googlePayConfiguration),
-                allowedCardNetworks = getAvailableCardNetworks(googlePayConfiguration, paymentMethod),
-                googlePayEnvironment = getGooglePayEnvironment(googlePayConfiguration),
-                amount = amount ?: DEFAULT_AMOUNT,
-                totalPriceStatus = totalPriceStatus ?: DEFAULT_TOTAL_PRICE_STATUS,
-                countryCode = countryCode,
-                merchantInfo = merchantInfo,
-                isAllowPrepaidCards = isAllowPrepaidCards ?: false,
-                isEmailRequired = isEmailRequired ?: false,
-                isExistingPaymentMethodRequired = isExistingPaymentMethodRequired ?: false,
-                isShippingAddressRequired = isShippingAddressRequired ?: false,
-                shippingAddressParameters = shippingAddressParameters,
-                isBillingAddressRequired = isBillingAddressRequired ?: false,
-                billingAddressParameters = billingAddressParameters,
-            )
-        }
+        return GooglePayComponentParams(
+            shopperLocale = shopperLocale,
+            environment = environment,
+            clientKey = clientKey,
+            isAnalyticsEnabled = isAnalyticsEnabled ?: true,
+            isCreatedByDropIn = false,
+            gatewayMerchantId = getPreferredGatewayMerchantId(paymentMethod),
+            allowedAuthMethods = getAvailableAuthMethods(),
+            allowedCardNetworks = getAvailableCardNetworks(paymentMethod),
+            googlePayEnvironment = getGooglePayEnvironment(),
+            amount = amount ?: DEFAULT_AMOUNT,
+            totalPriceStatus = totalPriceStatus ?: DEFAULT_TOTAL_PRICE_STATUS,
+            countryCode = countryCode,
+            merchantInfo = merchantInfo,
+            isAllowPrepaidCards = isAllowPrepaidCards ?: false,
+            isEmailRequired = isEmailRequired ?: false,
+            isExistingPaymentMethodRequired = isExistingPaymentMethodRequired ?: false,
+            isShippingAddressRequired = isShippingAddressRequired ?: false,
+            shippingAddressParameters = shippingAddressParameters,
+            isBillingAddressRequired = isBillingAddressRequired ?: false,
+            billingAddressParameters = billingAddressParameters,
+        )
     }
 
     /**
      * Returns the [GooglePayConfiguration.merchantAccount] if set, or falls back to the
      * paymentMethod.configuration.gatewayMerchantId field returned by the API.
      */
-    private fun getPreferredGatewayMerchantId(
-        googlePayConfiguration: GooglePayConfiguration,
+    private fun GooglePayConfiguration.getPreferredGatewayMerchantId(
         paymentMethod: PaymentMethod,
     ): String {
-        return googlePayConfiguration.merchantAccount
+        return merchantAccount
             ?: paymentMethod.configuration?.gatewayMerchantId
             ?: throw ComponentException(
                 "GooglePay merchantAccount not found. Update your API version or pass it manually inside your " +
@@ -83,16 +75,15 @@ internal class GooglePayComponentParamsMapper(
             )
     }
 
-    private fun getAvailableAuthMethods(googlePayConfiguration: GooglePayConfiguration): List<String> {
-        return googlePayConfiguration.allowedAuthMethods
+    private fun GooglePayConfiguration.getAvailableAuthMethods(): List<String> {
+        return allowedAuthMethods
             ?: AllowedAuthMethods.allAllowedAuthMethods
     }
 
-    private fun getAvailableCardNetworks(
-        googlePayConfiguration: GooglePayConfiguration,
+    private fun GooglePayConfiguration.getAvailableCardNetworks(
         paymentMethod: PaymentMethod
     ): List<String> {
-        return googlePayConfiguration.allowedCardNetworks
+        return allowedCardNetworks
             ?: getAvailableCardNetworksFromApi(paymentMethod)
             ?: AllowedCardNetworks.allAllowedCardNetworks
     }
@@ -114,13 +105,23 @@ internal class GooglePayComponentParamsMapper(
         }
     }
 
-    private fun getGooglePayEnvironment(googlePayConfiguration: GooglePayConfiguration): Int {
-        val googlePayEnvironment = googlePayConfiguration.googlePayEnvironment
+    private fun GooglePayConfiguration.getGooglePayEnvironment(): Int {
         return when {
             googlePayEnvironment != null -> googlePayEnvironment
-            googlePayConfiguration.environment == Environment.TEST -> WalletConstants.ENVIRONMENT_TEST
+            environment == Environment.TEST -> WalletConstants.ENVIRONMENT_TEST
             else -> WalletConstants.ENVIRONMENT_PRODUCTION
         }
+    }
+
+    private fun GooglePayComponentParams.override(overrideComponentParams: ComponentParams?): GooglePayComponentParams {
+        if (overrideComponentParams == null) return this
+        return copy(
+            shopperLocale = overrideComponentParams.shopperLocale,
+            environment = overrideComponentParams.environment,
+            clientKey = overrideComponentParams.clientKey,
+            isAnalyticsEnabled = overrideComponentParams.isAnalyticsEnabled,
+            isCreatedByDropIn = overrideComponentParams.isCreatedByDropIn,
+        )
     }
 
     companion object {

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayComponentParamsMapper.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayComponentParamsMapper.kt
@@ -8,6 +8,7 @@
 
 package com.adyen.checkout.googlepay
 
+import com.adyen.checkout.components.base.AmountComponentParams
 import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.model.payments.Amount
@@ -115,12 +116,14 @@ internal class GooglePayComponentParamsMapper(
 
     private fun GooglePayComponentParams.override(overrideComponentParams: ComponentParams?): GooglePayComponentParams {
         if (overrideComponentParams == null) return this
+        val amount = (overrideComponentParams as? AmountComponentParams)?.amount ?: amount
         return copy(
             shopperLocale = overrideComponentParams.shopperLocale,
             environment = overrideComponentParams.environment,
             clientKey = overrideComponentParams.clientKey,
             isAnalyticsEnabled = overrideComponentParams.isAnalyticsEnabled,
             isCreatedByDropIn = overrideComponentParams.isCreatedByDropIn,
+            amount = amount,
         )
     }
 

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayComponentProvider.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayComponentProvider.kt
@@ -86,7 +86,7 @@ class GooglePayComponentProvider(
         applicationContext: Application,
         paymentMethod: PaymentMethod,
         configuration: GooglePayConfiguration?,
-        callback: ComponentAvailableCallback<GooglePayConfiguration>
+        callback: ComponentAvailableCallback
     ) {
         if (configuration == null) {
             throw CheckoutException("GooglePayConfiguration cannot be null")
@@ -95,7 +95,7 @@ class GooglePayComponentProvider(
             GoogleApiAvailability.getInstance()
                 .isGooglePlayServicesAvailable(applicationContext) != ConnectionResult.SUCCESS
         ) {
-            callback.onAvailabilityResult(false, paymentMethod, configuration)
+            callback.onAvailabilityResult(false, paymentMethod)
             return
         }
         val callbackWeakReference = WeakReference(callback)
@@ -107,15 +107,15 @@ class GooglePayComponentProvider(
         val readyToPayRequest = GooglePayUtils.createIsReadyToPayRequest(componentParams)
         val readyToPayTask = paymentsClient.isReadyToPay(readyToPayRequest)
         readyToPayTask.addOnSuccessListener { result ->
-            callbackWeakReference.get()?.onAvailabilityResult(result == true, paymentMethod, configuration)
+            callbackWeakReference.get()?.onAvailabilityResult(result == true, paymentMethod)
         }
         readyToPayTask.addOnCanceledListener {
             Logger.e(TAG, "GooglePay readyToPay task is cancelled.")
-            callbackWeakReference.get()?.onAvailabilityResult(false, paymentMethod, configuration)
+            callbackWeakReference.get()?.onAvailabilityResult(false, paymentMethod)
         }
         readyToPayTask.addOnFailureListener {
             Logger.e(TAG, "GooglePay readyToPay task is failed.", it)
-            callbackWeakReference.get()?.onAvailabilityResult(false, paymentMethod, configuration)
+            callbackWeakReference.get()?.onAvailabilityResult(false, paymentMethod)
         }
     }
 

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayComponentProvider.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayComponentProvider.kt
@@ -20,7 +20,7 @@ import com.adyen.checkout.components.analytics.AnalyticsMapper
 import com.adyen.checkout.components.analytics.AnalyticsSource
 import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
 import com.adyen.checkout.components.api.AnalyticsService
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
@@ -40,12 +40,11 @@ private val TAG = LogUtil.getTag()
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class GooglePayComponentProvider(
-    parentConfiguration: Configuration? = null,
-    isCreatedByDropIn: Boolean = false,
+    overrideComponentParams: ComponentParams? = null,
 ) : PaymentComponentProvider<GooglePayComponent, GooglePayConfiguration>,
     PaymentMethodAvailabilityCheck<GooglePayConfiguration> {
 
-    private val componentParamsMapper = GooglePayComponentParamsMapper(parentConfiguration, isCreatedByDropIn)
+    private val componentParamsMapper = GooglePayComponentParamsMapper(overrideComponentParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.kt
@@ -98,29 +98,6 @@ class GooglePayConfiguration private constructor(
         ) : super(shopperLocale, environment, clientKey)
 
         /**
-         * Constructor that copies an existing configuration.
-         *
-         * @param configuration A configuration to initialize the builder.
-         */
-        constructor(configuration: GooglePayConfiguration) : super(configuration) {
-            merchantAccount = configuration.merchantAccount
-            googlePayEnvironment = configuration.googlePayEnvironment
-            amount = configuration.amount
-            totalPriceStatus = configuration.totalPriceStatus
-            countryCode = configuration.countryCode
-            merchantInfo = configuration.merchantInfo
-            allowedAuthMethods = configuration.allowedAuthMethods
-            allowedCardNetworks = configuration.allowedCardNetworks
-            isAllowPrepaidCards = configuration.isAllowPrepaidCards
-            isEmailRequired = configuration.isEmailRequired
-            isExistingPaymentMethodRequired = configuration.isExistingPaymentMethodRequired
-            isShippingAddressRequired = configuration.isShippingAddressRequired
-            shippingAddressParameters = configuration.shippingAddressParameters
-            isBillingAddressRequired = configuration.isBillingAddressRequired
-            billingAddressParameters = configuration.billingAddressParameters
-        }
-
-        /**
          * Set the merchant account to be put in the payment token from Google to Adyen.
          *
          * If not set then [PaymentMethod.configuration.gatewayMerchantId] will be used.

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/DefaultGooglePayDelegateTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/DefaultGooglePayDelegateTest.kt
@@ -56,10 +56,7 @@ internal class DefaultGooglePayDelegateTest(
         delegate = DefaultGooglePayDelegate(
             observerRepository = PaymentObserverRepository(),
             paymentMethod = PaymentMethod(),
-            componentParams = GooglePayComponentParamsMapper(
-                parentConfiguration = null,
-                isCreatedByDropIn = false
-            ).mapToParams(configuration, paymentMethod),
+            componentParams = GooglePayComponentParamsMapper(null).mapToParams(configuration, paymentMethod),
             analyticsRepository = analyticsRepository,
         )
     }

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/GooglePayComponentParamsMapperTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/GooglePayComponentParamsMapperTest.kt
@@ -8,6 +8,7 @@
 
 package com.adyen.checkout.googlepay
 
+import com.adyen.checkout.components.base.GenericComponentParams
 import com.adyen.checkout.components.model.paymentmethods.Configuration
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.model.payments.Amount
@@ -37,10 +38,7 @@ internal class GooglePayComponentParamsMapperTest {
     fun `when parent configuration is null and custom google pay configuration fields are null then all fields should match`() {
         val googlePayConfiguration = getGooglePayConfigurationBuilder().build()
 
-        val params = GooglePayComponentParamsMapper(
-            parentConfiguration = null,
-            isCreatedByDropIn = false
-        ).mapToParams(googlePayConfiguration, PaymentMethod())
+        val params = GooglePayComponentParamsMapper(null).mapToParams(googlePayConfiguration, PaymentMethod())
 
         val expected = getGooglePayComponentParams()
 
@@ -66,10 +64,7 @@ internal class GooglePayComponentParamsMapperTest {
             .setShippingAddressParameters(shippingAddressParameters).setShippingAddressRequired(true)
             .setTotalPriceStatus("STATUS").build()
 
-        val params = GooglePayComponentParamsMapper(
-            parentConfiguration = null,
-            isCreatedByDropIn = false
-        ).mapToParams(googlePayConfiguration, PaymentMethod())
+        val params = GooglePayComponentParamsMapper(null).mapToParams(googlePayConfiguration, PaymentMethod())
 
         val expected = getGooglePayComponentParams(
             shopperLocale = Locale.FRANCE,
@@ -99,18 +94,17 @@ internal class GooglePayComponentParamsMapperTest {
     fun `when parent configuration is set then parent configuration fields should override google pay configuration fields`() {
         val googlePayConfiguration = getGooglePayConfigurationBuilder().build()
 
-        // this is in practice DropInConfiguration, but we don't have access to it in this module and any Configuration
-        // class can work
-        val parentConfiguration = GooglePayConfiguration.Builder(
-            Locale.GERMAN, Environment.EUROPE, TEST_CLIENT_KEY_2
+        // this is in practice DropInComponentParams, but we don't have access to it in this module and any
+        // ComponentParams class can work
+        val overrideParams = GenericComponentParams(
+            shopperLocale = Locale.GERMAN,
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+            isAnalyticsEnabled = false,
+            isCreatedByDropIn = true,
         )
-            .setAnalyticsEnabled(false)
-            .build()
 
-        val params = GooglePayComponentParamsMapper(
-            parentConfiguration = parentConfiguration,
-            isCreatedByDropIn = true
-        ).mapToParams(
+        val params = GooglePayComponentParamsMapper(overrideParams).mapToParams(
             googlePayConfiguration, PaymentMethod()
         )
 
@@ -137,10 +131,7 @@ internal class GooglePayComponentParamsMapperTest {
             )
         )
 
-        val params = GooglePayComponentParamsMapper(
-            parentConfiguration = null,
-            isCreatedByDropIn = false
-        ).mapToParams(googlePayConfiguration, paymentMethod)
+        val params = GooglePayComponentParamsMapper(null).mapToParams(googlePayConfiguration, paymentMethod)
 
         val expected = getGooglePayComponentParams(
             gatewayMerchantId = "GATEWAY_MERCHANT_ID_1"
@@ -161,10 +152,7 @@ internal class GooglePayComponentParamsMapperTest {
             )
         )
 
-        val params = GooglePayComponentParamsMapper(
-            parentConfiguration = null,
-            isCreatedByDropIn = false
-        ).mapToParams(googlePayConfiguration, paymentMethod)
+        val params = GooglePayComponentParamsMapper(null).mapToParams(googlePayConfiguration, paymentMethod)
 
         val expected = getGooglePayComponentParams(
             gatewayMerchantId = "GATEWAY_MERCHANT_ID_2"
@@ -180,10 +168,7 @@ internal class GooglePayComponentParamsMapperTest {
         ).build()
 
         assertThrows<ComponentException> {
-            GooglePayComponentParamsMapper(
-                parentConfiguration = null,
-                isCreatedByDropIn = false
-            ).mapToParams(googlePayConfiguration, PaymentMethod())
+            GooglePayComponentParamsMapper(null).mapToParams(googlePayConfiguration, PaymentMethod())
         }
     }
 
@@ -195,10 +180,7 @@ internal class GooglePayComponentParamsMapperTest {
             brands = listOf("mc", "amex", "maestro", "discover")
         )
 
-        val params = GooglePayComponentParamsMapper(
-            parentConfiguration = null,
-            isCreatedByDropIn = false
-        ).mapToParams(googlePayConfiguration, paymentMethod)
+        val params = GooglePayComponentParamsMapper(null).mapToParams(googlePayConfiguration, paymentMethod)
 
         val expected = getGooglePayComponentParams(
             allowedCardNetworks = listOf("MASTERCARD", "AMEX", "DISCOVER")
@@ -212,10 +194,7 @@ internal class GooglePayComponentParamsMapperTest {
         val googlePayConfiguration =
             getGooglePayConfigurationBuilder().setGooglePayEnvironment(WalletConstants.ENVIRONMENT_PRODUCTION).build()
 
-        val params = GooglePayComponentParamsMapper(
-            parentConfiguration = null,
-            isCreatedByDropIn = false
-        ).mapToParams(googlePayConfiguration, PaymentMethod())
+        val params = GooglePayComponentParamsMapper(null).mapToParams(googlePayConfiguration, PaymentMethod())
 
         val expected = getGooglePayComponentParams(
             googlePayEnvironment = WalletConstants.ENVIRONMENT_PRODUCTION
@@ -228,10 +207,7 @@ internal class GooglePayComponentParamsMapperTest {
     fun `when google pay environment is not set and environment is TEST then google pay environment should be ENVIRONMENT_TEST`() {
         val googlePayConfiguration = getGooglePayConfigurationBuilder().build()
 
-        val params = GooglePayComponentParamsMapper(
-            parentConfiguration = null,
-            isCreatedByDropIn = false
-        ).mapToParams(googlePayConfiguration, PaymentMethod())
+        val params = GooglePayComponentParamsMapper(null).mapToParams(googlePayConfiguration, PaymentMethod())
 
         val expected = getGooglePayComponentParams(
             googlePayEnvironment = WalletConstants.ENVIRONMENT_TEST
@@ -246,10 +222,7 @@ internal class GooglePayComponentParamsMapperTest {
             shopperLocale = Locale.CHINA, environment = Environment.UNITED_STATES, clientKey = TEST_CLIENT_KEY_2
         ).setMerchantAccount(TEST_GATEWAY_MERCHANT_ID).build()
 
-        val params = GooglePayComponentParamsMapper(
-            parentConfiguration = null,
-            isCreatedByDropIn = false
-        ).mapToParams(googlePayConfiguration, PaymentMethod())
+        val params = GooglePayComponentParamsMapper(null).mapToParams(googlePayConfiguration, PaymentMethod())
 
         val expected = getGooglePayComponentParams(
             shopperLocale = Locale.CHINA,

--- a/ideal/src/main/java/com/adyen/checkout/ideal/IdealComponentProvider.kt
+++ b/ideal/src/main/java/com/adyen/checkout/ideal/IdealComponentProvider.kt
@@ -19,7 +19,7 @@ import com.adyen.checkout.components.analytics.AnalyticsMapper
 import com.adyen.checkout.components.analytics.AnalyticsSource
 import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
 import com.adyen.checkout.components.api.AnalyticsService
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
@@ -32,11 +32,10 @@ import com.adyen.checkout.issuerlist.IssuerListComponentParamsMapper
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class IdealComponentProvider(
-    parentConfiguration: Configuration? = null,
-    isCreatedByDropIn: Boolean = false,
+    overrideComponentParams: ComponentParams? = null,
 ) : PaymentComponentProvider<IdealComponent, IdealConfiguration> {
 
-    private val componentParamsMapper = IssuerListComponentParamsMapper(parentConfiguration, isCreatedByDropIn)
+    private val componentParamsMapper = IssuerListComponentParamsMapper(overrideComponentParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/ideal/src/main/java/com/adyen/checkout/ideal/IdealConfiguration.kt
+++ b/ideal/src/main/java/com/adyen/checkout/ideal/IdealConfiguration.kt
@@ -55,16 +55,6 @@ class IdealConfiguration private constructor(
             clientKey: String
         ) : super(shopperLocale, environment, clientKey)
 
-        /**
-         * Constructor that copies an existing configuration.
-         *
-         * @param configuration A configuration to initialize the builder.
-         */
-        constructor(configuration: IdealConfiguration) : super(configuration) {
-            viewType = configuration.viewType
-            hideIssuerLogos = configuration.hideIssuerLogos
-        }
-
         override fun buildInternal(): IdealConfiguration {
             return IdealConfiguration(
                 shopperLocale = shopperLocale,

--- a/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentComponentProvider.kt
+++ b/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentComponentProvider.kt
@@ -19,7 +19,7 @@ import com.adyen.checkout.components.analytics.AnalyticsMapper
 import com.adyen.checkout.components.analytics.AnalyticsSource
 import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
 import com.adyen.checkout.components.api.AnalyticsService
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.base.GenericComponentParamsMapper
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
@@ -31,11 +31,10 @@ import com.adyen.checkout.core.exception.ComponentException
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class InstantPaymentComponentProvider(
-    parentConfiguration: Configuration? = null,
-    isCreatedByDropIn: Boolean = false,
+    overrideComponentParams: ComponentParams? = null
 ) : PaymentComponentProvider<InstantPaymentComponent, InstantPaymentConfiguration> {
 
-    private val componentParamsMapper = GenericComponentParamsMapper(parentConfiguration, isCreatedByDropIn)
+    private val componentParamsMapper = GenericComponentParamsMapper(overrideComponentParams)
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,
         viewModelStoreOwner: ViewModelStoreOwner,

--- a/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentConfiguration.kt
+++ b/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentConfiguration.kt
@@ -54,13 +54,6 @@ class InstantPaymentConfiguration private constructor(
             clientKey
         )
 
-        /**
-         * Constructor that copies an existing configuration.
-         *
-         * @param configuration A configuration to initialize the builder.
-         */
-        constructor(configuration: InstantPaymentConfiguration) : super(configuration)
-
         override fun buildInternal(): InstantPaymentConfiguration {
             return InstantPaymentConfiguration(
                 shopperLocale = shopperLocale,

--- a/instant/src/test/java/com/adyen/checkout/instant/DefaultInstantPaymentDelegateTest.kt
+++ b/instant/src/test/java/com/adyen/checkout/instant/DefaultInstantPaymentDelegateTest.kt
@@ -47,10 +47,7 @@ class DefaultInstantPaymentDelegateTest(
         delegate = DefaultInstantPaymentDelegate(
             observerRepository = PaymentObserverRepository(),
             paymentMethod = PaymentMethod(type = TYPE),
-            componentParams = GenericComponentParamsMapper(
-                parentConfiguration = null,
-                isCreatedByDropIn = false
-            ).mapToParams(configuration),
+            componentParams = GenericComponentParamsMapper(null).mapToParams(configuration),
             analyticsRepository = analyticsRepository
         )
         Logger.setLogcatLevel(Logger.NONE)

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/IssuerListComponentParamsMapper.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/IssuerListComponentParamsMapper.kt
@@ -9,38 +9,44 @@
 package com.adyen.checkout.issuerlist
 
 import androidx.annotation.RestrictTo
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class IssuerListComponentParamsMapper(
-    private val parentConfiguration: Configuration?,
-    private val isCreatedByDropIn: Boolean,
+    private val overrideComponentParams: ComponentParams?,
     private val hideIssuerLogosDefaultValue: Boolean = false,
 ) {
 
     fun mapToParams(
         issuerListConfiguration: IssuerListConfiguration
     ): IssuerListComponentParams {
-        return mapToParams(
-            parentConfiguration = parentConfiguration ?: issuerListConfiguration,
-            issuerListConfiguration = issuerListConfiguration,
+        return issuerListConfiguration
+            .mapToParamsInternal()
+            .override(overrideComponentParams)
+    }
+
+    private fun IssuerListConfiguration.mapToParamsInternal(): IssuerListComponentParams {
+        return IssuerListComponentParams(
+            shopperLocale = shopperLocale,
+            environment = environment,
+            clientKey = clientKey,
+            isAnalyticsEnabled = isAnalyticsEnabled ?: true,
+            isCreatedByDropIn = false,
+            viewType = viewType ?: IssuerListViewType.RECYCLER_VIEW,
+            hideIssuerLogos = hideIssuerLogos ?: hideIssuerLogosDefaultValue,
         )
     }
 
-    private fun mapToParams(
-        parentConfiguration: Configuration,
-        issuerListConfiguration: IssuerListConfiguration,
+    private fun IssuerListComponentParams.override(
+        overrideComponentParams: ComponentParams?
     ): IssuerListComponentParams {
-        with(issuerListConfiguration) {
-            return IssuerListComponentParams(
-                shopperLocale = parentConfiguration.shopperLocale,
-                environment = parentConfiguration.environment,
-                clientKey = parentConfiguration.clientKey,
-                isAnalyticsEnabled = parentConfiguration.isAnalyticsEnabled ?: true,
-                isCreatedByDropIn = isCreatedByDropIn,
-                viewType = viewType ?: IssuerListViewType.RECYCLER_VIEW,
-                hideIssuerLogos = hideIssuerLogos ?: hideIssuerLogosDefaultValue,
-            )
-        }
+        if (overrideComponentParams == null) return this
+        return copy(
+            shopperLocale = overrideComponentParams.shopperLocale,
+            environment = overrideComponentParams.environment,
+            clientKey = overrideComponentParams.clientKey,
+            isAnalyticsEnabled = overrideComponentParams.isAnalyticsEnabled,
+            isCreatedByDropIn = overrideComponentParams.isCreatedByDropIn,
+        )
     }
 }

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/IssuerListConfiguration.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/IssuerListConfiguration.kt
@@ -38,8 +38,6 @@ abstract class IssuerListConfiguration : Configuration {
             clientKey: String
         ) : super(shopperLocale, environment, clientKey)
 
-        protected constructor(configuration: IssuerListConfigurationT) : super(configuration)
-
         /**
          * Sets the type of the view to be show with the component.
          *

--- a/issuer-list/src/test/java/com/adyen/checkout/issuerlist/DefaultIssuerListDelegateTest.kt
+++ b/issuer-list/src/test/java/com/adyen/checkout/issuerlist/DefaultIssuerListDelegateTest.kt
@@ -53,10 +53,7 @@ internal class DefaultIssuerListDelegateTest(
     fun beforeEach() {
         delegate = DefaultIssuerListDelegate(
             observerRepository = PaymentObserverRepository(),
-            componentParams = IssuerListComponentParamsMapper(
-                parentConfiguration = null,
-                isCreatedByDropIn = false
-            ).mapToParams(configuration),
+            componentParams = IssuerListComponentParamsMapper(null).mapToParams(configuration),
             paymentMethod = PaymentMethod(),
             analyticsRepository = analyticsRepository,
         ) { TestIssuerPaymentMethod() }
@@ -144,10 +141,7 @@ internal class DefaultIssuerListDelegateTest(
 
         delegate = DefaultIssuerListDelegate(
             observerRepository = PaymentObserverRepository(),
-            componentParams = IssuerListComponentParamsMapper(
-                parentConfiguration = null,
-                isCreatedByDropIn = false
-            ).mapToParams(configuration),
+            componentParams = IssuerListComponentParamsMapper(null).mapToParams(configuration),
             paymentMethod = PaymentMethod(),
             analyticsRepository = analyticsRepository
         ) { TestIssuerPaymentMethod() }
@@ -169,10 +163,7 @@ internal class DefaultIssuerListDelegateTest(
 
         delegate = DefaultIssuerListDelegate(
             observerRepository = PaymentObserverRepository(),
-            componentParams = IssuerListComponentParamsMapper(
-                parentConfiguration = null,
-                isCreatedByDropIn = false
-            ).mapToParams(configuration),
+            componentParams = IssuerListComponentParamsMapper(null).mapToParams(configuration),
             paymentMethod = PaymentMethod(),
             analyticsRepository = analyticsRepository,
         ) { TestIssuerPaymentMethod() }

--- a/issuer-list/src/test/java/com/adyen/checkout/issuerlist/IssuerListComponentParamsMapperTest.kt
+++ b/issuer-list/src/test/java/com/adyen/checkout/issuerlist/IssuerListComponentParamsMapperTest.kt
@@ -6,6 +6,7 @@
  * Created by josephj on 17/11/2022.
  */
 
+import com.adyen.checkout.components.base.GenericComponentParams
 import com.adyen.checkout.core.api.Environment
 import com.adyen.checkout.issuerlist.IssuerListComponentParams
 import com.adyen.checkout.issuerlist.IssuerListComponentParamsMapper
@@ -26,10 +27,7 @@ internal class IssuerListComponentParamsMapperTest {
         )
             .build()
 
-        val params = IssuerListComponentParamsMapper(
-            parentConfiguration = null,
-            isCreatedByDropIn = false
-        ).mapToParams(issuerListConfiguration)
+        val params = IssuerListComponentParamsMapper(null).mapToParams(issuerListConfiguration)
 
         val expected = IssuerListComponentParams(
             shopperLocale = Locale.US,
@@ -55,10 +53,7 @@ internal class IssuerListComponentParamsMapperTest {
             .setViewType(IssuerListViewType.SPINNER_VIEW)
             .build()
 
-        val params = IssuerListComponentParamsMapper(
-            parentConfiguration = null,
-            isCreatedByDropIn = false
-        ).mapToParams(issuerListConfiguration)
+        val params = IssuerListComponentParamsMapper(null).mapToParams(issuerListConfiguration)
 
         val expected = IssuerListComponentParams(
             shopperLocale = Locale.US,
@@ -84,20 +79,17 @@ internal class IssuerListComponentParamsMapperTest {
             .setViewType(IssuerListViewType.SPINNER_VIEW)
             .build()
 
-        // this is in practice DropInConfiguration, but we don't have access to it in this module and any Configuration
-        // class can work
-        val parentConfiguration = TestIssuerListConfiguration.Builder(
+        // this is in practice DropInComponentParams, but we don't have access to it in this module and any
+        // ComponentParams class can work
+        val overrideParams = GenericComponentParams(
             shopperLocale = Locale.GERMAN,
             environment = Environment.EUROPE,
             clientKey = TEST_CLIENT_KEY_2,
+            isAnalyticsEnabled = false,
+            isCreatedByDropIn = true,
         )
-            .setAnalyticsEnabled(false)
-            .build()
 
-        val params = IssuerListComponentParamsMapper(
-            parentConfiguration = parentConfiguration,
-            isCreatedByDropIn = true
-        ).mapToParams(issuerListConfiguration)
+        val params = IssuerListComponentParamsMapper(overrideParams).mapToParams(issuerListConfiguration)
 
         val expected = IssuerListComponentParams(
             shopperLocale = Locale.GERMAN,

--- a/issuer-list/src/test/java/com/adyen/checkout/issuerlist/utils/TestIssuerListConfiguration.kt
+++ b/issuer-list/src/test/java/com/adyen/checkout/issuerlist/utils/TestIssuerListConfiguration.kt
@@ -39,11 +39,6 @@ class TestIssuerListConfiguration private constructor(
             clientKey: String
         ) : super(shopperLocale, environment, clientKey)
 
-        constructor(configuration: TestIssuerListConfiguration) : super(configuration) {
-            viewType = configuration.viewType
-            hideIssuerLogos = configuration.hideIssuerLogos
-        }
-
         public override fun buildInternal(): TestIssuerListConfiguration {
             return TestIssuerListConfiguration(
                 shopperLocale = shopperLocale,

--- a/mbway/src/main/java/com/adyen/checkout/mbway/MBWayComponentProvider.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/MBWayComponentProvider.kt
@@ -19,7 +19,7 @@ import com.adyen.checkout.components.analytics.AnalyticsMapper
 import com.adyen.checkout.components.analytics.AnalyticsSource
 import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
 import com.adyen.checkout.components.api.AnalyticsService
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.base.GenericComponentParamsMapper
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
@@ -30,11 +30,10 @@ import com.adyen.checkout.core.exception.ComponentException
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class MBWayComponentProvider(
-    parentConfiguration: Configuration? = null,
-    isCreatedByDropIn: Boolean = false,
+    overrideComponentParams: ComponentParams? = null
 ) : PaymentComponentProvider<MBWayComponent, MBWayConfiguration> {
 
-    private val componentParamsMapper = GenericComponentParamsMapper(parentConfiguration, isCreatedByDropIn)
+    private val componentParamsMapper = GenericComponentParamsMapper(overrideComponentParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/mbway/src/main/java/com/adyen/checkout/mbway/MBWayConfiguration.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/MBWayConfiguration.kt
@@ -53,13 +53,6 @@ class MBWayConfiguration private constructor(
             clientKey
         )
 
-        /**
-         * Constructor that copies an existing configuration.
-         *
-         * @param configuration A configuration to initialize the builder.
-         */
-        constructor(configuration: MBWayConfiguration) : super(configuration)
-
         override fun buildInternal(): MBWayConfiguration {
             return MBWayConfiguration(
                 shopperLocale = shopperLocale,

--- a/mbway/src/test/java/com/adyen/checkout/mbway/DefaultMBWayDelegateTest.kt
+++ b/mbway/src/test/java/com/adyen/checkout/mbway/DefaultMBWayDelegateTest.kt
@@ -41,10 +41,7 @@ internal class DefaultMBWayDelegateTest(
     private val delegate = DefaultMBWayDelegate(
         observerRepository = PaymentObserverRepository(),
         paymentMethod = PaymentMethod(),
-        componentParams = GenericComponentParamsMapper(
-            parentConfiguration = null,
-            isCreatedByDropIn = false
-        ).mapToParams(configuration),
+        componentParams = GenericComponentParamsMapper(null).mapToParams(configuration),
         analyticsRepository = analyticsRepository,
     )
 

--- a/molpay/src/main/java/com/adyen/checkout/molpay/MolpayComponentProvider.kt
+++ b/molpay/src/main/java/com/adyen/checkout/molpay/MolpayComponentProvider.kt
@@ -19,7 +19,7 @@ import com.adyen.checkout.components.analytics.AnalyticsMapper
 import com.adyen.checkout.components.analytics.AnalyticsSource
 import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
 import com.adyen.checkout.components.api.AnalyticsService
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
@@ -32,11 +32,10 @@ import com.adyen.checkout.issuerlist.IssuerListComponentParamsMapper
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class MolpayComponentProvider(
-    parentConfiguration: Configuration? = null,
-    isCreatedByDropIn: Boolean = false,
+    overrideComponentParams: ComponentParams? = null,
 ) : PaymentComponentProvider<MolpayComponent, MolpayConfiguration> {
 
-    private val componentParamsMapper = IssuerListComponentParamsMapper(parentConfiguration, isCreatedByDropIn)
+    private val componentParamsMapper = IssuerListComponentParamsMapper(overrideComponentParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/molpay/src/main/java/com/adyen/checkout/molpay/MolpayConfiguration.kt
+++ b/molpay/src/main/java/com/adyen/checkout/molpay/MolpayConfiguration.kt
@@ -55,16 +55,6 @@ class MolpayConfiguration private constructor(
             clientKey: String
         ) : super(shopperLocale, environment, clientKey)
 
-        /**
-         * Constructor that copies an existing configuration.
-         *
-         * @param configuration A configuration to initialize the builder.
-         */
-        constructor(configuration: MolpayConfiguration) : super(configuration) {
-            viewType = configuration.viewType
-            hideIssuerLogos = configuration.hideIssuerLogos
-        }
-
         override fun buildInternal(): MolpayConfiguration {
             return MolpayConfiguration(
                 shopperLocale = shopperLocale,

--- a/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/DefaultOnlineBankingDelegateTest.kt
+++ b/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/DefaultOnlineBankingDelegateTest.kt
@@ -63,10 +63,7 @@ internal class DefaultOnlineBankingDelegateTest(
             pdfOpener = pdfOpener,
             paymentMethod = PaymentMethod(),
             analyticsRepository = analyticsRepository,
-            componentParams = GenericComponentParamsMapper(
-                parentConfiguration = null,
-                isCreatedByDropIn = false
-            ).mapToParams(configuration),
+            componentParams = GenericComponentParamsMapper(null).mapToParams(configuration),
             termsAndConditionsUrl = TEST_URL,
             paymentMethodFactory = { OnlineBankingCZPaymentMethod() }
         )

--- a/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZComponentProvider.kt
+++ b/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZComponentProvider.kt
@@ -19,7 +19,7 @@ import com.adyen.checkout.components.analytics.AnalyticsMapper
 import com.adyen.checkout.components.analytics.AnalyticsSource
 import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
 import com.adyen.checkout.components.api.AnalyticsService
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.base.GenericComponentParamsMapper
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
@@ -34,11 +34,10 @@ import com.adyen.checkout.onlinebankingcore.PdfOpener
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class OnlineBankingCZComponentProvider(
-    parentConfiguration: Configuration? = null,
-    isCreatedByDropIn: Boolean = false,
+    overrideComponentParams: ComponentParams? = null
 ) : PaymentComponentProvider<OnlineBankingComponent<OnlineBankingCZPaymentMethod>, OnlineBankingCZConfiguration> {
 
-    private val componentParamsMapper = GenericComponentParamsMapper(parentConfiguration, isCreatedByDropIn)
+    private val componentParamsMapper = GenericComponentParamsMapper(overrideComponentParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZConfiguration.kt
+++ b/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZConfiguration.kt
@@ -51,13 +51,6 @@ class OnlineBankingCZConfiguration private constructor(
             clientKey: String
         ) : super(shopperLocale, environment, clientKey)
 
-        /**
-         * Constructor that copies an existing configuration.
-         *
-         * @param configuration A configuration to initialize the builder.
-         */
-        constructor(configuration: OnlineBankingCZConfiguration) : super(configuration)
-
         override fun buildInternal(): OnlineBankingCZConfiguration {
             return OnlineBankingCZConfiguration(
                 shopperLocale = shopperLocale,

--- a/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLComponentProvider.kt
+++ b/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLComponentProvider.kt
@@ -19,7 +19,7 @@ import com.adyen.checkout.components.analytics.AnalyticsMapper
 import com.adyen.checkout.components.analytics.AnalyticsSource
 import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
 import com.adyen.checkout.components.api.AnalyticsService
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
@@ -32,11 +32,10 @@ import com.adyen.checkout.issuerlist.IssuerListComponentParamsMapper
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class OnlineBankingPLComponentProvider(
-    parentConfiguration: Configuration? = null,
-    isCreatedByDropIn: Boolean = false,
+    overrideComponentParams: ComponentParams? = null,
 ) : PaymentComponentProvider<OnlineBankingPLComponent, OnlineBankingPLConfiguration> {
 
-    private val componentParamsMapper = IssuerListComponentParamsMapper(parentConfiguration, isCreatedByDropIn)
+    private val componentParamsMapper = IssuerListComponentParamsMapper(overrideComponentParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLConfiguration.kt
+++ b/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLConfiguration.kt
@@ -53,16 +53,6 @@ class OnlineBankingPLConfiguration private constructor(
             clientKey: String
         ) : super(shopperLocale, environment, clientKey)
 
-        /**
-         * Constructor that copies an existing configuration.
-         *
-         * @param configuration A configuration to initialize the builder.
-         */
-        constructor(configuration: OnlineBankingPLConfiguration) : super(configuration) {
-            viewType = configuration.viewType
-            hideIssuerLogos = configuration.hideIssuerLogos
-        }
-
         override fun buildInternal(): OnlineBankingPLConfiguration {
             return OnlineBankingPLConfiguration(
                 shopperLocale = shopperLocale,

--- a/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKComponentProvider.kt
+++ b/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKComponentProvider.kt
@@ -19,7 +19,7 @@ import com.adyen.checkout.components.analytics.AnalyticsMapper
 import com.adyen.checkout.components.analytics.AnalyticsSource
 import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
 import com.adyen.checkout.components.api.AnalyticsService
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.base.GenericComponentParamsMapper
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
@@ -34,11 +34,10 @@ import com.adyen.checkout.onlinebankingcore.PdfOpener
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class OnlineBankingSKComponentProvider(
-    parentConfiguration: Configuration? = null,
-    isCreatedByDropIn: Boolean = false,
+    overrideComponentParams: ComponentParams? = null
 ) : PaymentComponentProvider<OnlineBankingComponent<OnlineBankingSKPaymentMethod>, OnlineBankingSKConfiguration> {
 
-    private val componentParamsMapper = GenericComponentParamsMapper(parentConfiguration, isCreatedByDropIn)
+    private val componentParamsMapper = GenericComponentParamsMapper(overrideComponentParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKConfiguration.kt
+++ b/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKConfiguration.kt
@@ -51,13 +51,6 @@ class OnlineBankingSKConfiguration private constructor(
             clientKey: String
         ) : super(shopperLocale, environment, clientKey)
 
-        /**
-         * Constructor that copies an existing configuration.
-         *
-         * @param configuration A configuration to initialize the builder.
-         */
-        constructor(configuration: OnlineBankingSKConfiguration) : super(configuration)
-
         override fun buildInternal(): OnlineBankingSKConfiguration {
             return OnlineBankingSKConfiguration(
                 shopperLocale = shopperLocale,

--- a/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingComponentProvider.kt
+++ b/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingComponentProvider.kt
@@ -19,7 +19,7 @@ import com.adyen.checkout.components.analytics.AnalyticsMapper
 import com.adyen.checkout.components.analytics.AnalyticsSource
 import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
 import com.adyen.checkout.components.api.AnalyticsService
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
@@ -32,11 +32,10 @@ import com.adyen.checkout.issuerlist.IssuerListComponentParamsMapper
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class OpenBankingComponentProvider(
-    parentConfiguration: Configuration? = null,
-    isCreatedByDropIn: Boolean = false,
+    overrideComponentParams: ComponentParams? = null,
 ) : PaymentComponentProvider<OpenBankingComponent, OpenBankingConfiguration> {
 
-    private val componentParamsMapper = IssuerListComponentParamsMapper(parentConfiguration, isCreatedByDropIn)
+    private val componentParamsMapper = IssuerListComponentParamsMapper(overrideComponentParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingConfiguration.kt
+++ b/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingConfiguration.kt
@@ -55,16 +55,6 @@ class OpenBankingConfiguration private constructor(
             clientKey: String
         ) : super(shopperLocale, environment, clientKey)
 
-        /**
-         * Constructor that copies an existing configuration.
-         *
-         * @param configuration A configuration to initialize the builder.
-         */
-        constructor(configuration: OpenBankingConfiguration) : super(configuration) {
-            viewType = configuration.viewType
-            hideIssuerLogos = configuration.hideIssuerLogos
-        }
-
         override fun buildInternal(): OpenBankingConfiguration {
             return OpenBankingConfiguration(
                 shopperLocale = shopperLocale,

--- a/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankComponentProvider.kt
+++ b/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankComponentProvider.kt
@@ -19,7 +19,7 @@ import com.adyen.checkout.components.analytics.AnalyticsMapper
 import com.adyen.checkout.components.analytics.AnalyticsSource
 import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
 import com.adyen.checkout.components.api.AnalyticsService
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.base.GenericComponentParamsMapper
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
@@ -30,11 +30,10 @@ import com.adyen.checkout.core.exception.ComponentException
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class PayByBankComponentProvider(
-    parentConfiguration: Configuration? = null,
-    isCreatedByDropIn: Boolean = false,
+    overrideComponentParams: ComponentParams? = null
 ) : PaymentComponentProvider<PayByBankComponent, PayByBankConfiguration> {
 
-    private val componentParamsMapper = GenericComponentParamsMapper(parentConfiguration, isCreatedByDropIn)
+    private val componentParamsMapper = GenericComponentParamsMapper(overrideComponentParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankConfiguration.kt
+++ b/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankConfiguration.kt
@@ -53,13 +53,6 @@ class PayByBankConfiguration private constructor(
             clientKey: String
         ) : super(shopperLocale, environment, clientKey)
 
-        /**
-         * Constructor that copies an existing configuration.
-         *
-         * @param configuration A configuration to initialize the builder.
-         */
-        constructor(configuration: PayByBankConfiguration) : super(configuration)
-
         override fun buildInternal(): PayByBankConfiguration {
             return PayByBankConfiguration(
                 shopperLocale = shopperLocale,

--- a/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeComponentProvider.kt
+++ b/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeComponentProvider.kt
@@ -16,7 +16,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
 import com.adyen.checkout.components.ActionComponentProvider
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.base.GenericComponentParamsMapper
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
@@ -31,11 +31,10 @@ import com.adyen.checkout.core.api.HttpClientFactory
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class QRCodeComponentProvider(
-    parentConfiguration: Configuration? = null,
-    isCreatedByDropIn: Boolean = false,
+    overrideComponentParams: ComponentParams? = null
 ) : ActionComponentProvider<QRCodeComponent, QRCodeConfiguration, QRCodeDelegate> {
 
-    private val componentParamsMapper = GenericComponentParamsMapper(parentConfiguration, isCreatedByDropIn)
+    private val componentParamsMapper = GenericComponentParamsMapper(overrideComponentParams)
 
     override fun <T> get(
         owner: T,

--- a/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeConfiguration.kt
+++ b/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeConfiguration.kt
@@ -53,13 +53,6 @@ class QRCodeConfiguration private constructor(
             clientKey
         )
 
-        /**
-         * Constructor that copies an existing configuration.
-         *
-         * @param configuration A configuration to initialize the builder.
-         */
-        constructor(configuration: QRCodeConfiguration) : super(configuration)
-
         override fun buildInternal(): QRCodeConfiguration {
             return QRCodeConfiguration(
                 shopperLocale = shopperLocale,

--- a/qr-code/src/test/java/com/adyen/checkout/qrcode/DefaultQRCodeDelegateTest.kt
+++ b/qr-code/src/test/java/com/adyen/checkout/qrcode/DefaultQRCodeDelegateTest.kt
@@ -66,10 +66,7 @@ internal class DefaultQRCodeDelegateTest(
         ).build()
         delegate = DefaultQRCodeDelegate(
             observerRepository = ActionObserverRepository(),
-            componentParams = GenericComponentParamsMapper(
-                parentConfiguration = null,
-                isCreatedByDropIn = false
-            ).mapToParams(configuration),
+            componentParams = GenericComponentParamsMapper(null).mapToParams(configuration),
             statusRepository = statusRepository,
             statusCountDownTimer = countDownTimer,
             redirectHandler = redirectHandler,

--- a/redirect/src/main/java/com/adyen/checkout/redirect/RedirectComponentProvider.kt
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/RedirectComponentProvider.kt
@@ -16,7 +16,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
 import com.adyen.checkout.components.ActionComponentProvider
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.base.GenericComponentParamsMapper
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
@@ -28,11 +28,10 @@ import com.adyen.checkout.components.repository.PaymentDataRepository
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class RedirectComponentProvider(
-    parentConfiguration: Configuration? = null,
-    isCreatedByDropIn: Boolean = false,
+    overrideComponentParams: ComponentParams? = null
 ) : ActionComponentProvider<RedirectComponent, RedirectConfiguration, RedirectDelegate> {
 
-    private val componentParamsMapper = GenericComponentParamsMapper(parentConfiguration, isCreatedByDropIn)
+    private val componentParamsMapper = GenericComponentParamsMapper(overrideComponentParams)
     override fun <T> get(
         owner: T,
         application: Application,

--- a/redirect/src/main/java/com/adyen/checkout/redirect/RedirectConfiguration.kt
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/RedirectConfiguration.kt
@@ -53,13 +53,6 @@ class RedirectConfiguration private constructor(
             clientKey
         )
 
-        /**
-         * Constructor that copies an existing configuration.
-         *
-         * @param configuration A configuration to initialize the builder.
-         */
-        constructor(configuration: RedirectConfiguration) : super(configuration)
-
         override fun buildInternal(): RedirectConfiguration {
             return RedirectConfiguration(
                 shopperLocale = shopperLocale,

--- a/redirect/src/test/java/com/adyen/checkout/redirect/DefaultRedirectDelegateTest.kt
+++ b/redirect/src/test/java/com/adyen/checkout/redirect/DefaultRedirectDelegateTest.kt
@@ -44,10 +44,7 @@ internal class DefaultRedirectDelegateTest {
         paymentDataRepository = PaymentDataRepository(SavedStateHandle())
         delegate = DefaultRedirectDelegate(
             ActionObserverRepository(),
-            GenericComponentParamsMapper(
-                parentConfiguration = null,
-                isCreatedByDropIn = false
-            ).mapToParams(configuration),
+            GenericComponentParamsMapper(null).mapToParams(configuration),
             redirectHandler,
             paymentDataRepository
         )

--- a/sepa/src/main/java/com/adyen/checkout/sepa/SepaComponentProvider.kt
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/SepaComponentProvider.kt
@@ -19,7 +19,7 @@ import com.adyen.checkout.components.analytics.AnalyticsMapper
 import com.adyen.checkout.components.analytics.AnalyticsSource
 import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
 import com.adyen.checkout.components.api.AnalyticsService
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.base.GenericComponentParamsMapper
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
@@ -30,11 +30,10 @@ import com.adyen.checkout.core.exception.ComponentException
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class SepaComponentProvider(
-    parentConfiguration: Configuration? = null,
-    isCreatedByDropIn: Boolean = false,
+    overrideComponentParams: ComponentParams? = null
 ) : PaymentComponentProvider<SepaComponent, SepaConfiguration> {
 
-    private val componentParamsMapper = GenericComponentParamsMapper(parentConfiguration, isCreatedByDropIn)
+    private val componentParamsMapper = GenericComponentParamsMapper(overrideComponentParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/sepa/src/main/java/com/adyen/checkout/sepa/SepaConfiguration.kt
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/SepaConfiguration.kt
@@ -53,13 +53,6 @@ class SepaConfiguration private constructor(
             clientKey: String
         ) : super(shopperLocale, environment, clientKey)
 
-        /**
-         * Constructor that copies an existing configuration.
-         *
-         * @param configuration A configuration to initialize the builder.
-         */
-        constructor(configuration: SepaConfiguration) : super(configuration)
-
         override fun buildInternal(): SepaConfiguration {
             return SepaConfiguration(
                 shopperLocale = shopperLocale,

--- a/sepa/src/test/java/com/adyen/checkout/sepa/DefaultSepaDelegateTest.kt
+++ b/sepa/src/test/java/com/adyen/checkout/sepa/DefaultSepaDelegateTest.kt
@@ -41,10 +41,7 @@ internal class DefaultSepaDelegateTest(
         delegate = DefaultSepaDelegate(
             observerRepository = PaymentObserverRepository(),
             paymentMethod = PaymentMethod(),
-            componentParams = GenericComponentParamsMapper(
-                parentConfiguration = null,
-                isCreatedByDropIn = false
-            ).mapToParams(configuration),
+            componentParams = GenericComponentParamsMapper(null).mapToParams(configuration),
             analyticsRepository = analyticsRepository,
         )
     }

--- a/voucher/src/main/java/com/adyen/checkout/voucher/VoucherComponentProvider.kt
+++ b/voucher/src/main/java/com/adyen/checkout/voucher/VoucherComponentProvider.kt
@@ -16,7 +16,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
 import com.adyen.checkout.components.ActionComponentProvider
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.base.GenericComponentParamsMapper
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
@@ -27,11 +27,10 @@ import com.adyen.checkout.components.util.PaymentMethodTypes
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class VoucherComponentProvider(
-    parentConfiguration: Configuration? = null,
-    isCreatedByDropIn: Boolean = false,
+    overrideComponentParams: ComponentParams? = null
 ) : ActionComponentProvider<VoucherComponent, VoucherConfiguration, VoucherDelegate> {
 
-    private val componentParamsMapper = GenericComponentParamsMapper(parentConfiguration, isCreatedByDropIn)
+    private val componentParamsMapper = GenericComponentParamsMapper(overrideComponentParams)
 
     override fun <T> get(
         owner: T,

--- a/voucher/src/main/java/com/adyen/checkout/voucher/VoucherConfiguration.kt
+++ b/voucher/src/main/java/com/adyen/checkout/voucher/VoucherConfiguration.kt
@@ -51,13 +51,6 @@ class VoucherConfiguration private constructor(
             clientKey
         )
 
-        /**
-         * Constructor that copies an existing configuration.
-         *
-         * @param configuration A configuration to initialize the builder.
-         */
-        constructor(configuration: VoucherConfiguration) : super(configuration)
-
         override fun buildInternal(): VoucherConfiguration {
             return VoucherConfiguration(
                 shopperLocale = shopperLocale,

--- a/voucher/src/test/java/com/adyen/checkout/voucher/DefaultVoucherDelegateTest.kt
+++ b/voucher/src/test/java/com/adyen/checkout/voucher/DefaultVoucherDelegateTest.kt
@@ -31,10 +31,7 @@ internal class DefaultVoucherDelegateTest {
         val configuration = VoucherConfiguration.Builder(Locale.getDefault(), Environment.TEST, TEST_CLIENT_KEY).build()
         delegate = DefaultVoucherDelegate(
             ActionObserverRepository(),
-            GenericComponentParamsMapper(
-                parentConfiguration = null,
-                isCreatedByDropIn = false
-            ).mapToParams(configuration),
+            GenericComponentParamsMapper(null).mapToParams(configuration),
         )
     }
 

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionComponentProvider.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionComponentProvider.kt
@@ -16,7 +16,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
 import com.adyen.checkout.components.ActionComponentProvider
-import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.base.GenericComponentParamsMapper
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
@@ -30,11 +30,10 @@ import com.tencent.mm.opensdk.openapi.WXAPIFactory
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class WeChatPayActionComponentProvider(
-    parentConfiguration: Configuration? = null,
-    isCreatedByDropIn: Boolean = false,
+    overrideComponentParams: ComponentParams? = null
 ) : ActionComponentProvider<WeChatPayActionComponent, WeChatPayActionConfiguration, WeChatDelegate> {
 
-    private val componentParamsMapper = GenericComponentParamsMapper(parentConfiguration, isCreatedByDropIn)
+    private val componentParamsMapper = GenericComponentParamsMapper(overrideComponentParams)
 
     override fun <T> get(
         owner: T,

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionConfiguration.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionConfiguration.kt
@@ -53,13 +53,6 @@ class WeChatPayActionConfiguration private constructor(
             clientKey: String
         ) : super(shopperLocale, environment, clientKey)
 
-        /**
-         * Constructor that copies an existing configuration.
-         *
-         * @param configuration A configuration to initialize the builder.
-         */
-        constructor(configuration: WeChatPayActionConfiguration) : super(configuration)
-
         override fun buildInternal(): WeChatPayActionConfiguration {
             return WeChatPayActionConfiguration(
                 shopperLocale = shopperLocale,

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayProvider.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayProvider.kt
@@ -28,9 +28,9 @@ class WeChatPayProvider : PaymentMethodAvailabilityCheck<Configuration> {
         applicationContext: Application,
         paymentMethod: PaymentMethod,
         configuration: Configuration?,
-        callback: ComponentAvailableCallback<Configuration>
+        callback: ComponentAvailableCallback
     ) {
-        callback.onAvailabilityResult(isAvailable(applicationContext), paymentMethod, configuration)
+        callback.onAvailabilityResult(isAvailable(applicationContext), paymentMethod)
     }
 
     private fun isAvailable(applicationContext: Application?): Boolean {

--- a/wechatpay/src/test/java/com/adyen/checkout/wechatpay/DefaultWeChatDelegateTest.kt
+++ b/wechatpay/src/test/java/com/adyen/checkout/wechatpay/DefaultWeChatDelegateTest.kt
@@ -58,10 +58,7 @@ internal class DefaultWeChatDelegateTest(
         paymentDataRepository = PaymentDataRepository(SavedStateHandle())
         delegate = DefaultWeChatDelegate(
             observerRepository = ActionObserverRepository(),
-            componentParams = GenericComponentParamsMapper(
-                parentConfiguration = null,
-                isCreatedByDropIn = false
-            ).mapToParams(configuration),
+            componentParams = GenericComponentParamsMapper(null).mapToParams(configuration),
             iwxApi = iwxApi,
             payRequestGenerator = weChatRequestGenerator,
             paymentDataRepository = paymentDataRepository,


### PR DESCRIPTION
## Description
Remove builder constructors that take a configuration as a param which we were using to copy merchant configurations and override some values inside them (mainly the amount). The new `ComponentParams` classes are supposed to replace that and the amount will be overriden there instead.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-549
