### PR TITLE
Fix payment methods headers

### DIFF
--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/viewmodel/PaymentMethodsListViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/viewmodel/PaymentMethodsListViewModel.kt
@@ -121,9 +121,9 @@ internal class PaymentMethodsListViewModel(
             val paymentMethodsList: List<PaymentMethodModel> = paymentMethods.mapToPaymentMethodModelList()
             if (paymentMethodsList.isNotEmpty()) {
                 val headerType = if (hasStoredPaymentMethods) {
-                    PaymentMethodHeader.TYPE_REGULAR_HEADER_WITHOUT_STORED
-                } else {
                     PaymentMethodHeader.TYPE_REGULAR_HEADER_WITH_STORED
+                } else {
+                    PaymentMethodHeader.TYPE_REGULAR_HEADER_WITHOUT_STORED
                 }
 
                 add(PaymentMethodHeader(headerType))


### PR DESCRIPTION
## Description
When there's stored payment methods, payment methods header should be `Select other method` and when there's no stored payment methods header should be `Payment Methods`

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-686

## Screenshots
<img width="200" alt="image" src="https://user-images.githubusercontent.com/9472753/206449203-113ea783-8332-48c2-9476-cf06de664d00.png"> <img width="200" alt="image" src="https://user-images.githubusercontent.com/9472753/206449560-9365119f-23e2-4d9f-904a-b747ea812896.png">




