### PR TITLE
Remove US debit cards from supported type

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/CardComponentParamsMapper.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponentParamsMapper.kt
@@ -9,6 +9,7 @@
 package com.adyen.checkout.card
 
 import com.adyen.checkout.card.data.CardType
+import com.adyen.checkout.card.data.RestrictedCardType
 import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.core.log.LogUtil
@@ -26,6 +27,7 @@ internal class CardComponentParamsMapper(
         return cardConfiguration
             .mapToParamsInternal(supportedCardTypes)
             .override(overrideComponentParams)
+            .removeRestrictedCards()
     }
 
     fun mapToParamsStored(
@@ -35,6 +37,7 @@ internal class CardComponentParamsMapper(
         return cardConfiguration
             .mapToParamsInternal(supportedCardTypes)
             .override(overrideComponentParams)
+            .removeRestrictedCards()
     }
 
     private fun CardConfiguration.mapToParamsInternal(
@@ -98,6 +101,12 @@ internal class CardComponentParamsMapper(
             clientKey = overrideComponentParams.clientKey,
             isAnalyticsEnabled = overrideComponentParams.isAnalyticsEnabled,
             isCreatedByDropIn = overrideComponentParams.isCreatedByDropIn,
+        )
+    }
+
+    private fun CardComponentParams.removeRestrictedCards(): CardComponentParams {
+        return copy(
+            supportedCardTypes = supportedCardTypes.filter { !RestrictedCardType.isRestrictedCardType(it.txVariant) }
         )
     }
 

--- a/card/src/main/java/com/adyen/checkout/card/CardComponentParamsMapper.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponentParamsMapper.kt
@@ -27,7 +27,6 @@ internal class CardComponentParamsMapper(
         return cardConfiguration
             .mapToParamsInternal(supportedCardTypes)
             .override(overrideComponentParams)
-            .removeRestrictedCards()
     }
 
     fun mapToParamsStored(
@@ -37,7 +36,6 @@ internal class CardComponentParamsMapper(
         return cardConfiguration
             .mapToParamsInternal(supportedCardTypes)
             .override(overrideComponentParams)
-            .removeRestrictedCards()
     }
 
     private fun CardConfiguration.mapToParamsInternal(
@@ -65,6 +63,7 @@ internal class CardComponentParamsMapper(
     /**
      * Check which set of supported cards to pass to the component.
      * Priority is: Custom -> PaymentMethod.brands -> Default
+     * remove restricted card type
      */
     private fun CardConfiguration.getSupportedCardTypes(
         paymentMethod: PaymentMethod
@@ -84,11 +83,15 @@ internal class CardComponentParamsMapper(
                 Logger.v(TAG, "Falling back to CardConfiguration.DEFAULT_SUPPORTED_CARDS_LIST")
                 CardConfiguration.DEFAULT_SUPPORTED_CARDS_LIST
             }
-        }
+        }.removeRestrictedCards()
     }
 
     private fun CardConfiguration.getSupportedCardTypesStored(): List<CardType> {
-        return supportedCardTypes.orEmpty()
+        return supportedCardTypes.orEmpty().removeRestrictedCards()
+    }
+
+    private fun List<CardType>.removeRestrictedCards(): List<CardType> {
+        return this.filter { !RestrictedCardType.isRestrictedCardType(it.txVariant) }
     }
 
     private fun CardComponentParams.override(
@@ -101,12 +104,6 @@ internal class CardComponentParamsMapper(
             clientKey = overrideComponentParams.clientKey,
             isAnalyticsEnabled = overrideComponentParams.isAnalyticsEnabled,
             isCreatedByDropIn = overrideComponentParams.isCreatedByDropIn,
-        )
-    }
-
-    private fun CardComponentParams.removeRestrictedCards(): CardComponentParams {
-        return copy(
-            supportedCardTypes = supportedCardTypes.filter { !RestrictedCardType.isRestrictedCardType(it.txVariant) }
         )
     }
 

--- a/card/src/main/java/com/adyen/checkout/card/data/RestrictedCardType.kt
+++ b/card/src/main/java/com/adyen/checkout/card/data/RestrictedCardType.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by onurk on 12/12/2022.
+ */
+
+package com.adyen.checkout.card.data
+
+enum class RestrictedCardType(val txVariant: String) {
+    ACCEL("accel"),
+    PULSE("pulse"),
+    STAR("star"),
+    NYCE("nyce");
+
+    companion object {
+        fun isRestrictedCardType(brand: String) = values().any { brand == it.txVariant }
+    }
+}

--- a/card/src/main/java/com/adyen/checkout/card/data/RestrictedCardType.kt
+++ b/card/src/main/java/com/adyen/checkout/card/data/RestrictedCardType.kt
@@ -8,7 +8,7 @@
 
 package com.adyen.checkout.card.data
 
-enum class RestrictedCardType(val txVariant: String) {
+internal enum class RestrictedCardType(val txVariant: String) {
     ACCEL("accel"),
     PULSE("pulse"),
     STAR("star"),

--- a/card/src/test/java/com/adyen/checkout/card/CardComponentParamsMapperTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/CardComponentParamsMapperTest.kt
@@ -9,6 +9,7 @@
 package com.adyen.checkout.card
 
 import com.adyen.checkout.card.data.CardType
+import com.adyen.checkout.card.data.RestrictedCardType
 import com.adyen.checkout.components.base.GenericComponentParams
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.core.api.Environment
@@ -117,6 +118,21 @@ internal class CardComponentParamsMapperTest {
 
         val expected = getCardComponentParams(
             supportedCardTypes = listOf(CardType.MAESTRO, CardType.BCMC)
+        )
+
+        assertEquals(expected, params)
+    }
+
+    @Test
+    fun `when there are any restricted card brand in payment method,they are removed from the params`() {
+        val cardConfiguration = getCardConfigurationBuilder().build()
+        val paymentMethod =
+            PaymentMethod(brands = listOf(RestrictedCardType.NYCE.txVariant, CardType.MASTERCARD.txVariant))
+
+        val params = CardComponentParamsMapper(null).mapToParamsDefault(cardConfiguration, paymentMethod)
+
+        val expected = getCardComponentParams(
+            supportedCardTypes = listOf(CardType.MASTERCARD)
         )
 
         assertEquals(expected, params)


### PR DESCRIPTION
## Description
  I removed US Debit cards from supported card type. 

## Checklist 
- [x] Changes are tested manually
- [x] Add relevant labels to PR
- [x] Code is unit tested

COAND-628
