### PR TITLE
Fix card examples becoming empty when re-opening the app

### DIFF
--- a/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponent.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponent.kt
@@ -76,7 +76,7 @@ class BacsDirectDebitComponent internal constructor(
      * @return whether the view was successfully changed.
      */
     fun setConfirmationMode(): Boolean {
-        return bacsDelegate.setMode(BacsDirectDebitMode.CONFIRMATION)
+        return (delegate as? BacsDirectDebitDelegate)?.setMode(BacsDirectDebitMode.CONFIRMATION) ?: false
     }
 
     /**
@@ -85,7 +85,7 @@ class BacsDirectDebitComponent internal constructor(
      * @return whether the view was successfully changed.
      */
     fun setInputMode(): Boolean {
-        return bacsDelegate.setMode(BacsDirectDebitMode.INPUT)
+        return (delegate as? BacsDirectDebitDelegate)?.setMode(BacsDirectDebitMode.INPUT) ?: false
     }
 
     /**

--- a/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponent.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponent.kt
@@ -94,7 +94,7 @@ class BacsDirectDebitComponent internal constructor(
      * @return Whether back press has been handled or not.
      */
     fun handleBackPress(): Boolean {
-        return bacsDelegate.handleBackPress()
+        return (delegate as? BacsDirectDebitDelegate)?.handleBackPress() ?: false
     }
 
     override fun isConfirmationRequired(): Boolean = bacsDelegate.isConfirmationRequired()

--- a/bacs/src/test/java/com/adyen/checkout/bacs/BacsDirectDebitComponentTest.kt
+++ b/bacs/src/test/java/com/adyen/checkout/bacs/BacsDirectDebitComponentTest.kt
@@ -135,12 +135,14 @@ internal class BacsDirectDebitComponentTest(
 
     @Test
     fun `when setConfirmationMode is called then delegate setMode is called`() {
+        whenever(actionHandlingComponent.activeDelegate) doReturn bacsDirectDebitDelegate
         component.setConfirmationMode()
         verify(bacsDirectDebitDelegate).setMode(BacsDirectDebitMode.CONFIRMATION)
     }
 
     @Test
     fun `when setInputMode is called then delegate setMode is called`() {
+        whenever(actionHandlingComponent.activeDelegate) doReturn bacsDirectDebitDelegate
         component.setInputMode()
         verify(bacsDirectDebitDelegate).setMode(BacsDirectDebitMode.INPUT)
     }

--- a/ui-core/src/main/java/com/adyen/checkout/components/ui/view/AdyenComponentView.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/components/ui/view/AdyenComponentView.kt
@@ -36,6 +36,7 @@ import com.adyen.checkout.core.log.Logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import java.lang.ref.WeakReference
 
 /**
  * A View that can display input and fill in details for a Component.
@@ -59,7 +60,8 @@ class AdyenComponentView @JvmOverloads constructor(
     private var isInteractionBlocked = false
 
     private var componentView: ComponentView? = null
-    private var componentViewType: ComponentViewType? = null
+
+    private var attachedComponent = WeakReference<Component?>(null)
 
     init {
         isVisible = isInEditMode
@@ -76,6 +78,10 @@ class AdyenComponentView @JvmOverloads constructor(
         component: T,
         lifecycleOwner: LifecycleOwner
     ) where T : ViewableComponent, T : Component {
+        if (component == attachedComponent.get()) return
+
+        attachedComponent = WeakReference(component)
+
         component.viewFlow
             .onEach { componentViewType ->
                 binding.frameLayoutComponentContainer.removeAllViews()
@@ -110,7 +116,6 @@ class AdyenComponentView @JvmOverloads constructor(
     ) {
         val componentView = viewType.viewProvider.getView(viewType, context, attrs, defStyleAttr)
         this.componentView = componentView
-        this.componentViewType = viewType
 
         val localizedContext = context.createLocalizedContext(componentParams.shopperLocale)
 


### PR DESCRIPTION
## Description
Prevent from components being attached multiple times to `AdyenComponentView`.

Bonus fix: handle back press correctly in BACS

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-711
