### PR TITLE
Close responses as soon as possible

### DIFF
--- a/checkout-core/src/main/java/com/adyen/checkout/core/api/OkHttpClient.kt
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/api/OkHttpClient.kt
@@ -75,12 +75,16 @@ internal class OkHttpClient(
             val response = call.execute()
 
             if (response.isSuccessful) {
-                return response.body
+                val bytes = response.body
                     ?.bytes()
                     ?: ByteArray(0)
+                response.body?.close()
+                return bytes
             } else {
                 val errorBody = response.errorBody()
-                throw HttpException(response.code, response.message, errorBody)
+                val exception = HttpException(response.code, response.message, errorBody)
+                response.body?.close()
+                throw exception
             }
         } catch (e: CancellationException) {
             call.cancel()

--- a/checkout-core/src/main/java/com/adyen/checkout/core/image/ImageLoader.kt
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/image/ImageLoader.kt
@@ -79,6 +79,8 @@ class DefaultImageLoader(context: Context) : ImageLoader {
                     onError(HttpException(response.code, response.message, null))
                 }
             }
+
+            response.body?.close()
         } catch (e: CancellationException) {
             call.cancel()
         } catch (e: IOException) {


### PR DESCRIPTION
## Description
According to the [OkHttp docs](https://github.com/square/okhttp/blob/cf2a40bdb997c359c0516941015181958f4381df/okhttp/src/main/kotlin/okhttp3/Call.kt#L42-L55) a Response(Body) should be closed asap to avoid memory leaks. I found these memory leaks while testing something, so that's how a found out.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually