### PR TITLE
Make delegates in control of showing submit button

### DIFF
--- a/bacs/src/main/java/com/adyen/checkout/bacs/DefaultBacsDirectDebitDelegate.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/DefaultBacsDirectDebitDelegate.kt
@@ -210,6 +210,8 @@ internal class DefaultBacsDirectDebitDelegate(
 
     override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
+    override fun shouldShowSubmitButton(): Boolean = isConfirmationRequired() && componentParams.isSubmitButtonVisible
+
     override fun onCleared() {
         removeObserver()
     }

--- a/bacs/src/test/java/com/adyen/checkout/bacs/DefaultBacsDirectDebitDelegateTest.kt
+++ b/bacs/src/test/java/com/adyen/checkout/bacs/DefaultBacsDirectDebitDelegateTest.kt
@@ -45,18 +45,7 @@ internal class DefaultBacsDirectDebitDelegateTest(
 
     @BeforeEach
     fun beforeEach() {
-        val configuration = BacsDirectDebitConfiguration.Builder(
-            Locale.US,
-            Environment.TEST,
-            TEST_CLIENT_KEY
-        ).build()
-        delegate = DefaultBacsDirectDebitDelegate(
-            observerRepository = PaymentObserverRepository(),
-            componentParams = ButtonComponentParamsMapper(null).mapToParams(configuration),
-            paymentMethod = PaymentMethod(),
-            analyticsRepository = analyticsRepository,
-            submitHandler = SubmitHandler()
-        )
+        delegate = createBacsDelegate()
         Logger.setLogcatLevel(Logger.NONE)
     }
 
@@ -429,6 +418,48 @@ internal class DefaultBacsDirectDebitDelegateTest(
         delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
         verify(analyticsRepository).sendAnalyticsEvent()
     }
+
+    @Nested
+    inner class SubmitButtonVisibilityTest {
+
+        @Test
+        fun `when submit button is configured to be hidden, then it should not show`() {
+            delegate = createBacsDelegate(
+                configuration = getDefaultBacsConfigurationBuilder()
+                    .setSubmitButtonVisible(false)
+                    .build()
+            )
+
+            assertFalse(delegate.shouldShowSubmitButton())
+        }
+
+        @Test
+        fun `when submit button is configured to be visible, then it should show`() {
+            delegate = createBacsDelegate(
+                configuration = getDefaultBacsConfigurationBuilder()
+                    .setSubmitButtonVisible(true)
+                    .build()
+            )
+
+            assertTrue(delegate.shouldShowSubmitButton())
+        }
+    }
+
+    private fun createBacsDelegate(
+        configuration: BacsDirectDebitConfiguration = getDefaultBacsConfigurationBuilder().build()
+    ) = DefaultBacsDirectDebitDelegate(
+        observerRepository = PaymentObserverRepository(),
+        componentParams = ButtonComponentParamsMapper(null).mapToParams(configuration),
+        paymentMethod = PaymentMethod(),
+        analyticsRepository = analyticsRepository,
+        submitHandler = SubmitHandler()
+    )
+
+    private fun getDefaultBacsConfigurationBuilder() = BacsDirectDebitConfiguration.Builder(
+        Locale.US,
+        Environment.TEST,
+        TEST_CLIENT_KEY
+    )
 
     companion object {
         private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfghjklzxcvbnmqwerty"

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/DefaultBcmcDelegate.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/DefaultBcmcDelegate.kt
@@ -297,6 +297,8 @@ internal class DefaultBcmcDelegate(
 
     override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
+    override fun shouldShowSubmitButton(): Boolean = isConfirmationRequired() && componentParams.isSubmitButtonVisible
+
     override fun onCleared() {
         removeObserver()
     }

--- a/blik/src/main/java/com/adyen/checkout/blik/DefaultBlikDelegate.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/DefaultBlikDelegate.kt
@@ -159,11 +159,13 @@ internal class DefaultBlikDelegate(
 
     override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
+    override fun shouldShowSubmitButton(): Boolean = isConfirmationRequired() && componentParams.isSubmitButtonVisible
+
+    override fun requiresInput(): Boolean = true
+
     override fun onCleared() {
         removeObserver()
     }
-
-    override fun requiresInput(): Boolean = true
 
     companion object {
         private val TAG = LogUtil.getTag()

--- a/blik/src/main/java/com/adyen/checkout/blik/StoredBlikDelegate.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/StoredBlikDelegate.kt
@@ -134,6 +134,8 @@ internal class StoredBlikDelegate(
 
     override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
+    override fun shouldShowSubmitButton(): Boolean = isConfirmationRequired() && componentParams.isSubmitButtonVisible
+
     override fun onCleared() {
         removeObserver()
     }

--- a/blik/src/test/java/com/adyen/checkout/blik/DefaultBlikDelegateTest.kt
+++ b/blik/src/test/java/com/adyen/checkout/blik/DefaultBlikDelegateTest.kt
@@ -43,18 +43,7 @@ internal class DefaultBlikDelegateTest(
 
     @BeforeEach
     fun beforeEach() {
-        val configuration = BlikConfiguration.Builder(
-            Locale.US,
-            Environment.TEST,
-            TEST_CLIENT_KEY
-        ).build()
-        delegate = DefaultBlikDelegate(
-            observerRepository = PaymentObserverRepository(),
-            componentParams = ButtonComponentParamsMapper(null).mapToParams(configuration),
-            paymentMethod = PaymentMethod(),
-            analyticsRepository = analyticsRepository,
-            submitHandler = SubmitHandler()
-        )
+        delegate = createBlikDelegate()
         Logger.setLogcatLevel(Logger.NONE)
     }
 
@@ -175,6 +164,48 @@ internal class DefaultBlikDelegateTest(
         delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
         verify(analyticsRepository).sendAnalyticsEvent()
     }
+
+    @Nested
+    inner class SubmitButtonVisibilityTest {
+
+        @Test
+        fun `when submit button is configured to be hidden, then it should not show`() {
+            delegate = createBlikDelegate(
+                configuration = getDefaultBlikConfigurationBuilder()
+                    .setSubmitButtonVisible(false)
+                    .build()
+            )
+
+            assertFalse(delegate.shouldShowSubmitButton())
+        }
+
+        @Test
+        fun `when submit button is configured to be visible, then it should show`() {
+            delegate = createBlikDelegate(
+                configuration = getDefaultBlikConfigurationBuilder()
+                    .setSubmitButtonVisible(true)
+                    .build()
+            )
+
+            assertTrue(delegate.shouldShowSubmitButton())
+        }
+    }
+
+    private fun createBlikDelegate(
+        configuration: BlikConfiguration = getDefaultBlikConfigurationBuilder().build()
+    ) = DefaultBlikDelegate(
+        observerRepository = PaymentObserverRepository(),
+        componentParams = ButtonComponentParamsMapper(null).mapToParams(configuration),
+        paymentMethod = PaymentMethod(),
+        analyticsRepository = analyticsRepository,
+        submitHandler = SubmitHandler()
+    )
+
+    private fun getDefaultBlikConfigurationBuilder() = BlikConfiguration.Builder(
+        Locale.US,
+        Environment.TEST,
+        TEST_CLIENT_KEY
+    )
 
     companion object {
         private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfghjklzxcvbnmqwerty"

--- a/card/src/main/java/com/adyen/checkout/card/DefaultCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/DefaultCardDelegate.kt
@@ -693,6 +693,8 @@ internal class DefaultCardDelegate(
 
     override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
+    override fun shouldShowSubmitButton(): Boolean = isConfirmationRequired() && componentParams.isSubmitButtonVisible
+
     override fun onCleared() {
         removeObserver()
         _coroutineScope = null

--- a/card/src/main/java/com/adyen/checkout/card/StoredCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/StoredCardDelegate.kt
@@ -402,6 +402,8 @@ internal class StoredCardDelegate(
 
     override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
+    override fun shouldShowSubmitButton(): Boolean = isConfirmationRequired() && componentParams.isSubmitButtonVisible
+
     override fun onCleared() {
         removeObserver()
         coroutineScope = null

--- a/card/src/test/java/com/adyen/checkout/card/DefaultCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/DefaultCardDelegateTest.kt
@@ -706,6 +706,32 @@ internal class DefaultCardDelegateTest(
         verify(analyticsRepository).sendAnalyticsEvent()
     }
 
+    @Nested
+    inner class SubmitButtonVisibilityTest {
+
+        @Test
+        fun `when submit button is configured to be hidden, then it should not show`() {
+            delegate = createCardDelegate(
+                configuration = getDefaultCardConfigurationBuilder()
+                    .setSubmitButtonVisible(false)
+                    .build()
+            )
+
+            assertFalse(delegate.shouldShowSubmitButton())
+        }
+
+        @Test
+        fun `when submit button is configured to be visible, then it should show`() {
+            delegate = createCardDelegate(
+                configuration = getDefaultCardConfigurationBuilder()
+                    .setSubmitButtonVisible(true)
+                    .build()
+            )
+
+            assertTrue(delegate.shouldShowSubmitButton())
+        }
+    }
+
     private fun createCardDelegate(
         publicKeyRepository: PublicKeyRepository = this.publicKeyRepository,
         addressRepository: AddressRepository = this.addressRepository,

--- a/card/src/test/java/com/adyen/checkout/card/StoredCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/StoredCardDelegateTest.kt
@@ -293,6 +293,38 @@ internal class StoredCardDelegateTest(
         }
     }
 
+    @Test
+    fun `when delegate is initialized then analytics event is sent`() = runTest {
+        delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+        verify(analyticsRepository).sendAnalyticsEvent()
+    }
+
+    @Nested
+    inner class SubmitButtonVisibilityTest {
+
+        @Test
+        fun `when submit button is configured to be hidden, then it should not show`() {
+            delegate = createCardDelegate(
+                configuration = getDefaultCardConfigurationBuilder()
+                    .setSubmitButtonVisible(false)
+                    .build()
+            )
+
+            assertFalse(delegate.shouldShowSubmitButton())
+        }
+
+        @Test
+        fun `when submit button is configured to be visible, then it should show`() {
+            delegate = createCardDelegate(
+                configuration = getDefaultCardConfigurationBuilder()
+                    .setSubmitButtonVisible(true)
+                    .build()
+            )
+
+            assertTrue(delegate.shouldShowSubmitButton())
+        }
+    }
+
     private fun createCardDelegate(
         publicKeyRepository: PublicKeyRepository = this.publicKeyRepository,
         cardEncrypter: CardEncrypter = this.cardEncrypter,
@@ -425,12 +457,6 @@ internal class StoredCardDelegateTest(
             panLength = panLength,
             isSelected = isSelected,
         )
-    }
-
-    @Test
-    fun `when delegate is initialized then analytics event is sent`() = runTest {
-        delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
-        verify(analyticsRepository).sendAnalyticsEvent()
     }
 
     companion object {

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/DefaultGiftCardDelegate.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/DefaultGiftCardDelegate.kt
@@ -227,6 +227,8 @@ internal class DefaultGiftCardDelegate(
 
     override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
+    override fun shouldShowSubmitButton(): Boolean = isConfirmationRequired() && componentParams.isSubmitButtonVisible
+
     override fun onCleared() {
         removeObserver()
     }

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/DefaultIssuerListDelegate.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/DefaultIssuerListDelegate.kt
@@ -151,6 +151,8 @@ class DefaultIssuerListDelegate<IssuerListPaymentMethodT : IssuerListPaymentMeth
 
     override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
+    override fun shouldShowSubmitButton(): Boolean = isConfirmationRequired() && componentParams.isSubmitButtonVisible
+
     override fun onCleared() {
         removeObserver()
     }

--- a/mbway/src/main/java/com/adyen/checkout/mbway/DefaultMBWayDelegate.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/DefaultMBWayDelegate.kt
@@ -169,6 +169,8 @@ internal class DefaultMBWayDelegate(
 
     override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
+    override fun shouldShowSubmitButton(): Boolean = isConfirmationRequired() && componentParams.isSubmitButtonVisible
+
     override fun onCleared() {
         removeObserver()
     }

--- a/online-banking-core/src/main/java/com/adyen/checkout/onlinebankingcore/DefaultOnlineBankingDelegate.kt
+++ b/online-banking-core/src/main/java/com/adyen/checkout/onlinebankingcore/DefaultOnlineBankingDelegate.kt
@@ -171,6 +171,8 @@ class DefaultOnlineBankingDelegate<IssuerListPaymentMethodT : IssuerListPaymentM
 
     override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
+    override fun shouldShowSubmitButton(): Boolean = isConfirmationRequired() && componentParams.isSubmitButtonVisible
+
     override fun onCleared() {
         removeObserver()
     }

--- a/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/utils/TestOnlineBankingConfiguration.kt
+++ b/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/utils/TestOnlineBankingConfiguration.kt
@@ -10,6 +10,8 @@ package com.adyen.checkout.onlinebankingcore.utils
 
 import android.content.Context
 import com.adyen.checkout.components.base.BaseConfigurationBuilder
+import com.adyen.checkout.components.base.ButtonConfiguration
+import com.adyen.checkout.components.base.ButtonConfigurationBuilder
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.model.payments.Amount
 import com.adyen.checkout.core.api.Environment
@@ -23,9 +25,13 @@ class TestOnlineBankingConfiguration private constructor(
     override val clientKey: String,
     override val isAnalyticsEnabled: Boolean?,
     override val amount: Amount,
-) : Configuration {
+    override val isSubmitButtonVisible: Boolean?,
+) : Configuration,
+    ButtonConfiguration {
 
-    class Builder : BaseConfigurationBuilder<TestOnlineBankingConfiguration, Builder> {
+    class Builder : BaseConfigurationBuilder<TestOnlineBankingConfiguration, Builder>, ButtonConfigurationBuilder {
+
+        private var isSubmitButtonVisible: Boolean? = null
 
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
@@ -39,6 +45,11 @@ class TestOnlineBankingConfiguration private constructor(
             clientKey: String
         ) : super(shopperLocale, environment, clientKey)
 
+        override fun setSubmitButtonVisible(isSubmitButtonVisible: Boolean): Builder {
+            this.isSubmitButtonVisible = isSubmitButtonVisible
+            return this
+        }
+
         override fun buildInternal(): TestOnlineBankingConfiguration {
             return TestOnlineBankingConfiguration(
                 shopperLocale = shopperLocale,
@@ -46,6 +57,7 @@ class TestOnlineBankingConfiguration private constructor(
                 clientKey = clientKey,
                 isAnalyticsEnabled = isAnalyticsEnabled,
                 amount = amount,
+                isSubmitButtonVisible = isSubmitButtonVisible,
             )
         }
     }

--- a/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZConfiguration.kt
+++ b/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZConfiguration.kt
@@ -11,6 +11,8 @@ package com.adyen.checkout.onlinebankingcz
 import android.content.Context
 import com.adyen.checkout.action.ActionHandlingPaymentMethodConfigurationBuilder
 import com.adyen.checkout.action.GenericActionConfiguration
+import com.adyen.checkout.components.base.ButtonConfiguration
+import com.adyen.checkout.components.base.ButtonConfigurationBuilder
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.model.payments.Amount
 import com.adyen.checkout.core.api.Environment
@@ -24,10 +26,14 @@ class OnlineBankingCZConfiguration private constructor(
     override val clientKey: String,
     override val isAnalyticsEnabled: Boolean?,
     override val amount: Amount,
+    override val isSubmitButtonVisible: Boolean?,
     internal val genericActionConfiguration: GenericActionConfiguration,
-) : Configuration {
+) : Configuration, ButtonConfiguration {
 
-    class Builder : ActionHandlingPaymentMethodConfigurationBuilder<OnlineBankingCZConfiguration, Builder> {
+    class Builder : ActionHandlingPaymentMethodConfigurationBuilder<OnlineBankingCZConfiguration, Builder>,
+        ButtonConfigurationBuilder {
+
+        private var isSubmitButtonVisible: Boolean? = null
 
         /**
          * Constructor for Builder with default values.
@@ -55,6 +61,11 @@ class OnlineBankingCZConfiguration private constructor(
             clientKey: String
         ) : super(shopperLocale, environment, clientKey)
 
+        override fun setSubmitButtonVisible(isSubmitButtonVisible: Boolean): Builder {
+            this.isSubmitButtonVisible = isSubmitButtonVisible
+            return this
+        }
+
         override fun buildInternal(): OnlineBankingCZConfiguration {
             return OnlineBankingCZConfiguration(
                 shopperLocale = shopperLocale,
@@ -62,6 +73,7 @@ class OnlineBankingCZConfiguration private constructor(
                 clientKey = clientKey,
                 isAnalyticsEnabled = isAnalyticsEnabled,
                 amount = amount,
+                isSubmitButtonVisible = isSubmitButtonVisible,
                 genericActionConfiguration = genericActionConfigurationBuilder.build(),
             )
         }

--- a/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZConfiguration.kt
+++ b/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZConfiguration.kt
@@ -19,6 +19,7 @@ import com.adyen.checkout.core.api.Environment
 import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
+@Suppress("LongParameterList")
 @Parcelize
 class OnlineBankingCZConfiguration private constructor(
     override val shopperLocale: Locale,
@@ -30,7 +31,8 @@ class OnlineBankingCZConfiguration private constructor(
     internal val genericActionConfiguration: GenericActionConfiguration,
 ) : Configuration, ButtonConfiguration {
 
-    class Builder : ActionHandlingPaymentMethodConfigurationBuilder<OnlineBankingCZConfiguration, Builder>,
+    class Builder :
+        ActionHandlingPaymentMethodConfigurationBuilder<OnlineBankingCZConfiguration, Builder>,
         ButtonConfigurationBuilder {
 
         private var isSubmitButtonVisible: Boolean? = null

--- a/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKConfiguration.kt
+++ b/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKConfiguration.kt
@@ -19,6 +19,7 @@ import com.adyen.checkout.core.api.Environment
 import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
+@Suppress("LongParameterList")
 @Parcelize
 class OnlineBankingSKConfiguration private constructor(
     override val shopperLocale: Locale,
@@ -31,7 +32,8 @@ class OnlineBankingSKConfiguration private constructor(
 ) : Configuration,
     ButtonConfiguration {
 
-    class Builder : ActionHandlingPaymentMethodConfigurationBuilder<OnlineBankingSKConfiguration, Builder>,
+    class Builder :
+        ActionHandlingPaymentMethodConfigurationBuilder<OnlineBankingSKConfiguration, Builder>,
         ButtonConfigurationBuilder {
 
         private var isSubmitButtonVisible: Boolean? = null

--- a/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKConfiguration.kt
+++ b/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKConfiguration.kt
@@ -11,6 +11,8 @@ package com.adyen.checkout.onlinebankingsk
 import android.content.Context
 import com.adyen.checkout.action.ActionHandlingPaymentMethodConfigurationBuilder
 import com.adyen.checkout.action.GenericActionConfiguration
+import com.adyen.checkout.components.base.ButtonConfiguration
+import com.adyen.checkout.components.base.ButtonConfigurationBuilder
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.components.model.payments.Amount
 import com.adyen.checkout.core.api.Environment
@@ -24,10 +26,15 @@ class OnlineBankingSKConfiguration private constructor(
     override val clientKey: String,
     override val isAnalyticsEnabled: Boolean?,
     override val amount: Amount,
+    override val isSubmitButtonVisible: Boolean?,
     internal val genericActionConfiguration: GenericActionConfiguration,
-) : Configuration {
+) : Configuration,
+    ButtonConfiguration {
 
-    class Builder : ActionHandlingPaymentMethodConfigurationBuilder<OnlineBankingSKConfiguration, Builder> {
+    class Builder : ActionHandlingPaymentMethodConfigurationBuilder<OnlineBankingSKConfiguration, Builder>,
+        ButtonConfigurationBuilder {
+
+        private var isSubmitButtonVisible: Boolean? = null
 
         /**
          * Constructor for Builder with default values.
@@ -55,6 +62,11 @@ class OnlineBankingSKConfiguration private constructor(
             clientKey: String
         ) : super(shopperLocale, environment, clientKey)
 
+        override fun setSubmitButtonVisible(isSubmitButtonVisible: Boolean): Builder {
+            this.isSubmitButtonVisible = isSubmitButtonVisible
+            return this
+        }
+
         override fun buildInternal(): OnlineBankingSKConfiguration {
             return OnlineBankingSKConfiguration(
                 shopperLocale = shopperLocale,
@@ -62,6 +74,7 @@ class OnlineBankingSKConfiguration private constructor(
                 clientKey = clientKey,
                 isAnalyticsEnabled = isAnalyticsEnabled,
                 amount = amount,
+                isSubmitButtonVisible = isSubmitButtonVisible,
                 genericActionConfiguration = genericActionConfigurationBuilder.build(),
             )
         }

--- a/paybybank/src/main/java/com/adyen/checkout/paybybank/DefaultPayByBankDelegate.kt
+++ b/paybybank/src/main/java/com/adyen/checkout/paybybank/DefaultPayByBankDelegate.kt
@@ -201,6 +201,9 @@ internal class DefaultPayByBankDelegate(
 
     override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
+    // Pay by bank should not show a button as the entries navigate to the next step.
+    override fun shouldShowSubmitButton(): Boolean = false
+
     override fun onCleared() {
         removeObserver()
     }

--- a/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankComponent.kt
+++ b/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankComponent.kt
@@ -14,7 +14,6 @@ import androidx.lifecycle.viewModelScope
 import com.adyen.checkout.action.ActionHandlingComponent
 import com.adyen.checkout.action.DefaultActionHandlingComponent
 import com.adyen.checkout.action.GenericActionDelegate
-import com.adyen.checkout.components.ButtonComponent
 import com.adyen.checkout.components.PaymentComponent
 import com.adyen.checkout.components.PaymentComponentEvent
 import com.adyen.checkout.components.PaymentComponentProvider
@@ -37,7 +36,6 @@ class PayByBankComponent internal constructor(
 ) : ViewModel(),
     PaymentComponent<PaymentComponentState<PayByBankPaymentMethod>>,
     ViewableComponent,
-    ButtonComponent,
     ActionHandlingComponent by actionHandlingComponent {
 
     override val delegate: ComponentDelegate get() = actionHandlingComponent.activeDelegate
@@ -65,8 +63,6 @@ class PayByBankComponent internal constructor(
         payByBankDelegate.removeObserver()
         genericActionDelegate.removeObserver()
     }
-
-    override fun isConfirmationRequired(): Boolean = payByBankDelegate.isConfirmationRequired()
 
     override fun onCleared() {
         super.onCleared()

--- a/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankComponentProvider.kt
+++ b/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankComponentProvider.kt
@@ -27,7 +27,6 @@ import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.repository.PaymentObserverRepository
-import com.adyen.checkout.components.ui.SubmitHandler
 import com.adyen.checkout.core.api.HttpClientFactory
 import com.adyen.checkout.core.exception.ComponentException
 
@@ -67,7 +66,6 @@ class PayByBankComponentProvider(
                     paymentMethod = paymentMethod,
                     componentParams = componentParams,
                     analyticsRepository = analyticsRepository,
-                    submitHandler = SubmitHandler(),
                 )
 
                 val genericActionDelegate = GenericActionComponentProvider(componentParams).getDelegate(

--- a/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankDelegate.kt
+++ b/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankDelegate.kt
@@ -11,17 +11,13 @@ package com.adyen.checkout.paybybank
 import com.adyen.checkout.components.PaymentComponentState
 import com.adyen.checkout.components.base.PaymentComponentDelegate
 import com.adyen.checkout.components.model.payments.request.PayByBankPaymentMethod
-import com.adyen.checkout.components.ui.ButtonDelegate
-import com.adyen.checkout.components.ui.UIStateDelegate
 import com.adyen.checkout.components.ui.ViewProvidingDelegate
 import com.adyen.checkout.issuerlist.IssuerModel
 import kotlinx.coroutines.flow.Flow
 
 interface PayByBankDelegate :
     PaymentComponentDelegate<PaymentComponentState<PayByBankPaymentMethod>>,
-    ViewProvidingDelegate,
-    ButtonDelegate,
-    UIStateDelegate {
+    ViewProvidingDelegate {
 
     val outputData: PayByBankOutputData
 
@@ -29,7 +25,11 @@ interface PayByBankDelegate :
 
     val componentStateFlow: Flow<PaymentComponentState<PayByBankPaymentMethod>>
 
+    val submitFlow: Flow<PaymentComponentState<PayByBankPaymentMethod>>
+
     fun getIssuers(): List<IssuerModel>
 
     fun updateInputData(update: PayByBankInputData.() -> Unit)
+
+    fun onSubmit()
 }

--- a/paybybank/src/test/java/com/adyen/checkout/paybybank/DefaultPayByBankDelegateTest.kt
+++ b/paybybank/src/test/java/com/adyen/checkout/paybybank/DefaultPayByBankDelegateTest.kt
@@ -14,7 +14,6 @@ import com.adyen.checkout.components.base.GenericComponentParamsMapper
 import com.adyen.checkout.components.model.paymentmethods.Issuer
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
 import com.adyen.checkout.components.repository.PaymentObserverRepository
-import com.adyen.checkout.components.ui.SubmitHandler
 import com.adyen.checkout.core.api.Environment
 import com.adyen.checkout.core.log.Logger
 import com.adyen.checkout.issuerlist.IssuerModel
@@ -57,7 +56,6 @@ internal class DefaultPayByBankDelegateTest(
             componentParams = GenericComponentParamsMapper(null).mapToParams(configuration),
             paymentMethod = PaymentMethod(),
             analyticsRepository = analyticsRepository,
-            submitHandler = SubmitHandler()
         )
         Logger.setLogcatLevel(Logger.NONE)
     }
@@ -148,7 +146,6 @@ internal class DefaultPayByBankDelegateTest(
                 issuers = emptyList()
             ),
             analyticsRepository = analyticsRepository,
-            submitHandler = SubmitHandler()
         )
         delegate.viewFlow.test {
             assertEquals(null, expectMostRecentItem())
@@ -167,7 +164,6 @@ internal class DefaultPayByBankDelegateTest(
                 )
             ),
             analyticsRepository = analyticsRepository,
-            submitHandler = SubmitHandler()
         )
         delegate.viewFlow.test {
             assertEquals(PayByBankComponentViewType, expectMostRecentItem())

--- a/paybybank/src/test/java/com/adyen/checkout/paybybank/PayByBankComponentTest.kt
+++ b/paybybank/src/test/java/com/adyen/checkout/paybybank/PayByBankComponentTest.kt
@@ -134,10 +134,4 @@ internal class PayByBankComponentTest(
             expectNoEvents()
         }
     }
-
-    @Test
-    fun `when isConfirmationRequired, then delegate is called`() {
-        component.isConfirmationRequired()
-        verify(payByBankDelegate).isConfirmationRequired()
-    }
 }

--- a/sepa/src/main/java/com/adyen/checkout/sepa/DefaultSepaDelegate.kt
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/DefaultSepaDelegate.kt
@@ -141,6 +141,8 @@ internal class DefaultSepaDelegate(
 
     override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
+    override fun shouldShowSubmitButton(): Boolean = isConfirmationRequired() && componentParams.isSubmitButtonVisible
+
     override fun onCleared() {
         removeObserver()
     }

--- a/ui-core/src/main/java/com/adyen/checkout/components/ui/ButtonDelegate.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/components/ui/ButtonDelegate.kt
@@ -25,4 +25,6 @@ interface ButtonDelegate {
      * not.
      */
     fun isConfirmationRequired(): Boolean
+
+    fun shouldShowSubmitButton(): Boolean
 }

--- a/ui-core/src/main/java/com/adyen/checkout/components/ui/view/AdyenComponentView.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/components/ui/view/AdyenComponentView.kt
@@ -145,7 +145,7 @@ class AdyenComponentView @JvmOverloads constructor(
     }
 
     private fun setPaymentPendingInitialization(pending: Boolean) {
-        binding.payButton.isVisible = !pending
+        binding.payButton.isVisible = binding.payButton.isVisible && !pending
         if (pending) binding.progressBar.show() else binding.progressBar.hide()
     }
 

--- a/ui-core/src/main/java/com/adyen/checkout/components/ui/view/AdyenComponentView.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/components/ui/view/AdyenComponentView.kt
@@ -117,7 +117,8 @@ class AdyenComponentView @JvmOverloads constructor(
 
         componentView.initView(delegate, coroutineScope, localizedContext)
 
-        if ((delegate as? ButtonDelegate)?.isConfirmationRequired() == true) {
+        val buttonDelegate = (delegate as? ButtonDelegate)
+        if (buttonDelegate?.isConfirmationRequired() == true) {
             val uiStateDelegate = (delegate as? UIStateDelegate)
             uiStateDelegate?.uiStateFlow?.onEach {
                 // TODO check if setPaymentPendingInitialization has to be called on each event?
@@ -133,9 +134,9 @@ class AdyenComponentView @JvmOverloads constructor(
                 }
             }?.launchIn(coroutineScope)
 
-            binding.payButton.isVisible = true
+            binding.payButton.isVisible = buttonDelegate.shouldShowSubmitButton()
             binding.payButton.setOnClickListener {
-                (delegate as? ButtonDelegate)?.onSubmit()
+                buttonDelegate.onSubmit()
             }
         } else {
             binding.payButton.isVisible = false


### PR DESCRIPTION
## Description
`ButtonDelegate`s now have this `shouldShowSubmitButton` method that `AdyenComponentView` uses to show or hide the submit button.

`PayByBankDelegate` implemented the `ButtonDelegate` and `UIStateDelegate` interfaces, which it shouldn't. Pay by bank doesn't show a button, so there is no need for this.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-691
