### PR TITLE
Stop default country picker from picking first alphabetically available country

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/DefaultCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/DefaultCardDelegate.kt
@@ -227,6 +227,7 @@ internal class DefaultCardDelegate(
             .onEach { countries ->
                 Logger.d(TAG, "New countries emitted - countries: ${countries.size}")
                 val countryOptions = AddressFormUtils.initializeCountryOptions(
+                    shopperLocale = componentParams.shopperLocale,
                     addressParams = componentParams.addressParams,
                     countryList = countries
                 )

--- a/card/src/main/java/com/adyen/checkout/card/util/AddressFormUtils.kt
+++ b/card/src/main/java/com/adyen/checkout/card/util/AddressFormUtils.kt
@@ -6,6 +6,7 @@ import com.adyen.checkout.card.AddressParams
 import com.adyen.checkout.card.api.model.AddressItem
 import com.adyen.checkout.card.ui.model.AddressListItem
 import com.adyen.checkout.components.model.payments.request.Address
+import java.util.Locale
 
 internal object AddressFormUtils {
 
@@ -23,9 +24,8 @@ internal object AddressFormUtils {
                 it.copy(selected = it.code == code)
             }
         } else {
-            list.mapIndexed { index, addressListItem ->
-                val isFirstItem = index == 0
-                addressListItem.copy(selected = isFirstItem)
+            list.map { addressListItem ->
+                addressListItem.copy(selected = false)
             }
         }
     }
@@ -44,6 +44,7 @@ internal object AddressFormUtils {
      * @return Country options.
      */
     fun initializeCountryOptions(
+        shopperLocale: Locale,
         addressParams: AddressParams?,
         countryList: List<AddressItem>
     ): List<AddressListItem> {
@@ -57,11 +58,29 @@ internal object AddressFormUtils {
                     countryList
                 }
 
-                val defaultCountryCode = addressParams.defaultCountryCode.orEmpty()
+                val defaultCountryCode = getInitialCountryCode(
+                    shopperLocale = shopperLocale,
+                    addressParams = addressParams
+                )
                 markAddressListItemSelected(mapToListItem(filteredCountryList), defaultCountryCode)
             }
             else -> emptyList()
         }
+    }
+
+    /**
+     * Get initial country code.
+     *
+     * @param shopperLocale Locale value from dropIn configuration or card component configuration.
+     * @param addressParams Full address params
+     *
+     * @return 2 digit string value of default supported country.
+     */
+    private fun getInitialCountryCode(
+        shopperLocale: Locale,
+        addressParams: AddressParams.FullAddress
+    ): String {
+        return addressParams.defaultCountryCode ?: shopperLocale.country.orEmpty()
     }
 
     /**

--- a/card/src/test/java/com/adyen/checkout/card/AddressFormUtilsTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/AddressFormUtilsTest.kt
@@ -5,6 +5,7 @@ import com.adyen.checkout.card.ui.model.AddressListItem
 import com.adyen.checkout.card.util.AddressFormUtils
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import java.util.Locale
 
 @Suppress("MaxLineLength")
 internal class AddressFormUtilsTest {
@@ -49,7 +50,7 @@ internal class AddressFormUtilsTest {
     }
 
     @Test
-    fun markAddressListItemSelected_CodeNotProvided_ExpectFirstItemSelected() {
+    fun `when there's no item selected on address list and code not provided expect nothing selected`() {
         val input = listOf(
             AddressListItem(
                 name = "Canada",
@@ -71,7 +72,7 @@ internal class AddressFormUtilsTest {
             AddressListItem(
                 name = "Canada",
                 code = "CA",
-                selected = true
+                selected = false
             ),
             AddressListItem(
                 name = "United States",
@@ -88,7 +89,7 @@ internal class AddressFormUtilsTest {
     }
 
     @Test
-    fun markAddressListItemSelected_ListNotContainingItemWithGivenCode_ExpectFirstItemSelected() {
+    fun `when there's no item selected on address list and list not containing item with given code expect nothing selected`() {
         val input = listOf(
             AddressListItem(
                 name = "Canada",
@@ -110,7 +111,7 @@ internal class AddressFormUtilsTest {
             AddressListItem(
                 name = "Canada",
                 code = "CA",
-                selected = true
+                selected = false
             ),
             AddressListItem(
                 name = "United States",
@@ -146,7 +147,7 @@ internal class AddressFormUtilsTest {
         val expected = emptyList<AddressListItem>()
         assertEquals(
             expected,
-            AddressFormUtils.initializeCountryOptions(addressParams, inputCountryList)
+            AddressFormUtils.initializeCountryOptions(Locale.getDefault(), addressParams, inputCountryList)
         )
     }
 
@@ -170,12 +171,12 @@ internal class AddressFormUtilsTest {
         val expected = emptyList<AddressListItem>()
         assertEquals(
             expected,
-            AddressFormUtils.initializeCountryOptions(addressParams, inputCountryList)
+            AddressFormUtils.initializeCountryOptions(Locale.getDefault(), addressParams, inputCountryList)
         )
     }
 
     @Test
-    fun `initializeCountryOptions_AddressConfigurationIsFullAddressWithoutDefaultCountryCode_ExpectListWithFirstItemSelected`() {
+    fun `initialize country options, address configuration is full address without default country code and locale with country that is not supported expect list with nothing selected`() {
         val addressParams = AddressParams.FullAddress(addressFieldPolicy = Required())
         val inputCountryList = listOf(
             AddressItem(
@@ -195,7 +196,7 @@ internal class AddressFormUtilsTest {
             AddressListItem(
                 name = "Canada",
                 code = "CA",
-                selected = true
+                selected = false
             ),
             AddressListItem(
                 name = "United States",
@@ -210,7 +211,47 @@ internal class AddressFormUtilsTest {
         )
         assertEquals(
             expected,
-            AddressFormUtils.initializeCountryOptions(addressParams, inputCountryList)
+            AddressFormUtils.initializeCountryOptions(Locale.GERMANY, addressParams, inputCountryList)
+        )
+    }
+
+    @Test
+    fun `when country options address configuration is full, address without default country code and locale with country that is supported expect list with locale country selected`() {
+        val addressParams = AddressParams.FullAddress(addressFieldPolicy = Required())
+        val inputCountryList = listOf(
+            AddressItem(
+                id = "CA",
+                name = "Canada"
+            ),
+            AddressItem(
+                id = "US",
+                name = "United States"
+            ),
+            AddressItem(
+                id = "GB",
+                name = "United Kingdom"
+            )
+        )
+        val expected = listOf(
+            AddressListItem(
+                name = "Canada",
+                code = "CA",
+                selected = false
+            ),
+            AddressListItem(
+                name = "United States",
+                code = "US",
+                selected = true
+            ),
+            AddressListItem(
+                name = "United Kingdom",
+                code = "GB",
+                selected = false
+            )
+        )
+        assertEquals(
+            expected,
+            AddressFormUtils.initializeCountryOptions(Locale.US, addressParams, inputCountryList)
         )
     }
 
@@ -250,7 +291,7 @@ internal class AddressFormUtilsTest {
         )
         assertEquals(
             expected,
-            AddressFormUtils.initializeCountryOptions(addressParams, inputCountryList)
+            AddressFormUtils.initializeCountryOptions(Locale.getDefault(), addressParams, inputCountryList)
         )
     }
 
@@ -279,7 +320,7 @@ internal class AddressFormUtilsTest {
             AddressListItem(
                 name = "Canada",
                 code = "CA",
-                selected = true
+                selected = false
             ),
             AddressListItem(
                 name = "United Kingdom",
@@ -289,12 +330,12 @@ internal class AddressFormUtilsTest {
         )
         assertEquals(
             expected,
-            AddressFormUtils.initializeCountryOptions(addressParams, inputCountryList)
+            AddressFormUtils.initializeCountryOptions(Locale.getDefault(), addressParams, inputCountryList)
         )
     }
 
     @Test
-    fun initializeStateOptions_ExpectListWithFirstItemSelected() {
+    fun `initialize state options expect list with nothing selected`() {
         val input = listOf(
             AddressItem(
                 id = "AL",
@@ -313,7 +354,7 @@ internal class AddressFormUtilsTest {
             AddressListItem(
                 code = "AL",
                 name = "Alabama",
-                selected = true
+                selected = false
             ),
             AddressListItem(
                 code = "MA",

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/configuration/CheckoutConfigurationProvider.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/configuration/CheckoutConfigurationProvider.kt
@@ -79,7 +79,7 @@ internal class CheckoutConfigurationProvider @Inject constructor(
         0 -> AddressConfiguration.None
         1 -> AddressConfiguration.PostalCode()
         else -> AddressConfiguration.FullAddress(
-            defaultCountryCode = "NL",
+            defaultCountryCode = null,
             supportedCountryCodes = listOf("NL", "GB", "US", "CA", "BR"),
             addressFieldPolicy = AddressConfiguration.CardAddressFieldPolicy.OptionalForCardTypes(
                 brands = listOf("jcb")


### PR DESCRIPTION
## Description

 - Stop default country picker to first alphabetically available country Instead of choosing the first available option.
- States are not selected by default to first option you need to select them.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-668
