### PR TITLE
Fix stored payment methods not showing directly

### DIFF
--- a/example-app/src/main/java/com/adyen/checkout/example/repositories/PaymentsRepository.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/repositories/PaymentsRepository.kt
@@ -21,7 +21,6 @@ import com.adyen.checkout.sessions.model.SessionModel
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import org.json.JSONObject
-import java.lang.ref.SoftReference
 
 interface PaymentsRepository {
     suspend fun getSessionAsync(sessionRequest: SessionRequest): SessionModel?
@@ -38,23 +37,14 @@ interface PaymentsRepository {
 @Suppress("TooManyFunctions")
 internal class PaymentsRepositoryImpl(private val checkoutApiService: CheckoutApiService) : PaymentsRepository {
 
-    private val paymentMethodCache = HashMap<PaymentMethodsRequest, SoftReference<PaymentMethodsApiResponse?>>()
-
     override suspend fun getSessionAsync(sessionRequest: SessionRequest): SessionModel? {
         return safeApiCall { checkoutApiService.sessionsAsync(sessionRequest) }
     }
 
     override suspend fun getPaymentMethods(paymentMethodsRequest: PaymentMethodsRequest): PaymentMethodsApiResponse? {
-        var response = paymentMethodCache[paymentMethodsRequest]?.get()
-
-        if (response == null) {
-            response = safeApiCall(
-                call = { checkoutApiService.paymentMethodsAsync(paymentMethodsRequest) }
-            )
-            paymentMethodCache[paymentMethodsRequest] = SoftReference(response)
-        }
-
-        return response
+        return safeApiCall(
+            call = { checkoutApiService.paymentMethodsAsync(paymentMethodsRequest) }
+        )
     }
 
     override fun paymentsRequest(paymentsRequest: PaymentsRequest): JSONObject? {

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/card/CardActivity.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/card/CardActivity.kt
@@ -47,12 +47,11 @@ class CardActivity : AppCompatActivity() {
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch { cardViewModel.paymentMethodFlow.collect(::setupCardView) }
                 launch { cardViewModel.cardViewState.collect(::onCardViewState) }
                 launch { cardViewModel.events.collect(::onCardEvent) }
             }
         }
-
-        cardViewModel.onCreate()
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -77,8 +76,6 @@ class CardActivity : AppCompatActivity() {
                 binding.cardContainer.isVisible = true
                 binding.progressIndicator.isVisible = false
                 binding.errorView.isVisible = false
-
-                setupCardView(cardViewState.paymentMethod)
             }
             CardViewState.Error -> {
                 binding.errorView.isVisible = true

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/card/CardViewState.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/card/CardViewState.kt
@@ -1,12 +1,10 @@
 package com.adyen.checkout.example.ui.card
 
-import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
-
 internal sealed class CardViewState {
 
     object Loading : CardViewState()
 
-    data class ShowComponent(val paymentMethod: PaymentMethod) : CardViewState()
+    object ShowComponent : CardViewState()
 
     object Error : CardViewState()
 }


### PR DESCRIPTION
## Description
1. Click "Change payment method"
2. Remove a stored payment method
3. Navigate back
4. The stored payment method still shows in the preselected screen

The payment method request was cached and since the request doesn't change when removing a stored pm, the cached version was returned. The caching is now moved to the card example to avoid unnecessary requests there.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-687
