### PR TITLE
Refactor PreselectedStoredPaymentMethodFragment

### DIFF
--- a/blik/src/main/java/com/adyen/checkout/blik/BlikComponent.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/BlikComponent.kt
@@ -70,10 +70,6 @@ class BlikComponent internal constructor(
         genericActionDelegate.removeObserver()
     }
 
-    override fun requiresInput(): Boolean {
-        return blikDelegate.requiresInput()
-    }
-
     override fun isConfirmationRequired(): Boolean = blikDelegate.isConfirmationRequired()
 
     override fun submit() {

--- a/blik/src/main/java/com/adyen/checkout/blik/BlikDelegate.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/BlikDelegate.kt
@@ -28,7 +28,5 @@ interface BlikDelegate :
 
     val componentStateFlow: Flow<PaymentComponentState<BlikPaymentMethod>>
 
-    fun requiresInput(): Boolean
-
     fun updateInputData(update: BlikInputData.() -> Unit)
 }

--- a/blik/src/main/java/com/adyen/checkout/blik/DefaultBlikDelegate.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/DefaultBlikDelegate.kt
@@ -161,8 +161,6 @@ internal class DefaultBlikDelegate(
 
     override fun shouldShowSubmitButton(): Boolean = isConfirmationRequired() && componentParams.isSubmitButtonVisible
 
-    override fun requiresInput(): Boolean = true
-
     override fun onCleared() {
         removeObserver()
     }

--- a/blik/src/main/java/com/adyen/checkout/blik/StoredBlikDelegate.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/StoredBlikDelegate.kt
@@ -130,8 +130,6 @@ internal class StoredBlikDelegate(
         )
     }
 
-    override fun requiresInput(): Boolean = false
-
     override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType
 
     override fun shouldShowSubmitButton(): Boolean = isConfirmationRequired() && componentParams.isSubmitButtonVisible

--- a/card/src/main/java/com/adyen/checkout/card/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponent.kt
@@ -75,8 +75,6 @@ class CardComponent internal constructor(
         genericActionDelegate.removeObserver()
     }
 
-    override fun requiresInput() = cardDelegate.requiresInput()
-
     override fun isConfirmationRequired(): Boolean = cardDelegate.isConfirmationRequired()
 
     override fun submit() {

--- a/card/src/main/java/com/adyen/checkout/card/CardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardDelegate.kt
@@ -29,7 +29,5 @@ interface CardDelegate :
 
     val exceptionFlow: Flow<CheckoutException>
 
-    fun requiresInput(): Boolean
-
     fun updateInputData(update: CardInputData.() -> Unit)
 }

--- a/card/src/main/java/com/adyen/checkout/card/CardView.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardView.kt
@@ -717,9 +717,7 @@ internal class CardView @JvmOverloads constructor(
         binding.textInputLayoutPostalCode.isVisible = false
         binding.addressFormInput.isVisible = false
 
-        if (cardDelegate.requiresInput()) {
-            binding.textInputLayoutSecurityCode.editText?.requestFocus()
-        }
+        binding.textInputLayoutSecurityCode.takeIf { isVisible }?.requestFocus()
     }
 
     private fun updateInstallmentSelection(installmentModel: InstallmentModel?) {

--- a/card/src/main/java/com/adyen/checkout/card/DefaultCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/DefaultCardDelegate.kt
@@ -502,10 +502,6 @@ internal class DefaultCardDelegate(
         return componentParams.kcpAuthVisibility == KCPAuthVisibility.SHOW
     }
 
-    override fun requiresInput(): Boolean {
-        return true
-    }
-
     private fun getHolderNameUIState(): InputFieldUIState {
         return if (isHolderNameRequired()) InputFieldUIState.REQUIRED else InputFieldUIState.HIDDEN
     }

--- a/card/src/main/java/com/adyen/checkout/card/StoredCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/StoredCardDelegate.kt
@@ -307,10 +307,6 @@ internal class StoredCardDelegate(
         return componentParams.isHideCvcStoredCard || noCvcBrands.contains(cardType)
     }
 
-    override fun requiresInput(): Boolean {
-        return !componentParams.isHideCvcStoredCard
-    }
-
     private fun mapComponentState(
         encryptedCard: EncryptedCard,
         cardNumber: String,

--- a/components-core/src/main/java/com/adyen/checkout/components/PaymentComponent.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/PaymentComponent.kt
@@ -25,11 +25,4 @@ interface PaymentComponent<ComponentStateT : PaymentComponentState<*>> : Compone
 
     // TODO documentation
     fun removeObserver()
-
-    /**
-     * Checks if the component in its current configuration needs any input from the user to make the /payments call.
-     *
-     * @return If there is required user input or not.
-     */
-    fun requiresInput(): Boolean = true
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/stored/PreselectedStoredPaymentMethodFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/stored/PreselectedStoredPaymentMethodFragment.kt
@@ -22,6 +22,7 @@ import com.adyen.checkout.components.ComponentError
 import com.adyen.checkout.components.PaymentComponent
 import com.adyen.checkout.components.image.loadLogo
 import com.adyen.checkout.components.model.paymentmethods.StoredPaymentMethod
+import com.adyen.checkout.components.ui.util.PayButtonFormatter
 import com.adyen.checkout.components.util.DateUtils
 import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.core.exception.ComponentException
@@ -137,11 +138,15 @@ internal class PreselectedStoredPaymentMethodFragment : DropInBottomSheetDialogF
     private fun updateButtonState(buttonState: ButtonState) {
         setPaymentPendingInitialization(buttonState is ButtonState.Loading)
         when (buttonState) {
-            is ButtonState.TextOnly -> {
+            is ButtonState.ContinueButton -> {
                 binding.payButton.setText(buttonState.labelResId)
             }
-            is ButtonState.TextWithAmount -> {
-                binding.payButton.text = getString(buttonState.labelResId, buttonState.amountString)
+            is ButtonState.PayButton -> {
+                binding.payButton.text = PayButtonFormatter.getPayButtonText(
+                    amount = buttonState.amount,
+                    locale = buttonState.shopperLocale,
+                    localizedContext = requireContext(),
+                )
             }
             is ButtonState.Loading -> {
                 // already handled

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/stored/PreselectedStoredPaymentMethodFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/stored/PreselectedStoredPaymentMethodFragment.kt
@@ -11,7 +11,6 @@ package com.adyen.checkout.dropin.ui.stored
 import android.annotation.SuppressLint
 import android.content.DialogInterface
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -21,12 +20,8 @@ import androidx.lifecycle.lifecycleScope
 import com.adyen.checkout.components.ButtonComponent
 import com.adyen.checkout.components.ComponentError
 import com.adyen.checkout.components.PaymentComponent
-import com.adyen.checkout.components.PaymentComponentEvent
 import com.adyen.checkout.components.image.loadLogo
 import com.adyen.checkout.components.model.paymentmethods.StoredPaymentMethod
-import com.adyen.checkout.components.ui.PaymentComponentUIState
-import com.adyen.checkout.components.ui.UIStateDelegate
-import com.adyen.checkout.components.util.CurrencyUtils
 import com.adyen.checkout.components.util.DateUtils
 import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.core.exception.ComponentException
@@ -35,18 +30,17 @@ import com.adyen.checkout.core.log.Logger
 import com.adyen.checkout.dropin.R
 import com.adyen.checkout.dropin.databinding.FragmentStoredPaymentMethodBinding
 import com.adyen.checkout.dropin.getComponentFor
+import com.adyen.checkout.dropin.ui.arguments
 import com.adyen.checkout.dropin.ui.base.DropInBottomSheetDialogFragment
 import com.adyen.checkout.dropin.ui.paymentmethods.GenericStoredModel
 import com.adyen.checkout.dropin.ui.paymentmethods.StoredCardModel
+import com.adyen.checkout.dropin.ui.paymentmethods.StoredPaymentMethodModel
 import com.adyen.checkout.dropin.ui.viewModelsFactory
+import com.adyen.checkout.dropin.ui.viewmodel.ButtonState
+import com.adyen.checkout.dropin.ui.viewmodel.PreselectedStoredEvent
 import com.adyen.checkout.dropin.ui.viewmodel.PreselectedStoredPaymentViewModel
-import com.adyen.checkout.dropin.ui.viewmodel.PreselectedStoredState
-import com.adyen.checkout.dropin.ui.viewmodel.PreselectedStoredState.ShowStoredPaymentDialog
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-
-private val TAG = LogUtil.getTag()
-private const val STORED_PAYMENT_KEY = "STORED_PAYMENT"
 
 @Suppress("TooManyFunctions")
 internal class PreselectedStoredPaymentMethodFragment : DropInBottomSheetDialogFragment() {
@@ -54,86 +48,53 @@ internal class PreselectedStoredPaymentMethodFragment : DropInBottomSheetDialogF
     private val storedPaymentViewModel: PreselectedStoredPaymentViewModel by viewModelsFactory {
         PreselectedStoredPaymentViewModel(
             storedPaymentMethod,
-            component.requiresInput(),
-            dropInViewModel.dropInConfiguration
+            dropInViewModel.amount,
+            dropInViewModel.dropInConfiguration,
         )
     }
 
     private var _binding: FragmentStoredPaymentMethodBinding? = null
     private val binding: FragmentStoredPaymentMethodBinding get() = requireNotNull(_binding)
-    private lateinit var storedPaymentMethod: StoredPaymentMethod
+    private val storedPaymentMethod: StoredPaymentMethod by arguments(STORED_PAYMENT_KEY)
     private lateinit var component: PaymentComponent<*>
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        storedPaymentMethod = arguments?.getParcelable(STORED_PAYMENT_KEY) ?: StoredPaymentMethod()
-
         if (storedPaymentMethod.type.isNullOrEmpty()) {
             throw ComponentException("Stored payment method is empty or not found.")
         }
 
         component =
             getComponentFor(this, storedPaymentMethod, dropInViewModel.dropInConfiguration, dropInViewModel.amount)
-        component.observe(viewLifecycleOwner, ::onPaymentComponentEvent)
+        component.observe(viewLifecycleOwner, storedPaymentViewModel::onPaymentComponentEvent)
 
         _binding = FragmentStoredPaymentMethodBinding.inflate(inflater, container, false)
         return binding.root
-    }
-
-    private fun observeUIState() {
-        val uiStateDelegate = component.delegate as? UIStateDelegate
-
-        if (uiStateDelegate == null) {
-            Log.e(TAG, "Delegate is not type of UIStateDelegate")
-            return
-        }
-
-        uiStateDelegate.uiStateFlow
-            .onEach {
-                setPaymentPendingInitialization(it is PaymentComponentUIState.Loading)
-            }.launchIn(viewLifecycleOwner.lifecycleScope)
-    }
-
-    private fun onPaymentComponentEvent(event: PaymentComponentEvent<*>) {
-        when (event) {
-            is PaymentComponentEvent.StateChanged -> {
-                // no ops
-            }
-            is PaymentComponentEvent.Error -> handleError(event.error)
-            is PaymentComponentEvent.ActionDetails -> {
-                throw IllegalStateException("This event should not be used in drop-in")
-            }
-            is PaymentComponentEvent.Submit -> protocol.requestPaymentsCall(event.state)
-        }
     }
 
     @SuppressLint("ResourceAsColor")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         Logger.d(TAG, "onViewCreated")
-        binding.paymentMethodsListHeader.paymentMethodHeaderTitle.setText(R.string.store_payment_methods_header)
-        binding.storedPaymentMethodItem.root.setBackgroundColor(android.R.color.transparent)
+
+        initView()
         observeState()
-        observe()
-        observeUIState()
+        observeEvents()
+    }
 
-        if (component.requiresInput()) {
-            binding.payButton.setText(R.string.continue_button)
-        } else {
-            val value = CurrencyUtils.formatAmount(
-                dropInViewModel.amount,
-                dropInViewModel.dropInConfiguration.shopperLocale
-            )
-            binding.payButton.text = getString(R.string.pay_button_with_value, value)
-        }
+    private fun initView() {
+        binding.paymentMethodsListHeader.paymentMethodHeaderTitle.setText(R.string.store_payment_methods_header)
 
-        if (dropInViewModel.dropInConfiguration.isRemovingStoredPaymentMethodsEnabled) {
+        val isRemovingStoredPaymentMethodsEnabled =
+            dropInViewModel.dropInConfiguration.isRemovingStoredPaymentMethodsEnabled
+        binding.storedPaymentMethodItem.swipeToRevealLayout.setDragLocked(!isRemovingStoredPaymentMethodsEnabled)
+        if (isRemovingStoredPaymentMethodsEnabled) {
             binding.storedPaymentMethodItem.paymentMethodItemUnderlayButton.setOnClickListener {
                 showRemoveStoredPaymentDialog()
             }
         }
 
         binding.payButton.setOnClickListener {
-            storedPaymentViewModel.payButtonClicked()
+            storedPaymentViewModel.onButtonClicked()
         }
 
         binding.changePaymentMethodButton.setOnClickListener {
@@ -142,18 +103,50 @@ internal class PreselectedStoredPaymentMethodFragment : DropInBottomSheetDialogF
     }
 
     private fun observeState() {
-        storedPaymentViewModel.componentFragmentState.onEach {
-            Logger.v(TAG, "state: $it")
-            when (it) {
-                is ShowStoredPaymentDialog -> protocol.showStoredComponentDialog(storedPaymentMethod, true)
-                is PreselectedStoredState.Submit -> {
-                    (component as? ButtonComponent)?.submit()
-                        ?: throw CheckoutException("Component must be of type ButtonComponent.")
-                }
-                else -> { // do nothing
-                }
-            }
+        storedPaymentViewModel.uiStateFlow.onEach { state ->
+            Logger.v(TAG, "state: $state")
+            updateStoredPaymentMethodItem(state.storedPaymentMethodModel)
+            updateButtonState(state.buttonState)
         }.launchIn(viewLifecycleOwner.lifecycleScope)
+    }
+
+    private fun updateStoredPaymentMethodItem(storedPaymentMethodModel: StoredPaymentMethodModel) {
+        when (storedPaymentMethodModel) {
+            is StoredCardModel -> {
+                binding.storedPaymentMethodItem.textViewTitle.text =
+                    requireActivity().getString(R.string.card_number_4digit, storedPaymentMethodModel.lastFour)
+                binding.storedPaymentMethodItem.imageViewLogo.loadLogo(
+                    environment = dropInViewModel.dropInConfiguration.environment,
+                    txVariant = storedPaymentMethodModel.imageId,
+                )
+                binding.storedPaymentMethodItem.textViewDetail.text =
+                    DateUtils.parseDateToView(storedPaymentMethodModel.expiryMonth, storedPaymentMethodModel.expiryYear)
+                binding.storedPaymentMethodItem.textViewDetail.isVisible = true
+            }
+            is GenericStoredModel -> {
+                binding.storedPaymentMethodItem.textViewTitle.text = storedPaymentMethodModel.name
+                binding.storedPaymentMethodItem.textViewDetail.isVisible = false
+                binding.storedPaymentMethodItem.imageViewLogo.loadLogo(
+                    environment = dropInViewModel.dropInConfiguration.environment,
+                    txVariant = storedPaymentMethodModel.imageId,
+                )
+            }
+        }
+    }
+
+    private fun updateButtonState(buttonState: ButtonState) {
+        setPaymentPendingInitialization(buttonState is ButtonState.Loading)
+        when (buttonState) {
+            is ButtonState.TextOnly -> {
+                binding.payButton.setText(buttonState.labelResId)
+            }
+            is ButtonState.TextWithAmount -> {
+                binding.payButton.text = getString(buttonState.labelResId, buttonState.amountString)
+            }
+            is ButtonState.Loading -> {
+                // already handled
+            }
+        }
     }
 
     private fun setPaymentPendingInitialization(pending: Boolean) {
@@ -161,36 +154,29 @@ internal class PreselectedStoredPaymentMethodFragment : DropInBottomSheetDialogF
         if (pending) binding.progressBar.show() else binding.progressBar.hide()
     }
 
-    private fun handleError(componentError: ComponentError) {
-        Logger.e(TAG, componentError.errorMessage)
-        protocol.showError(getString(R.string.component_error), componentError.errorMessage, true)
-    }
-
-    private fun observe() {
-        storedPaymentViewModel.storedPaymentLiveData.onEach {
-            binding.storedPaymentMethodItem.swipeToRevealLayout.setDragLocked(!it.isRemovable)
-            when (it) {
-                is StoredCardModel -> {
-                    binding.storedPaymentMethodItem.textViewTitle.text =
-                        requireActivity().getString(R.string.card_number_4digit, it.lastFour)
-                    binding.storedPaymentMethodItem.imageViewLogo.loadLogo(
-                        environment = dropInViewModel.dropInConfiguration.environment,
-                        txVariant = it.imageId,
-                    )
-                    binding.storedPaymentMethodItem.textViewDetail.text =
-                        DateUtils.parseDateToView(it.expiryMonth, it.expiryYear)
-                    binding.storedPaymentMethodItem.textViewDetail.isVisible = true
+    private fun observeEvents() {
+        storedPaymentViewModel.eventsFlow.onEach { event ->
+            when (event) {
+                is PreselectedStoredEvent.ShowStoredPaymentScreen -> {
+                    protocol.showStoredComponentDialog(storedPaymentMethod, true)
                 }
-                is GenericStoredModel -> {
-                    binding.storedPaymentMethodItem.textViewTitle.text = it.name
-                    binding.storedPaymentMethodItem.textViewDetail.isVisible = false
-                    binding.storedPaymentMethodItem.imageViewLogo.loadLogo(
-                        environment = dropInViewModel.dropInConfiguration.environment,
-                        txVariant = it.imageId,
-                    )
+                is PreselectedStoredEvent.SubmitComponent -> {
+                    (component as? ButtonComponent)?.submit()
+                        ?: throw CheckoutException("Component must be of type ButtonComponent.")
+                }
+                is PreselectedStoredEvent.RequestPaymentsCall -> {
+                    protocol.requestPaymentsCall(event.state)
+                }
+                is PreselectedStoredEvent.ShowError -> {
+                    handleError(event.componentError)
                 }
             }
         }.launchIn(viewLifecycleOwner.lifecycleScope)
+    }
+
+    private fun handleError(componentError: ComponentError) {
+        Logger.e(TAG, componentError.errorMessage)
+        protocol.showError(getString(R.string.component_error), componentError.errorMessage, true)
     }
 
     private fun showRemoveStoredPaymentDialog() {
@@ -223,6 +209,9 @@ internal class PreselectedStoredPaymentMethodFragment : DropInBottomSheetDialogF
     }
 
     companion object {
+        private val TAG = LogUtil.getTag()
+        private const val STORED_PAYMENT_KEY = "STORED_PAYMENT"
+
         @JvmStatic
         fun newInstance(storedPaymentMethod: StoredPaymentMethod) =
             PreselectedStoredPaymentMethodFragment().apply {

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/viewmodel/PreselectedStoredPaymentViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/viewmodel/PreselectedStoredPaymentViewModel.kt
@@ -8,51 +8,128 @@
 
 package com.adyen.checkout.dropin.ui.viewmodel
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
+import com.adyen.checkout.components.ComponentError
+import com.adyen.checkout.components.PaymentComponentEvent
+import com.adyen.checkout.components.PaymentComponentState
+import com.adyen.checkout.components.channel.bufferedChannel
 import com.adyen.checkout.components.model.paymentmethods.StoredPaymentMethod
-import com.adyen.checkout.core.log.LogUtil
+import com.adyen.checkout.components.model.payments.Amount
+import com.adyen.checkout.components.util.CurrencyUtils
+import com.adyen.checkout.components.util.isZero
 import com.adyen.checkout.dropin.DropInConfiguration
+import com.adyen.checkout.dropin.R
 import com.adyen.checkout.dropin.ui.paymentmethods.StoredPaymentMethodModel
 import com.adyen.checkout.dropin.ui.stored.mapStoredModel
-import com.adyen.checkout.dropin.ui.viewmodel.PreselectedStoredState.Idle
-import com.adyen.checkout.dropin.ui.viewmodel.PreselectedStoredState.ShowStoredPaymentDialog
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 
 internal class PreselectedStoredPaymentViewModel(
-    storedPaymentMethod: StoredPaymentMethod,
-    private val componentRequiresInput: Boolean,
-    dropInConfiguration: DropInConfiguration,
+    private val storedPaymentMethod: StoredPaymentMethod,
+    private val amount: Amount,
+    private val dropInConfiguration: DropInConfiguration,
 ) : ViewModel() {
 
-    companion object {
-        private val TAG = LogUtil.getTag()
-    }
+    private val _uiStateFlow = MutableStateFlow(getInitialUIState())
+    val uiStateFlow: Flow<PreselectedStoredState> = _uiStateFlow
 
-    private val storedPaymentMethodMutableLiveData = MutableStateFlow(
-        storedPaymentMethod.mapStoredModel(
+    private val eventsChannel: Channel<PreselectedStoredEvent> = bufferedChannel()
+    val eventsFlow: Flow<PreselectedStoredEvent> = eventsChannel.receiveAsFlow()
+
+    private var componentState: PaymentComponentState<*>? = null
+
+    private fun getInitialUIState(): PreselectedStoredState {
+        val storedPaymentMethodModel = storedPaymentMethod.mapStoredModel(
             dropInConfiguration.isRemovingStoredPaymentMethodsEnabled,
             dropInConfiguration.environment,
         )
-    )
-    val storedPaymentLiveData: Flow<StoredPaymentMethodModel> = storedPaymentMethodMutableLiveData
+        return PreselectedStoredState(
+            storedPaymentMethodModel = storedPaymentMethodModel,
+            buttonState = ButtonState.TextOnly(R.string.continue_button)
+        )
+    }
 
-    private val componentFragmentStateMutable = MutableStateFlow<PreselectedStoredState>(Idle)
-    val componentFragmentState: Flow<PreselectedStoredState> = componentFragmentStateMutable
+    fun onPaymentComponentEvent(event: PaymentComponentEvent<*>) {
+        when (event) {
+            is PaymentComponentEvent.StateChanged -> {
+                componentState = event.state
+                val buttonState = getButtonState(event.state)
+                val newState = _uiStateFlow.value.copy(buttonState = buttonState)
+                _uiStateFlow.tryEmit(newState)
+            }
+            is PaymentComponentEvent.Error -> {
+                eventsChannel.trySend(PreselectedStoredEvent.ShowError(event.error))
+            }
+            is PaymentComponentEvent.Submit -> {
+                eventsChannel.trySend(PreselectedStoredEvent.RequestPaymentsCall(event.state))
+            }
+            is PaymentComponentEvent.ActionDetails -> {
+                throw IllegalStateException("This event should not be used in drop-in")
+            }
+        }
+    }
 
-    fun payButtonClicked() {
-        if (componentRequiresInput) {
-            componentFragmentStateMutable.tryEmit(ShowStoredPaymentDialog)
+    private fun getButtonState(state: PaymentComponentState<*>): ButtonState {
+        return when {
+            !state.isInputValid -> {
+                // component requires user input -> use Continue and load the component in a fragment on click
+                ButtonState.TextOnly(R.string.continue_button)
+            }
+            // TODO extract this logic and the one in AdyenComponentView to separate method
+            amount.isZero -> {
+                ButtonState.TextOnly(R.string.confirm_preauthorization)
+            }
+            else -> {
+                val amountString = CurrencyUtils.formatAmount(
+                    amount,
+                    dropInConfiguration.shopperLocale
+                )
+                ButtonState.TextWithAmount(R.string.pay_button_with_value, amountString)
+            }
+        }
+    }
+
+    fun onButtonClicked() {
+        val componentState = componentState ?: return
+
+        if (!componentState.isInputValid) {
+            // component requires user input -> load the stored component in a separate fragment
+            eventsChannel.trySend(PreselectedStoredEvent.ShowStoredPaymentScreen)
             return
         }
-        componentFragmentStateMutable.tryEmit(PreselectedStoredState.Submit)
+
+        // component does not require user input -> we should submit it directly instead of switch to a new screen
+        eventsChannel.trySend(PreselectedStoredEvent.SubmitComponent)
+
+        if (!componentState.isValid) {
+            // component is not yet ready for submitting -> show a loading indicator until the component tells us we can
+            // make the payments call (by returning PaymentComponentEvent.Submit)
+            val newState = _uiStateFlow.value.copy(buttonState = ButtonState.Loading)
+            _uiStateFlow.tryEmit(newState)
+        }
     }
 }
 
-sealed class PreselectedStoredState {
-    object Idle : PreselectedStoredState()
-    object ShowStoredPaymentDialog : PreselectedStoredState()
-    object Submit : PreselectedStoredState()
+internal data class PreselectedStoredState(
+    val storedPaymentMethodModel: StoredPaymentMethodModel,
+    val buttonState: ButtonState,
+)
 
-    override fun toString(): String = this::class.simpleName ?: ""
+internal sealed class ButtonState {
+    object Loading : ButtonState()
+    data class TextOnly(@StringRes val labelResId: Int) : ButtonState()
+    data class TextWithAmount(
+        @StringRes val labelResId: Int,
+        val amountString: String
+    ) : ButtonState()
+}
+
+internal sealed class PreselectedStoredEvent {
+    object ShowStoredPaymentScreen : PreselectedStoredEvent()
+    object SubmitComponent : PreselectedStoredEvent()
+    data class RequestPaymentsCall(val state: PaymentComponentState<*>) : PreselectedStoredEvent()
+    data class ShowError(val componentError: ComponentError) : PreselectedStoredEvent()
 }

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/ui/viewmodel/PreselectedStoredPaymentViewModelTest.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/ui/viewmodel/PreselectedStoredPaymentViewModelTest.kt
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 28/12/2022.
+ */
+
+package com.adyen.checkout.dropin.ui.viewmodel
+
+import app.cash.turbine.test
+import com.adyen.checkout.components.ActionComponentData
+import com.adyen.checkout.components.ComponentError
+import com.adyen.checkout.components.PaymentComponentEvent
+import com.adyen.checkout.components.PaymentComponentState
+import com.adyen.checkout.components.model.paymentmethods.StoredPaymentMethod
+import com.adyen.checkout.components.model.payments.Amount
+import com.adyen.checkout.components.model.payments.request.PaymentComponentData
+import com.adyen.checkout.core.api.Environment
+import com.adyen.checkout.core.exception.CheckoutException
+import com.adyen.checkout.dropin.DropInConfiguration
+import com.adyen.checkout.dropin.ui.paymentmethods.GenericStoredModel
+import com.adyen.checkout.test.TestDispatcherExtension
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.fail
+import org.mockito.junit.jupiter.MockitoExtension
+import java.util.Locale
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(MockitoExtension::class, TestDispatcherExtension::class)
+internal class PreselectedStoredPaymentViewModelTest {
+    private val storedPaymentMethod = StoredPaymentMethod()
+    private val dropInConfiguration = DropInConfiguration.Builder(Locale.US, Environment.TEST, TEST_CLIENT_KEY).build()
+
+    private lateinit var viewModel: PreselectedStoredPaymentViewModel
+
+    @BeforeEach
+    fun setup() {
+        viewModel = PreselectedStoredPaymentViewModel(
+            storedPaymentMethod,
+            TEST_AMOUNT,
+            dropInConfiguration,
+        )
+    }
+
+    @Test
+    fun `when view model is initialized then uiStateFlow has a matching initial value`() = runTest {
+        val dropInConfiguration = DropInConfiguration.Builder(
+            Locale.US,
+            Environment.TEST,
+            TEST_CLIENT_KEY
+        )
+            .setEnableRemovingStoredPaymentMethods(true)
+            .build()
+
+        viewModel = PreselectedStoredPaymentViewModel(
+            storedPaymentMethod,
+            TEST_AMOUNT,
+            dropInConfiguration,
+        )
+
+        viewModel.uiStateFlow.test {
+            val actual = awaitItem()
+
+            with(actual.storedPaymentMethodModel) {
+                this as? GenericStoredModel
+                    ?: fail("Expected: GenericStoredModel, Actual: ${this::class.java.simpleName}")
+                assertTrue(isRemovable)
+                assertEquals(Environment.TEST, environment)
+            }
+
+            assertEquals(ButtonState.ContinueButton(), actual.buttonState)
+        }
+    }
+
+    @Test
+    fun `when component emits a new state with invalid input then button state should be continue button`() =
+        runTest {
+            viewModel.uiStateFlow.test {
+                val componentState = PaymentComponentState(PaymentComponentData(), isInputValid = false, isReady = true)
+                viewModel.onPaymentComponentEvent(PaymentComponentEvent.StateChanged(componentState))
+
+                assertEquals(ButtonState.ContinueButton(), awaitItem().buttonState)
+            }
+        }
+
+    @Test
+    fun `when component emits a new state with valid input then button state should be pay button`() =
+        runTest {
+            viewModel.uiStateFlow.test {
+                val componentState = PaymentComponentState(PaymentComponentData(), isInputValid = true, isReady = true)
+                viewModel.onPaymentComponentEvent(PaymentComponentEvent.StateChanged(componentState))
+
+                assertEquals(ButtonState.PayButton(TEST_AMOUNT, Locale.US), expectMostRecentItem().buttonState)
+            }
+        }
+
+    @Test
+    fun `when component emits an error then view model should propagate this error`() = runTest {
+        viewModel.eventsFlow.test {
+            val componentError = ComponentError(CheckoutException("Test message", Exception("Test exception")))
+            viewModel.onPaymentComponentEvent(PaymentComponentEvent.Error<PaymentComponentState<*>>(componentError))
+
+            assertEquals(PreselectedStoredEvent.ShowError(componentError), awaitItem())
+        }
+    }
+
+    @Test
+    fun `when component emits a submit event then view model should emit to request a payments call`() = runTest {
+        viewModel.eventsFlow.test {
+            val componentState = PaymentComponentState(PaymentComponentData(), isInputValid = true, isReady = true)
+            viewModel.onPaymentComponentEvent(PaymentComponentEvent.Submit(componentState))
+
+            assertEquals(PreselectedStoredEvent.RequestPaymentsCall(componentState), awaitItem())
+        }
+    }
+
+    @Test
+    fun `when component emits an action event then view model should throw an exception`() = runTest {
+        viewModel.eventsFlow.test {
+            assertThrows<IllegalStateException> {
+                viewModel.onPaymentComponentEvent(
+                    PaymentComponentEvent.ActionDetails<PaymentComponentState<*>>(ActionComponentData())
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `when button is clicked with an invalid input then view model should request showing the stored component in a new screen`() =
+        runTest {
+            viewModel.eventsFlow.test {
+                val componentState = PaymentComponentState(PaymentComponentData(), isInputValid = false, isReady = true)
+                viewModel.onPaymentComponentEvent(PaymentComponentEvent.StateChanged(componentState))
+                viewModel.onButtonClicked()
+
+                assertEquals(PreselectedStoredEvent.ShowStoredPaymentScreen, awaitItem())
+            }
+        }
+
+    @Test
+    fun `when button is clicked with a valid input then view model should request submitting the component`() =
+        runTest {
+            viewModel.eventsFlow.test {
+                val componentState = PaymentComponentState(PaymentComponentData(), isInputValid = true, isReady = true)
+                viewModel.onPaymentComponentEvent(PaymentComponentEvent.StateChanged(componentState))
+                viewModel.onButtonClicked()
+
+                assertEquals(PreselectedStoredEvent.SubmitComponent, awaitItem())
+            }
+        }
+
+    @Test
+    fun `when button is clicked with a valid input but non ready state then button state should become loading`() =
+        runTest {
+            viewModel.uiStateFlow.test {
+                val componentState = PaymentComponentState(PaymentComponentData(), isInputValid = true, isReady = false)
+                viewModel.onPaymentComponentEvent(PaymentComponentEvent.StateChanged(componentState))
+                viewModel.onButtonClicked()
+
+                assertEquals(ButtonState.Loading, expectMostRecentItem().buttonState)
+            }
+        }
+
+    @Test
+    fun `when button is clicked with a valid input and a ready state then button state should remain pay button`() =
+        runTest {
+            viewModel.uiStateFlow.test {
+                val componentState = PaymentComponentState(PaymentComponentData(), isInputValid = true, isReady = true)
+                viewModel.onPaymentComponentEvent(PaymentComponentEvent.StateChanged(componentState))
+                viewModel.onButtonClicked()
+
+                assertEquals(ButtonState.PayButton(TEST_AMOUNT, Locale.US), expectMostRecentItem().buttonState)
+            }
+        }
+
+    companion object {
+        private val TEST_AMOUNT = Amount("USD", 1337)
+        private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
+    }
+}

--- a/ui-core/src/main/java/com/adyen/checkout/components/ui/util/PayButtonFormatter.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/components/ui/util/PayButtonFormatter.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 28/12/2022.
+ */
+
+package com.adyen.checkout.components.ui.util
+
+import android.content.Context
+import androidx.annotation.RestrictTo
+import androidx.annotation.StringRes
+import com.adyen.checkout.components.model.payments.Amount
+import com.adyen.checkout.components.ui.R
+import com.adyen.checkout.components.util.CurrencyUtils
+import com.adyen.checkout.components.util.isEmpty
+import com.adyen.checkout.components.util.isZero
+import java.util.Locale
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+object PayButtonFormatter {
+
+    @Suppress("LongParameterList")
+    fun getPayButtonText(
+        amount: Amount,
+        locale: Locale,
+        localizedContext: Context,
+        @StringRes emptyAmountStringResId: Int = R.string.pay_button,
+        @StringRes zeroAmountStringResId: Int = R.string.confirm_preauthorization,
+        @StringRes positiveAmountStringResId: Int = R.string.pay_button_with_value,
+    ): String {
+        return when {
+            amount.isEmpty -> {
+                localizedContext.getString(emptyAmountStringResId)
+            }
+            amount.isZero -> {
+                localizedContext.getString(zeroAmountStringResId)
+            }
+            else -> {
+                localizedContext.getString(positiveAmountStringResId, CurrencyUtils.formatAmount(amount, locale))
+            }
+        }
+    }
+}

--- a/ui-core/src/main/java/com/adyen/checkout/components/ui/view/AdyenComponentView.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/components/ui/view/AdyenComponentView.kt
@@ -24,14 +24,11 @@ import com.adyen.checkout.components.ui.ButtonDelegate
 import com.adyen.checkout.components.ui.ComponentView
 import com.adyen.checkout.components.ui.PaymentComponentUIEvent
 import com.adyen.checkout.components.ui.PaymentComponentUIState
-import com.adyen.checkout.components.ui.R
 import com.adyen.checkout.components.ui.UIStateDelegate
 import com.adyen.checkout.components.ui.ViewProvidingDelegate
 import com.adyen.checkout.components.ui.ViewableComponent
 import com.adyen.checkout.components.ui.databinding.AdyenComponentViewBinding
-import com.adyen.checkout.components.util.CurrencyUtils
-import com.adyen.checkout.components.util.isEmpty
-import com.adyen.checkout.components.util.isZero
+import com.adyen.checkout.components.ui.util.PayButtonFormatter
 import com.adyen.checkout.core.log.LogUtil
 import com.adyen.checkout.core.log.Logger
 import kotlinx.coroutines.CoroutineScope
@@ -154,15 +151,13 @@ class AdyenComponentView @JvmOverloads constructor(
         componentParams: ComponentParams,
         localizedContext: Context
     ) {
-        if (viewType is AmountButtonComponentViewType && !componentParams.amount.isEmpty) {
-            text = if (componentParams.amount.isZero) {
-                localizedContext.getString(R.string.confirm_preauthorization)
-            } else {
-                localizedContext.getString(
-                    R.string.pay_button_with_value,
-                    CurrencyUtils.formatAmount(componentParams.amount, componentParams.shopperLocale)
-                )
-            }
+        if (viewType is AmountButtonComponentViewType) {
+            text = PayButtonFormatter.getPayButtonText(
+                amount = componentParams.amount,
+                locale = componentParams.shopperLocale,
+                localizedContext = localizedContext,
+                emptyAmountStringResId = viewType.buttonTextResId
+            )
         } else if (viewType is ButtonComponentViewType) {
             text = localizedContext.getString(viewType.buttonTextResId)
         }


### PR DESCRIPTION
## Description
`PreselectedStoredPaymentMethodFragment` logic should be moved to the view model, and it should not rely on `requiresInput()` anymore, but instead we can make use of the component state.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-698
