### PR TITLE
Add analytics to all payment components

### DIFF
--- a/action/src/test/java/com/adyen/checkout/action/TestActionDelegate.kt
+++ b/action/src/test/java/com/adyen/checkout/action/TestActionDelegate.kt
@@ -139,6 +139,8 @@ internal class Test3DS2Delegate : Adyen3DS2Delegate {
 
     var handleActionCalled = false
 
+    override fun initialize(coroutineScope: CoroutineScope) = Unit
+
     override fun set3DS2UICustomization(uiCustomization: UiCustomization?) {
         this.uiCustomization = uiCustomization
     }

--- a/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponent.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponent.kt
@@ -36,6 +36,10 @@ class BacsDirectDebitComponent internal constructor(
 
     override val viewFlow: Flow<ComponentViewType?> = delegate.viewFlow
 
+    init {
+        delegate.initialize(viewModelScope)
+    }
+
     override fun observe(
         lifecycleOwner: LifecycleOwner,
         callback: (PaymentComponentEvent<BacsDirectDebitComponentState>) -> Unit

--- a/bacs/src/main/java/com/adyen/checkout/bacs/DefaultBacsDirectDebitDelegate.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/DefaultBacsDirectDebitDelegate.kt
@@ -11,6 +11,7 @@ package com.adyen.checkout.bacs
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LifecycleOwner
 import com.adyen.checkout.components.PaymentComponentEvent
+import com.adyen.checkout.components.analytics.AnalyticsRepository
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.model.payments.request.BacsDirectDebitPaymentMethod
 import com.adyen.checkout.components.model.payments.request.PaymentComponentData
@@ -22,12 +23,14 @@ import com.adyen.checkout.core.log.Logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 
 @Suppress("TooManyFunctions")
 internal class DefaultBacsDirectDebitDelegate(
     private val observerRepository: PaymentObserverRepository,
     override val componentParams: BacsDirectDebitComponentParams,
     private val paymentMethod: PaymentMethod,
+    private val analyticsRepository: AnalyticsRepository,
 ) : BacsDirectDebitDelegate {
 
     private val inputData: BacsDirectDebitInputData = BacsDirectDebitInputData()
@@ -44,6 +47,17 @@ internal class DefaultBacsDirectDebitDelegate(
     @Suppress("VariableNaming", "PropertyName")
     internal val _viewFlow = MutableStateFlow(BacsComponentViewType.INPUT)
     override val viewFlow: Flow<ComponentViewType?> = _viewFlow
+
+    override fun initialize(coroutineScope: CoroutineScope) {
+        sendAnalyticsEvent(coroutineScope)
+    }
+
+    private fun sendAnalyticsEvent(coroutineScope: CoroutineScope) {
+        Logger.v(TAG, "sendAnalyticsEvent")
+        coroutineScope.launch {
+            analyticsRepository.sendAnalyticsEvent()
+        }
+    }
 
     override fun observe(
         lifecycleOwner: LifecycleOwner,

--- a/bacs/src/test/java/com/adyen/checkout/bacs/DefaultBacsDirectDebitDelegateTest.kt
+++ b/bacs/src/test/java/com/adyen/checkout/bacs/DefaultBacsDirectDebitDelegateTest.kt
@@ -9,13 +9,16 @@
 package com.adyen.checkout.bacs
 
 import app.cash.turbine.test
+import com.adyen.checkout.components.analytics.AnalyticsRepository
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.repository.PaymentObserverRepository
 import com.adyen.checkout.components.ui.FieldState
 import com.adyen.checkout.components.ui.Validation
 import com.adyen.checkout.core.api.Environment
 import com.adyen.checkout.core.log.Logger
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -25,12 +28,16 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
 import java.util.Locale
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(MockitoExtension::class)
-internal class DefaultBacsDirectDebitDelegateTest {
+internal class DefaultBacsDirectDebitDelegateTest(
+    @Mock private val analyticsRepository: AnalyticsRepository,
+) {
 
     private lateinit var delegate: DefaultBacsDirectDebitDelegate
 
@@ -47,7 +54,8 @@ internal class DefaultBacsDirectDebitDelegateTest {
                 parentConfiguration = null,
                 isCreatedByDropIn = false
             ).mapToParams(configuration),
-            paymentMethod = PaymentMethod()
+            paymentMethod = PaymentMethod(),
+            analyticsRepository = analyticsRepository,
         )
         Logger.setLogcatLevel(Logger.NONE)
     }
@@ -414,6 +422,12 @@ internal class DefaultBacsDirectDebitDelegateTest {
                 }
             }
         }
+    }
+
+    @Test
+    fun `when delegate is initialized then analytics event is sent`() = runTest {
+        delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+        verify(analyticsRepository).sendAnalyticsEvent()
     }
 
     companion object {

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcComponentProvider.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcComponentProvider.kt
@@ -15,6 +15,10 @@ import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
 import com.adyen.checkout.card.CardValidationMapper
 import com.adyen.checkout.components.PaymentComponentProvider
+import com.adyen.checkout.components.analytics.AnalyticsMapper
+import com.adyen.checkout.components.analytics.AnalyticsSource
+import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
+import com.adyen.checkout.components.api.AnalyticsService
 import com.adyen.checkout.components.api.PublicKeyService
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.base.lifecycle.get
@@ -53,6 +57,14 @@ class BcmcComponentProvider(
         val cardValidationMapper = CardValidationMapper()
         val genericEncrypter = DefaultGenericEncrypter()
         val cardEncrypter = DefaultCardEncrypter(genericEncrypter)
+        val analyticsService = AnalyticsService(httpClient)
+        val analyticsRepository = DefaultAnalyticsRepository(
+            packageName = application.packageName,
+            locale = componentParams.shopperLocale,
+            source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+            analyticsService = analyticsService,
+            analyticsMapper = AnalyticsMapper(),
+        )
         val bcmcFactory = viewModelFactory(savedStateRegistryOwner, defaultArgs) { savedStateHandle ->
             BcmcComponent(
                 savedStateHandle = savedStateHandle,
@@ -62,7 +74,8 @@ class BcmcComponentProvider(
                     publicKeyRepository = publicKeyRepository,
                     componentParams = componentParams,
                     cardValidationMapper = cardValidationMapper,
-                    cardEncrypter = cardEncrypter
+                    cardEncrypter = cardEncrypter,
+                    analyticsRepository = analyticsRepository,
                 ),
                 configuration = configuration,
             )

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcDelegate.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcDelegate.kt
@@ -13,7 +13,6 @@ import com.adyen.checkout.components.base.PaymentComponentDelegate
 import com.adyen.checkout.components.model.payments.request.CardPaymentMethod
 import com.adyen.checkout.components.ui.ViewProvidingDelegate
 import com.adyen.checkout.core.exception.CheckoutException
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 
 interface BcmcDelegate :
@@ -29,8 +28,6 @@ interface BcmcDelegate :
     val componentStateFlow: Flow<PaymentComponentState<CardPaymentMethod>>
 
     val exceptionFlow: Flow<CheckoutException>
-
-    fun initialize(coroutineScope: CoroutineScope)
 
     fun isCardNumberSupported(cardNumber: String?): Boolean
 

--- a/blik/src/main/java/com/adyen/checkout/blik/BlikComponent.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/BlikComponent.kt
@@ -37,6 +37,10 @@ class BlikComponent internal constructor(
 
     override val viewFlow: Flow<ComponentViewType?> = delegate.viewFlow
 
+    init {
+        delegate.initialize(viewModelScope)
+    }
+
     override fun observe(
         lifecycleOwner: LifecycleOwner,
         callback: (PaymentComponentEvent<PaymentComponentState<BlikPaymentMethod>>) -> Unit

--- a/blik/src/main/java/com/adyen/checkout/blik/DefaultBlikDelegate.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/DefaultBlikDelegate.kt
@@ -12,6 +12,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LifecycleOwner
 import com.adyen.checkout.components.PaymentComponentEvent
 import com.adyen.checkout.components.PaymentComponentState
+import com.adyen.checkout.components.analytics.AnalyticsRepository
 import com.adyen.checkout.components.base.GenericComponentParams
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.model.payments.request.BlikPaymentMethod
@@ -24,12 +25,14 @@ import com.adyen.checkout.core.log.Logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 
 @Suppress("TooManyFunctions")
 internal class DefaultBlikDelegate(
     private val observerRepository: PaymentObserverRepository,
     override val componentParams: GenericComponentParams,
-    val paymentMethod: PaymentMethod
+    private val paymentMethod: PaymentMethod,
+    private val analyticsRepository: AnalyticsRepository,
 ) : BlikDelegate {
 
     private val inputData: BlikInputData = BlikInputData()
@@ -47,6 +50,17 @@ internal class DefaultBlikDelegate(
 
     init {
         updateComponentState(outputData)
+    }
+
+    override fun initialize(coroutineScope: CoroutineScope) {
+        sendAnalyticsEvent(coroutineScope)
+    }
+
+    private fun sendAnalyticsEvent(coroutineScope: CoroutineScope) {
+        Logger.v(TAG, "sendAnalyticsEvent")
+        coroutineScope.launch {
+            analyticsRepository.sendAnalyticsEvent()
+        }
     }
 
     override fun observe(

--- a/blik/src/main/java/com/adyen/checkout/blik/StoredBlikDelegate.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/StoredBlikDelegate.kt
@@ -11,6 +11,7 @@ package com.adyen.checkout.blik
 import androidx.lifecycle.LifecycleOwner
 import com.adyen.checkout.components.PaymentComponentEvent
 import com.adyen.checkout.components.PaymentComponentState
+import com.adyen.checkout.components.analytics.AnalyticsRepository
 import com.adyen.checkout.components.base.GenericComponentParams
 import com.adyen.checkout.components.model.paymentmethods.StoredPaymentMethod
 import com.adyen.checkout.components.model.payments.request.BlikPaymentMethod
@@ -23,11 +24,13 @@ import com.adyen.checkout.core.log.Logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 
 internal class StoredBlikDelegate(
     private val observerRepository: PaymentObserverRepository,
     override val componentParams: GenericComponentParams,
-    val storedPaymentMethod: StoredPaymentMethod
+    private val storedPaymentMethod: StoredPaymentMethod,
+    private val analyticsRepository: AnalyticsRepository,
 ) : BlikDelegate {
 
     private val _outputDataFlow = MutableStateFlow(createOutputData())
@@ -40,6 +43,17 @@ internal class StoredBlikDelegate(
     override val componentStateFlow: Flow<PaymentComponentState<BlikPaymentMethod>> = _componentStateFlow
 
     override val viewFlow: Flow<ComponentViewType?> = MutableStateFlow(BlikComponentViewType)
+
+    override fun initialize(coroutineScope: CoroutineScope) {
+        sendAnalyticsEvent(coroutineScope)
+    }
+
+    private fun sendAnalyticsEvent(coroutineScope: CoroutineScope) {
+        Logger.v(TAG, "sendAnalyticsEvent")
+        coroutineScope.launch {
+            analyticsRepository.sendAnalyticsEvent()
+        }
+    }
 
     override fun observe(
         lifecycleOwner: LifecycleOwner,

--- a/blik/src/test/java/com/adyen/checkout/blik/DefaultBlikDelegateTest.kt
+++ b/blik/src/test/java/com/adyen/checkout/blik/DefaultBlikDelegateTest.kt
@@ -9,12 +9,15 @@
 package com.adyen.checkout.blik
 
 import app.cash.turbine.test
+import com.adyen.checkout.components.analytics.AnalyticsRepository
 import com.adyen.checkout.components.base.GenericComponentParamsMapper
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.repository.PaymentObserverRepository
 import com.adyen.checkout.core.api.Environment
 import com.adyen.checkout.core.log.Logger
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -24,12 +27,16 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
 import java.util.Locale
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(MockitoExtension::class)
-internal class DefaultBlikDelegateTest {
+internal class DefaultBlikDelegateTest(
+    @Mock private val analyticsRepository: AnalyticsRepository,
+) {
 
     private lateinit var delegate: DefaultBlikDelegate
 
@@ -41,12 +48,13 @@ internal class DefaultBlikDelegateTest {
             TEST_CLIENT_KEY
         ).build()
         delegate = DefaultBlikDelegate(
-            PaymentObserverRepository(),
-            GenericComponentParamsMapper(
+            observerRepository = PaymentObserverRepository(),
+            componentParams = GenericComponentParamsMapper(
                 parentConfiguration = null,
                 isCreatedByDropIn = false
             ).mapToParams(configuration),
-            PaymentMethod()
+            paymentMethod = PaymentMethod(),
+            analyticsRepository = analyticsRepository,
         )
         Logger.setLogcatLevel(Logger.NONE)
     }
@@ -161,6 +169,12 @@ internal class DefaultBlikDelegateTest {
                 cancelAndIgnoreRemainingEvents()
             }
         }
+    }
+
+    @Test
+    fun `when delegate is initialized then analytics event is sent`() = runTest {
+        delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+        verify(analyticsRepository).sendAnalyticsEvent()
     }
 
     companion object {

--- a/card/src/main/java/com/adyen/checkout/card/CardComponentProvider.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponentProvider.kt
@@ -138,11 +138,21 @@ class CardComponentProvider(
             configuration.clientKey
         ).build()
 
+        val analyticsService = AnalyticsService(httpClient)
+        val analyticsRepository = DefaultAnalyticsRepository(
+            packageName = application.packageName,
+            locale = componentParams.shopperLocale,
+            source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, storedPaymentMethod),
+            analyticsService = analyticsService,
+            analyticsMapper = AnalyticsMapper(),
+        )
+
         val factory = viewModelFactory(savedStateRegistryOwner, defaultArgs) { savedStateHandle ->
             val cardDelegate = StoredCardDelegate(
                 observerRepository = PaymentObserverRepository(),
                 storedPaymentMethod = storedPaymentMethod,
                 componentParams = componentParams,
+                analyticsRepository = analyticsRepository,
                 cardEncrypter = cardEncrypter,
                 publicKeyRepository = publicKeyRepository,
             )

--- a/card/src/main/java/com/adyen/checkout/card/CardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardDelegate.kt
@@ -11,7 +11,6 @@ package com.adyen.checkout.card
 import com.adyen.checkout.components.base.PaymentComponentDelegate
 import com.adyen.checkout.components.ui.ViewProvidingDelegate
 import com.adyen.checkout.core.exception.CheckoutException
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 
 interface CardDelegate :
@@ -25,8 +24,6 @@ interface CardDelegate :
     val componentStateFlow: Flow<CardComponentState>
 
     val exceptionFlow: Flow<CheckoutException>
-
-    fun initialize(coroutineScope: CoroutineScope)
 
     fun requiresInput(): Boolean
 

--- a/card/src/main/java/com/adyen/checkout/card/DefaultCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/DefaultCardDelegate.kt
@@ -108,6 +108,7 @@ internal class DefaultCardDelegate(
     }
 
     private fun sendAnalyticsEvent(coroutineScope: CoroutineScope) {
+        Logger.v(TAG, "sendAnalyticsEvent")
         coroutineScope.launch {
             analyticsRepository.sendAnalyticsEvent()
         }

--- a/card/src/main/java/com/adyen/checkout/card/StoredCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/StoredCardDelegate.kt
@@ -17,6 +17,7 @@ import com.adyen.checkout.card.data.ExpiryDate
 import com.adyen.checkout.card.util.AddressValidationUtils
 import com.adyen.checkout.card.util.CardValidationUtils
 import com.adyen.checkout.components.PaymentComponentEvent
+import com.adyen.checkout.components.analytics.AnalyticsRepository
 import com.adyen.checkout.components.channel.bufferedChannel
 import com.adyen.checkout.components.model.paymentmethods.StoredPaymentMethod
 import com.adyen.checkout.components.model.payments.request.CardPaymentMethod
@@ -49,6 +50,7 @@ internal class StoredCardDelegate(
     private val observerRepository: PaymentObserverRepository,
     private val storedPaymentMethod: StoredPaymentMethod,
     override val componentParams: CardComponentParams,
+    private val analyticsRepository: AnalyticsRepository,
     private val cardEncrypter: CardEncrypter,
     private val publicKeyRepository: PublicKeyRepository,
 ) : CardDelegate {
@@ -90,8 +92,16 @@ internal class StoredCardDelegate(
 
     override fun initialize(coroutineScope: CoroutineScope) {
         this.coroutineScope = coroutineScope
+        sendAnalyticsEvent(coroutineScope)
         initializeInputData()
         fetchPublicKey()
+    }
+
+    private fun sendAnalyticsEvent(coroutineScope: CoroutineScope) {
+        Logger.v(TAG, "sendAnalyticsEvent")
+        coroutineScope.launch {
+            analyticsRepository.sendAnalyticsEvent()
+        }
     }
 
     override fun observe(

--- a/components-core/src/main/java/com/adyen/checkout/components/base/ActionDelegate.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/base/ActionDelegate.kt
@@ -23,13 +23,6 @@ interface ActionDelegate : ComponentDelegate {
     fun handleAction(action: Action, activity: Activity)
 
     /**
-     * Override this method if you need to initialize your delegate and use a [CoroutineScope] inside it.
-     *
-     * Use [onCleared] to clear any local reference to [CoroutineScope].
-     */
-    fun initialize(coroutineScope: CoroutineScope) = Unit
-
-    /**
      * Override this method if you need to emit to the [exceptionFlow] from outside of this class.
      */
     fun onError(e: CheckoutException) = Unit

--- a/components-core/src/main/java/com/adyen/checkout/components/base/ComponentDelegate.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/base/ComponentDelegate.kt
@@ -8,8 +8,19 @@
 
 package com.adyen.checkout.components.base
 
+import kotlinx.coroutines.CoroutineScope
+
 interface ComponentDelegate {
     val componentParams: ComponentParams
+
+    /**
+     * Use this method if your delegate needs to use a [CoroutineScope].
+     *
+     * Do not keep a local references of this scope if you don't need to.
+     *
+     * If you have to keep any references to [CoroutineScope], use [onCleared] to clear them.
+     */
+    fun initialize(coroutineScope: CoroutineScope)
 
     fun onCleared()
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/base/PaymentComponentDelegate.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/base/PaymentComponentDelegate.kt
@@ -23,6 +23,8 @@ interface PaymentComponentDelegate<
 
     fun getPaymentMethodType(): String
 
+    fun initialize(coroutineScope: CoroutineScope)
+
     fun observe(
         lifecycleOwner: LifecycleOwner,
         coroutineScope: CoroutineScope,

--- a/components-core/src/main/java/com/adyen/checkout/components/base/PaymentComponentDelegate.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/base/PaymentComponentDelegate.kt
@@ -23,8 +23,6 @@ interface PaymentComponentDelegate<
 
     fun getPaymentMethodType(): String
 
-    fun initialize(coroutineScope: CoroutineScope)
-
     fun observe(
         lifecycleOwner: LifecycleOwner,
         coroutineScope: CoroutineScope,

--- a/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayComponentProvider.kt
+++ b/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayComponentProvider.kt
@@ -15,12 +15,17 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
 import com.adyen.checkout.components.PaymentComponentProvider
+import com.adyen.checkout.components.analytics.AnalyticsMapper
+import com.adyen.checkout.components.analytics.AnalyticsSource
+import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
+import com.adyen.checkout.components.api.AnalyticsService
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.model.payments.request.DotpayPaymentMethod
 import com.adyen.checkout.components.repository.PaymentObserverRepository
+import com.adyen.checkout.core.api.HttpClientFactory
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.issuerlist.DefaultIssuerListDelegate
 import com.adyen.checkout.issuerlist.IssuerListComponentParamsMapper
@@ -47,10 +52,20 @@ class DotpayComponentProvider(
         val genericFactory: ViewModelProvider.Factory =
             viewModelFactory(savedStateRegistryOwner, defaultArgs) { savedStateHandle ->
                 val componentParams = componentParamsMapper.mapToParams(configuration)
+                val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
+                val analyticsService = AnalyticsService(httpClient)
+                val analyticsRepository = DefaultAnalyticsRepository(
+                    packageName = application.packageName,
+                    locale = componentParams.shopperLocale,
+                    source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                    analyticsService = analyticsService,
+                    analyticsMapper = AnalyticsMapper(),
+                )
                 val delegate = DefaultIssuerListDelegate(
                     observerRepository = PaymentObserverRepository(),
                     componentParams = componentParams,
-                    paymentMethod = paymentMethod
+                    paymentMethod = paymentMethod,
+                    analyticsRepository = analyticsRepository,
                 ) { DotpayPaymentMethod() }
                 DotpayComponent(savedStateHandle, delegate, configuration)
             }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/viewmodel/DropInViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/viewmodel/DropInViewModel.kt
@@ -189,6 +189,7 @@ internal class DropInViewModel(
     }
 
     private fun sendAnalyticsEvent() {
+        Logger.v(TAG, "sendAnalyticsEvent")
         viewModelScope.launch {
             analyticsRepository.sendAnalyticsEvent()
         }

--- a/entercash/src/main/java/com/adyen/checkout/entercash/EntercashComponentProvider.kt
+++ b/entercash/src/main/java/com/adyen/checkout/entercash/EntercashComponentProvider.kt
@@ -15,12 +15,17 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
 import com.adyen.checkout.components.PaymentComponentProvider
+import com.adyen.checkout.components.analytics.AnalyticsMapper
+import com.adyen.checkout.components.analytics.AnalyticsSource
+import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
+import com.adyen.checkout.components.api.AnalyticsService
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.model.payments.request.EntercashPaymentMethod
 import com.adyen.checkout.components.repository.PaymentObserverRepository
+import com.adyen.checkout.core.api.HttpClientFactory
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.issuerlist.DefaultIssuerListDelegate
 import com.adyen.checkout.issuerlist.IssuerListComponentParamsMapper
@@ -47,10 +52,20 @@ class EntercashComponentProvider(
         val genericFactory: ViewModelProvider.Factory =
             viewModelFactory(savedStateRegistryOwner, defaultArgs) { savedStateHandle ->
                 val componentParams = componentParamsMapper.mapToParams(configuration)
+                val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
+                val analyticsService = AnalyticsService(httpClient)
+                val analyticsRepository = DefaultAnalyticsRepository(
+                    packageName = application.packageName,
+                    locale = componentParams.shopperLocale,
+                    source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                    analyticsService = analyticsService,
+                    analyticsMapper = AnalyticsMapper(),
+                )
                 val delegate = DefaultIssuerListDelegate(
                     observerRepository = PaymentObserverRepository(),
                     componentParams = componentParams,
-                    paymentMethod = paymentMethod
+                    paymentMethod = paymentMethod,
+                    analyticsRepository = analyticsRepository,
                 ) { EntercashPaymentMethod() }
                 EntercashComponent(
                     savedStateHandle,

--- a/eps/src/main/java/com/adyen/checkout/eps/EPSComponentProvider.kt
+++ b/eps/src/main/java/com/adyen/checkout/eps/EPSComponentProvider.kt
@@ -15,12 +15,17 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
 import com.adyen.checkout.components.PaymentComponentProvider
+import com.adyen.checkout.components.analytics.AnalyticsMapper
+import com.adyen.checkout.components.analytics.AnalyticsSource
+import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
+import com.adyen.checkout.components.api.AnalyticsService
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.model.payments.request.EPSPaymentMethod
 import com.adyen.checkout.components.repository.PaymentObserverRepository
+import com.adyen.checkout.core.api.HttpClientFactory
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.issuerlist.DefaultIssuerListDelegate
 import com.adyen.checkout.issuerlist.IssuerListComponentParamsMapper
@@ -51,10 +56,20 @@ class EPSComponentProvider(
         val genericFactory: ViewModelProvider.Factory =
             viewModelFactory(savedStateRegistryOwner, defaultArgs) { savedStateHandle ->
                 val componentParams = componentParamsMapper.mapToParams(configuration)
+                val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
+                val analyticsService = AnalyticsService(httpClient)
+                val analyticsRepository = DefaultAnalyticsRepository(
+                    packageName = application.packageName,
+                    locale = componentParams.shopperLocale,
+                    source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                    analyticsService = analyticsService,
+                    analyticsMapper = AnalyticsMapper(),
+                )
                 val delegate = DefaultIssuerListDelegate(
                     observerRepository = PaymentObserverRepository(),
                     componentParams = componentParams,
-                    paymentMethod = paymentMethod
+                    paymentMethod = paymentMethod,
+                    analyticsRepository = analyticsRepository,
                 ) { EPSPaymentMethod() }
                 EPSComponent(savedStateHandle, delegate, configuration)
             }

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/DefaultGiftCardDelegate.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/DefaultGiftCardDelegate.kt
@@ -11,6 +11,7 @@ package com.adyen.checkout.giftcard
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LifecycleOwner
 import com.adyen.checkout.components.PaymentComponentEvent
+import com.adyen.checkout.components.analytics.AnalyticsRepository
 import com.adyen.checkout.components.base.GenericComponentParams
 import com.adyen.checkout.components.channel.bufferedChannel
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
@@ -39,6 +40,7 @@ import kotlinx.coroutines.launch
 internal class DefaultGiftCardDelegate(
     private val observerRepository: PaymentObserverRepository,
     private val paymentMethod: PaymentMethod,
+    private val analyticsRepository: AnalyticsRepository,
     private val publicKeyRepository: PublicKeyRepository,
     override val componentParams: GenericComponentParams,
     private val cardEncrypter: CardEncrypter,
@@ -62,6 +64,18 @@ internal class DefaultGiftCardDelegate(
     private var publicKey: String? = null
 
     override fun initialize(coroutineScope: CoroutineScope) {
+        sendAnalyticsEvent(coroutineScope)
+        fetchPublicKey(coroutineScope)
+    }
+
+    private fun sendAnalyticsEvent(coroutineScope: CoroutineScope) {
+        Logger.v(TAG, "sendAnalyticsEvent")
+        coroutineScope.launch {
+            analyticsRepository.sendAnalyticsEvent()
+        }
+    }
+
+    private fun fetchPublicKey(coroutineScope: CoroutineScope) {
         Logger.d(TAG, "fetchPublicKey")
         coroutineScope.launch {
             publicKeyRepository.fetchPublicKey(

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardComponentProvider.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardComponentProvider.kt
@@ -14,6 +14,10 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
 import com.adyen.checkout.components.PaymentComponentProvider
+import com.adyen.checkout.components.analytics.AnalyticsMapper
+import com.adyen.checkout.components.analytics.AnalyticsSource
+import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
+import com.adyen.checkout.components.api.AnalyticsService
 import com.adyen.checkout.components.api.PublicKeyService
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.base.GenericComponentParamsMapper
@@ -52,11 +56,20 @@ class GiftCardComponentProvider(
             val componentParams = componentParamsMapper.mapToParams(configuration)
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
             val publicKeyService = PublicKeyService(httpClient)
+            val analyticsService = AnalyticsService(httpClient)
+            val analyticsRepository = DefaultAnalyticsRepository(
+                packageName = application.packageName,
+                locale = componentParams.shopperLocale,
+                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsService = analyticsService,
+                analyticsMapper = AnalyticsMapper(),
+            )
             GiftCardComponent(
                 savedStateHandle = savedStateHandle,
                 delegate = DefaultGiftCardDelegate(
                     observerRepository = PaymentObserverRepository(),
                     paymentMethod = paymentMethod,
+                    analyticsRepository = analyticsRepository,
                     publicKeyRepository = DefaultPublicKeyRepository(publicKeyService),
                     componentParams = componentParams,
                     cardEncrypter = cardEncrypter,

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardDelegate.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardDelegate.kt
@@ -11,7 +11,6 @@ package com.adyen.checkout.giftcard
 import com.adyen.checkout.components.base.PaymentComponentDelegate
 import com.adyen.checkout.components.ui.ViewProvidingDelegate
 import com.adyen.checkout.core.exception.CheckoutException
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 
 interface GiftCardDelegate :
@@ -25,8 +24,6 @@ interface GiftCardDelegate :
     val componentStateFlow: Flow<GiftCardComponentState>
 
     val exceptionFlow: Flow<CheckoutException>
-
-    fun initialize(coroutineScope: CoroutineScope)
 
     fun updateInputData(update: GiftCardInputData.() -> Unit)
 }

--- a/giftcard/src/test/java/com/adyen/checkout/giftcard/DefaultGiftCardDelegateTest.kt
+++ b/giftcard/src/test/java/com/adyen/checkout/giftcard/DefaultGiftCardDelegateTest.kt
@@ -9,6 +9,7 @@
 package com.adyen.checkout.giftcard
 
 import app.cash.turbine.test
+import com.adyen.checkout.components.analytics.AnalyticsRepository
 import com.adyen.checkout.components.base.GenericComponentParamsMapper
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.repository.PaymentObserverRepository
@@ -29,12 +30,16 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
 import java.util.Locale
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(MockitoExtension::class, TestDispatcherExtension::class)
-internal class DefaultGiftCardDelegateTest {
+internal class DefaultGiftCardDelegateTest(
+    @Mock private val analyticsRepository: AnalyticsRepository,
+) {
 
     private lateinit var cardEncrypter: TestCardEncrypter
     private lateinit var publicKeyRepository: TestPublicKeyRepository
@@ -58,6 +63,7 @@ internal class DefaultGiftCardDelegateTest {
                 isCreatedByDropIn = false
             ).mapToParams(configuration),
             cardEncrypter = cardEncrypter,
+            analyticsRepository = analyticsRepository,
         )
     }
 
@@ -139,6 +145,12 @@ internal class DefaultGiftCardDelegateTest {
                 assertEquals("0000", componentState.lastFourDigits)
             }
         }
+    }
+
+    @Test
+    fun `when delegate is initialized then analytics event is sent`() = runTest {
+        delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+        verify(analyticsRepository).sendAnalyticsEvent()
     }
 
     companion object {

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayComponent.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayComponent.kt
@@ -36,6 +36,10 @@ class GooglePayComponent internal constructor(
     ),
     ActivityResultHandlingComponent {
 
+    init {
+        delegate.initialize(viewModelScope)
+    }
+
     override fun observe(
         lifecycleOwner: LifecycleOwner,
         callback: (PaymentComponentEvent<GooglePayComponentState>) -> Unit

--- a/ideal/src/main/java/com/adyen/checkout/ideal/IdealComponentProvider.kt
+++ b/ideal/src/main/java/com/adyen/checkout/ideal/IdealComponentProvider.kt
@@ -15,12 +15,17 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
 import com.adyen.checkout.components.PaymentComponentProvider
+import com.adyen.checkout.components.analytics.AnalyticsMapper
+import com.adyen.checkout.components.analytics.AnalyticsSource
+import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
+import com.adyen.checkout.components.api.AnalyticsService
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.model.payments.request.IdealPaymentMethod
 import com.adyen.checkout.components.repository.PaymentObserverRepository
+import com.adyen.checkout.core.api.HttpClientFactory
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.issuerlist.DefaultIssuerListDelegate
 import com.adyen.checkout.issuerlist.IssuerListComponentParamsMapper
@@ -47,10 +52,20 @@ class IdealComponentProvider(
         val genericFactory: ViewModelProvider.Factory =
             viewModelFactory(savedStateRegistryOwner, defaultArgs) { savedStateHandle ->
                 val componentParams = componentParamsMapper.mapToParams(configuration)
+                val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
+                val analyticsService = AnalyticsService(httpClient)
+                val analyticsRepository = DefaultAnalyticsRepository(
+                    packageName = application.packageName,
+                    locale = componentParams.shopperLocale,
+                    source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                    analyticsService = analyticsService,
+                    analyticsMapper = AnalyticsMapper(),
+                )
                 val delegate = DefaultIssuerListDelegate(
                     observerRepository = PaymentObserverRepository(),
                     componentParams = componentParams,
-                    paymentMethod = paymentMethod
+                    paymentMethod = paymentMethod,
+                    analyticsRepository = analyticsRepository,
                 ) { IdealPaymentMethod() }
                 IdealComponent(savedStateHandle, delegate, configuration)
             }

--- a/instant/src/main/java/com/adyen/checkout/instant/DefaultInstantPaymentDelegate.kt
+++ b/instant/src/main/java/com/adyen/checkout/instant/DefaultInstantPaymentDelegate.kt
@@ -11,6 +11,7 @@ package com.adyen.checkout.instant
 import androidx.lifecycle.LifecycleOwner
 import com.adyen.checkout.components.PaymentComponentEvent
 import com.adyen.checkout.components.PaymentComponentState
+import com.adyen.checkout.components.analytics.AnalyticsRepository
 import com.adyen.checkout.components.base.GenericComponentParams
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.model.payments.request.GenericPaymentMethod
@@ -18,14 +19,18 @@ import com.adyen.checkout.components.model.payments.request.PaymentComponentData
 import com.adyen.checkout.components.model.payments.request.PaymentMethodDetails
 import com.adyen.checkout.components.repository.PaymentObserverRepository
 import com.adyen.checkout.components.util.PaymentMethodTypes
+import com.adyen.checkout.core.log.LogUtil
+import com.adyen.checkout.core.log.Logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 
 internal class DefaultInstantPaymentDelegate(
     private val observerRepository: PaymentObserverRepository,
     private val paymentMethod: PaymentMethod,
     override val componentParams: GenericComponentParams,
+    private val analyticsRepository: AnalyticsRepository,
 ) : InstantPaymentDelegate {
 
     override val componentStateFlow: Flow<PaymentComponentState<PaymentMethodDetails>> =
@@ -37,6 +42,17 @@ internal class DefaultInstantPaymentDelegate(
         val paymentComponentData = PaymentComponentData<PaymentMethodDetails>()
         paymentComponentData.paymentMethod = GenericPaymentMethod(paymentMethod.type)
         return PaymentComponentState(paymentComponentData, isInputValid = true, isReady = true)
+    }
+
+    override fun initialize(coroutineScope: CoroutineScope) {
+        sendAnalyticsEvent(coroutineScope)
+    }
+
+    private fun sendAnalyticsEvent(coroutineScope: CoroutineScope) {
+        Logger.v(TAG, "sendAnalyticsEvent")
+        coroutineScope.launch {
+            analyticsRepository.sendAnalyticsEvent()
+        }
     }
 
     override fun observe(
@@ -59,5 +75,9 @@ internal class DefaultInstantPaymentDelegate(
 
     override fun onCleared() {
         removeObserver()
+    }
+
+    companion object {
+        private val TAG = LogUtil.getTag()
     }
 }

--- a/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentComponent.kt
+++ b/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentComponent.kt
@@ -26,6 +26,10 @@ class InstantPaymentComponent internal constructor(
     configuration
 ) {
 
+    init {
+        delegate.initialize(viewModelScope)
+    }
+
     override fun observe(
         lifecycleOwner: LifecycleOwner,
         callback: (PaymentComponentEvent<PaymentComponentState<PaymentMethodDetails>>) -> Unit

--- a/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentComponentProvider.kt
+++ b/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentComponentProvider.kt
@@ -15,6 +15,10 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
 import com.adyen.checkout.components.PaymentComponentProvider
+import com.adyen.checkout.components.analytics.AnalyticsMapper
+import com.adyen.checkout.components.analytics.AnalyticsSource
+import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
+import com.adyen.checkout.components.api.AnalyticsService
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.base.GenericComponentParamsMapper
 import com.adyen.checkout.components.base.lifecycle.get
@@ -22,6 +26,7 @@ import com.adyen.checkout.components.base.lifecycle.viewModelFactory
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.repository.PaymentObserverRepository
 import com.adyen.checkout.components.util.PaymentMethodTypes
+import com.adyen.checkout.core.api.HttpClientFactory
 import com.adyen.checkout.core.exception.ComponentException
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -45,12 +50,22 @@ class InstantPaymentComponentProvider(
         val genericFactory: ViewModelProvider.Factory =
             viewModelFactory(savedStateRegistryOwner, defaultArgs) { savedStateHandle ->
                 val componentParams = componentParamsMapper.mapToParams(configuration)
+                val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
+                val analyticsService = AnalyticsService(httpClient)
+                val analyticsRepository = DefaultAnalyticsRepository(
+                    packageName = application.packageName,
+                    locale = componentParams.shopperLocale,
+                    source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                    analyticsService = analyticsService,
+                    analyticsMapper = AnalyticsMapper(),
+                )
                 InstantPaymentComponent(
                     savedStateHandle = savedStateHandle,
                     delegate = DefaultInstantPaymentDelegate(
                         observerRepository = PaymentObserverRepository(),
                         paymentMethod = paymentMethod,
                         componentParams = componentParams,
+                        analyticsRepository = analyticsRepository,
                     ),
                     configuration = configuration
                 )

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/IssuerListComponent.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/IssuerListComponent.kt
@@ -39,6 +39,10 @@ abstract class IssuerListComponent<IssuerListPaymentMethodT : IssuerListPaymentM
 
     override val viewFlow: Flow<ComponentViewType?> = delegate.viewFlow
 
+    init {
+        delegate.initialize(viewModelScope)
+    }
+
     override fun observe(
         lifecycleOwner: LifecycleOwner,
         callback: (PaymentComponentEvent<PaymentComponentState<IssuerListPaymentMethodT>>) -> Unit

--- a/mbway/src/main/java/com/adyen/checkout/mbway/DefaultMBWayDelegate.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/DefaultMBWayDelegate.kt
@@ -12,6 +12,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LifecycleOwner
 import com.adyen.checkout.components.PaymentComponentEvent
 import com.adyen.checkout.components.PaymentComponentState
+import com.adyen.checkout.components.analytics.AnalyticsRepository
 import com.adyen.checkout.components.base.GenericComponentParams
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.model.payments.request.MBWayPaymentMethod
@@ -26,12 +27,14 @@ import com.adyen.checkout.core.log.Logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 
 @Suppress("TooManyFunctions")
 internal class DefaultMBWayDelegate(
     private val observerRepository: PaymentObserverRepository,
-    val paymentMethod: PaymentMethod,
+    private val paymentMethod: PaymentMethod,
     override val componentParams: GenericComponentParams,
+    private val analyticsRepository: AnalyticsRepository,
 ) : MBWayDelegate {
 
     private val inputData = MBWayInputData()
@@ -48,6 +51,17 @@ internal class DefaultMBWayDelegate(
 
     init {
         updateComponentState(outputData)
+    }
+
+    override fun initialize(coroutineScope: CoroutineScope) {
+        sendAnalyticsEvent(coroutineScope)
+    }
+
+    private fun sendAnalyticsEvent(coroutineScope: CoroutineScope) {
+        Logger.v(TAG, "sendAnalyticsEvent")
+        coroutineScope.launch {
+            analyticsRepository.sendAnalyticsEvent()
+        }
     }
 
     override fun observe(

--- a/mbway/src/main/java/com/adyen/checkout/mbway/MBWayComponent.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/MBWayComponent.kt
@@ -37,6 +37,10 @@ class MBWayComponent internal constructor(
 
     override val viewFlow: Flow<ComponentViewType?> = delegate.viewFlow
 
+    init {
+        delegate.initialize(viewModelScope)
+    }
+
     override fun observe(
         lifecycleOwner: LifecycleOwner,
         callback: (PaymentComponentEvent<PaymentComponentState<MBWayPaymentMethod>>) -> Unit

--- a/mbway/src/main/java/com/adyen/checkout/mbway/MBWayComponentProvider.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/MBWayComponentProvider.kt
@@ -15,12 +15,17 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
 import com.adyen.checkout.components.PaymentComponentProvider
+import com.adyen.checkout.components.analytics.AnalyticsMapper
+import com.adyen.checkout.components.analytics.AnalyticsSource
+import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
+import com.adyen.checkout.components.api.AnalyticsService
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.base.GenericComponentParamsMapper
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.repository.PaymentObserverRepository
+import com.adyen.checkout.core.api.HttpClientFactory
 import com.adyen.checkout.core.exception.ComponentException
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -45,12 +50,22 @@ class MBWayComponentProvider(
         val genericFactory: ViewModelProvider.Factory =
             viewModelFactory(savedStateRegistryOwner, defaultArgs) { savedStateHandle ->
                 val componentParams = componentParamsMapper.mapToParams(configuration)
+                val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
+                val analyticsService = AnalyticsService(httpClient)
+                val analyticsRepository = DefaultAnalyticsRepository(
+                    packageName = application.packageName,
+                    locale = componentParams.shopperLocale,
+                    source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                    analyticsService = analyticsService,
+                    analyticsMapper = AnalyticsMapper(),
+                )
                 MBWayComponent(
                     savedStateHandle,
                     DefaultMBWayDelegate(
                         observerRepository = PaymentObserverRepository(),
                         paymentMethod = paymentMethod,
                         componentParams = componentParams,
+                        analyticsRepository = analyticsRepository,
                     ),
                     configuration
                 )

--- a/molpay/src/main/java/com/adyen/checkout/molpay/MolpayComponentProvider.kt
+++ b/molpay/src/main/java/com/adyen/checkout/molpay/MolpayComponentProvider.kt
@@ -15,12 +15,17 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
 import com.adyen.checkout.components.PaymentComponentProvider
+import com.adyen.checkout.components.analytics.AnalyticsMapper
+import com.adyen.checkout.components.analytics.AnalyticsSource
+import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
+import com.adyen.checkout.components.api.AnalyticsService
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.model.payments.request.MolpayPaymentMethod
 import com.adyen.checkout.components.repository.PaymentObserverRepository
+import com.adyen.checkout.core.api.HttpClientFactory
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.issuerlist.DefaultIssuerListDelegate
 import com.adyen.checkout.issuerlist.IssuerListComponentParamsMapper
@@ -47,10 +52,20 @@ class MolpayComponentProvider(
         val genericFactory: ViewModelProvider.Factory =
             viewModelFactory(savedStateRegistryOwner, defaultArgs) { savedStateHandle ->
                 val componentParams = componentParamsMapper.mapToParams(configuration)
+                val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
+                val analyticsService = AnalyticsService(httpClient)
+                val analyticsRepository = DefaultAnalyticsRepository(
+                    packageName = application.packageName,
+                    locale = componentParams.shopperLocale,
+                    source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                    analyticsService = analyticsService,
+                    analyticsMapper = AnalyticsMapper(),
+                )
                 val delegate = DefaultIssuerListDelegate(
                     observerRepository = PaymentObserverRepository(),
                     componentParams = componentParams,
-                    paymentMethod = paymentMethod
+                    paymentMethod = paymentMethod,
+                    analyticsRepository = analyticsRepository,
                 ) { MolpayPaymentMethod() }
                 MolpayComponent(savedStateHandle, delegate, configuration)
             }

--- a/online-banking-core/src/main/java/com/adyen/checkout/onlinebankingcore/OnlineBankingComponent.kt
+++ b/online-banking-core/src/main/java/com/adyen/checkout/onlinebankingcore/OnlineBankingComponent.kt
@@ -33,6 +33,10 @@ abstract class OnlineBankingComponent<IssuerListPaymentMethodT : IssuerListPayme
 
     override val viewFlow: Flow<ComponentViewType?> = delegate.viewFlow
 
+    init {
+        delegate.initialize(viewModelScope)
+    }
+
     override fun observe(
         lifecycleOwner: LifecycleOwner,
         callback: (PaymentComponentEvent<PaymentComponentState<IssuerListPaymentMethodT>>) -> Unit

--- a/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLComponentProvider.kt
+++ b/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLComponentProvider.kt
@@ -15,12 +15,17 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
 import com.adyen.checkout.components.PaymentComponentProvider
+import com.adyen.checkout.components.analytics.AnalyticsMapper
+import com.adyen.checkout.components.analytics.AnalyticsSource
+import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
+import com.adyen.checkout.components.api.AnalyticsService
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.model.payments.request.OnlineBankingPLPaymentMethod
 import com.adyen.checkout.components.repository.PaymentObserverRepository
+import com.adyen.checkout.core.api.HttpClientFactory
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.issuerlist.DefaultIssuerListDelegate
 import com.adyen.checkout.issuerlist.IssuerListComponentParamsMapper
@@ -47,10 +52,20 @@ class OnlineBankingPLComponentProvider(
         val genericFactory: ViewModelProvider.Factory =
             viewModelFactory(savedStateRegistryOwner, defaultArgs) { savedStateHandle ->
                 val componentParams = componentParamsMapper.mapToParams(configuration)
+                val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
+                val analyticsService = AnalyticsService(httpClient)
+                val analyticsRepository = DefaultAnalyticsRepository(
+                    packageName = application.packageName,
+                    locale = componentParams.shopperLocale,
+                    source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                    analyticsService = analyticsService,
+                    analyticsMapper = AnalyticsMapper(),
+                )
                 val delegate = DefaultIssuerListDelegate(
                     observerRepository = PaymentObserverRepository(),
                     componentParams = componentParams,
-                    paymentMethod = paymentMethod
+                    paymentMethod = paymentMethod,
+                    analyticsRepository = analyticsRepository,
                 ) { OnlineBankingPLPaymentMethod() }
                 OnlineBankingPLComponent(
                     savedStateHandle,

--- a/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKComponentProvider.kt
+++ b/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKComponentProvider.kt
@@ -15,6 +15,10 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
 import com.adyen.checkout.components.PaymentComponentProvider
+import com.adyen.checkout.components.analytics.AnalyticsMapper
+import com.adyen.checkout.components.analytics.AnalyticsSource
+import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
+import com.adyen.checkout.components.api.AnalyticsService
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.base.GenericComponentParamsMapper
 import com.adyen.checkout.components.base.lifecycle.get
@@ -22,6 +26,7 @@ import com.adyen.checkout.components.base.lifecycle.viewModelFactory
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.model.payments.request.OnlineBankingSKPaymentMethod
 import com.adyen.checkout.components.repository.PaymentObserverRepository
+import com.adyen.checkout.core.api.HttpClientFactory
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.onlinebankingcore.DefaultOnlineBankingDelegate
 import com.adyen.checkout.onlinebankingcore.OnlineBankingComponent
@@ -49,12 +54,22 @@ class OnlineBankingSKComponentProvider(
         val genericFactory: ViewModelProvider.Factory =
             viewModelFactory(savedStateRegistryOwner, defaultArgs) { savedStateHandle ->
                 val componentParams = componentParamsMapper.mapToParams(configuration)
+                val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
+                val analyticsService = AnalyticsService(httpClient)
+                val analyticsRepository = DefaultAnalyticsRepository(
+                    packageName = application.packageName,
+                    locale = componentParams.shopperLocale,
+                    source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                    analyticsService = analyticsService,
+                    analyticsMapper = AnalyticsMapper(),
+                )
                 val delegate =
                     DefaultOnlineBankingDelegate(
                         observerRepository = PaymentObserverRepository(),
                         pdfOpener = PdfOpener(),
                         paymentMethod = paymentMethod,
                         componentParams = componentParams,
+                        analyticsRepository = analyticsRepository,
                         termsAndConditionsUrl = OnlineBankingSKComponent.TERMS_CONDITIONS_URL
                     ) { OnlineBankingSKPaymentMethod() }
 

--- a/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingComponentProvider.kt
+++ b/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingComponentProvider.kt
@@ -15,12 +15,17 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
 import com.adyen.checkout.components.PaymentComponentProvider
+import com.adyen.checkout.components.analytics.AnalyticsMapper
+import com.adyen.checkout.components.analytics.AnalyticsSource
+import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
+import com.adyen.checkout.components.api.AnalyticsService
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.model.payments.request.OpenBankingPaymentMethod
 import com.adyen.checkout.components.repository.PaymentObserverRepository
+import com.adyen.checkout.core.api.HttpClientFactory
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.issuerlist.DefaultIssuerListDelegate
 import com.adyen.checkout.issuerlist.IssuerListComponentParamsMapper
@@ -47,10 +52,20 @@ class OpenBankingComponentProvider(
         val genericFactory: ViewModelProvider.Factory =
             viewModelFactory(savedStateRegistryOwner, defaultArgs) { savedStateHandle ->
                 val componentParams = componentParamsMapper.mapToParams(configuration)
+                val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
+                val analyticsService = AnalyticsService(httpClient)
+                val analyticsRepository = DefaultAnalyticsRepository(
+                    packageName = application.packageName,
+                    locale = componentParams.shopperLocale,
+                    source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                    analyticsService = analyticsService,
+                    analyticsMapper = AnalyticsMapper(),
+                )
                 val delegate = DefaultIssuerListDelegate(
                     observerRepository = PaymentObserverRepository(),
                     componentParams = componentParams,
-                    paymentMethod = paymentMethod
+                    paymentMethod = paymentMethod,
+                    analyticsRepository = analyticsRepository,
                 ) { OpenBankingPaymentMethod() }
                 OpenBankingComponent(
                     savedStateHandle,

--- a/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankComponent.kt
+++ b/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankComponent.kt
@@ -35,6 +35,10 @@ class PayByBankComponent internal constructor(
 
     override val viewFlow: Flow<ComponentViewType?> = delegate.viewFlow
 
+    init {
+        delegate.initialize(viewModelScope)
+    }
+
     override fun observe(
         lifecycleOwner: LifecycleOwner,
         callback: (PaymentComponentEvent<PaymentComponentState<PayByBankPaymentMethod>>) -> Unit

--- a/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankComponentProvider.kt
+++ b/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankComponentProvider.kt
@@ -15,12 +15,17 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
 import com.adyen.checkout.components.PaymentComponentProvider
+import com.adyen.checkout.components.analytics.AnalyticsMapper
+import com.adyen.checkout.components.analytics.AnalyticsSource
+import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
+import com.adyen.checkout.components.api.AnalyticsService
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.base.GenericComponentParamsMapper
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.repository.PaymentObserverRepository
+import com.adyen.checkout.core.api.HttpClientFactory
 import com.adyen.checkout.core.exception.ComponentException
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -45,12 +50,22 @@ class PayByBankComponentProvider(
         val genericFactory: ViewModelProvider.Factory =
             viewModelFactory(savedStateRegistryOwner, defaultArgs) { savedStateHandle ->
                 val componentParams = componentParamsMapper.mapToParams(configuration)
+                val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
+                val analyticsService = AnalyticsService(httpClient)
+                val analyticsRepository = DefaultAnalyticsRepository(
+                    packageName = application.packageName,
+                    locale = componentParams.shopperLocale,
+                    source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                    analyticsService = analyticsService,
+                    analyticsMapper = AnalyticsMapper(),
+                )
                 PayByBankComponent(
                     savedStateHandle,
                     DefaultPayByBankDelegate(
                         PaymentObserverRepository(),
                         paymentMethod,
                         componentParams,
+                        analyticsRepository = analyticsRepository,
                     ),
                     configuration,
                 )

--- a/redirect/src/main/java/com/adyen/checkout/redirect/DefaultRedirectDelegate.kt
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/DefaultRedirectDelegate.kt
@@ -49,6 +49,10 @@ internal class DefaultRedirectDelegate(
 
     override val viewFlow: Flow<ComponentViewType?> = MutableStateFlow(RedirectComponentViewType)
 
+    override fun initialize(coroutineScope: CoroutineScope) {
+        // no ops
+    }
+
     override fun observe(
         lifecycleOwner: LifecycleOwner,
         coroutineScope: CoroutineScope,

--- a/sepa/src/main/java/com/adyen/checkout/sepa/DefaultSepaDelegate.kt
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/DefaultSepaDelegate.kt
@@ -4,6 +4,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LifecycleOwner
 import com.adyen.checkout.components.PaymentComponentEvent
 import com.adyen.checkout.components.PaymentComponentState
+import com.adyen.checkout.components.analytics.AnalyticsRepository
 import com.adyen.checkout.components.base.GenericComponentParams
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.model.payments.request.PaymentComponentData
@@ -16,11 +17,14 @@ import com.adyen.checkout.core.log.Logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 
+@Suppress("TooManyFunctions")
 internal class DefaultSepaDelegate(
     private val observerRepository: PaymentObserverRepository,
     override val componentParams: GenericComponentParams,
-    private val paymentMethod: PaymentMethod
+    private val paymentMethod: PaymentMethod,
+    private val analyticsRepository: AnalyticsRepository,
 ) : SepaDelegate {
 
     private val inputData: SepaInputData = SepaInputData()
@@ -34,6 +38,17 @@ internal class DefaultSepaDelegate(
     override val componentStateFlow: Flow<PaymentComponentState<SepaPaymentMethod>> = _componentStateFlow
 
     override val viewFlow: Flow<ComponentViewType?> = MutableStateFlow(SepaComponentViewType)
+
+    override fun initialize(coroutineScope: CoroutineScope) {
+        sendAnalyticsEvent(coroutineScope)
+    }
+
+    private fun sendAnalyticsEvent(coroutineScope: CoroutineScope) {
+        Logger.v(TAG, "sendAnalyticsEvent")
+        coroutineScope.launch {
+            analyticsRepository.sendAnalyticsEvent()
+        }
+    }
 
     override fun observe(
         lifecycleOwner: LifecycleOwner,

--- a/sepa/src/main/java/com/adyen/checkout/sepa/SepaComponent.kt
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/SepaComponent.kt
@@ -39,6 +39,10 @@ class SepaComponent internal constructor(
 
     override val viewFlow: Flow<ComponentViewType?> = delegate.viewFlow
 
+    init {
+        delegate.initialize(viewModelScope)
+    }
+
     override fun observe(
         lifecycleOwner: LifecycleOwner,
         callback: (PaymentComponentEvent<PaymentComponentState<SepaPaymentMethod>>) -> Unit

--- a/sepa/src/main/java/com/adyen/checkout/sepa/SepaComponentProvider.kt
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/SepaComponentProvider.kt
@@ -15,12 +15,17 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
 import com.adyen.checkout.components.PaymentComponentProvider
+import com.adyen.checkout.components.analytics.AnalyticsMapper
+import com.adyen.checkout.components.analytics.AnalyticsSource
+import com.adyen.checkout.components.analytics.DefaultAnalyticsRepository
+import com.adyen.checkout.components.api.AnalyticsService
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.base.GenericComponentParamsMapper
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.repository.PaymentObserverRepository
+import com.adyen.checkout.core.api.HttpClientFactory
 import com.adyen.checkout.core.exception.ComponentException
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -45,9 +50,23 @@ class SepaComponentProvider(
         val genericFactory: ViewModelProvider.Factory =
             viewModelFactory(savedStateRegistryOwner, defaultArgs) { savedStateHandle ->
                 val componentParams = componentParamsMapper.mapToParams(configuration)
+                val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
+                val analyticsService = AnalyticsService(httpClient)
+                val analyticsRepository = DefaultAnalyticsRepository(
+                    packageName = application.packageName,
+                    locale = componentParams.shopperLocale,
+                    source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                    analyticsService = analyticsService,
+                    analyticsMapper = AnalyticsMapper(),
+                )
                 SepaComponent(
                     savedStateHandle,
-                    DefaultSepaDelegate(PaymentObserverRepository(), componentParams, paymentMethod),
+                    DefaultSepaDelegate(
+                        observerRepository = PaymentObserverRepository(),
+                        componentParams = componentParams,
+                        paymentMethod = paymentMethod,
+                        analyticsRepository = analyticsRepository
+                    ),
                     configuration,
                 )
             }

--- a/voucher/src/main/java/com/adyen/checkout/voucher/DefaultVoucherDelegate.kt
+++ b/voucher/src/main/java/com/adyen/checkout/voucher/DefaultVoucherDelegate.kt
@@ -41,6 +41,10 @@ internal class DefaultVoucherDelegate(
 
     override val viewFlow: Flow<ComponentViewType?> = MutableStateFlow(VoucherComponentViewType)
 
+    override fun initialize(coroutineScope: CoroutineScope) {
+        // no ops
+    }
+
     override fun observe(
         lifecycleOwner: LifecycleOwner,
         coroutineScope: CoroutineScope,

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/DefaultWeChatDelegate.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/DefaultWeChatDelegate.kt
@@ -54,6 +54,10 @@ internal class DefaultWeChatDelegate(
 
     override val viewFlow: Flow<ComponentViewType?> = MutableStateFlow(WeChatComponentViewType)
 
+    override fun initialize(coroutineScope: CoroutineScope) {
+        // no ops
+    }
+
     override fun observe(
         lifecycleOwner: LifecycleOwner,
         coroutineScope: CoroutineScope,


### PR DESCRIPTION
## Description
Include `AnalyticsRepository` in all `PaymentComponentDelegate`s and send an analytics event on component initialisation.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-679
