### PR TITLE
Fix docs for EPSConfiguration.Builder.setHideIssuerLogos

### DIFF
--- a/eps/src/main/java/com/adyen/checkout/eps/EPSConfiguration.kt
+++ b/eps/src/main/java/com/adyen/checkout/eps/EPSConfiguration.kt
@@ -49,6 +49,17 @@ class EPSConfiguration private constructor(
         )
 
         /**
+         * Sets whether the logos should be shown next to the issuers name.
+         *
+         * Default is true.
+         *
+         * @param hideIssuerLogos if issuer logos should be hidden or not.
+         */
+        override fun setHideIssuerLogos(hideIssuerLogos: Boolean): Builder {
+            return super.setHideIssuerLogos(hideIssuerLogos)
+        }
+
+        /**
          * Builder with required parameters.
          *
          * @param shopperLocale The Locale of the shopper.

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/IssuerListConfiguration.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/IssuerListConfiguration.kt
@@ -57,13 +57,13 @@ abstract class IssuerListConfiguration : Configuration, ButtonConfiguration {
         }
 
         /**
-         * Sets whether the logos should be shows next to the issuers name.
+         * Sets whether the logos should be shown next to the issuers name.
          *
          * Default is false.
          *
          * @param hideIssuerLogos if issuer logos should be hidden or not.
          */
-        fun setHideIssuerLogos(hideIssuerLogos: Boolean): IssuerListBuilderT {
+        open fun setHideIssuerLogos(hideIssuerLogos: Boolean): IssuerListBuilderT {
             this.hideIssuerLogos = hideIssuerLogos
             @Suppress("UNCHECKED_CAST")
             return this as IssuerListBuilderT


### PR DESCRIPTION
## Description
The docs for `IssuerListConfiguration.Builder.setHideIssuerLogos` state that the default value is false, while for EPS that default value is actually true.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-549
