### PR TITLE
Remove the brand list if a card brand is detected

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/CardOutputData.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardOutputData.kt
@@ -43,6 +43,7 @@ data class CardOutputData(
     @StringRes
     val kcpBirthDateOrTaxNumberHint: Int?,
     val componentMode: ComponentMode,
+    val isCardListVisible: Boolean
 ) : OutputData {
 
     override val isValid: Boolean

--- a/card/src/main/java/com/adyen/checkout/card/CardView.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardView.kt
@@ -183,7 +183,7 @@ internal class CardView @JvmOverloads constructor(
         updateCountries(cardOutputData.countryOptions)
         updateStates(cardOutputData.stateOptions)
         updateAddressHint(cardOutputData.addressUIState, cardOutputData.addressState.isOptional)
-        setCardList(cardOutputData.cardBrands)
+        setCardList(cardOutputData.cardBrands, cardOutputData.isCardListVisible)
     }
 
     @Suppress("ComplexMethod", "LongMethod")
@@ -734,15 +734,15 @@ internal class CardView @JvmOverloads constructor(
         }
     }
 
-    private fun setCardList(cards: List<CardListItem>) {
-        binding.recyclerViewCardList.isVisible = cards.isNotEmpty()
-
-        if (cardListAdapter == null) {
-            cardListAdapter = CardListAdapter()
-            binding.recyclerViewCardList.adapter = cardListAdapter
+    private fun setCardList(cards: List<CardListItem>, isCardListVisible: Boolean) {
+        binding.recyclerViewCardList.isVisible = isCardListVisible
+        if (isCardListVisible) {
+            if (cardListAdapter == null) {
+                cardListAdapter = CardListAdapter()
+                binding.recyclerViewCardList.adapter = cardListAdapter
+            }
+            cardListAdapter?.submitList(cards)
         }
-
-        cardListAdapter?.submitList(cards)
     }
 
     private fun isStoredPaymentMethod(outputData: CardOutputData): Boolean {

--- a/card/src/main/java/com/adyen/checkout/card/DefaultCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/DefaultCardDelegate.kt
@@ -310,8 +310,14 @@ internal class DefaultCardDelegate(
             isDualBranded = isDualBrandedFlow(filteredDetectedCardTypes),
             kcpBirthDateOrTaxNumberHint = getKcpBirthDateOrTaxNumberHint(inputData.kcpBirthDateOrTaxNumber),
             componentMode = ComponentMode.DEFAULT,
+            isCardListVisible = isCardListVisible(getCardBrands(detectedCardTypes), filteredDetectedCardTypes)
         )
     }
+
+    private fun isCardListVisible(
+        cardBrands: List<CardListItem>,
+        detectedCardTypes: List<DetectedCardType>
+    ): Boolean = cardBrands.isNotEmpty() && detectedCardTypes.isEmpty()
 
     override fun getPaymentMethodType(): String {
         return paymentMethod.type ?: PaymentMethodTypes.UNKNOWN

--- a/card/src/main/java/com/adyen/checkout/card/StoredCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/StoredCardDelegate.kt
@@ -202,6 +202,7 @@ internal class StoredCardDelegate(
             isDualBranded = false,
             kcpBirthDateOrTaxNumberHint = null,
             componentMode = ComponentMode.STORED,
+            isCardListVisible = false
         )
     }
 

--- a/card/src/main/java/com/adyen/checkout/card/test/TestDetectCardTypeRepository.kt
+++ b/card/src/main/java/com/adyen/checkout/card/test/TestDetectCardTypeRepository.kt
@@ -15,6 +15,7 @@ import com.adyen.checkout.card.data.DetectedCardType
 import com.adyen.checkout.card.repository.DetectCardTypeRepository
 import com.adyen.checkout.card.test.TestDetectCardTypeRepository.TestDetectedCardType.DETECTED_LOCALLY
 import com.adyen.checkout.card.test.TestDetectCardTypeRepository.TestDetectedCardType.DUAL_BRANDED
+import com.adyen.checkout.card.test.TestDetectCardTypeRepository.TestDetectedCardType.EMPTY
 import com.adyen.checkout.card.test.TestDetectCardTypeRepository.TestDetectedCardType.ERROR
 import com.adyen.checkout.card.test.TestDetectCardTypeRepository.TestDetectedCardType.FETCHED_FROM_NETWORK
 import kotlinx.coroutines.CoroutineScope
@@ -47,6 +48,7 @@ internal class TestDetectCardTypeRepository : DetectCardTypeRepository {
             DETECTED_LOCALLY -> getDetectedCardTypesLocal(supportedCardTypes)
             FETCHED_FROM_NETWORK -> getDetectedCardTypesNetwork(supportedCardTypes)
             DUAL_BRANDED -> getDetectedCardTypesDualBranded(supportedCardTypes)
+            EMPTY -> emptyList()
         } ?: return
 
         _detectedCardTypesFlow.tryEmit(detectedCardTypes)
@@ -57,6 +59,7 @@ internal class TestDetectCardTypeRepository : DetectCardTypeRepository {
         DETECTED_LOCALLY,
         FETCHED_FROM_NETWORK,
         DUAL_BRANDED,
+        EMPTY,
     }
 
     fun getDetectedCardTypesLocal(supportedCardTypes: List<CardType>): List<DetectedCardType> {

--- a/card/src/test/java/com/adyen/checkout/card/StoredCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/StoredCardDelegateTest.kt
@@ -407,6 +407,7 @@ internal class StoredCardDelegateTest(
         countryOptions: List<AddressListItem> = emptyList(),
         stateOptions: List<AddressListItem> = emptyList(),
         cardBrands: List<CardListItem> = emptyList(),
+        isCardListVisible: Boolean = false
     ): CardOutputData {
         return CardOutputData(
             cardNumberState = cardNumberState,
@@ -434,6 +435,7 @@ internal class StoredCardDelegateTest(
             isDualBranded = false,
             kcpBirthDateOrTaxNumberHint = null,
             componentMode = ComponentMode.STORED,
+            isCardListVisible = isCardListVisible
         )
     }
 


### PR DESCRIPTION
## Description
if a card brand is detected when a user enters a card number, the supported card list should be hidden.
The card list visibility logic was moved from view to delegate
| Before  | A brand is detected |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/9745693/209958161-42968acb-7eba-4f48-8c68-f182f1e63f49.png" width="200" height="400" /> | <img src="https://user-images.githubusercontent.com/9745693/209958214-642784fb-38c7-407d-bd17-27fa06a01c1d.png" width="200" height="400" />
  |

## Checklist 
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-627
