### PR TITLE
Move `isConfirmationRequired` check to delegates

### DIFF
--- a/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponent.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponent.kt
@@ -15,6 +15,7 @@ import com.adyen.checkout.action.ActionHandlingComponent
 import com.adyen.checkout.action.DefaultActionHandlingComponent
 import com.adyen.checkout.action.GenericActionDelegate
 import com.adyen.checkout.bacs.BacsDirectDebitComponent.Companion.PROVIDER
+import com.adyen.checkout.components.ButtonComponent
 import com.adyen.checkout.components.PaymentComponent
 import com.adyen.checkout.components.PaymentComponentEvent
 import com.adyen.checkout.components.PaymentComponentProvider
@@ -38,6 +39,7 @@ class BacsDirectDebitComponent internal constructor(
 ) : ViewModel(),
     PaymentComponent<BacsDirectDebitComponentState>,
     ViewableComponent,
+    ButtonComponent,
     ActionHandlingComponent by actionHandlingComponent {
 
     override val delegate: ComponentDelegate get() = actionHandlingComponent.activeDelegate
@@ -93,6 +95,8 @@ class BacsDirectDebitComponent internal constructor(
     fun handleBackPress(): Boolean {
         return bacsDelegate.handleBackPress()
     }
+
+    override fun isConfirmationRequired(): Boolean = bacsDelegate.isConfirmationRequired()
 
     override fun onCleared() {
         super.onCleared()

--- a/bacs/src/main/java/com/adyen/checkout/bacs/DefaultBacsDirectDebitDelegate.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/DefaultBacsDirectDebitDelegate.kt
@@ -57,7 +57,7 @@ internal class DefaultBacsDirectDebitDelegate(
 
     @VisibleForTesting
     @Suppress("VariableNaming", "PropertyName")
-    internal val _viewFlow = MutableStateFlow(BacsComponentViewType.INPUT)
+    internal val _viewFlow: MutableStateFlow<ComponentViewType?> = MutableStateFlow(BacsComponentViewType.INPUT)
     override val viewFlow: Flow<ComponentViewType?> = _viewFlow
 
     private val _uiStateFlow = MutableStateFlow<PaymentComponentUIState>(PaymentComponentUIState.Idle)
@@ -208,7 +208,6 @@ internal class DefaultBacsDirectDebitDelegate(
         )
     }
 
-    @Suppress("USELESS_IS_CHECK")
     override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
     override fun onCleared() {

--- a/bacs/src/main/java/com/adyen/checkout/bacs/DefaultBacsDirectDebitDelegate.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/DefaultBacsDirectDebitDelegate.kt
@@ -21,6 +21,7 @@ import com.adyen.checkout.components.repository.PaymentObserverRepository
 import com.adyen.checkout.components.ui.PaymentComponentUIEvent
 import com.adyen.checkout.components.ui.PaymentComponentUIState
 import com.adyen.checkout.components.ui.SubmitHandler
+import com.adyen.checkout.components.ui.view.ButtonComponentViewType
 import com.adyen.checkout.components.ui.view.ComponentViewType
 import com.adyen.checkout.components.util.PaymentMethodTypes
 import com.adyen.checkout.core.log.LogUtil
@@ -206,6 +207,9 @@ internal class DefaultBacsDirectDebitDelegate(
             mode = outputData.mode
         )
     }
+
+    @Suppress("USELESS_IS_CHECK")
+    override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
     override fun onCleared() {
         removeObserver()

--- a/bacs/src/test/java/com/adyen/checkout/bacs/BacsDirectDebitComponentTest.kt
+++ b/bacs/src/test/java/com/adyen/checkout/bacs/BacsDirectDebitComponentTest.kt
@@ -143,4 +143,10 @@ internal class BacsDirectDebitComponentTest(
         component.setInputMode()
         verify(bacsDirectDebitDelegate).setMode(BacsDirectDebitMode.INPUT)
     }
+
+    @Test
+    fun `when isConfirmationRequired, then delegate is called`() {
+        component.isConfirmationRequired()
+        verify(bacsDirectDebitDelegate).isConfirmationRequired()
+    }
 }

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcComponent.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcComponent.kt
@@ -15,6 +15,7 @@ import com.adyen.checkout.action.DefaultActionHandlingComponent
 import com.adyen.checkout.action.GenericActionDelegate
 import com.adyen.checkout.bcmc.BcmcComponent.Companion.PROVIDER
 import com.adyen.checkout.card.data.CardType
+import com.adyen.checkout.components.ButtonComponent
 import com.adyen.checkout.components.PaymentComponent
 import com.adyen.checkout.components.PaymentComponentEvent
 import com.adyen.checkout.components.PaymentComponentProvider
@@ -40,6 +41,7 @@ class BcmcComponent internal constructor(
 ) : ViewModel(),
     PaymentComponent<PaymentComponentState<CardPaymentMethod>>,
     ViewableComponent,
+    ButtonComponent,
     ActionHandlingComponent by actionHandlingComponent {
 
     override val delegate: ComponentDelegate get() = actionHandlingComponent.activeDelegate
@@ -67,6 +69,8 @@ class BcmcComponent internal constructor(
         bcmcDelegate.removeObserver()
         genericActionDelegate.removeObserver()
     }
+
+    override fun isConfirmationRequired(): Boolean = bcmcDelegate.isConfirmationRequired()
 
     override fun onCleared() {
         super.onCleared()

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/DefaultBcmcDelegate.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/DefaultBcmcDelegate.kt
@@ -76,7 +76,7 @@ internal class DefaultBcmcDelegate(
 
     override val outputData get() = _outputDataFlow.value
 
-    private val _viewFlow = MutableStateFlow(BcmcComponentViewType)
+    private val _viewFlow: MutableStateFlow<ComponentViewType?> = MutableStateFlow(BcmcComponentViewType)
     override val viewFlow: Flow<ComponentViewType?> = _viewFlow
 
     private val submitChannel: Channel<PaymentComponentState<CardPaymentMethod>> = bufferedChannel()
@@ -295,7 +295,6 @@ internal class DefaultBcmcDelegate(
         return CardType.estimate(cardNumber).contains(BcmcComponent.SUPPORTED_CARD_TYPE)
     }
 
-    @Suppress("USELESS_IS_CHECK")
     override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
     override fun onCleared() {

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/DefaultBcmcDelegate.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/DefaultBcmcDelegate.kt
@@ -30,6 +30,7 @@ import com.adyen.checkout.components.ui.PaymentComponentUIEvent
 import com.adyen.checkout.components.ui.PaymentComponentUIState
 import com.adyen.checkout.components.ui.SubmitHandler
 import com.adyen.checkout.components.ui.Validation
+import com.adyen.checkout.components.ui.view.ButtonComponentViewType
 import com.adyen.checkout.components.ui.view.ComponentViewType
 import com.adyen.checkout.components.util.PaymentMethodTypes
 import com.adyen.checkout.core.exception.CheckoutException
@@ -75,7 +76,8 @@ internal class DefaultBcmcDelegate(
 
     override val outputData get() = _outputDataFlow.value
 
-    override val viewFlow: Flow<ComponentViewType?> = MutableStateFlow(BcmcComponentViewType)
+    private val _viewFlow = MutableStateFlow(BcmcComponentViewType)
+    override val viewFlow: Flow<ComponentViewType?> = _viewFlow
 
     private val submitChannel: Channel<PaymentComponentState<CardPaymentMethod>> = bufferedChannel()
     override val submitFlow: Flow<PaymentComponentState<CardPaymentMethod>> = submitChannel.receiveAsFlow()
@@ -292,6 +294,9 @@ internal class DefaultBcmcDelegate(
         if (cardNumber.isNullOrEmpty()) return false
         return CardType.estimate(cardNumber).contains(BcmcComponent.SUPPORTED_CARD_TYPE)
     }
+
+    @Suppress("USELESS_IS_CHECK")
+    override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
     override fun onCleared() {
         removeObserver()

--- a/bcmc/src/test/java/com/adyen/checkout/bcmc/BcmcComponentTest.kt
+++ b/bcmc/src/test/java/com/adyen/checkout/bcmc/BcmcComponentTest.kt
@@ -133,4 +133,10 @@ internal class BcmcComponentTest(
             expectNoEvents()
         }
     }
+
+    @Test
+    fun `when isConfirmationRequired, then delegate is called`() {
+        component.isConfirmationRequired()
+        verify(bcmcDelegate).isConfirmationRequired()
+    }
 }

--- a/blik/src/main/java/com/adyen/checkout/blik/BlikComponent.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/BlikComponent.kt
@@ -14,6 +14,7 @@ import com.adyen.checkout.action.ActionHandlingComponent
 import com.adyen.checkout.action.DefaultActionHandlingComponent
 import com.adyen.checkout.action.GenericActionDelegate
 import com.adyen.checkout.blik.BlikComponent.Companion.PROVIDER
+import com.adyen.checkout.components.ButtonComponent
 import com.adyen.checkout.components.PaymentComponent
 import com.adyen.checkout.components.PaymentComponentEvent
 import com.adyen.checkout.components.PaymentComponentState
@@ -39,6 +40,7 @@ class BlikComponent internal constructor(
 ) : ViewModel(),
     PaymentComponent<PaymentComponentState<BlikPaymentMethod>>,
     ViewableComponent,
+    ButtonComponent,
     ActionHandlingComponent by actionHandlingComponent {
 
     override val delegate: ComponentDelegate get() = actionHandlingComponent.activeDelegate
@@ -70,6 +72,8 @@ class BlikComponent internal constructor(
     override fun requiresInput(): Boolean {
         return blikDelegate.requiresInput()
     }
+
+    override fun isConfirmationRequired(): Boolean = blikDelegate.isConfirmationRequired()
 
     override fun onCleared() {
         super.onCleared()

--- a/blik/src/main/java/com/adyen/checkout/blik/DefaultBlikDelegate.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/DefaultBlikDelegate.kt
@@ -22,6 +22,7 @@ import com.adyen.checkout.components.repository.PaymentObserverRepository
 import com.adyen.checkout.components.ui.PaymentComponentUIEvent
 import com.adyen.checkout.components.ui.PaymentComponentUIState
 import com.adyen.checkout.components.ui.SubmitHandler
+import com.adyen.checkout.components.ui.view.ButtonComponentViewType
 import com.adyen.checkout.components.ui.view.ComponentViewType
 import com.adyen.checkout.components.util.PaymentMethodTypes
 import com.adyen.checkout.core.log.LogUtil
@@ -53,7 +54,8 @@ internal class DefaultBlikDelegate(
     private val _componentStateFlow = MutableStateFlow(createComponentState())
     override val componentStateFlow: Flow<PaymentComponentState<BlikPaymentMethod>> = _componentStateFlow
 
-    override val viewFlow: Flow<ComponentViewType?> = MutableStateFlow(BlikComponentViewType)
+    private val _viewFlow = MutableStateFlow(BlikComponentViewType)
+    override val viewFlow: Flow<ComponentViewType?> = _viewFlow
 
     private val submitChannel: Channel<PaymentComponentState<BlikPaymentMethod>> = bufferedChannel()
     override val submitFlow: Flow<PaymentComponentState<BlikPaymentMethod>> = submitChannel.receiveAsFlow()
@@ -154,6 +156,9 @@ internal class DefaultBlikDelegate(
             uiStateChannel = _uiStateFlow
         )
     }
+
+    @Suppress("USELESS_IS_CHECK")
+    override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
     override fun onCleared() {
         removeObserver()

--- a/blik/src/main/java/com/adyen/checkout/blik/DefaultBlikDelegate.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/DefaultBlikDelegate.kt
@@ -54,7 +54,7 @@ internal class DefaultBlikDelegate(
     private val _componentStateFlow = MutableStateFlow(createComponentState())
     override val componentStateFlow: Flow<PaymentComponentState<BlikPaymentMethod>> = _componentStateFlow
 
-    private val _viewFlow = MutableStateFlow(BlikComponentViewType)
+    private val _viewFlow: MutableStateFlow<ComponentViewType?> = MutableStateFlow(BlikComponentViewType)
     override val viewFlow: Flow<ComponentViewType?> = _viewFlow
 
     private val submitChannel: Channel<PaymentComponentState<BlikPaymentMethod>> = bufferedChannel()
@@ -157,7 +157,6 @@ internal class DefaultBlikDelegate(
         )
     }
 
-    @Suppress("USELESS_IS_CHECK")
     override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
     override fun onCleared() {

--- a/blik/src/main/java/com/adyen/checkout/blik/StoredBlikDelegate.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/StoredBlikDelegate.kt
@@ -51,7 +51,7 @@ internal class StoredBlikDelegate(
     private val _componentStateFlow = MutableStateFlow(createComponentState())
     override val componentStateFlow: Flow<PaymentComponentState<BlikPaymentMethod>> = _componentStateFlow
 
-    private val _viewFlow = MutableStateFlow(BlikComponentViewType)
+    private val _viewFlow: MutableStateFlow<ComponentViewType?> = MutableStateFlow(BlikComponentViewType)
     override val viewFlow: Flow<ComponentViewType?> = _viewFlow
 
     private val submitChannel: Channel<PaymentComponentState<BlikPaymentMethod>> = bufferedChannel()
@@ -132,7 +132,6 @@ internal class StoredBlikDelegate(
 
     override fun requiresInput(): Boolean = false
 
-    @Suppress("USELESS_IS_CHECK")
     override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
     override fun onCleared() {

--- a/blik/src/main/java/com/adyen/checkout/blik/StoredBlikDelegate.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/StoredBlikDelegate.kt
@@ -21,6 +21,7 @@ import com.adyen.checkout.components.repository.PaymentObserverRepository
 import com.adyen.checkout.components.ui.PaymentComponentUIEvent
 import com.adyen.checkout.components.ui.PaymentComponentUIState
 import com.adyen.checkout.components.ui.SubmitHandler
+import com.adyen.checkout.components.ui.view.ButtonComponentViewType
 import com.adyen.checkout.components.ui.view.ComponentViewType
 import com.adyen.checkout.components.util.PaymentMethodTypes
 import com.adyen.checkout.core.log.LogUtil
@@ -50,7 +51,8 @@ internal class StoredBlikDelegate(
     private val _componentStateFlow = MutableStateFlow(createComponentState())
     override val componentStateFlow: Flow<PaymentComponentState<BlikPaymentMethod>> = _componentStateFlow
 
-    override val viewFlow: Flow<ComponentViewType?> = MutableStateFlow(BlikComponentViewType)
+    private val _viewFlow = MutableStateFlow(BlikComponentViewType)
+    override val viewFlow: Flow<ComponentViewType?> = _viewFlow
 
     private val submitChannel: Channel<PaymentComponentState<BlikPaymentMethod>> = bufferedChannel()
     override val submitFlow: Flow<PaymentComponentState<BlikPaymentMethod>> = submitChannel.receiveAsFlow()
@@ -129,6 +131,9 @@ internal class StoredBlikDelegate(
     }
 
     override fun requiresInput(): Boolean = false
+
+    @Suppress("USELESS_IS_CHECK")
+    override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
     override fun onCleared() {
         removeObserver()

--- a/blik/src/test/java/com/adyen/checkout/blik/BlikComponentTest.kt
+++ b/blik/src/test/java/com/adyen/checkout/blik/BlikComponentTest.kt
@@ -133,4 +133,10 @@ internal class BlikComponentTest(
             expectNoEvents()
         }
     }
+
+    @Test
+    fun `when isConfirmationRequired, then delegate is called`() {
+        component.isConfirmationRequired()
+        verify(blikDelegate).isConfirmationRequired()
+    }
 }

--- a/card/src/main/java/com/adyen/checkout/card/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponent.kt
@@ -15,6 +15,7 @@ import com.adyen.checkout.action.ActionHandlingComponent
 import com.adyen.checkout.action.DefaultActionHandlingComponent
 import com.adyen.checkout.action.GenericActionDelegate
 import com.adyen.checkout.card.CardComponent.Companion.PROVIDER
+import com.adyen.checkout.components.ButtonComponent
 import com.adyen.checkout.components.PaymentComponent
 import com.adyen.checkout.components.PaymentComponentEvent
 import com.adyen.checkout.components.StoredPaymentComponentProvider
@@ -39,6 +40,7 @@ class CardComponent internal constructor(
     ViewModel(),
     PaymentComponent<CardComponentState>,
     ViewableComponent,
+    ButtonComponent,
     ActionHandlingComponent by actionHandlingComponent {
 
     override val delegate: ComponentDelegate get() = actionHandlingComponent.activeDelegate
@@ -73,6 +75,8 @@ class CardComponent internal constructor(
     }
 
     override fun requiresInput() = cardDelegate.requiresInput()
+
+    override fun isConfirmationRequired(): Boolean = cardDelegate.isConfirmationRequired()
 
     override fun onCleared() {
         super.onCleared()

--- a/card/src/main/java/com/adyen/checkout/card/DefaultCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/DefaultCardDelegate.kt
@@ -96,7 +96,7 @@ internal class DefaultCardDelegate(
     private var _coroutineScope: CoroutineScope? = null
     private val coroutineScope: CoroutineScope get() = requireNotNull(_coroutineScope)
 
-    private val _viewFlow = MutableStateFlow(CardComponentViewType)
+    private val _viewFlow: MutableStateFlow<ComponentViewType?> = MutableStateFlow(CardComponentViewType)
     override val viewFlow: Flow<ComponentViewType?> = _viewFlow
 
     private val submitChannel: Channel<CardComponentState> = bufferedChannel()
@@ -691,7 +691,6 @@ internal class DefaultCardDelegate(
         }
     }
 
-    @Suppress("USELESS_IS_CHECK")
     override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
     override fun onCleared() {

--- a/card/src/main/java/com/adyen/checkout/card/DefaultCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/DefaultCardDelegate.kt
@@ -39,6 +39,7 @@ import com.adyen.checkout.components.ui.PaymentComponentUIEvent
 import com.adyen.checkout.components.ui.PaymentComponentUIState
 import com.adyen.checkout.components.ui.SubmitHandler
 import com.adyen.checkout.components.ui.Validation
+import com.adyen.checkout.components.ui.view.ButtonComponentViewType
 import com.adyen.checkout.components.ui.view.ComponentViewType
 import com.adyen.checkout.components.util.PaymentMethodTypes
 import com.adyen.checkout.core.exception.CheckoutException
@@ -95,7 +96,8 @@ internal class DefaultCardDelegate(
     private var _coroutineScope: CoroutineScope? = null
     private val coroutineScope: CoroutineScope get() = requireNotNull(_coroutineScope)
 
-    override val viewFlow: Flow<ComponentViewType?> = MutableStateFlow(CardComponentViewType)
+    private val _viewFlow = MutableStateFlow(CardComponentViewType)
+    override val viewFlow: Flow<ComponentViewType?> = _viewFlow
 
     private val submitChannel: Channel<CardComponentState> = bufferedChannel()
     override val submitFlow: Flow<CardComponentState> = submitChannel.receiveAsFlow()
@@ -688,6 +690,9 @@ internal class DefaultCardDelegate(
             )
         }
     }
+
+    @Suppress("USELESS_IS_CHECK")
+    override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
     override fun onCleared() {
         removeObserver()

--- a/card/src/main/java/com/adyen/checkout/card/StoredCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/StoredCardDelegate.kt
@@ -30,6 +30,7 @@ import com.adyen.checkout.components.ui.PaymentComponentUIEvent
 import com.adyen.checkout.components.ui.PaymentComponentUIState
 import com.adyen.checkout.components.ui.SubmitHandler
 import com.adyen.checkout.components.ui.Validation
+import com.adyen.checkout.components.ui.view.ButtonComponentViewType
 import com.adyen.checkout.components.ui.view.ComponentViewType
 import com.adyen.checkout.components.util.PaymentMethodTypes
 import com.adyen.checkout.core.exception.CheckoutException
@@ -88,7 +89,8 @@ internal class StoredCardDelegate(
     private val exceptionChannel: Channel<CheckoutException> = bufferedChannel()
     override val exceptionFlow: Flow<CheckoutException> = exceptionChannel.receiveAsFlow()
 
-    override val viewFlow: Flow<ComponentViewType?> = MutableStateFlow(CardComponentViewType)
+    private val _viewFlow = MutableStateFlow(CardComponentViewType)
+    override val viewFlow: Flow<ComponentViewType?> = _viewFlow
 
     private val submitChannel: Channel<CardComponentState> = bufferedChannel()
     override val submitFlow: Flow<CardComponentState> = submitChannel.receiveAsFlow()
@@ -397,6 +399,9 @@ internal class StoredCardDelegate(
     private fun getPaymentMethodId(): String {
         return storedPaymentMethod.id ?: "ID_NOT_FOUND"
     }
+
+    @Suppress("USELESS_IS_CHECK")
+    override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
     override fun onCleared() {
         removeObserver()

--- a/card/src/main/java/com/adyen/checkout/card/StoredCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/StoredCardDelegate.kt
@@ -89,7 +89,7 @@ internal class StoredCardDelegate(
     private val exceptionChannel: Channel<CheckoutException> = bufferedChannel()
     override val exceptionFlow: Flow<CheckoutException> = exceptionChannel.receiveAsFlow()
 
-    private val _viewFlow = MutableStateFlow(CardComponentViewType)
+    private val _viewFlow: MutableStateFlow<ComponentViewType?> = MutableStateFlow(CardComponentViewType)
     override val viewFlow: Flow<ComponentViewType?> = _viewFlow
 
     private val submitChannel: Channel<CardComponentState> = bufferedChannel()
@@ -400,7 +400,6 @@ internal class StoredCardDelegate(
         return storedPaymentMethod.id ?: "ID_NOT_FOUND"
     }
 
-    @Suppress("USELESS_IS_CHECK")
     override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
     override fun onCleared() {

--- a/card/src/test/java/com/adyen/checkout/card/CardComponentTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/CardComponentTest.kt
@@ -129,4 +129,10 @@ internal class CardComponentTest(
             expectNoEvents()
         }
     }
+
+    @Test
+    fun `when isConfirmationRequired, then delegate is called`() {
+        component.isConfirmationRequired()
+        verify(cardDelegate).isConfirmationRequired()
+    }
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/ButtonComponent.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/ButtonComponent.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 20/12/2022.
+ */
+
+package com.adyen.checkout.components
+
+interface ButtonComponent {
+
+    fun isConfirmationRequired(): Boolean
+}

--- a/components-core/src/main/java/com/adyen/checkout/components/ButtonComponent.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/ButtonComponent.kt
@@ -10,5 +10,17 @@ package com.adyen.checkout.components
 
 interface ButtonComponent {
 
+    /**
+     * Tells if the view interaction requires confirmation from the user to start the payment flow.
+     * Confirmation usually is obtained by a "Pay" button the user need to press to start processing the payment.
+     * If confirmation is not required, it means the view handles input in a way that the user has already expressed the
+     * desire to continue.
+     *
+     * Each type of view always returns the same value, so if the type of view is known, there is no need to check this
+     * method.
+     *
+     * @return If an update from the component attached to this View requires further user confirmation to continue or
+     * not.
+     */
     fun isConfirmationRequired(): Boolean
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/ButtonComponent.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/ButtonComponent.kt
@@ -11,6 +11,7 @@ package com.adyen.checkout.components
 interface ButtonComponent {
 
     /**
+     * TODO: Update docs
      * Tells if the view interaction requires confirmation from the user to start the payment flow.
      * Confirmation usually is obtained by a "Pay" button the user need to press to start processing the payment.
      * If confirmation is not required, it means the view handles input in a way that the user has already expressed the

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/BacsDirectDebitDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/BacsDirectDebitDialogFragment.kt
@@ -51,7 +51,7 @@ internal class BacsDirectDebitDialogFragment : BaseComponentDialogFragment() {
 
         binding.bacsView.attach(bacsDirectDebitComponent, viewLifecycleOwner)
 
-        if (binding.bacsView.isConfirmationRequired) {
+        if (bacsDirectDebitComponent.isConfirmationRequired()) {
             setInitViewState(BottomSheetBehavior.STATE_EXPANDED)
             binding.bacsView.requestFocus()
         }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/CardComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/CardComponentDialogFragment.kt
@@ -26,6 +26,8 @@ internal class CardComponentDialogFragment : BaseComponentDialogFragment() {
     private var _binding: FragmentCardComponentBinding? = null
     private val binding: FragmentCardComponentBinding get() = requireNotNull(_binding)
 
+    private val cardComponent: CardComponent by lazy { component as CardComponent }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentCardComponentBinding.inflate(inflater, container, false)
         return binding.root
@@ -44,7 +46,7 @@ internal class CardComponentDialogFragment : BaseComponentDialogFragment() {
 
         binding.cardView.attach(component as CardComponent, viewLifecycleOwner)
 
-        if (binding.cardView.isConfirmationRequired) {
+        if (cardComponent.isConfirmationRequired()) {
             setInitViewState(BottomSheetBehavior.STATE_EXPANDED)
             binding.cardView.requestFocus()
         }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/GenericComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/GenericComponentDialogFragment.kt
@@ -12,6 +12,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import com.adyen.checkout.components.ButtonComponent
 import com.adyen.checkout.components.ComponentError
 import com.adyen.checkout.components.PaymentComponent
 import com.adyen.checkout.components.PaymentComponentEvent
@@ -27,10 +28,6 @@ internal class GenericComponentDialogFragment : BaseComponentDialogFragment() {
 
     private var _binding: FragmentGenericComponentBinding? = null
     private val binding: FragmentGenericComponentBinding get() = requireNotNull(_binding)
-
-    companion object : BaseCompanion<GenericComponentDialogFragment>(GenericComponentDialogFragment::class.java) {
-        private val TAG = LogUtil.getTag()
-    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentGenericComponentBinding.inflate(inflater, container, false)
@@ -53,7 +50,7 @@ internal class GenericComponentDialogFragment : BaseComponentDialogFragment() {
         if (component is ViewableComponent) {
             binding.componentView.attach(component, viewLifecycleOwner)
 
-            if (binding.componentView.isConfirmationRequired) {
+            if ((component as? ButtonComponent)?.isConfirmationRequired() == true) {
                 setInitViewState(BottomSheetBehavior.STATE_EXPANDED)
                 binding.componentView.requestFocus()
             }
@@ -77,5 +74,9 @@ internal class GenericComponentDialogFragment : BaseComponentDialogFragment() {
     override fun onDestroyView() {
         _binding = null
         super.onDestroyView()
+    }
+
+    companion object : BaseCompanion<GenericComponentDialogFragment>(GenericComponentDialogFragment::class.java) {
+        private val TAG = LogUtil.getTag()
     }
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/GiftCardComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/GiftCardComponentDialogFragment.kt
@@ -22,6 +22,7 @@ import com.adyen.checkout.core.log.LogUtil
 import com.adyen.checkout.core.log.Logger
 import com.adyen.checkout.dropin.databinding.FragmentGiftcardComponentBinding
 import com.adyen.checkout.dropin.ui.base.BaseComponentDialogFragment
+import com.adyen.checkout.giftcard.GiftCardComponent
 import com.adyen.checkout.giftcard.GiftCardComponentState
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 
@@ -30,9 +31,7 @@ internal class GiftCardComponentDialogFragment : BaseComponentDialogFragment() {
     private var _binding: FragmentGiftcardComponentBinding? = null
     private val binding: FragmentGiftcardComponentBinding get() = requireNotNull(_binding)
 
-    companion object : BaseCompanion<GiftCardComponentDialogFragment>(GiftCardComponentDialogFragment::class.java) {
-        private val TAG = LogUtil.getTag()
-    }
+    private val giftCardComponent: GiftCardComponent by lazy { component as GiftCardComponent }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentGiftcardComponentBinding.inflate(inflater, container, false)
@@ -57,7 +56,7 @@ internal class GiftCardComponentDialogFragment : BaseComponentDialogFragment() {
 
         binding.giftCardView.attach(component, viewLifecycleOwner)
 
-        if (binding.giftCardView.isConfirmationRequired) {
+        if (giftCardComponent.isConfirmationRequired()) {
             setInitViewState(BottomSheetBehavior.STATE_EXPANDED)
             binding.giftCardView.requestFocus()
         }
@@ -86,5 +85,9 @@ internal class GiftCardComponentDialogFragment : BaseComponentDialogFragment() {
     override fun onDestroyView() {
         _binding = null
         super.onDestroyView()
+    }
+
+    companion object : BaseCompanion<GiftCardComponentDialogFragment>(GiftCardComponentDialogFragment::class.java) {
+        private val TAG = LogUtil.getTag()
     }
 }

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/DefaultGiftCardDelegate.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/DefaultGiftCardDelegate.kt
@@ -22,6 +22,7 @@ import com.adyen.checkout.components.repository.PublicKeyRepository
 import com.adyen.checkout.components.ui.PaymentComponentUIEvent
 import com.adyen.checkout.components.ui.PaymentComponentUIState
 import com.adyen.checkout.components.ui.SubmitHandler
+import com.adyen.checkout.components.ui.view.ButtonComponentViewType
 import com.adyen.checkout.components.ui.view.ComponentViewType
 import com.adyen.checkout.components.util.PaymentMethodTypes
 import com.adyen.checkout.core.exception.CheckoutException
@@ -63,7 +64,8 @@ internal class DefaultGiftCardDelegate(
     private val exceptionChannel: Channel<CheckoutException> = bufferedChannel()
     override val exceptionFlow: Flow<CheckoutException> = exceptionChannel.receiveAsFlow()
 
-    override val viewFlow: Flow<ComponentViewType?> = MutableStateFlow(GiftCardComponentViewType)
+    private val _viewFlow = MutableStateFlow(GiftCardComponentViewType)
+    override val viewFlow: Flow<ComponentViewType?> = _viewFlow
 
     private val submitChannel: Channel<GiftCardComponentState> = bufferedChannel()
     override val submitFlow: Flow<GiftCardComponentState> = submitChannel.receiveAsFlow()
@@ -222,6 +224,9 @@ internal class DefaultGiftCardDelegate(
     override fun getPaymentMethodType(): String {
         return paymentMethod.type ?: PaymentMethodTypes.UNKNOWN
     }
+
+    @Suppress("USELESS_IS_CHECK")
+    override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
     override fun onCleared() {
         removeObserver()

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/DefaultGiftCardDelegate.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/DefaultGiftCardDelegate.kt
@@ -64,7 +64,7 @@ internal class DefaultGiftCardDelegate(
     private val exceptionChannel: Channel<CheckoutException> = bufferedChannel()
     override val exceptionFlow: Flow<CheckoutException> = exceptionChannel.receiveAsFlow()
 
-    private val _viewFlow = MutableStateFlow(GiftCardComponentViewType)
+    private val _viewFlow: MutableStateFlow<ComponentViewType?> = MutableStateFlow(GiftCardComponentViewType)
     override val viewFlow: Flow<ComponentViewType?> = _viewFlow
 
     private val submitChannel: Channel<GiftCardComponentState> = bufferedChannel()
@@ -225,7 +225,6 @@ internal class DefaultGiftCardDelegate(
         return paymentMethod.type ?: PaymentMethodTypes.UNKNOWN
     }
 
-    @Suppress("USELESS_IS_CHECK")
     override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
     override fun onCleared() {

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardComponent.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardComponent.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.viewModelScope
 import com.adyen.checkout.action.ActionHandlingComponent
 import com.adyen.checkout.action.DefaultActionHandlingComponent
 import com.adyen.checkout.action.GenericActionDelegate
+import com.adyen.checkout.components.ButtonComponent
 import com.adyen.checkout.components.PaymentComponent
 import com.adyen.checkout.components.PaymentComponentEvent
 import com.adyen.checkout.components.PaymentComponentProvider
@@ -37,6 +38,7 @@ class GiftCardComponent internal constructor(
 ) : ViewModel(),
     PaymentComponent<GiftCardComponentState>,
     ViewableComponent,
+    ButtonComponent,
     ActionHandlingComponent by actionHandlingComponent {
 
     override val delegate: ComponentDelegate get() = actionHandlingComponent.activeDelegate
@@ -64,6 +66,8 @@ class GiftCardComponent internal constructor(
         giftCardDelegate.removeObserver()
         genericActionDelegate.removeObserver()
     }
+
+    override fun isConfirmationRequired(): Boolean = giftCardDelegate.isConfirmationRequired()
 
     override fun onCleared() {
         super.onCleared()

--- a/giftcard/src/test/java/com/adyen/checkout/giftcard/GiftCardComponentTest.kt
+++ b/giftcard/src/test/java/com/adyen/checkout/giftcard/GiftCardComponentTest.kt
@@ -131,4 +131,10 @@ internal class GiftCardComponentTest(
             expectNoEvents()
         }
     }
+
+    @Test
+    fun `when isConfirmationRequired, then delegate is called`() {
+        component.isConfirmationRequired()
+        verify(giftCardDelegate).isConfirmationRequired()
+    }
 }

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/DefaultIssuerListDelegate.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/DefaultIssuerListDelegate.kt
@@ -20,6 +20,7 @@ import com.adyen.checkout.components.model.payments.request.IssuerListPaymentMet
 import com.adyen.checkout.components.model.payments.request.PaymentComponentData
 import com.adyen.checkout.components.repository.PaymentObserverRepository
 import com.adyen.checkout.components.ui.SubmitHandler
+import com.adyen.checkout.components.ui.view.ButtonComponentViewType
 import com.adyen.checkout.components.ui.view.ComponentViewType
 import com.adyen.checkout.components.util.PaymentMethodTypes
 import com.adyen.checkout.core.log.LogUtil
@@ -52,7 +53,8 @@ class DefaultIssuerListDelegate<IssuerListPaymentMethodT : IssuerListPaymentMeth
     private val _componentStateFlow = MutableStateFlow(createComponentState())
     override val componentStateFlow: Flow<PaymentComponentState<IssuerListPaymentMethodT>> = _componentStateFlow
 
-    override val viewFlow: Flow<ComponentViewType?> = MutableStateFlow(getIssuerListComponentViewType())
+    private val _viewFlow = MutableStateFlow(getIssuerListComponentViewType())
+    override val viewFlow: Flow<ComponentViewType?> = _viewFlow
 
     private val submitChannel: Channel<PaymentComponentState<IssuerListPaymentMethodT>> = bufferedChannel()
     override val submitFlow: Flow<PaymentComponentState<IssuerListPaymentMethodT>> = submitChannel.receiveAsFlow()
@@ -146,6 +148,8 @@ class DefaultIssuerListDelegate<IssuerListPaymentMethodT : IssuerListPaymentMeth
     override fun getPaymentMethodType(): String {
         return paymentMethod.type ?: PaymentMethodTypes.UNKNOWN
     }
+
+    override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
     override fun onCleared() {
         removeObserver()

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/DefaultIssuerListDelegate.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/DefaultIssuerListDelegate.kt
@@ -53,7 +53,7 @@ class DefaultIssuerListDelegate<IssuerListPaymentMethodT : IssuerListPaymentMeth
     private val _componentStateFlow = MutableStateFlow(createComponentState())
     override val componentStateFlow: Flow<PaymentComponentState<IssuerListPaymentMethodT>> = _componentStateFlow
 
-    private val _viewFlow = MutableStateFlow(getIssuerListComponentViewType())
+    private val _viewFlow: MutableStateFlow<ComponentViewType?> = MutableStateFlow(getIssuerListComponentViewType())
     override val viewFlow: Flow<ComponentViewType?> = _viewFlow
 
     private val submitChannel: Channel<PaymentComponentState<IssuerListPaymentMethodT>> = bufferedChannel()

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/IssuerListComponent.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/IssuerListComponent.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.viewModelScope
 import com.adyen.checkout.action.ActionHandlingComponent
 import com.adyen.checkout.action.DefaultActionHandlingComponent
 import com.adyen.checkout.action.GenericActionDelegate
+import com.adyen.checkout.components.ButtonComponent
 import com.adyen.checkout.components.PaymentComponent
 import com.adyen.checkout.components.PaymentComponentEvent
 import com.adyen.checkout.components.PaymentComponentState
@@ -36,6 +37,7 @@ abstract class IssuerListComponent<IssuerListPaymentMethodT : IssuerListPaymentM
 ) : ViewModel(),
     PaymentComponent<PaymentComponentState<IssuerListPaymentMethodT>>,
     ViewableComponent,
+    ButtonComponent,
     ActionHandlingComponent by actionHandlingComponent {
 
     final override val delegate: ComponentDelegate get() = actionHandlingComponent.activeDelegate
@@ -63,6 +65,8 @@ abstract class IssuerListComponent<IssuerListPaymentMethodT : IssuerListPaymentM
         issuerListDelegate.removeObserver()
         genericActionDelegate.removeObserver()
     }
+
+    override fun isConfirmationRequired(): Boolean = issuerListDelegate.isConfirmationRequired()
 
     override fun onCleared() {
         super.onCleared()

--- a/issuer-list/src/test/java/com/adyen/checkout/issuerlist/IssuerListComponentTest.kt
+++ b/issuer-list/src/test/java/com/adyen/checkout/issuerlist/IssuerListComponentTest.kt
@@ -137,4 +137,10 @@ internal class IssuerListComponentTest(
             expectNoEvents()
         }
     }
+
+    @Test
+    fun `when isConfirmationRequired, then delegate is called`() {
+        component.isConfirmationRequired()
+        verify(issuerListDelegate).isConfirmationRequired()
+    }
 }

--- a/mbway/src/main/java/com/adyen/checkout/mbway/DefaultMBWayDelegate.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/DefaultMBWayDelegate.kt
@@ -22,6 +22,7 @@ import com.adyen.checkout.components.repository.PaymentObserverRepository
 import com.adyen.checkout.components.ui.PaymentComponentUIEvent
 import com.adyen.checkout.components.ui.PaymentComponentUIState
 import com.adyen.checkout.components.ui.SubmitHandler
+import com.adyen.checkout.components.ui.view.ButtonComponentViewType
 import com.adyen.checkout.components.ui.view.ComponentViewType
 import com.adyen.checkout.components.util.CountryInfo
 import com.adyen.checkout.components.util.CountryUtils
@@ -54,7 +55,8 @@ internal class DefaultMBWayDelegate(
 
     override val outputData: MBWayOutputData get() = _outputDataFlow.value
 
-    override val viewFlow: Flow<ComponentViewType?> = MutableStateFlow(MbWayComponentViewType)
+    private val _viewFlow = MutableStateFlow(MbWayComponentViewType)
+    override val viewFlow: Flow<ComponentViewType?> = _viewFlow
 
     private val submitChannel: Channel<PaymentComponentState<MBWayPaymentMethod>> = bufferedChannel()
     override val submitFlow: Flow<PaymentComponentState<MBWayPaymentMethod>> = submitChannel.receiveAsFlow()
@@ -149,6 +151,10 @@ internal class DefaultMBWayDelegate(
         )
     }
 
+    private fun componentStateChanged(componentState: PaymentComponentState<MBWayPaymentMethod>) {
+        _componentStateFlow.tryEmit(componentState)
+    }
+
     override fun getSupportedCountries(): List<CountryInfo> = CountryUtils.getCountries(SUPPORTED_COUNTRIES)
 
     override fun onSubmit() {
@@ -161,12 +167,11 @@ internal class DefaultMBWayDelegate(
         )
     }
 
+    @Suppress("USELESS_IS_CHECK")
+    override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
+
     override fun onCleared() {
         removeObserver()
-    }
-
-    private fun componentStateChanged(componentState: PaymentComponentState<MBWayPaymentMethod>) {
-        _componentStateFlow.tryEmit(componentState)
     }
 
     companion object {

--- a/mbway/src/main/java/com/adyen/checkout/mbway/DefaultMBWayDelegate.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/DefaultMBWayDelegate.kt
@@ -55,7 +55,7 @@ internal class DefaultMBWayDelegate(
 
     override val outputData: MBWayOutputData get() = _outputDataFlow.value
 
-    private val _viewFlow = MutableStateFlow(MbWayComponentViewType)
+    private val _viewFlow: MutableStateFlow<ComponentViewType?> = MutableStateFlow(MbWayComponentViewType)
     override val viewFlow: Flow<ComponentViewType?> = _viewFlow
 
     private val submitChannel: Channel<PaymentComponentState<MBWayPaymentMethod>> = bufferedChannel()
@@ -167,7 +167,6 @@ internal class DefaultMBWayDelegate(
         )
     }
 
-    @Suppress("USELESS_IS_CHECK")
     override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
     override fun onCleared() {

--- a/mbway/src/main/java/com/adyen/checkout/mbway/MBWayComponent.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/MBWayComponent.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.viewModelScope
 import com.adyen.checkout.action.ActionHandlingComponent
 import com.adyen.checkout.action.DefaultActionHandlingComponent
 import com.adyen.checkout.action.GenericActionDelegate
+import com.adyen.checkout.components.ButtonComponent
 import com.adyen.checkout.components.PaymentComponent
 import com.adyen.checkout.components.PaymentComponentEvent
 import com.adyen.checkout.components.PaymentComponentProvider
@@ -39,6 +40,7 @@ class MBWayComponent internal constructor(
 ) : ViewModel(),
     PaymentComponent<PaymentComponentState<MBWayPaymentMethod>>,
     ViewableComponent,
+    ButtonComponent,
     ActionHandlingComponent by actionHandlingComponent {
 
     override val delegate: ComponentDelegate get() = actionHandlingComponent.activeDelegate
@@ -66,6 +68,8 @@ class MBWayComponent internal constructor(
         mbWayDelegate.removeObserver()
         genericActionDelegate.removeObserver()
     }
+
+    override fun isConfirmationRequired(): Boolean = mbWayDelegate.isConfirmationRequired()
 
     override fun onCleared() {
         super.onCleared()

--- a/mbway/src/test/java/com/adyen/checkout/mbway/MBWayComponentTest.kt
+++ b/mbway/src/test/java/com/adyen/checkout/mbway/MBWayComponentTest.kt
@@ -133,4 +133,10 @@ internal class MBWayComponentTest(
             expectNoEvents()
         }
     }
+
+    @Test
+    fun `when isConfirmationRequired, then delegate is called`() {
+        component.isConfirmationRequired()
+        verify(mbWayDelegate).isConfirmationRequired()
+    }
 }

--- a/online-banking-core/src/main/java/com/adyen/checkout/onlinebankingcore/DefaultOnlineBankingDelegate.kt
+++ b/online-banking-core/src/main/java/com/adyen/checkout/onlinebankingcore/DefaultOnlineBankingDelegate.kt
@@ -24,6 +24,7 @@ import com.adyen.checkout.components.repository.PaymentObserverRepository
 import com.adyen.checkout.components.ui.PaymentComponentUIEvent
 import com.adyen.checkout.components.ui.PaymentComponentUIState
 import com.adyen.checkout.components.ui.SubmitHandler
+import com.adyen.checkout.components.ui.view.ButtonComponentViewType
 import com.adyen.checkout.components.ui.view.ComponentViewType
 import com.adyen.checkout.components.util.PaymentMethodTypes
 import com.adyen.checkout.core.exception.CheckoutException
@@ -62,7 +63,8 @@ class DefaultOnlineBankingDelegate<IssuerListPaymentMethodT : IssuerListPaymentM
     private val exceptionChannel: Channel<CheckoutException> = bufferedChannel()
     override val exceptionFlow: Flow<CheckoutException> = exceptionChannel.receiveAsFlow()
 
-    override val viewFlow: Flow<ComponentViewType?> = MutableStateFlow(OnlineBankingComponentViewType)
+    private val _viewFlow = MutableStateFlow(OnlineBankingComponentViewType)
+    override val viewFlow: Flow<ComponentViewType?> = _viewFlow
 
     private val submitChannel: Channel<PaymentComponentState<IssuerListPaymentMethodT>> = bufferedChannel()
     override val submitFlow: Flow<PaymentComponentState<IssuerListPaymentMethodT>> = submitChannel.receiveAsFlow()
@@ -166,6 +168,9 @@ class DefaultOnlineBankingDelegate<IssuerListPaymentMethodT : IssuerListPaymentM
             uiStateChannel = _uiStateFlow
         )
     }
+
+    @Suppress("USELESS_IS_CHECK")
+    override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
     override fun onCleared() {
         removeObserver()

--- a/online-banking-core/src/main/java/com/adyen/checkout/onlinebankingcore/DefaultOnlineBankingDelegate.kt
+++ b/online-banking-core/src/main/java/com/adyen/checkout/onlinebankingcore/DefaultOnlineBankingDelegate.kt
@@ -63,7 +63,7 @@ class DefaultOnlineBankingDelegate<IssuerListPaymentMethodT : IssuerListPaymentM
     private val exceptionChannel: Channel<CheckoutException> = bufferedChannel()
     override val exceptionFlow: Flow<CheckoutException> = exceptionChannel.receiveAsFlow()
 
-    private val _viewFlow = MutableStateFlow(OnlineBankingComponentViewType)
+    private val _viewFlow: MutableStateFlow<ComponentViewType?> = MutableStateFlow(OnlineBankingComponentViewType)
     override val viewFlow: Flow<ComponentViewType?> = _viewFlow
 
     private val submitChannel: Channel<PaymentComponentState<IssuerListPaymentMethodT>> = bufferedChannel()
@@ -169,7 +169,6 @@ class DefaultOnlineBankingDelegate<IssuerListPaymentMethodT : IssuerListPaymentM
         )
     }
 
-    @Suppress("USELESS_IS_CHECK")
     override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
     override fun onCleared() {

--- a/online-banking-core/src/main/java/com/adyen/checkout/onlinebankingcore/OnlineBankingComponent.kt
+++ b/online-banking-core/src/main/java/com/adyen/checkout/onlinebankingcore/OnlineBankingComponent.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.viewModelScope
 import com.adyen.checkout.action.ActionHandlingComponent
 import com.adyen.checkout.action.DefaultActionHandlingComponent
 import com.adyen.checkout.action.GenericActionDelegate
+import com.adyen.checkout.components.ButtonComponent
 import com.adyen.checkout.components.PaymentComponent
 import com.adyen.checkout.components.PaymentComponentEvent
 import com.adyen.checkout.components.PaymentComponentState
@@ -33,6 +34,7 @@ abstract class OnlineBankingComponent<IssuerListPaymentMethodT : IssuerListPayme
 ) : ViewModel(),
     PaymentComponent<PaymentComponentState<IssuerListPaymentMethodT>>,
     ViewableComponent,
+    ButtonComponent,
     ActionHandlingComponent by actionHandlingComponent {
 
     override val delegate: ComponentDelegate get() = actionHandlingComponent.activeDelegate
@@ -60,6 +62,8 @@ abstract class OnlineBankingComponent<IssuerListPaymentMethodT : IssuerListPayme
         onlineBankingDelegate.removeObserver()
         genericActionDelegate.removeObserver()
     }
+
+    override fun isConfirmationRequired(): Boolean = onlineBankingDelegate.isConfirmationRequired()
 
     override fun onCleared() {
         super.onCleared()

--- a/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/OnlineBankingComponentTest.kt
+++ b/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/OnlineBankingComponentTest.kt
@@ -138,4 +138,10 @@ internal class OnlineBankingComponentTest(
             expectNoEvents()
         }
     }
+
+    @Test
+    fun `when isConfirmationRequired, then delegate is called`() {
+        component.isConfirmationRequired()
+        verify(onlineBankingDelegate).isConfirmationRequired()
+    }
 }

--- a/paybybank/src/main/java/com/adyen/checkout/paybybank/DefaultPayByBankDelegate.kt
+++ b/paybybank/src/main/java/com/adyen/checkout/paybybank/DefaultPayByBankDelegate.kt
@@ -55,7 +55,7 @@ internal class DefaultPayByBankDelegate(
     private val _componentStateFlow = MutableStateFlow(createComponentState())
     override val componentStateFlow: Flow<PaymentComponentState<PayByBankPaymentMethod>> = _componentStateFlow
 
-    private val _viewFlow = MutableStateFlow<ComponentViewType?>(null)
+    private val _viewFlow: MutableStateFlow<ComponentViewType?> = MutableStateFlow<ComponentViewType?>(null)
     override val viewFlow: Flow<ComponentViewType?> = _viewFlow
 
     private val submitChannel: Channel<PaymentComponentState<PayByBankPaymentMethod>> = bufferedChannel()

--- a/paybybank/src/main/java/com/adyen/checkout/paybybank/DefaultPayByBankDelegate.kt
+++ b/paybybank/src/main/java/com/adyen/checkout/paybybank/DefaultPayByBankDelegate.kt
@@ -24,6 +24,7 @@ import com.adyen.checkout.components.repository.PaymentObserverRepository
 import com.adyen.checkout.components.ui.PaymentComponentUIEvent
 import com.adyen.checkout.components.ui.PaymentComponentUIState
 import com.adyen.checkout.components.ui.SubmitHandler
+import com.adyen.checkout.components.ui.view.ButtonComponentViewType
 import com.adyen.checkout.components.ui.view.ComponentViewType
 import com.adyen.checkout.components.util.PaymentMethodTypes
 import com.adyen.checkout.core.log.LogUtil
@@ -197,6 +198,8 @@ internal class DefaultPayByBankDelegate(
             uiStateChannel = _uiStateFlow
         )
     }
+
+    override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
     override fun onCleared() {
         removeObserver()

--- a/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankComponent.kt
+++ b/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankComponent.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.viewModelScope
 import com.adyen.checkout.action.ActionHandlingComponent
 import com.adyen.checkout.action.DefaultActionHandlingComponent
 import com.adyen.checkout.action.GenericActionDelegate
+import com.adyen.checkout.components.ButtonComponent
 import com.adyen.checkout.components.PaymentComponent
 import com.adyen.checkout.components.PaymentComponentEvent
 import com.adyen.checkout.components.PaymentComponentProvider
@@ -36,6 +37,7 @@ class PayByBankComponent internal constructor(
 ) : ViewModel(),
     PaymentComponent<PaymentComponentState<PayByBankPaymentMethod>>,
     ViewableComponent,
+    ButtonComponent,
     ActionHandlingComponent by actionHandlingComponent {
 
     override val delegate: ComponentDelegate get() = actionHandlingComponent.activeDelegate
@@ -63,6 +65,8 @@ class PayByBankComponent internal constructor(
         payByBankDelegate.removeObserver()
         genericActionDelegate.removeObserver()
     }
+
+    override fun isConfirmationRequired(): Boolean = payByBankDelegate.isConfirmationRequired()
 
     override fun onCleared() {
         super.onCleared()

--- a/paybybank/src/test/java/com/adyen/checkout/paybybank/PayByBankComponentTest.kt
+++ b/paybybank/src/test/java/com/adyen/checkout/paybybank/PayByBankComponentTest.kt
@@ -101,20 +101,21 @@ internal class PayByBankComponentTest(
     }
 
     @Test
-    fun `when pay by bank delegate view flow emits a value then component view flow should match that value`() = runTest {
-        val payByBankDelegateViewFlow = MutableStateFlow(TestComponentViewType.VIEW_TYPE_1)
-        whenever(payByBankDelegate.viewFlow) doReturn payByBankDelegateViewFlow
-        component = PayByBankComponent(payByBankDelegate, genericActionDelegate, actionHandlingComponent)
+    fun `when pay by bank delegate view flow emits a value then component view flow should match that value`() =
+        runTest {
+            val payByBankDelegateViewFlow = MutableStateFlow(TestComponentViewType.VIEW_TYPE_1)
+            whenever(payByBankDelegate.viewFlow) doReturn payByBankDelegateViewFlow
+            component = PayByBankComponent(payByBankDelegate, genericActionDelegate, actionHandlingComponent)
 
-        component.viewFlow.test {
-            assertEquals(TestComponentViewType.VIEW_TYPE_1, awaitItem())
+            component.viewFlow.test {
+                assertEquals(TestComponentViewType.VIEW_TYPE_1, awaitItem())
 
-            payByBankDelegateViewFlow.emit(TestComponentViewType.VIEW_TYPE_2)
-            assertEquals(TestComponentViewType.VIEW_TYPE_2, awaitItem())
+                payByBankDelegateViewFlow.emit(TestComponentViewType.VIEW_TYPE_2)
+                assertEquals(TestComponentViewType.VIEW_TYPE_2, awaitItem())
 
-            expectNoEvents()
+                expectNoEvents()
+            }
         }
-    }
 
     @Test
     fun `when action delegate view flow emits a value then component view flow should match that value`() = runTest {
@@ -132,5 +133,11 @@ internal class PayByBankComponentTest(
 
             expectNoEvents()
         }
+    }
+
+    @Test
+    fun `when isConfirmationRequired, then delegate is called`() {
+        component.isConfirmationRequired()
+        verify(payByBankDelegate).isConfirmationRequired()
     }
 }

--- a/sepa/src/main/java/com/adyen/checkout/sepa/DefaultSepaDelegate.kt
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/DefaultSepaDelegate.kt
@@ -45,7 +45,7 @@ internal class DefaultSepaDelegate(
     private val _componentStateFlow = MutableStateFlow(createComponentState())
     override val componentStateFlow: Flow<PaymentComponentState<SepaPaymentMethod>> = _componentStateFlow
 
-    private val _viewFlow = MutableStateFlow(SepaComponentViewType)
+    private val _viewFlow: MutableStateFlow<ComponentViewType?> = MutableStateFlow(SepaComponentViewType)
     override val viewFlow: Flow<ComponentViewType?> = _viewFlow
 
     private val submitChannel: Channel<PaymentComponentState<SepaPaymentMethod>> = bufferedChannel()
@@ -139,7 +139,6 @@ internal class DefaultSepaDelegate(
         )
     }
 
-    @Suppress("USELESS_IS_CHECK")
     override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
     override fun onCleared() {

--- a/sepa/src/main/java/com/adyen/checkout/sepa/DefaultSepaDelegate.kt
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/DefaultSepaDelegate.kt
@@ -14,6 +14,7 @@ import com.adyen.checkout.components.repository.PaymentObserverRepository
 import com.adyen.checkout.components.ui.PaymentComponentUIEvent
 import com.adyen.checkout.components.ui.PaymentComponentUIState
 import com.adyen.checkout.components.ui.SubmitHandler
+import com.adyen.checkout.components.ui.view.ButtonComponentViewType
 import com.adyen.checkout.components.ui.view.ComponentViewType
 import com.adyen.checkout.components.util.PaymentMethodTypes
 import com.adyen.checkout.core.log.LogUtil
@@ -44,7 +45,8 @@ internal class DefaultSepaDelegate(
     private val _componentStateFlow = MutableStateFlow(createComponentState())
     override val componentStateFlow: Flow<PaymentComponentState<SepaPaymentMethod>> = _componentStateFlow
 
-    override val viewFlow: Flow<ComponentViewType?> = MutableStateFlow(SepaComponentViewType)
+    private val _viewFlow = MutableStateFlow(SepaComponentViewType)
+    override val viewFlow: Flow<ComponentViewType?> = _viewFlow
 
     private val submitChannel: Channel<PaymentComponentState<SepaPaymentMethod>> = bufferedChannel()
     override val submitFlow: Flow<PaymentComponentState<SepaPaymentMethod>> = submitChannel.receiveAsFlow()
@@ -136,6 +138,9 @@ internal class DefaultSepaDelegate(
             uiStateChannel = _uiStateFlow
         )
     }
+
+    @Suppress("USELESS_IS_CHECK")
+    override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
     override fun onCleared() {
         removeObserver()

--- a/sepa/src/main/java/com/adyen/checkout/sepa/SepaComponent.kt
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/SepaComponent.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.viewModelScope
 import com.adyen.checkout.action.ActionHandlingComponent
 import com.adyen.checkout.action.DefaultActionHandlingComponent
 import com.adyen.checkout.action.GenericActionDelegate
+import com.adyen.checkout.components.ButtonComponent
 import com.adyen.checkout.components.PaymentComponent
 import com.adyen.checkout.components.PaymentComponentEvent
 import com.adyen.checkout.components.PaymentComponentProvider
@@ -39,6 +40,7 @@ class SepaComponent internal constructor(
 ) : ViewModel(),
     PaymentComponent<PaymentComponentState<SepaPaymentMethod>>,
     ViewableComponent,
+    ButtonComponent,
     ActionHandlingComponent by actionHandlingComponent {
 
     override val delegate: ComponentDelegate get() = actionHandlingComponent.activeDelegate
@@ -66,6 +68,8 @@ class SepaComponent internal constructor(
         sepaDelegate.removeObserver()
         genericActionDelegate.removeObserver()
     }
+
+    override fun isConfirmationRequired(): Boolean = sepaDelegate.isConfirmationRequired()
 
     override fun onCleared() {
         super.onCleared()

--- a/sepa/src/test/java/com/adyen/checkout/sepa/SepaComponentTest.kt
+++ b/sepa/src/test/java/com/adyen/checkout/sepa/SepaComponentTest.kt
@@ -133,4 +133,10 @@ internal class SepaComponentTest(
             expectNoEvents()
         }
     }
+
+    @Test
+    fun `when isConfirmationRequired, then delegate is called`() {
+        component.isConfirmationRequired()
+        verify(sepaDelegate).isConfirmationRequired()
+    }
 }

--- a/ui-core/src/main/java/com/adyen/checkout/components/ui/ButtonDelegate.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/components/ui/ButtonDelegate.kt
@@ -10,4 +10,6 @@ interface ButtonDelegate {
     val submitFlow: Flow<PaymentComponentState<out PaymentMethodDetails>>
 
     fun onSubmit()
+
+    fun isConfirmationRequired(): Boolean
 }

--- a/ui-core/src/main/java/com/adyen/checkout/components/ui/ButtonDelegate.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/components/ui/ButtonDelegate.kt
@@ -11,5 +11,17 @@ interface ButtonDelegate {
 
     fun onSubmit()
 
+    /**
+     * Tells if the view interaction requires confirmation from the user to start the payment flow.
+     * Confirmation usually is obtained by a "Pay" button the user need to press to start processing the payment.
+     * If confirmation is not required, it means the view handles input in a way that the user has already expressed the
+     * desire to continue.
+     *
+     * Each type of view always returns the same value, so if the type of view is known, there is no need to check this
+     * method.
+     *
+     * @return If an update from the component attached to this View requires further user confirmation to continue or
+     * not.
+     */
     fun isConfirmationRequired(): Boolean
 }

--- a/ui-core/src/main/java/com/adyen/checkout/components/ui/ButtonDelegate.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/components/ui/ButtonDelegate.kt
@@ -12,6 +12,7 @@ interface ButtonDelegate {
     fun onSubmit()
 
     /**
+     * TODO: Update docs
      * Tells if the view interaction requires confirmation from the user to start the payment flow.
      * Confirmation usually is obtained by a "Pay" button the user need to press to start processing the payment.
      * If confirmation is not required, it means the view handles input in a way that the user has already expressed the

--- a/ui-core/src/main/java/com/adyen/checkout/components/ui/view/AdyenComponentView.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/components/ui/view/AdyenComponentView.kt
@@ -115,7 +115,7 @@ class AdyenComponentView @JvmOverloads constructor(
 
         componentView.initView(delegate, coroutineScope, localizedContext)
 
-        if (isConfirmationRequired) {
+        if ((delegate as? ButtonDelegate)?.isConfirmationRequired() == true) {
             val uiStateDelegate = (delegate as? UIStateDelegate)
             uiStateDelegate?.uiStateFlow?.onEach {
                 // TODO check if setPaymentPendingInitialization has to be called on each event?
@@ -164,21 +164,6 @@ class AdyenComponentView @JvmOverloads constructor(
             text = localizedContext.getString(viewType.buttonTextResId)
         }
     }
-
-    /**
-     * Tells if the view interaction requires confirmation from the user to start the payment flow.
-     * Confirmation usually is obtained by a "Pay" button the user need to press to start processing the payment.
-     * If confirmation is not required, it means the view handles input in a way that the user has already expressed the
-     * desire to continue.
-     *
-     * Each type of view always returns the same value, so if the type of view is known, there is no need to check this
-     * method.
-     *
-     * @return If an update from the component attached to this View requires further user confirmation to continue or
-     * not.
-     */
-    val isConfirmationRequired: Boolean
-        get() = componentViewType is ButtonComponentViewType
 
     /**
      * Highlight and focus on the current validation errors for the user to take action.


### PR DESCRIPTION
## Description
The view shouldn't have this logic, so it makes sense to move it to the delegates. Also this is a part needed for a bigger refactor.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-691
