### PR TITLE
Fix crash in generic action handling

### DIFF
--- a/ui-core/src/main/java/com/adyen/checkout/components/ui/view/AdyenComponentView.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/components/ui/view/AdyenComponentView.kt
@@ -57,6 +57,11 @@ class AdyenComponentView @JvmOverloads constructor(
             .onEach { componentViewType ->
                 removeAllViews()
 
+                if (componentViewType == null) {
+                    Logger.i(TAG, "Component view type is null, ignoring.")
+                    return@onEach
+                }
+
                 val delegate = component.delegate
                 if (delegate !is ViewProvidingDelegate) {
                     Logger.i(TAG, "View attached to non viewable component, ignoring.")
@@ -76,13 +81,11 @@ class AdyenComponentView @JvmOverloads constructor(
     }
 
     private fun loadView(
-        viewType: ComponentViewType?,
+        viewType: ComponentViewType,
         delegate: ComponentDelegate,
         componentParams: ComponentParams,
         coroutineScope: CoroutineScope,
     ) {
-        viewType ?: return
-
         val componentView = viewType.viewProvider.getView(viewType, context, attrs, defStyleAttr)
         this.componentView = componentView
 


### PR DESCRIPTION
## Description
1. Open Ideal (or any payment method that's using an action)
2. Crash

When the ComponentViewType is null then there most likely also is no delegate, but we were trying to get the delegate anyway. A simple check before fixes it.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-650
