### PR TITLE
Prevent duplicate toast messages in MainActivity

### DIFF
--- a/example-app/src/main/java/com/adyen/checkout/example/ui/main/MainActivity.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/main/MainActivity.kt
@@ -65,7 +65,7 @@ class MainActivity : AppCompatActivity(), DropInCallback {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch { viewModel.viewState.collect(::onViewState) }
-                launch { viewModel.navigateTo.collect(::onNavigateTo) }
+                launch { viewModel.eventFlow.collect(::onMainEvent) }
             }
         }
     }
@@ -85,26 +85,22 @@ class MainActivity : AppCompatActivity(), DropInCallback {
         return super.onOptionsItemSelected(item)
     }
 
-    override fun onDropInResult(dropInResult: DropInResult?) {
-        if (dropInResult == null) return
-        when (dropInResult) {
-            is DropInResult.CancelledByUser -> Toast.makeText(this, "Canceled by user", Toast.LENGTH_SHORT).show()
-            is DropInResult.Error -> Toast.makeText(this, dropInResult.reason, Toast.LENGTH_SHORT).show()
-            is DropInResult.Finished -> Toast.makeText(this, dropInResult.result, Toast.LENGTH_SHORT).show()
-        }
-    }
+    override fun onDropInResult(dropInResult: DropInResult?) = viewModel.onDropInResult(dropInResult)
 
     private fun onViewState(viewState: MainViewState) {
         when (viewState) {
-            is MainViewState.Error -> {
-                setLoading(false)
-                Toast.makeText(this, viewState.message, Toast.LENGTH_SHORT).show()
-            }
             MainViewState.Loading -> setLoading(true)
             is MainViewState.Result -> {
                 setLoading(false)
                 componentItemAdapter?.items = viewState.items
             }
+        }
+    }
+
+    private fun onMainEvent(event: MainEvent) {
+        when (event) {
+            is MainEvent.NavigateTo -> onNavigateTo(event.destination)
+            is MainEvent.Toast -> Toast.makeText(this, event.message, Toast.LENGTH_SHORT).show()
         }
     }
 

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/main/MainEvent.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/main/MainEvent.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 19/12/2022.
+ */
+
+package com.adyen.checkout.example.ui.main
+
+internal sealed class MainEvent {
+    data class NavigateTo(val destination: MainNavigation) : MainEvent()
+    data class Toast(val message: String) : MainEvent()
+}

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/main/MainViewState.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/main/MainViewState.kt
@@ -10,6 +10,5 @@ package com.adyen.checkout.example.ui.main
 
 internal sealed class MainViewState {
     object Loading : MainViewState()
-    data class Error(val message: String) : MainViewState()
     data class Result(val items: List<ComponentItem>) : MainViewState()
 }


### PR DESCRIPTION
## Description
1. Turn off internet on your device
2. Click an entry in MainActivity
3. See error toast
4. Rotate device
5. See error toast again

Errors were a view state, so they would display the toast again and again on for example a configuration change. Now errors are an event to ensure the toast is displayed only once. 

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually