### PR TITLE
Add option to add action configs to payment method configs

### DIFF
--- a/action/src/main/java/com/adyen/checkout/action/ActionHandlingConfigurationBuilder.kt
+++ b/action/src/main/java/com/adyen/checkout/action/ActionHandlingConfigurationBuilder.kt
@@ -1,0 +1,43 @@
+package com.adyen.checkout.action
+
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.adyen3ds2.Adyen3DS2Configuration
+import com.adyen.checkout.await.AwaitConfiguration
+import com.adyen.checkout.qrcode.QRCodeConfiguration
+import com.adyen.checkout.redirect.RedirectConfiguration
+import com.adyen.checkout.voucher.VoucherConfiguration
+import com.adyen.checkout.wechatpay.WeChatPayActionConfiguration
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+interface ActionHandlingConfigurationBuilder {
+
+    /**
+     * Add configuration for 3DS2 action.
+     */
+    fun add3ds2ActionConfiguration(configuration: Adyen3DS2Configuration): ActionHandlingConfigurationBuilder
+
+    /**
+     * Add configuration for Await action.
+     */
+    fun addAwaitActionConfiguration(configuration: AwaitConfiguration): ActionHandlingConfigurationBuilder
+
+    /**
+     * Add configuration for QR code action.
+     */
+    fun addQRCodeActionConfiguration(configuration: QRCodeConfiguration): ActionHandlingConfigurationBuilder
+
+    /**
+     * Add configuration for Redirect action.
+     */
+    fun addRedirectActionConfiguration(configuration: RedirectConfiguration): ActionHandlingConfigurationBuilder
+
+    /**
+     * Add configuration for Voucher action.
+     */
+    fun addVoucherActionConfiguration(configuration: VoucherConfiguration): ActionHandlingConfigurationBuilder
+
+    /**
+     * Add configuration for WeChat Pay action.
+     */
+    fun addWeChatPayActionConfiguration(configuration: WeChatPayActionConfiguration): ActionHandlingConfigurationBuilder
+}

--- a/action/src/main/java/com/adyen/checkout/action/ActionHandlingConfigurationBuilder.kt
+++ b/action/src/main/java/com/adyen/checkout/action/ActionHandlingConfigurationBuilder.kt
@@ -9,35 +9,35 @@ import com.adyen.checkout.voucher.VoucherConfiguration
 import com.adyen.checkout.wechatpay.WeChatPayActionConfiguration
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-interface ActionHandlingConfigurationBuilder {
+interface ActionHandlingConfigurationBuilder<BuilderT> {
 
     /**
      * Add configuration for 3DS2 action.
      */
-    fun add3ds2ActionConfiguration(configuration: Adyen3DS2Configuration): ActionHandlingConfigurationBuilder
+    fun add3ds2ActionConfiguration(configuration: Adyen3DS2Configuration): BuilderT
 
     /**
      * Add configuration for Await action.
      */
-    fun addAwaitActionConfiguration(configuration: AwaitConfiguration): ActionHandlingConfigurationBuilder
+    fun addAwaitActionConfiguration(configuration: AwaitConfiguration): BuilderT
 
     /**
      * Add configuration for QR code action.
      */
-    fun addQRCodeActionConfiguration(configuration: QRCodeConfiguration): ActionHandlingConfigurationBuilder
+    fun addQRCodeActionConfiguration(configuration: QRCodeConfiguration): BuilderT
 
     /**
      * Add configuration for Redirect action.
      */
-    fun addRedirectActionConfiguration(configuration: RedirectConfiguration): ActionHandlingConfigurationBuilder
+    fun addRedirectActionConfiguration(configuration: RedirectConfiguration): BuilderT
 
     /**
      * Add configuration for Voucher action.
      */
-    fun addVoucherActionConfiguration(configuration: VoucherConfiguration): ActionHandlingConfigurationBuilder
+    fun addVoucherActionConfiguration(configuration: VoucherConfiguration): BuilderT
 
     /**
      * Add configuration for WeChat Pay action.
      */
-    fun addWeChatPayActionConfiguration(configuration: WeChatPayActionConfiguration): ActionHandlingConfigurationBuilder
+    fun addWeChatPayActionConfiguration(configuration: WeChatPayActionConfiguration): BuilderT
 }

--- a/action/src/main/java/com/adyen/checkout/action/ActionHandlingPaymentMethodConfigurationBuilder.kt
+++ b/action/src/main/java/com/adyen/checkout/action/ActionHandlingPaymentMethodConfigurationBuilder.kt
@@ -1,0 +1,110 @@
+package com.adyen.checkout.action
+
+import android.content.Context
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.adyen3ds2.Adyen3DS2Configuration
+import com.adyen.checkout.await.AwaitConfiguration
+import com.adyen.checkout.components.base.BaseConfigurationBuilder
+import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.core.api.Environment
+import com.adyen.checkout.core.util.LocaleUtil
+import com.adyen.checkout.qrcode.QRCodeConfiguration
+import com.adyen.checkout.redirect.RedirectConfiguration
+import com.adyen.checkout.voucher.VoucherConfiguration
+import com.adyen.checkout.wechatpay.WeChatPayActionConfiguration
+import java.util.Locale
+
+@Suppress("UNCHECKED_CAST")
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+abstract class ActionHandlingPaymentMethodConfigurationBuilder<
+    ConfigurationT : Configuration,
+    BuilderT : BaseConfigurationBuilder<ConfigurationT, BuilderT>
+    >(
+    shopperLocale: Locale,
+    environment: Environment,
+    clientKey: String
+) : BaseConfigurationBuilder<ConfigurationT, BuilderT>(shopperLocale, environment, clientKey),
+    ActionHandlingConfigurationBuilder<BuilderT> {
+
+    protected val genericActionConfigurationBuilder = GenericActionConfiguration.Builder(
+        shopperLocale = shopperLocale,
+        environment = environment,
+        clientKey = clientKey,
+    )
+
+    /**
+     * Constructor that provides default values.
+     *
+     * @param context A Context
+     * @param environment   The [Environment] to be used for network calls to Adyen.
+     * @param clientKey Your Client Key used for network calls from the SDK to Adyen.
+     */
+    constructor(
+        context: Context,
+        environment: Environment,
+        clientKey: String
+    ) : this(
+        LocaleUtil.getLocale(context),
+        environment,
+        clientKey
+    )
+
+    /**
+     * Constructor that copies an existing configuration.
+     *
+     * @param configuration A configuration to initialize the builder.
+     */
+    constructor(configuration: ConfigurationT) : this(
+        configuration.shopperLocale,
+        configuration.environment,
+        configuration.clientKey
+    )
+
+    /**
+     * Add configuration for 3DS2 action.
+     */
+    final override fun add3ds2ActionConfiguration(configuration: Adyen3DS2Configuration): BuilderT {
+        genericActionConfigurationBuilder.add3ds2ActionConfiguration(configuration)
+        return this as BuilderT
+    }
+
+    /**
+     * Add configuration for Await action.
+     */
+    final override fun addAwaitActionConfiguration(configuration: AwaitConfiguration): BuilderT {
+        genericActionConfigurationBuilder.addAwaitActionConfiguration(configuration)
+        return this as BuilderT
+    }
+
+    /**
+     * Add configuration for QR code action.
+     */
+    final override fun addQRCodeActionConfiguration(configuration: QRCodeConfiguration): BuilderT {
+        genericActionConfigurationBuilder.addQRCodeActionConfiguration(configuration)
+        return this as BuilderT
+    }
+
+    /**
+     * Add configuration for Redirect action.
+     */
+    final override fun addRedirectActionConfiguration(configuration: RedirectConfiguration): BuilderT {
+        genericActionConfigurationBuilder.addRedirectActionConfiguration(configuration)
+        return this as BuilderT
+    }
+
+    /**
+     * Add configuration for Voucher action.
+     */
+    final override fun addVoucherActionConfiguration(configuration: VoucherConfiguration): BuilderT {
+        genericActionConfigurationBuilder.addVoucherActionConfiguration(configuration)
+        return this as BuilderT
+    }
+
+    /**
+     * Add configuration for WeChat Pay action.
+     */
+    final override fun addWeChatPayActionConfiguration(configuration: WeChatPayActionConfiguration): BuilderT {
+        genericActionConfigurationBuilder.addWeChatPayActionConfiguration(configuration)
+        return this as BuilderT
+    }
+}

--- a/action/src/main/java/com/adyen/checkout/action/GenericActionConfiguration.kt
+++ b/action/src/main/java/com/adyen/checkout/action/GenericActionConfiguration.kt
@@ -53,7 +53,8 @@ class GenericActionConfiguration private constructor(
      * Builder for creating a [GenericActionConfiguration] where you can set specific Configurations for an action
      */
     @Suppress("unused")
-    class Builder : BaseConfigurationBuilder<GenericActionConfiguration, Builder>,
+    class Builder :
+        BaseConfigurationBuilder<GenericActionConfiguration, Builder>,
         ActionHandlingConfigurationBuilder<Builder> {
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/action/src/main/java/com/adyen/checkout/action/GenericActionConfiguration.kt
+++ b/action/src/main/java/com/adyen/checkout/action/GenericActionConfiguration.kt
@@ -53,7 +53,8 @@ class GenericActionConfiguration private constructor(
      * Builder for creating a [GenericActionConfiguration] where you can set specific Configurations for an action
      */
     @Suppress("unused")
-    class Builder : BaseConfigurationBuilder<GenericActionConfiguration, Builder>, ActionHandlingConfigurationBuilder {
+    class Builder : BaseConfigurationBuilder<GenericActionConfiguration, Builder>,
+        ActionHandlingConfigurationBuilder<Builder> {
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         val availableActionConfigs = HashMap<Class<*>, Configuration>()

--- a/action/src/main/java/com/adyen/checkout/action/GenericActionConfiguration.kt
+++ b/action/src/main/java/com/adyen/checkout/action/GenericActionConfiguration.kt
@@ -53,7 +53,7 @@ class GenericActionConfiguration private constructor(
      * Builder for creating a [GenericActionConfiguration] where you can set specific Configurations for an action
      */
     @Suppress("unused")
-    class Builder : BaseConfigurationBuilder<GenericActionConfiguration, Builder> {
+    class Builder : BaseConfigurationBuilder<GenericActionConfiguration, Builder>, ActionHandlingConfigurationBuilder {
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         val availableActionConfigs = HashMap<Class<*>, Configuration>()
@@ -87,7 +87,7 @@ class GenericActionConfiguration private constructor(
         /**
          * Add configuration for 3DS2 action.
          */
-        fun add3ds2ActionConfiguration(configuration: Adyen3DS2Configuration): Builder {
+        override fun add3ds2ActionConfiguration(configuration: Adyen3DS2Configuration): Builder {
             availableActionConfigs[configuration::class.java] = configuration
             return this
         }
@@ -95,7 +95,7 @@ class GenericActionConfiguration private constructor(
         /**
          * Add configuration for Await action.
          */
-        fun addAwaitActionConfiguration(configuration: AwaitConfiguration): Builder {
+        override fun addAwaitActionConfiguration(configuration: AwaitConfiguration): Builder {
             availableActionConfigs[configuration::class.java] = configuration
             return this
         }
@@ -103,7 +103,7 @@ class GenericActionConfiguration private constructor(
         /**
          * Add configuration for QR code action.
          */
-        fun addQRCodeActionConfiguration(configuration: QRCodeConfiguration): Builder {
+        override fun addQRCodeActionConfiguration(configuration: QRCodeConfiguration): Builder {
             availableActionConfigs[configuration::class.java] = configuration
             return this
         }
@@ -111,7 +111,7 @@ class GenericActionConfiguration private constructor(
         /**
          * Add configuration for Redirect action.
          */
-        fun addRedirectActionConfiguration(configuration: RedirectConfiguration): Builder {
+        override fun addRedirectActionConfiguration(configuration: RedirectConfiguration): Builder {
             availableActionConfigs[configuration::class.java] = configuration
             return this
         }
@@ -119,7 +119,7 @@ class GenericActionConfiguration private constructor(
         /**
          * Add configuration for WeChat Pay action.
          */
-        fun addWeChatPayActionConfiguration(configuration: WeChatPayActionConfiguration): Builder {
+        override fun addWeChatPayActionConfiguration(configuration: WeChatPayActionConfiguration): Builder {
             availableActionConfigs[configuration::class.java] = configuration
             return this
         }
@@ -127,7 +127,7 @@ class GenericActionConfiguration private constructor(
         /**
          * Add configuration for Voucher action.
          */
-        fun addVoucherActionConfiguration(configuration: VoucherConfiguration): Builder {
+        override fun addVoucherActionConfiguration(configuration: VoucherConfiguration): Builder {
             availableActionConfigs[configuration::class.java] = configuration
             return this
         }

--- a/bacs/build.gradle
+++ b/bacs/build.gradle
@@ -39,6 +39,7 @@ android {
 
 dependencies {
     // Checkout
+    api project(':action')
     api project(':ui-core')
 
     // Dependencies

--- a/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitConfiguration.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitConfiguration.kt
@@ -9,9 +9,10 @@
 package com.adyen.checkout.bacs
 
 import android.content.Context
+import com.adyen.checkout.action.ActionHandlingPaymentMethodConfigurationBuilder
+import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.components.base.AmountConfiguration
 import com.adyen.checkout.components.base.AmountConfigurationBuilder
-import com.adyen.checkout.components.base.BaseConfigurationBuilder
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.model.payments.Amount
 import com.adyen.checkout.components.util.CheckoutCurrency
@@ -27,9 +28,12 @@ class BacsDirectDebitConfiguration private constructor(
     override val clientKey: String,
     override val amount: Amount?,
     override val isAnalyticsEnabled: Boolean?,
+    internal val genericActionConfiguration: GenericActionConfiguration,
 ) : Configuration, AmountConfiguration {
 
-    class Builder : BaseConfigurationBuilder<BacsDirectDebitConfiguration, Builder>, AmountConfigurationBuilder {
+    class Builder :
+        ActionHandlingPaymentMethodConfigurationBuilder<BacsDirectDebitConfiguration, Builder>,
+        AmountConfigurationBuilder {
 
         internal var amount: Amount? = null
 
@@ -66,6 +70,7 @@ class BacsDirectDebitConfiguration private constructor(
                 clientKey = clientKey,
                 amount = amount,
                 isAnalyticsEnabled = isAnalyticsEnabled,
+                genericActionConfiguration = genericActionConfigurationBuilder.build(),
             )
         }
 

--- a/bcmc/build.gradle
+++ b/bcmc/build.gradle
@@ -43,6 +43,7 @@ android {
 
 dependencies {
     // Checkout
+    api project(":action")
     api project(":card")
 
     // If 3DS2 SDK is present.

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcConfiguration.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcConfiguration.kt
@@ -8,7 +8,8 @@
 package com.adyen.checkout.bcmc
 
 import android.content.Context
-import com.adyen.checkout.components.base.BaseConfigurationBuilder
+import com.adyen.checkout.action.ActionHandlingPaymentMethodConfigurationBuilder
+import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.core.api.Environment
 import kotlinx.parcelize.Parcelize
@@ -27,12 +28,13 @@ class BcmcConfiguration private constructor(
     val isHolderNameRequired: Boolean?,
     val shopperReference: String?,
     val isStorePaymentFieldVisible: Boolean?,
+    internal val genericActionConfiguration: GenericActionConfiguration,
 ) : Configuration {
 
     /**
      * Builder to create a [BcmcConfiguration].
      */
-    class Builder : BaseConfigurationBuilder<BcmcConfiguration, Builder> {
+    class Builder : ActionHandlingPaymentMethodConfigurationBuilder<BcmcConfiguration, Builder> {
 
         private var isHolderNameRequired: Boolean? = null
         private var showStorePaymentField: Boolean? = null
@@ -117,6 +119,7 @@ class BcmcConfiguration private constructor(
                 isHolderNameRequired = isHolderNameRequired,
                 shopperReference = shopperReference,
                 isStorePaymentFieldVisible = showStorePaymentField,
+                genericActionConfiguration = genericActionConfigurationBuilder.build(),
             )
         }
     }

--- a/blik/build.gradle
+++ b/blik/build.gradle
@@ -39,6 +39,7 @@ android {
 
 dependencies {
     // Checkout
+    api project(':action')
     api project(':ui-core')
 
     // Dependencies

--- a/blik/src/main/java/com/adyen/checkout/blik/BlikConfiguration.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/BlikConfiguration.kt
@@ -8,7 +8,8 @@
 package com.adyen.checkout.blik
 
 import android.content.Context
-import com.adyen.checkout.components.base.BaseConfigurationBuilder
+import com.adyen.checkout.action.ActionHandlingPaymentMethodConfigurationBuilder
+import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.core.api.Environment
 import kotlinx.parcelize.Parcelize
@@ -20,12 +21,13 @@ class BlikConfiguration private constructor(
     override val environment: Environment,
     override val clientKey: String,
     override val isAnalyticsEnabled: Boolean?,
+    internal val genericActionConfiguration: GenericActionConfiguration,
 ) : Configuration {
 
     /**
      * Builder to create a [BlikConfiguration].
      */
-    class Builder : BaseConfigurationBuilder<BlikConfiguration, Builder> {
+    class Builder : ActionHandlingPaymentMethodConfigurationBuilder<BlikConfiguration, Builder> {
 
         /**
          * Constructor for Builder with default values.
@@ -59,6 +61,7 @@ class BlikConfiguration private constructor(
                 environment = environment,
                 clientKey = clientKey,
                 isAnalyticsEnabled = isAnalyticsEnabled,
+                genericActionConfiguration = genericActionConfigurationBuilder.build(),
             )
         }
     }

--- a/card/src/main/java/com/adyen/checkout/card/CardComponentProvider.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponentProvider.kt
@@ -15,7 +15,6 @@ import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
 import com.adyen.checkout.action.DefaultActionHandlingComponent
 import com.adyen.checkout.action.GenericActionComponent
-import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.card.api.AddressService
 import com.adyen.checkout.card.api.BinLookupService
 import com.adyen.checkout.card.repository.DefaultAddressRepository
@@ -76,12 +75,6 @@ class CardComponentProvider(
             analyticsMapper = AnalyticsMapper(),
         )
 
-        val actionConfiguration = GenericActionConfiguration.Builder(
-            configuration.shopperLocale,
-            configuration.environment,
-            configuration.clientKey
-        ).build()
-
         val factory = viewModelFactory(savedStateRegistryOwner, defaultArgs) { savedStateHandle ->
             val cardDelegate = DefaultCardDelegate(
                 observerRepository = PaymentObserverRepository(),
@@ -97,9 +90,9 @@ class CardComponentProvider(
             )
 
             val genericActionDelegate = GenericActionComponent.PROVIDER.getDelegate(
-                actionConfiguration,
-                savedStateHandle,
-                application,
+                configuration = configuration.genericActionConfiguration,
+                savedStateHandle = savedStateHandle,
+                application = application,
             )
 
             CardComponent(
@@ -129,12 +122,6 @@ class CardComponentProvider(
         val genericEncrypter = DefaultGenericEncrypter()
         val cardEncrypter = DefaultCardEncrypter(genericEncrypter)
 
-        val actionConfiguration = GenericActionConfiguration.Builder(
-            configuration.shopperLocale,
-            configuration.environment,
-            configuration.clientKey
-        ).build()
-
         val analyticsService = AnalyticsService(httpClient)
         val analyticsRepository = DefaultAnalyticsRepository(
             packageName = application.packageName,
@@ -155,9 +142,9 @@ class CardComponentProvider(
             )
 
             val genericActionDelegate = GenericActionComponent.PROVIDER.getDelegate(
-                actionConfiguration,
-                savedStateHandle,
-                application,
+                configuration = configuration.genericActionConfiguration,
+                savedStateHandle = savedStateHandle,
+                application = application,
             )
 
             CardComponent(

--- a/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
@@ -8,19 +8,12 @@
 package com.adyen.checkout.card
 
 import android.content.Context
-import com.adyen.checkout.action.ActionHandlingConfigurationBuilder
+import com.adyen.checkout.action.ActionHandlingPaymentMethodConfigurationBuilder
 import com.adyen.checkout.action.GenericActionConfiguration
-import com.adyen.checkout.adyen3ds2.Adyen3DS2Configuration
-import com.adyen.checkout.await.AwaitConfiguration
 import com.adyen.checkout.card.data.CardType
-import com.adyen.checkout.components.base.BaseConfigurationBuilder
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.core.api.Environment
-import com.adyen.checkout.qrcode.QRCodeConfiguration
-import com.adyen.checkout.redirect.RedirectConfiguration
-import com.adyen.checkout.voucher.VoucherConfiguration
-import com.adyen.checkout.wechatpay.WeChatPayActionConfiguration
 import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
@@ -51,7 +44,7 @@ class CardConfiguration private constructor(
      * Builder to create a [CardConfiguration].
      */
     @Suppress("TooManyFunctions")
-    class Builder : BaseConfigurationBuilder<CardConfiguration, Builder>, ActionHandlingConfigurationBuilder {
+    class Builder : ActionHandlingPaymentMethodConfigurationBuilder<CardConfiguration, Builder> {
         private var supportedCardTypes: List<CardType>? = null
         private var holderNameRequired: Boolean? = null
         private var isStorePaymentFieldVisible: Boolean? = null
@@ -62,12 +55,6 @@ class CardConfiguration private constructor(
         private var kcpAuthVisibility: KCPAuthVisibility? = null
         private var installmentConfiguration: InstallmentConfiguration? = null
         private var addressConfiguration: AddressConfiguration? = null
-
-        private val genericActionConfigurationBuilder = GenericActionConfiguration.Builder(
-            shopperLocale = shopperLocale,
-            environment = environment,
-            clientKey = clientKey,
-        )
 
         /**
          * Constructor for Builder with default values.
@@ -225,54 +212,6 @@ class CardConfiguration private constructor(
          */
         fun setAddressConfiguration(addressConfiguration: AddressConfiguration): Builder {
             this.addressConfiguration = addressConfiguration
-            return this
-        }
-
-        /**
-         * Add configuration for 3DS2 action.
-         */
-        override fun add3ds2ActionConfiguration(configuration: Adyen3DS2Configuration): Builder {
-            genericActionConfigurationBuilder.add3ds2ActionConfiguration(configuration)
-            return this
-        }
-
-        /**
-         * Add configuration for Await action.
-         */
-        override fun addAwaitActionConfiguration(configuration: AwaitConfiguration): Builder {
-            genericActionConfigurationBuilder.addAwaitActionConfiguration(configuration)
-            return this
-        }
-
-        /**
-         * Add configuration for QR code action.
-         */
-        override fun addQRCodeActionConfiguration(configuration: QRCodeConfiguration): Builder {
-            genericActionConfigurationBuilder.addQRCodeActionConfiguration(configuration)
-            return this
-        }
-
-        /**
-         * Add configuration for Redirect action.
-         */
-        override fun addRedirectActionConfiguration(configuration: RedirectConfiguration): Builder {
-            genericActionConfigurationBuilder.addRedirectActionConfiguration(configuration)
-            return this
-        }
-
-        /**
-         * Add configuration for Voucher action.
-         */
-        override fun addVoucherActionConfiguration(configuration: VoucherConfiguration): Builder {
-            genericActionConfigurationBuilder.addVoucherActionConfiguration(configuration)
-            return this
-        }
-
-        /**
-         * Add configuration for WeChat Pay action.
-         */
-        override fun addWeChatPayActionConfiguration(configuration: WeChatPayActionConfiguration): Builder {
-            genericActionConfigurationBuilder.addWeChatPayActionConfiguration(configuration)
             return this
         }
 

--- a/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
@@ -8,14 +8,19 @@
 package com.adyen.checkout.card
 
 import android.content.Context
+import com.adyen.checkout.action.ActionHandlingConfigurationBuilder
 import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.adyen3ds2.Adyen3DS2Configuration
+import com.adyen.checkout.await.AwaitConfiguration
 import com.adyen.checkout.card.data.CardType
 import com.adyen.checkout.components.base.BaseConfigurationBuilder
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.core.api.Environment
+import com.adyen.checkout.qrcode.QRCodeConfiguration
 import com.adyen.checkout.redirect.RedirectConfiguration
+import com.adyen.checkout.voucher.VoucherConfiguration
+import com.adyen.checkout.wechatpay.WeChatPayActionConfiguration
 import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
@@ -46,7 +51,7 @@ class CardConfiguration private constructor(
      * Builder to create a [CardConfiguration].
      */
     @Suppress("TooManyFunctions")
-    class Builder : BaseConfigurationBuilder<CardConfiguration, Builder> {
+    class Builder : BaseConfigurationBuilder<CardConfiguration, Builder>, ActionHandlingConfigurationBuilder {
         private var supportedCardTypes: List<CardType>? = null
         private var holderNameRequired: Boolean? = null
         private var isStorePaymentFieldVisible: Boolean? = null
@@ -226,16 +231,48 @@ class CardConfiguration private constructor(
         /**
          * Add configuration for 3DS2 action.
          */
-        fun add3ds2ActionConfiguration(configuration: Adyen3DS2Configuration): Builder {
+        override fun add3ds2ActionConfiguration(configuration: Adyen3DS2Configuration): Builder {
             genericActionConfigurationBuilder.add3ds2ActionConfiguration(configuration)
+            return this
+        }
+
+        /**
+         * Add configuration for Await action.
+         */
+        override fun addAwaitActionConfiguration(configuration: AwaitConfiguration): Builder {
+            genericActionConfigurationBuilder.addAwaitActionConfiguration(configuration)
+            return this
+        }
+
+        /**
+         * Add configuration for QR code action.
+         */
+        override fun addQRCodeActionConfiguration(configuration: QRCodeConfiguration): Builder {
+            genericActionConfigurationBuilder.addQRCodeActionConfiguration(configuration)
             return this
         }
 
         /**
          * Add configuration for Redirect action.
          */
-        fun addRedirectActionConfiguration(configuration: RedirectConfiguration): Builder {
+        override fun addRedirectActionConfiguration(configuration: RedirectConfiguration): Builder {
             genericActionConfigurationBuilder.addRedirectActionConfiguration(configuration)
+            return this
+        }
+
+        /**
+         * Add configuration for Voucher action.
+         */
+        override fun addVoucherActionConfiguration(configuration: VoucherConfiguration): Builder {
+            genericActionConfigurationBuilder.addVoucherActionConfiguration(configuration)
+            return this
+        }
+
+        /**
+         * Add configuration for WeChat Pay action.
+         */
+        override fun addWeChatPayActionConfiguration(configuration: WeChatPayActionConfiguration): Builder {
+            genericActionConfigurationBuilder.addWeChatPayActionConfiguration(configuration)
             return this
         }
 

--- a/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
@@ -8,11 +8,14 @@
 package com.adyen.checkout.card
 
 import android.content.Context
+import com.adyen.checkout.action.GenericActionConfiguration
+import com.adyen.checkout.adyen3ds2.Adyen3DS2Configuration
 import com.adyen.checkout.card.data.CardType
 import com.adyen.checkout.components.base.BaseConfigurationBuilder
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.core.api.Environment
+import com.adyen.checkout.redirect.RedirectConfiguration
 import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
@@ -36,6 +39,7 @@ class CardConfiguration private constructor(
     val kcpAuthVisibility: KCPAuthVisibility?,
     val installmentConfiguration: InstallmentConfiguration?,
     val addressConfiguration: AddressConfiguration?,
+    internal val genericActionConfiguration: GenericActionConfiguration,
 ) : Configuration {
 
     /**
@@ -53,6 +57,12 @@ class CardConfiguration private constructor(
         private var kcpAuthVisibility: KCPAuthVisibility? = null
         private var installmentConfiguration: InstallmentConfiguration? = null
         private var addressConfiguration: AddressConfiguration? = null
+
+        private val genericActionConfigurationBuilder = GenericActionConfiguration.Builder(
+            shopperLocale = shopperLocale,
+            environment = environment,
+            clientKey = clientKey,
+        )
 
         /**
          * Constructor for Builder with default values.
@@ -214,6 +224,22 @@ class CardConfiguration private constructor(
         }
 
         /**
+         * Add configuration for 3DS2 action.
+         */
+        fun add3ds2ActionConfiguration(configuration: Adyen3DS2Configuration): Builder {
+            genericActionConfigurationBuilder.add3ds2ActionConfiguration(configuration)
+            return this
+        }
+
+        /**
+         * Add configuration for Redirect action.
+         */
+        fun addRedirectActionConfiguration(configuration: RedirectConfiguration): Builder {
+            genericActionConfigurationBuilder.addRedirectActionConfiguration(configuration)
+            return this
+        }
+
+        /**
          * Build [CardConfiguration] object from [CardConfiguration.Builder] inputs.
          *
          * @return [CardConfiguration]
@@ -234,6 +260,7 @@ class CardConfiguration private constructor(
                 kcpAuthVisibility = kcpAuthVisibility,
                 installmentConfiguration = installmentConfiguration,
                 addressConfiguration = addressConfiguration,
+                genericActionConfiguration = genericActionConfigurationBuilder.build()
             )
         }
     }

--- a/components-core/src/main/java/com/adyen/checkout/components/base/BaseConfigurationBuilder.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/base/BaseConfigurationBuilder.kt
@@ -1,6 +1,7 @@
 package com.adyen.checkout.components.base
 
 import android.content.Context
+import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.util.ValidationUtils
 import com.adyen.checkout.core.api.Environment
 import com.adyen.checkout.core.exception.CheckoutException
@@ -14,6 +15,7 @@ import java.util.Locale
  * @param environment   The [Environment] to be used for network calls to Adyen.
  * @param clientKey     Your Client Key used for network calls from the SDK to Adyen.
  */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 abstract class BaseConfigurationBuilder<
     ConfigurationT : Configuration,
     BuilderT : BaseConfigurationBuilder<ConfigurationT, BuilderT>

--- a/dotpay/build.gradle
+++ b/dotpay/build.gradle
@@ -35,6 +35,7 @@ android {
 
 dependencies {
     // Checkout
+    api project(':action')
     api project(':issuer-list')
 
     // Dependencies

--- a/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayConfiguration.kt
+++ b/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayConfiguration.kt
@@ -8,6 +8,7 @@
 package com.adyen.checkout.dotpay
 
 import android.content.Context
+import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.core.api.Environment
 import com.adyen.checkout.issuerlist.IssuerListConfiguration
 import com.adyen.checkout.issuerlist.IssuerListViewType
@@ -22,6 +23,7 @@ class DotpayConfiguration private constructor(
     override val isAnalyticsEnabled: Boolean?,
     override val viewType: IssuerListViewType?,
     override val hideIssuerLogos: Boolean?,
+    internal val genericActionConfiguration: GenericActionConfiguration,
 ) : IssuerListConfiguration() {
 
     /**
@@ -63,6 +65,7 @@ class DotpayConfiguration private constructor(
                 isAnalyticsEnabled = isAnalyticsEnabled,
                 viewType = viewType,
                 hideIssuerLogos = hideIssuerLogos,
+                genericActionConfiguration = genericActionConfigurationBuilder.build(),
             )
         }
     }

--- a/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayConfiguration.kt
+++ b/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayConfiguration.kt
@@ -16,6 +16,7 @@ import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
 @Parcelize
+@Suppress("LongParameterList")
 class DotpayConfiguration private constructor(
     override val shopperLocale: Locale,
     override val environment: Environment,

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
@@ -12,7 +12,6 @@ package com.adyen.checkout.dropin
 
 import android.app.Application
 import androidx.fragment.app.Fragment
-import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.bacs.BacsDirectDebitComponent
 import com.adyen.checkout.bacs.BacsDirectDebitComponentProvider
 import com.adyen.checkout.bacs.BacsDirectDebitConfiguration
@@ -252,18 +251,6 @@ internal fun <T : Configuration> getDefaultConfigForPaymentMethod(
 
     @Suppress("UNCHECKED_CAST")
     return builder.build() as T
-}
-
-internal fun createGenericActionConfiguration(dropInConfiguration: DropInConfiguration): GenericActionConfiguration {
-    return GenericActionConfiguration.Builder(
-        dropInConfiguration.shopperLocale,
-        dropInConfiguration.environment,
-        dropInConfiguration.clientKey
-    ).apply {
-        dropInConfiguration.availableActionConfigs.entries.forEach { entry ->
-            availableActionConfigs[entry.key] = entry.value
-        }
-    }.build()
 }
 
 private inline fun <reified T : Configuration> getConfigurationForPaymentMethodOrNull(

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
@@ -10,17 +10,14 @@ package com.adyen.checkout.dropin
 
 import android.content.Context
 import android.os.Bundle
-import com.adyen.checkout.action.ActionHandlingConfigurationBuilder
+import com.adyen.checkout.action.ActionHandlingPaymentMethodConfigurationBuilder
 import com.adyen.checkout.action.GenericActionConfiguration
-import com.adyen.checkout.adyen3ds2.Adyen3DS2Configuration
-import com.adyen.checkout.await.AwaitConfiguration
 import com.adyen.checkout.bacs.BacsDirectDebitConfiguration
 import com.adyen.checkout.bcmc.BcmcConfiguration
 import com.adyen.checkout.blik.BlikConfiguration
 import com.adyen.checkout.card.CardConfiguration
 import com.adyen.checkout.components.base.AmountConfiguration
 import com.adyen.checkout.components.base.AmountConfigurationBuilder
-import com.adyen.checkout.components.base.BaseConfigurationBuilder
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.model.payments.Amount
 import com.adyen.checkout.components.util.CheckoutCurrency
@@ -40,11 +37,7 @@ import com.adyen.checkout.onlinebankingcz.OnlineBankingCZConfiguration
 import com.adyen.checkout.onlinebankingpl.OnlineBankingPLConfiguration
 import com.adyen.checkout.onlinebankingsk.OnlineBankingSKConfiguration
 import com.adyen.checkout.openbanking.OpenBankingConfiguration
-import com.adyen.checkout.qrcode.QRCodeConfiguration
-import com.adyen.checkout.redirect.RedirectConfiguration
 import com.adyen.checkout.sepa.SepaConfiguration
-import com.adyen.checkout.voucher.VoucherConfiguration
-import com.adyen.checkout.wechatpay.WeChatPayActionConfiguration
 import kotlinx.parcelize.Parcelize
 import java.util.Locale
 import kotlin.collections.set
@@ -84,9 +77,8 @@ class DropInConfiguration private constructor(
      */
     @Suppress("unused", "TooManyFunctions")
     class Builder :
-        BaseConfigurationBuilder<DropInConfiguration, Builder>,
-        AmountConfigurationBuilder,
-        ActionHandlingConfigurationBuilder {
+        ActionHandlingPaymentMethodConfigurationBuilder<DropInConfiguration, Builder>,
+        AmountConfigurationBuilder {
 
         private val availablePaymentConfigs = HashMap<String, Configuration>()
 
@@ -95,12 +87,6 @@ class DropInConfiguration private constructor(
         private var skipListWhenSinglePaymentMethod: Boolean = false
         private var isRemovingStoredPaymentMethodsEnabled: Boolean = false
         private var additionalDataForDropInService: Bundle? = null
-
-        private val genericActionConfigurationBuilder = GenericActionConfiguration.Builder(
-            shopperLocale = shopperLocale,
-            environment = environment,
-            clientKey = clientKey,
-        )
 
         /**
          * Create a [DropInConfiguration]
@@ -319,54 +305,6 @@ class DropInConfiguration private constructor(
          */
         fun addBacsDirectDebitConfiguration(bacsDirectDebitConfiguration: BacsDirectDebitConfiguration): Builder {
             availablePaymentConfigs[PaymentMethodTypes.BACS] = bacsDirectDebitConfiguration
-            return this
-        }
-
-        /**
-         * Add configuration for 3DS2 action.
-         */
-        override fun add3ds2ActionConfiguration(configuration: Adyen3DS2Configuration): Builder {
-            genericActionConfigurationBuilder.add3ds2ActionConfiguration(configuration)
-            return this
-        }
-
-        /**
-         * Add configuration for Await action.
-         */
-        override fun addAwaitActionConfiguration(configuration: AwaitConfiguration): Builder {
-            genericActionConfigurationBuilder.addAwaitActionConfiguration(configuration)
-            return this
-        }
-
-        /**
-         * Add configuration for QR code action.
-         */
-        override fun addQRCodeActionConfiguration(configuration: QRCodeConfiguration): Builder {
-            genericActionConfigurationBuilder.addQRCodeActionConfiguration(configuration)
-            return this
-        }
-
-        /**
-         * Add configuration for Redirect action.
-         */
-        override fun addRedirectActionConfiguration(configuration: RedirectConfiguration): Builder {
-            genericActionConfigurationBuilder.addRedirectActionConfiguration(configuration)
-            return this
-        }
-
-        /**
-         * Add configuration for Voucher action.
-         */
-        override fun addVoucherActionConfiguration(configuration: VoucherConfiguration): Builder {
-            genericActionConfigurationBuilder.addVoucherActionConfiguration(configuration)
-            return this
-        }
-
-        /**
-         * Add configuration for WeChat Pay action.
-         */
-        override fun addWeChatPayActionConfiguration(configuration: WeChatPayActionConfiguration): Builder {
-            genericActionConfigurationBuilder.addWeChatPayActionConfiguration(configuration)
             return this
         }
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInActivity.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/DropInActivity.kt
@@ -40,7 +40,6 @@ import com.adyen.checkout.dropin.DropIn
 import com.adyen.checkout.dropin.DropInConfiguration
 import com.adyen.checkout.dropin.DropInPrefs
 import com.adyen.checkout.dropin.R
-import com.adyen.checkout.dropin.createGenericActionConfiguration
 import com.adyen.checkout.dropin.databinding.ActivityDropInBinding
 import com.adyen.checkout.dropin.service.BalanceDropInServiceResult
 import com.adyen.checkout.dropin.service.BaseDropInServiceResult
@@ -488,7 +487,7 @@ internal class DropInActivity :
         Logger.d(TAG, "showActionDialog")
         setLoading(false)
         hideAllScreens()
-        val actionConfiguration = createGenericActionConfiguration(dropInViewModel.dropInConfiguration)
+        val actionConfiguration = dropInViewModel.dropInConfiguration.genericActionConfiguration
         val actionFragment = ActionComponentDialogFragment.newInstance(action, actionConfiguration)
         actionFragment.show(supportFragmentManager, ACTION_FRAGMENT_TAG)
     }

--- a/entercash/build.gradle
+++ b/entercash/build.gradle
@@ -35,6 +35,7 @@ android {
 
 dependencies {
     // Checkout
+    api project(':action')
     api project(':issuer-list')
 
     // Dependencies

--- a/entercash/src/main/java/com/adyen/checkout/entercash/EntercashConfiguration.kt
+++ b/entercash/src/main/java/com/adyen/checkout/entercash/EntercashConfiguration.kt
@@ -8,6 +8,7 @@
 package com.adyen.checkout.entercash
 
 import android.content.Context
+import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.core.api.Environment
 import com.adyen.checkout.issuerlist.IssuerListConfiguration
 import com.adyen.checkout.issuerlist.IssuerListViewType
@@ -22,6 +23,7 @@ class EntercashConfiguration private constructor(
     override val isAnalyticsEnabled: Boolean?,
     override val viewType: IssuerListViewType?,
     override val hideIssuerLogos: Boolean?,
+    internal val genericActionConfiguration: GenericActionConfiguration,
 ) : IssuerListConfiguration() {
 
     /**
@@ -63,6 +65,7 @@ class EntercashConfiguration private constructor(
                 isAnalyticsEnabled = isAnalyticsEnabled,
                 viewType = viewType,
                 hideIssuerLogos = hideIssuerLogos,
+                genericActionConfiguration = genericActionConfigurationBuilder.build(),
             )
         }
     }

--- a/entercash/src/main/java/com/adyen/checkout/entercash/EntercashConfiguration.kt
+++ b/entercash/src/main/java/com/adyen/checkout/entercash/EntercashConfiguration.kt
@@ -16,6 +16,7 @@ import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
 @Parcelize
+@Suppress("LongParameterList")
 class EntercashConfiguration private constructor(
     override val shopperLocale: Locale,
     override val environment: Environment,

--- a/eps/build.gradle
+++ b/eps/build.gradle
@@ -35,6 +35,7 @@ android {
 
 dependencies {
     // Checkout
+    api project(':action')
     api project(':issuer-list')
 
     // Dependencies

--- a/eps/src/main/java/com/adyen/checkout/eps/EPSConfiguration.kt
+++ b/eps/src/main/java/com/adyen/checkout/eps/EPSConfiguration.kt
@@ -16,6 +16,7 @@ import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
 @Parcelize
+@Suppress("LongParameterList")
 class EPSConfiguration private constructor(
     override val shopperLocale: Locale,
     override val environment: Environment,

--- a/eps/src/main/java/com/adyen/checkout/eps/EPSConfiguration.kt
+++ b/eps/src/main/java/com/adyen/checkout/eps/EPSConfiguration.kt
@@ -8,11 +8,12 @@
 package com.adyen.checkout.eps
 
 import android.content.Context
+import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.core.api.Environment
 import com.adyen.checkout.issuerlist.IssuerListConfiguration
 import com.adyen.checkout.issuerlist.IssuerListViewType
-import java.util.Locale
 import kotlinx.parcelize.Parcelize
+import java.util.Locale
 
 @Parcelize
 class EPSConfiguration private constructor(
@@ -22,6 +23,7 @@ class EPSConfiguration private constructor(
     override val isAnalyticsEnabled: Boolean?,
     override val viewType: IssuerListViewType?,
     override val hideIssuerLogos: Boolean?,
+    internal val genericActionConfiguration: GenericActionConfiguration,
 ) : IssuerListConfiguration() {
 
     /**
@@ -63,6 +65,7 @@ class EPSConfiguration private constructor(
                 isAnalyticsEnabled = isAnalyticsEnabled,
                 viewType = viewType,
                 hideIssuerLogos = hideIssuerLogos,
+                genericActionConfiguration = genericActionConfigurationBuilder.build(),
             )
         }
     }

--- a/giftcard/build.gradle
+++ b/giftcard/build.gradle
@@ -42,8 +42,9 @@ android {
 
 dependencies {
     // Checkout
-    api project(':ui-core')
+    api project(':action')
     api project(':cse')
+    api project(':ui-core')
 
     // Dependencies
     implementation libraries.material

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardConfiguration.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardConfiguration.kt
@@ -8,7 +8,8 @@
 package com.adyen.checkout.giftcard
 
 import android.content.Context
-import com.adyen.checkout.components.base.BaseConfigurationBuilder
+import com.adyen.checkout.action.ActionHandlingPaymentMethodConfigurationBuilder
+import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.core.api.Environment
 import kotlinx.parcelize.Parcelize
@@ -20,12 +21,13 @@ class GiftCardConfiguration private constructor(
     override val environment: Environment,
     override val clientKey: String,
     override val isAnalyticsEnabled: Boolean?,
+    internal val genericActionConfiguration: GenericActionConfiguration,
 ) : Configuration {
 
     /**
      * Builder to create a [GiftCardConfiguration].
      */
-    class Builder : BaseConfigurationBuilder<GiftCardConfiguration, Builder> {
+    class Builder : ActionHandlingPaymentMethodConfigurationBuilder<GiftCardConfiguration, Builder> {
 
         /**
          * Constructor for Builder with default values.
@@ -59,6 +61,7 @@ class GiftCardConfiguration private constructor(
                 environment = environment,
                 clientKey = clientKey,
                 isAnalyticsEnabled = isAnalyticsEnabled,
+                genericActionConfiguration = genericActionConfigurationBuilder.build(),
             )
         }
     }

--- a/googlepay/build.gradle
+++ b/googlepay/build.gradle
@@ -35,6 +35,7 @@ android {
 
 dependencies {
     // Checkout
+    api project(':action')
     api project(':components-core')
 
     // Dependencies

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.kt
@@ -10,9 +10,10 @@
 package com.adyen.checkout.googlepay
 
 import android.content.Context
+import com.adyen.checkout.action.ActionHandlingPaymentMethodConfigurationBuilder
+import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.components.base.AmountConfiguration
 import com.adyen.checkout.components.base.AmountConfigurationBuilder
-import com.adyen.checkout.components.base.BaseConfigurationBuilder
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.model.payments.Amount
@@ -48,13 +49,16 @@ class GooglePayConfiguration private constructor(
     val shippingAddressParameters: ShippingAddressParameters?,
     val isBillingAddressRequired: Boolean?,
     val billingAddressParameters: BillingAddressParameters?,
+    internal val genericActionConfiguration: GenericActionConfiguration,
 ) : Configuration, AmountConfiguration {
 
     /**
      * Builder to create a [GooglePayConfiguration].
      */
     @Suppress("TooManyFunctions")
-    class Builder : BaseConfigurationBuilder<GooglePayConfiguration, Builder>, AmountConfigurationBuilder {
+    class Builder :
+        ActionHandlingPaymentMethodConfigurationBuilder<GooglePayConfiguration, Builder>,
+        AmountConfigurationBuilder {
         private var merchantAccount: String? = null
         private var googlePayEnvironment: Int? = null
         private var amount: Amount? = null
@@ -344,6 +348,7 @@ class GooglePayConfiguration private constructor(
                 shippingAddressParameters = shippingAddressParameters,
                 isBillingAddressRequired = isBillingAddressRequired,
                 billingAddressParameters = billingAddressParameters,
+                genericActionConfiguration = genericActionConfigurationBuilder.build(),
             )
         }
     }

--- a/ideal/build.gradle
+++ b/ideal/build.gradle
@@ -35,6 +35,7 @@ android {
 
 dependencies {
     // Checkout
+    api project(':action')
     api project(':issuer-list')
 
     // Dependencies

--- a/ideal/src/main/java/com/adyen/checkout/ideal/IdealConfiguration.kt
+++ b/ideal/src/main/java/com/adyen/checkout/ideal/IdealConfiguration.kt
@@ -16,6 +16,7 @@ import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
 @Parcelize
+@Suppress("LongParameterList")
 class IdealConfiguration private constructor(
     override val shopperLocale: Locale,
     override val environment: Environment,

--- a/ideal/src/main/java/com/adyen/checkout/ideal/IdealConfiguration.kt
+++ b/ideal/src/main/java/com/adyen/checkout/ideal/IdealConfiguration.kt
@@ -8,6 +8,7 @@
 package com.adyen.checkout.ideal
 
 import android.content.Context
+import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.core.api.Environment
 import com.adyen.checkout.issuerlist.IssuerListConfiguration
 import com.adyen.checkout.issuerlist.IssuerListViewType
@@ -22,6 +23,7 @@ class IdealConfiguration private constructor(
     override val isAnalyticsEnabled: Boolean?,
     override val viewType: IssuerListViewType?,
     override val hideIssuerLogos: Boolean?,
+    internal val genericActionConfiguration: GenericActionConfiguration,
 ) : IssuerListConfiguration() {
 
     /**
@@ -63,6 +65,7 @@ class IdealConfiguration private constructor(
                 isAnalyticsEnabled = isAnalyticsEnabled,
                 viewType = viewType,
                 hideIssuerLogos = hideIssuerLogos,
+                genericActionConfiguration = genericActionConfigurationBuilder.build(),
             )
         }
     }

--- a/instant/build.gradle
+++ b/instant/build.gradle
@@ -30,6 +30,7 @@ android {
 }
 dependencies {
     // Checkout
+    api project(':action')
     api project(':components-core')
 
     // Dependencies

--- a/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentConfiguration.kt
+++ b/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentConfiguration.kt
@@ -9,7 +9,8 @@
 package com.adyen.checkout.instant
 
 import android.content.Context
-import com.adyen.checkout.components.base.BaseConfigurationBuilder
+import com.adyen.checkout.action.ActionHandlingPaymentMethodConfigurationBuilder
+import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.core.api.Environment
 import kotlinx.parcelize.Parcelize
@@ -21,12 +22,13 @@ class InstantPaymentConfiguration private constructor(
     override val environment: Environment,
     override val clientKey: String,
     override val isAnalyticsEnabled: Boolean?,
+    internal val genericActionConfiguration: GenericActionConfiguration,
 ) : Configuration {
 
     /**
      * Builder to create a [InstantPaymentConfiguration].
      */
-    class Builder : BaseConfigurationBuilder<InstantPaymentConfiguration, Builder> {
+    class Builder : ActionHandlingPaymentMethodConfigurationBuilder<InstantPaymentConfiguration, Builder> {
 
         /**
          * Constructor for Builder with default values.
@@ -60,6 +62,7 @@ class InstantPaymentConfiguration private constructor(
                 environment = environment,
                 clientKey = clientKey,
                 isAnalyticsEnabled = isAnalyticsEnabled,
+                genericActionConfiguration = genericActionConfigurationBuilder.build(),
             )
         }
     }

--- a/issuer-list/build.gradle
+++ b/issuer-list/build.gradle
@@ -39,6 +39,7 @@ android {
 
 dependencies {
     // Checkout
+    api project(':action')
     api project(':ui-core')
 
     // Dependencies

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/IssuerListConfiguration.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/IssuerListConfiguration.kt
@@ -8,7 +8,7 @@
 package com.adyen.checkout.issuerlist
 
 import android.content.Context
-import com.adyen.checkout.components.base.BaseConfigurationBuilder
+import com.adyen.checkout.action.ActionHandlingPaymentMethodConfigurationBuilder
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.core.api.Environment
 import java.util.Locale
@@ -21,7 +21,7 @@ abstract class IssuerListConfiguration : Configuration {
     abstract class IssuerListBuilder<
         IssuerListConfigurationT : IssuerListConfiguration,
         IssuerListBuilderT : IssuerListBuilder<IssuerListConfigurationT, IssuerListBuilderT>
-        > : BaseConfigurationBuilder<IssuerListConfigurationT, IssuerListBuilderT> {
+        > : ActionHandlingPaymentMethodConfigurationBuilder<IssuerListConfigurationT, IssuerListBuilderT> {
 
         protected open var viewType: IssuerListViewType? = null
         protected open var hideIssuerLogos: Boolean? = null

--- a/mbway/build.gradle
+++ b/mbway/build.gradle
@@ -38,6 +38,7 @@ android {
 
 dependencies {
     // Checkout
+    api project(':action')
     api project(':ui-core')
 
     // Dependencies

--- a/mbway/src/main/java/com/adyen/checkout/mbway/MBWayConfiguration.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/MBWayConfiguration.kt
@@ -8,7 +8,8 @@
 package com.adyen.checkout.mbway
 
 import android.content.Context
-import com.adyen.checkout.components.base.BaseConfigurationBuilder
+import com.adyen.checkout.action.ActionHandlingPaymentMethodConfigurationBuilder
+import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.core.api.Environment
 import kotlinx.parcelize.Parcelize
@@ -20,12 +21,13 @@ class MBWayConfiguration private constructor(
     override val environment: Environment,
     override val clientKey: String,
     override val isAnalyticsEnabled: Boolean?,
+    internal val genericActionConfiguration: GenericActionConfiguration,
 ) : Configuration {
 
     /**
      * Builder to create a [MBWayConfiguration].
      */
-    class Builder : BaseConfigurationBuilder<MBWayConfiguration, Builder> {
+    class Builder : ActionHandlingPaymentMethodConfigurationBuilder<MBWayConfiguration, Builder> {
 
         /**
          * Constructor for Builder with default values.
@@ -59,6 +61,7 @@ class MBWayConfiguration private constructor(
                 environment = environment,
                 clientKey = clientKey,
                 isAnalyticsEnabled = isAnalyticsEnabled,
+                genericActionConfiguration = genericActionConfigurationBuilder.build(),
             )
         }
     }

--- a/molpay/build.gradle
+++ b/molpay/build.gradle
@@ -35,6 +35,7 @@ android {
 
 dependencies {
     // Checkout
+    api project(':action')
     api project(':issuer-list')
 
     // Dependencies

--- a/molpay/src/main/java/com/adyen/checkout/molpay/MolpayConfiguration.kt
+++ b/molpay/src/main/java/com/adyen/checkout/molpay/MolpayConfiguration.kt
@@ -8,6 +8,7 @@
 package com.adyen.checkout.molpay
 
 import android.content.Context
+import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.core.api.Environment
 import com.adyen.checkout.issuerlist.IssuerListConfiguration
 import com.adyen.checkout.issuerlist.IssuerListViewType
@@ -22,6 +23,7 @@ class MolpayConfiguration private constructor(
     override val isAnalyticsEnabled: Boolean?,
     override val viewType: IssuerListViewType?,
     override val hideIssuerLogos: Boolean?,
+    internal val genericActionConfiguration: GenericActionConfiguration,
 ) : IssuerListConfiguration() {
 
     /**
@@ -63,6 +65,7 @@ class MolpayConfiguration private constructor(
                 isAnalyticsEnabled = isAnalyticsEnabled,
                 viewType = viewType,
                 hideIssuerLogos = hideIssuerLogos,
+                genericActionConfiguration = genericActionConfigurationBuilder.build(),
             )
         }
     }

--- a/molpay/src/main/java/com/adyen/checkout/molpay/MolpayConfiguration.kt
+++ b/molpay/src/main/java/com/adyen/checkout/molpay/MolpayConfiguration.kt
@@ -16,6 +16,7 @@ import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
 @Parcelize
+@Suppress("LongParameterList")
 class MolpayConfiguration private constructor(
     override val shopperLocale: Locale,
     override val environment: Environment,

--- a/online-banking-cz/build.gradle
+++ b/online-banking-cz/build.gradle
@@ -34,5 +34,6 @@ android {
 
 dependencies {
     // Checkout
+    api project(':action')
     api project(':online-banking-core')
 }

--- a/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZConfiguration.kt
+++ b/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZConfiguration.kt
@@ -9,7 +9,8 @@
 package com.adyen.checkout.onlinebankingcz
 
 import android.content.Context
-import com.adyen.checkout.components.base.BaseConfigurationBuilder
+import com.adyen.checkout.action.ActionHandlingPaymentMethodConfigurationBuilder
+import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.core.api.Environment
 import kotlinx.parcelize.Parcelize
@@ -21,9 +22,10 @@ class OnlineBankingCZConfiguration private constructor(
     override val environment: Environment,
     override val clientKey: String,
     override val isAnalyticsEnabled: Boolean?,
+    internal val genericActionConfiguration: GenericActionConfiguration,
 ) : Configuration {
 
-    class Builder : BaseConfigurationBuilder<OnlineBankingCZConfiguration, Builder> {
+    class Builder : ActionHandlingPaymentMethodConfigurationBuilder<OnlineBankingCZConfiguration, Builder> {
 
         /**
          * Constructor for Builder with default values.
@@ -57,6 +59,7 @@ class OnlineBankingCZConfiguration private constructor(
                 environment = environment,
                 clientKey = clientKey,
                 isAnalyticsEnabled = isAnalyticsEnabled,
+                genericActionConfiguration = genericActionConfigurationBuilder.build(),
             )
         }
     }

--- a/online-banking-pl/build.gradle
+++ b/online-banking-pl/build.gradle
@@ -34,6 +34,7 @@ android {
 
 dependencies {
     // Checkout
+    api project(':action')
     api project(':issuer-list')
 
     // Dependencies

--- a/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLConfiguration.kt
+++ b/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLConfiguration.kt
@@ -17,6 +17,7 @@ import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
 @Parcelize
+@Suppress("LongParameterList")
 class OnlineBankingPLConfiguration private constructor(
     override val shopperLocale: Locale,
     override val environment: Environment,

--- a/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLConfiguration.kt
+++ b/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLConfiguration.kt
@@ -9,6 +9,7 @@
 package com.adyen.checkout.onlinebankingpl
 
 import android.content.Context
+import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.core.api.Environment
 import com.adyen.checkout.issuerlist.IssuerListConfiguration
 import com.adyen.checkout.issuerlist.IssuerListViewType
@@ -23,6 +24,7 @@ class OnlineBankingPLConfiguration private constructor(
     override val isAnalyticsEnabled: Boolean?,
     override val viewType: IssuerListViewType?,
     override val hideIssuerLogos: Boolean?,
+    internal val genericActionConfiguration: GenericActionConfiguration,
 ) : IssuerListConfiguration() {
 
     class Builder : IssuerListBuilder<OnlineBankingPLConfiguration, Builder> {
@@ -61,6 +63,7 @@ class OnlineBankingPLConfiguration private constructor(
                 isAnalyticsEnabled = isAnalyticsEnabled,
                 viewType = viewType,
                 hideIssuerLogos = hideIssuerLogos,
+                genericActionConfiguration = genericActionConfigurationBuilder.build(),
             )
         }
     }

--- a/online-banking-sk/build.gradle
+++ b/online-banking-sk/build.gradle
@@ -34,5 +34,6 @@ android {
 
 dependencies {
     // Checkout
+    api project(':action')
     api project(':online-banking-core')
 }

--- a/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKConfiguration.kt
+++ b/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKConfiguration.kt
@@ -9,7 +9,8 @@
 package com.adyen.checkout.onlinebankingsk
 
 import android.content.Context
-import com.adyen.checkout.components.base.BaseConfigurationBuilder
+import com.adyen.checkout.action.ActionHandlingPaymentMethodConfigurationBuilder
+import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.core.api.Environment
 import kotlinx.parcelize.Parcelize
@@ -21,9 +22,10 @@ class OnlineBankingSKConfiguration private constructor(
     override val environment: Environment,
     override val clientKey: String,
     override val isAnalyticsEnabled: Boolean?,
+    internal val genericActionConfiguration: GenericActionConfiguration,
 ) : Configuration {
 
-    class Builder : BaseConfigurationBuilder<OnlineBankingSKConfiguration, Builder> {
+    class Builder : ActionHandlingPaymentMethodConfigurationBuilder<OnlineBankingSKConfiguration, Builder> {
 
         /**
          * Constructor for Builder with default values.
@@ -57,6 +59,7 @@ class OnlineBankingSKConfiguration private constructor(
                 environment = environment,
                 clientKey = clientKey,
                 isAnalyticsEnabled = isAnalyticsEnabled,
+                genericActionConfiguration = genericActionConfigurationBuilder.build(),
             )
         }
     }

--- a/openbanking/build.gradle
+++ b/openbanking/build.gradle
@@ -35,6 +35,7 @@ android {
 
 dependencies {
     // Checkout
+    api project(':action')
     api project(':issuer-list')
 
     // Dependencies

--- a/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingConfiguration.kt
+++ b/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingConfiguration.kt
@@ -8,6 +8,7 @@
 package com.adyen.checkout.openbanking
 
 import android.content.Context
+import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.core.api.Environment
 import com.adyen.checkout.issuerlist.IssuerListConfiguration
 import com.adyen.checkout.issuerlist.IssuerListViewType
@@ -22,6 +23,7 @@ class OpenBankingConfiguration private constructor(
     override val isAnalyticsEnabled: Boolean?,
     override val viewType: IssuerListViewType?,
     override val hideIssuerLogos: Boolean?,
+    internal val genericActionConfiguration: GenericActionConfiguration,
 ) : IssuerListConfiguration() {
 
     /**
@@ -63,6 +65,7 @@ class OpenBankingConfiguration private constructor(
                 isAnalyticsEnabled = isAnalyticsEnabled,
                 viewType = viewType,
                 hideIssuerLogos = hideIssuerLogos,
+                genericActionConfiguration = genericActionConfigurationBuilder.build(),
             )
         }
     }

--- a/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingConfiguration.kt
+++ b/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingConfiguration.kt
@@ -16,6 +16,7 @@ import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
 @Parcelize
+@Suppress("LongParameterList")
 class OpenBankingConfiguration private constructor(
     override val shopperLocale: Locale,
     override val environment: Environment,

--- a/paybybank/build.gradle
+++ b/paybybank/build.gradle
@@ -30,6 +30,7 @@ android {
 
 dependencies {
     // Checkout
+    api project(':action')
     api project(':components-core')
     api project(':issuer-list')
 

--- a/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankConfiguration.kt
+++ b/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankConfiguration.kt
@@ -9,7 +9,8 @@
 package com.adyen.checkout.paybybank
 
 import android.content.Context
-import com.adyen.checkout.components.base.BaseConfigurationBuilder
+import com.adyen.checkout.action.ActionHandlingPaymentMethodConfigurationBuilder
+import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.core.api.Environment
 import kotlinx.parcelize.Parcelize
@@ -21,12 +22,13 @@ class PayByBankConfiguration private constructor(
     override val environment: Environment,
     override val clientKey: String,
     override val isAnalyticsEnabled: Boolean?,
+    internal val genericActionConfiguration: GenericActionConfiguration,
 ) : Configuration {
 
     /**
      * Builder to create a [PayByBankConfiguration].
      */
-    class Builder : BaseConfigurationBuilder<PayByBankConfiguration, Builder> {
+    class Builder : ActionHandlingPaymentMethodConfigurationBuilder<PayByBankConfiguration, Builder> {
         /**
          * Constructor for Builder with default values.
          *
@@ -59,6 +61,7 @@ class PayByBankConfiguration private constructor(
                 environment = environment,
                 clientKey = clientKey,
                 isAnalyticsEnabled = isAnalyticsEnabled,
+                genericActionConfiguration = genericActionConfigurationBuilder.build(),
             )
         }
     }

--- a/sepa/build.gradle
+++ b/sepa/build.gradle
@@ -43,6 +43,7 @@ android {
 
 dependencies {
     // Checkout
+    api project(':action')
     api project(':ui-core')
 
     // Dependencies

--- a/sepa/src/main/java/com/adyen/checkout/sepa/SepaConfiguration.kt
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/SepaConfiguration.kt
@@ -8,7 +8,8 @@
 package com.adyen.checkout.sepa
 
 import android.content.Context
-import com.adyen.checkout.components.base.BaseConfigurationBuilder
+import com.adyen.checkout.action.ActionHandlingPaymentMethodConfigurationBuilder
+import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.core.api.Environment
 import kotlinx.parcelize.Parcelize
@@ -20,12 +21,13 @@ class SepaConfiguration private constructor(
     override val environment: Environment,
     override val clientKey: String,
     override val isAnalyticsEnabled: Boolean?,
+    internal val genericActionConfiguration: GenericActionConfiguration,
 ) : Configuration {
 
     /**
      * Builder to create a [SepaConfiguration].
      */
-    class Builder : BaseConfigurationBuilder<SepaConfiguration, Builder> {
+    class Builder : ActionHandlingPaymentMethodConfigurationBuilder<SepaConfiguration, Builder> {
 
         /**
          * Constructor for Builder with default values.
@@ -59,6 +61,7 @@ class SepaConfiguration private constructor(
                 environment = environment,
                 clientKey = clientKey,
                 isAnalyticsEnabled = isAnalyticsEnabled,
+                genericActionConfiguration = genericActionConfigurationBuilder.build(),
             )
         }
     }


### PR DESCRIPTION
## Description
Because components will be able to handle any action it should be possible to configure actions for components. It's now possible to do that by calling `add...ActionConfiguration` on any payment method component configuration.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-681
