### PR TITLE
Fix white space at the bottom of bottom sheets

### DIFF
--- a/drop-in/src/main/res/layout/fragment_bacs_direct_debit_component.xml
+++ b/drop-in/src/main/res/layout/fragment_bacs_direct_debit_component.xml
@@ -10,8 +10,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:paddingBottom="@dimen/standard_margin">
+    android:orientation="vertical">
 
     <TextView
         android:id="@+id/header"

--- a/drop-in/src/main/res/layout/fragment_generic_component.xml
+++ b/drop-in/src/main/res/layout/fragment_generic_component.xml
@@ -10,8 +10,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:paddingBottom="@dimen/standard_margin">
+    android:orientation="vertical">
 
     <include
         layout="@layout/bottom_sheet_indicator"
@@ -29,8 +28,7 @@
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1"
-        android:paddingBottom="@dimen/standard_margin">
+        android:layout_weight="1">
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/drop-in/src/main/res/layout/fragment_giftcard_component.xml
+++ b/drop-in/src/main/res/layout/fragment_giftcard_component.xml
@@ -10,8 +10,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:paddingBottom="@dimen/standard_margin">
+    android:orientation="vertical">
 
     <include
         layout="@layout/bottom_sheet_indicator"
@@ -29,8 +28,7 @@
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1"
-        android:paddingBottom="@dimen/standard_margin">
+        android:layout_weight="1">
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/example-app/src/main/res/values/colors.xml
+++ b/example-app/src/main/res/values/colors.xml
@@ -16,7 +16,6 @@
     <color name="text_color">@color/color_adyen_dark</color>
 
     <color name="color_white">#FFFFFF</color>
-    <color name="color_transparent">#00000000</color>
     <color name="color_adyen_green">#0abf53</color>
     <color name="color_adyen_dark">#00112c</color>
 

--- a/example-app/src/main/res/values/styles.xml
+++ b/example-app/src/main/res/values/styles.xml
@@ -22,7 +22,7 @@
         <item name="android:textColorTertiary">@color/text_color_primary</item>
         <item name="android:textColorLink">@color/textColorLink</item>
         <item name="android:statusBarColor">@color/color_background</item>
-        <item name="android:navigationBarColor">@color/color_transparent</item>
+        <item name="android:navigationBarColor">@color/color_background</item>
         <item name="android:windowLightStatusBar" tools:ignore="NewApi">
             @bool/has_light_system_bars
         </item>


### PR DESCRIPTION
## Description
The navigation bar color was transparent in the example app. This causes problems with window insets on lower API versions, so the navigation bar color is now the same as the background color. Also, we had unnecessary padding at the bottom of some fragments, so that is now gone.


| Before | After |
|-------|-------|
| ![image](https://user-images.githubusercontent.com/17701279/210070737-06a5d059-f34e-41ef-9dc9-a5f3eec5697b.png) | ![image](https://user-images.githubusercontent.com/17701279/210070580-e863a886-ec8a-4d3b-b406-ff9bcf1df2d7.png) |

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-696
