### PR TITLE
Add action component callback to handle events from action components

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.viewModelScope
 import com.adyen.checkout.components.ActionComponent
 import com.adyen.checkout.components.ActionComponentEvent
 import com.adyen.checkout.components.ActionComponentProvider
+import com.adyen.checkout.components.base.ActionComponentEventHandler
 import com.adyen.checkout.components.base.IntentHandlingComponent
 import com.adyen.checkout.components.model.payments.response.Action
 import com.adyen.checkout.components.ui.ViewableComponent
@@ -26,6 +27,7 @@ import kotlinx.coroutines.flow.Flow
 
 class Adyen3DS2Component internal constructor(
     override val delegate: Adyen3DS2Delegate,
+    internal val actionComponentEventHandler: ActionComponentEventHandler,
 ) : ViewModel(),
     ActionComponent,
     IntentHandlingComponent,

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
@@ -39,11 +39,11 @@ class Adyen3DS2Component internal constructor(
         delegate.initialize(viewModelScope)
     }
 
-    override fun observe(lifecycleOwner: LifecycleOwner, callback: (ActionComponentEvent) -> Unit) {
+    internal fun observe(lifecycleOwner: LifecycleOwner, callback: (ActionComponentEvent) -> Unit) {
         delegate.observe(lifecycleOwner, viewModelScope, callback)
     }
 
-    override fun removeObserver() {
+    internal fun removeObserver() {
         delegate.removeObserver()
     }
 

--- a/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/Adyen3DS2ComponentTest.kt
+++ b/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/Adyen3DS2ComponentTest.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.viewModelScope
 import app.cash.turbine.test
 import com.adyen.checkout.components.ActionComponentEvent
+import com.adyen.checkout.components.base.ActionComponentEventHandler
 import com.adyen.checkout.components.model.payments.response.Threeds2Action
 import com.adyen.checkout.components.test.TestComponentViewType
 import com.adyen.checkout.core.log.Logger
@@ -38,6 +39,7 @@ import org.mockito.kotlin.whenever
 @ExtendWith(MockitoExtension::class, TestDispatcherExtension::class)
 internal class Adyen3DS2ComponentTest(
     @Mock private val adyen3DS2Delegate: Adyen3DS2Delegate,
+    @Mock private val actionComponentEventHandler: ActionComponentEventHandler,
 ) {
 
     private lateinit var component: Adyen3DS2Component
@@ -47,7 +49,7 @@ internal class Adyen3DS2ComponentTest(
         Logger.setLogcatLevel(Logger.NONE)
 
         whenever(adyen3DS2Delegate.viewFlow) doReturn MutableStateFlow(Adyen3DS2ComponentViewType)
-        component = Adyen3DS2Component(adyen3DS2Delegate)
+        component = Adyen3DS2Component(adyen3DS2Delegate, actionComponentEventHandler)
     }
 
     @Test
@@ -91,7 +93,7 @@ internal class Adyen3DS2ComponentTest(
     fun `when delegate view flow emits a value then component view flow should match that value`() = runTest {
         val delegateViewFlow = MutableStateFlow(TestComponentViewType.VIEW_TYPE_1)
         whenever(adyen3DS2Delegate.viewFlow) doReturn delegateViewFlow
-        component = Adyen3DS2Component(adyen3DS2Delegate)
+        component = Adyen3DS2Component(adyen3DS2Delegate, actionComponentEventHandler)
 
         component.viewFlow.test {
             assertEquals(TestComponentViewType.VIEW_TYPE_1, awaitItem())

--- a/action/src/main/java/com/adyen/checkout/action/GenericActionComponent.kt
+++ b/action/src/main/java/com/adyen/checkout/action/GenericActionComponent.kt
@@ -42,11 +42,11 @@ class GenericActionComponent internal constructor(
         genericActionDelegate.initialize(viewModelScope)
     }
 
-    override fun observe(lifecycleOwner: LifecycleOwner, callback: (ActionComponentEvent) -> Unit) {
+    internal fun observe(lifecycleOwner: LifecycleOwner, callback: (ActionComponentEvent) -> Unit) {
         genericActionDelegate.observe(lifecycleOwner, viewModelScope, callback)
     }
 
-    override fun removeObserver() {
+    internal fun removeObserver() {
         genericActionDelegate.removeObserver()
     }
 

--- a/action/src/main/java/com/adyen/checkout/action/GenericActionComponent.kt
+++ b/action/src/main/java/com/adyen/checkout/action/GenericActionComponent.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.viewModelScope
 import com.adyen.checkout.components.ActionComponent
 import com.adyen.checkout.components.ActionComponentEvent
 import com.adyen.checkout.components.ActionComponentProvider
+import com.adyen.checkout.components.base.ActionComponentEventHandler
 import com.adyen.checkout.components.ui.view.ComponentViewType
 import com.adyen.checkout.components.base.ActionDelegate
 import com.adyen.checkout.components.base.IntentHandlingComponent
@@ -23,7 +24,8 @@ import kotlinx.coroutines.flow.Flow
 
 class GenericActionComponent internal constructor(
     private val genericActionDelegate: GenericActionDelegate,
-    private val actionHandlingComponent: ActionHandlingComponent
+    private val actionHandlingComponent: ActionHandlingComponent,
+    internal val actionComponentEventHandler: ActionComponentEventHandler,
 ) : ViewModel(),
     ActionComponent,
     ViewableComponent,

--- a/action/src/test/java/com/adyen/checkout/action/GenericActionComponentTest.kt
+++ b/action/src/test/java/com/adyen/checkout/action/GenericActionComponentTest.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.viewModelScope
 import app.cash.turbine.test
 import com.adyen.checkout.components.ActionComponentEvent
+import com.adyen.checkout.components.base.ActionComponentEventHandler
 import com.adyen.checkout.components.base.ActionDelegate
 import com.adyen.checkout.components.test.TestComponentViewType
 import com.adyen.checkout.core.log.Logger
@@ -37,6 +38,7 @@ internal class GenericActionComponentTest(
     @Mock private val actionDelegate: ActionDelegate,
     @Mock private val genericActionDelegate: GenericActionDelegate,
     @Mock private val actionHandlingComponent: DefaultActionHandlingComponent,
+    @Mock private val actionComponentEventHandler: ActionComponentEventHandler,
 ) {
 
     private lateinit var component: GenericActionComponent
@@ -47,7 +49,7 @@ internal class GenericActionComponentTest(
 
         whenever(genericActionDelegate.delegate) doReturn actionDelegate
         whenever(genericActionDelegate.viewFlow) doReturn MutableStateFlow(TestComponentViewType.VIEW_TYPE_1)
-        component = GenericActionComponent(genericActionDelegate, actionHandlingComponent)
+        component = GenericActionComponent(genericActionDelegate, actionHandlingComponent, actionComponentEventHandler)
     }
 
     @Test
@@ -96,7 +98,7 @@ internal class GenericActionComponentTest(
     fun `when delegate view flow emits a value then component view flow should match that value`() = runTest {
         val delegateViewFlow = MutableStateFlow(TestComponentViewType.VIEW_TYPE_1)
         whenever(genericActionDelegate.viewFlow) doReturn delegateViewFlow
-        component = GenericActionComponent(genericActionDelegate, actionHandlingComponent)
+        component = GenericActionComponent(genericActionDelegate, actionHandlingComponent, actionComponentEventHandler)
 
         component.viewFlow.test {
             assertEquals(TestComponentViewType.VIEW_TYPE_1, awaitItem())

--- a/await/src/main/java/com/adyen/checkout/await/AwaitComponent.kt
+++ b/await/src/main/java/com/adyen/checkout/await/AwaitComponent.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.viewModelScope
 import com.adyen.checkout.components.ActionComponent
 import com.adyen.checkout.components.ActionComponentEvent
 import com.adyen.checkout.components.ActionComponentProvider
+import com.adyen.checkout.components.base.ActionComponentEventHandler
 import com.adyen.checkout.components.model.payments.response.Action
 import com.adyen.checkout.components.ui.ViewableComponent
 import com.adyen.checkout.components.ui.view.ComponentViewType
@@ -23,6 +24,7 @@ import kotlinx.coroutines.flow.Flow
 
 class AwaitComponent internal constructor(
     override val delegate: AwaitDelegate,
+    internal val actionComponentEventHandler: ActionComponentEventHandler,
 ) : ViewModel(),
     ActionComponent,
     ViewableComponent {

--- a/await/src/main/java/com/adyen/checkout/await/AwaitComponent.kt
+++ b/await/src/main/java/com/adyen/checkout/await/AwaitComponent.kt
@@ -35,11 +35,11 @@ class AwaitComponent internal constructor(
         delegate.initialize(viewModelScope)
     }
 
-    override fun observe(lifecycleOwner: LifecycleOwner, callback: (ActionComponentEvent) -> Unit) {
+    internal fun observe(lifecycleOwner: LifecycleOwner, callback: (ActionComponentEvent) -> Unit) {
         delegate.observe(lifecycleOwner, viewModelScope, callback)
     }
 
-    override fun removeObserver() {
+    internal fun removeObserver() {
         delegate.removeObserver()
     }
 

--- a/await/src/test/java/com/adyen/checkout/await/AwaitComponentTest.kt
+++ b/await/src/test/java/com/adyen/checkout/await/AwaitComponentTest.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.viewModelScope
 import app.cash.turbine.test
 import com.adyen.checkout.components.ActionComponentEvent
+import com.adyen.checkout.components.base.ActionComponentEventHandler
 import com.adyen.checkout.components.model.payments.response.AwaitAction
 import com.adyen.checkout.components.test.TestComponentViewType
 import com.adyen.checkout.core.log.Logger
@@ -36,6 +37,7 @@ import org.mockito.kotlin.whenever
 @ExtendWith(MockitoExtension::class, TestDispatcherExtension::class)
 internal class AwaitComponentTest(
     @Mock private val awaitDelegate: AwaitDelegate,
+    @Mock private val actionComponentEventHandler: ActionComponentEventHandler,
 ) {
 
     private lateinit var component: AwaitComponent
@@ -45,7 +47,7 @@ internal class AwaitComponentTest(
         Logger.setLogcatLevel(Logger.NONE)
 
         whenever(awaitDelegate.viewFlow) doReturn MutableStateFlow(AwaitComponentViewType)
-        component = AwaitComponent(awaitDelegate)
+        component = AwaitComponent(awaitDelegate, actionComponentEventHandler)
     }
 
     @Test
@@ -89,7 +91,7 @@ internal class AwaitComponentTest(
     fun `when delegate view flow emits a value then component view flow should match that value`() = runTest {
         val delegateViewFlow = MutableStateFlow(TestComponentViewType.VIEW_TYPE_1)
         whenever(awaitDelegate.viewFlow) doReturn delegateViewFlow
-        component = AwaitComponent(awaitDelegate)
+        component = AwaitComponent(awaitDelegate, actionComponentEventHandler)
 
         component.viewFlow.test {
             assertEquals(TestComponentViewType.VIEW_TYPE_1, awaitItem())

--- a/components-core/src/main/java/com/adyen/checkout/components/ActionComponent.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/ActionComponent.kt
@@ -8,7 +8,6 @@
 package com.adyen.checkout.components
 
 import android.app.Activity
-import androidx.lifecycle.LifecycleOwner
 import com.adyen.checkout.components.model.payments.response.Action
 
 /**
@@ -19,12 +18,6 @@ import com.adyen.checkout.components.model.payments.response.Action
  * Result on the [ActionComponentData] if populated can be considered valid to be sent back to the payments/details/ API
  */
 interface ActionComponent : Component {
-
-    // TODO documentation
-    fun observe(lifecycleOwner: LifecycleOwner, callback: (ActionComponentEvent) -> Unit)
-
-    // TODO documentation
-    fun removeObserver()
 
     /**
      * Provide the action from the API response that needs to be handled.

--- a/components-core/src/main/java/com/adyen/checkout/components/base/ActionComponentCallback.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/base/ActionComponentCallback.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2023 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ozgur on 24/1/2023.
+ */
+
+package com.adyen.checkout.components.base
+
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.components.ActionComponentData
+import com.adyen.checkout.components.ComponentError
+
+// TODO SESSIONS: docs
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+interface ActionComponentCallback {
+    fun onAdditionalDetails(actionComponentData: ActionComponentData)
+    fun onError(componentError: ComponentError)
+}

--- a/components-core/src/main/java/com/adyen/checkout/components/base/ActionComponentEventHandler.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/base/ActionComponentEventHandler.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2023 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ozgur on 24/1/2023.
+ */
+
+package com.adyen.checkout.components.base
+
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.components.ActionComponentEvent
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+interface ActionComponentEventHandler {
+    fun onActionComponentEvent(event: ActionComponentEvent)
+}

--- a/components-core/src/main/java/com/adyen/checkout/components/base/DefaultActionComponentEventHandler.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/base/DefaultActionComponentEventHandler.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ozgur on 24/1/2023.
+ */
+
+package com.adyen.checkout.components.base
+
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.components.ActionComponentEvent
+import com.adyen.checkout.core.log.LogUtil
+import com.adyen.checkout.core.log.Logger
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class DefaultActionComponentEventHandler(
+    private val actionComponentCallback: ActionComponentCallback
+) : ActionComponentEventHandler {
+
+    override fun onActionComponentEvent(event: ActionComponentEvent) {
+        Logger.v(TAG, "Event received $event")
+        when (event) {
+            is ActionComponentEvent.ActionDetails -> actionComponentCallback.onAdditionalDetails(event.data)
+            is ActionComponentEvent.Error -> actionComponentCallback.onError(event.error)
+        }
+    }
+
+    companion object {
+        private val TAG = LogUtil.getTag()
+    }
+}

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/action/ActionComponentDialogFragment.kt
@@ -22,8 +22,8 @@ import com.adyen.checkout.action.GenericActionComponent
 import com.adyen.checkout.action.GenericActionComponentProvider
 import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.components.ActionComponentData
-import com.adyen.checkout.components.ActionComponentEvent
 import com.adyen.checkout.components.ComponentError
+import com.adyen.checkout.components.base.ActionComponentCallback
 import com.adyen.checkout.components.model.payments.response.Action
 import com.adyen.checkout.core.exception.CancellationException
 import com.adyen.checkout.core.exception.CheckoutException
@@ -40,7 +40,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
 @SuppressWarnings("TooManyFunctions")
-internal class ActionComponentDialogFragment : DropInBottomSheetDialogFragment() {
+internal class ActionComponentDialogFragment : DropInBottomSheetDialogFragment(), ActionComponentCallback {
 
     private var _binding: FragmentGenericActionComponentBinding? = null
     private val binding: FragmentGenericActionComponentBinding get() = requireNotNull(_binding)
@@ -72,7 +72,8 @@ internal class ActionComponentDialogFragment : DropInBottomSheetDialogFragment()
             actionComponent = GenericActionComponentProvider(componentParams).get(
                 this,
                 requireActivity().application,
-                actionConfiguration
+                actionConfiguration,
+                this
             )
 
             if (shouldFinishWithAction()) {
@@ -82,19 +83,19 @@ internal class ActionComponentDialogFragment : DropInBottomSheetDialogFragment()
                 }
             }
 
-            actionComponent.observe(viewLifecycleOwner, ::onActionComponentEvent)
-
             binding.componentView.attach(actionComponent, viewLifecycleOwner)
         } catch (e: CheckoutException) {
             handleError(ComponentError(e))
         }
     }
 
-    private fun onActionComponentEvent(event: ActionComponentEvent) {
-        when (event) {
-            is ActionComponentEvent.ActionDetails -> onActionComponentDataChanged(event.data)
-            is ActionComponentEvent.Error -> onError(event.error)
-        }
+    override fun onAdditionalDetails(actionComponentData: ActionComponentData) {
+        onActionComponentDataChanged(actionComponentData)
+    }
+
+    override fun onError(componentError: ComponentError) {
+        Logger.d(TAG, "onError")
+        handleError(componentError)
     }
 
     private fun initObservers() {
@@ -140,13 +141,6 @@ internal class ActionComponentDialogFragment : DropInBottomSheetDialogFragment()
         Logger.d(TAG, "onActionComponentDataChanged")
         if (actionComponentData != null) {
             protocol.requestDetailsCall(actionComponentData)
-        }
-    }
-
-    private fun onError(error: ComponentError?) {
-        Logger.d(TAG, "onError")
-        if (error != null) {
-            handleError(error)
         }
     }
 

--- a/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeComponent.kt
+++ b/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeComponent.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.viewModelScope
 import com.adyen.checkout.components.ActionComponent
 import com.adyen.checkout.components.ActionComponentEvent
 import com.adyen.checkout.components.ActionComponentProvider
+import com.adyen.checkout.components.base.ActionComponentEventHandler
 import com.adyen.checkout.components.base.IntentHandlingComponent
 import com.adyen.checkout.components.model.payments.response.Action
 import com.adyen.checkout.components.ui.ViewableComponent
@@ -25,6 +26,7 @@ import kotlinx.coroutines.flow.Flow
 
 class QRCodeComponent internal constructor(
     override val delegate: QRCodeDelegate,
+    internal val actionComponentEventHandler: ActionComponentEventHandler,
 ) : ViewModel(),
     ActionComponent,
     IntentHandlingComponent,

--- a/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeComponent.kt
+++ b/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeComponent.kt
@@ -38,11 +38,11 @@ class QRCodeComponent internal constructor(
         delegate.initialize(viewModelScope)
     }
 
-    override fun observe(lifecycleOwner: LifecycleOwner, callback: (ActionComponentEvent) -> Unit) {
+    internal fun observe(lifecycleOwner: LifecycleOwner, callback: (ActionComponentEvent) -> Unit) {
         delegate.observe(lifecycleOwner, viewModelScope, callback)
     }
 
-    override fun removeObserver() {
+    internal fun removeObserver() {
         delegate.removeObserver()
     }
 

--- a/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeComponentProvider.kt
+++ b/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeComponentProvider.kt
@@ -11,12 +11,15 @@ package com.adyen.checkout.qrcode
 import android.app.Application
 import android.os.Bundle
 import androidx.annotation.RestrictTo
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
 import com.adyen.checkout.components.ActionComponentProvider
+import com.adyen.checkout.components.base.ActionComponentCallback
 import com.adyen.checkout.components.base.ComponentParams
+import com.adyen.checkout.components.base.DefaultActionComponentEventHandler
 import com.adyen.checkout.components.base.GenericComponentParamsMapper
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
@@ -36,20 +39,13 @@ class QRCodeComponentProvider(
 
     private val componentParamsMapper = GenericComponentParamsMapper(overrideComponentParams)
 
-    override fun <T> get(
-        owner: T,
-        application: Application,
-        configuration: QRCodeConfiguration,
-        key: String?,
-    ): QRCodeComponent where T : SavedStateRegistryOwner, T : ViewModelStoreOwner {
-        return get(owner, owner, application, configuration, null, key)
-    }
-
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,
         viewModelStoreOwner: ViewModelStoreOwner,
+        lifecycleOwner: LifecycleOwner,
         application: Application,
         configuration: QRCodeConfiguration,
+        callback: ActionComponentCallback,
         defaultArgs: Bundle?,
         key: String?,
     ): QRCodeComponent {
@@ -57,9 +53,13 @@ class QRCodeComponentProvider(
             val qrCodeDelegate = getDelegate(configuration, savedStateHandle, application)
             QRCodeComponent(
                 delegate = qrCodeDelegate,
+                actionComponentEventHandler = DefaultActionComponentEventHandler(callback)
             )
         }
         return ViewModelProvider(viewModelStoreOwner, qrCodeFactory)[key, QRCodeComponent::class.java]
+            .also { component ->
+                component.observe(lifecycleOwner, component.actionComponentEventHandler::onActionComponentEvent)
+            }
     }
 
     override fun getDelegate(

--- a/qr-code/src/test/java/com/adyen/checkout/qrcode/QRCodeComponentTest.kt
+++ b/qr-code/src/test/java/com/adyen/checkout/qrcode/QRCodeComponentTest.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.viewModelScope
 import app.cash.turbine.test
 import com.adyen.checkout.components.ActionComponentEvent
+import com.adyen.checkout.components.base.ActionComponentEventHandler
 import com.adyen.checkout.components.model.payments.response.QrCodeAction
 import com.adyen.checkout.core.log.Logger
 import com.adyen.checkout.test.TestDispatcherExtension
@@ -36,6 +37,7 @@ import org.mockito.kotlin.whenever
 @ExtendWith(MockitoExtension::class, TestDispatcherExtension::class)
 internal class QRCodeComponentTest(
     @Mock private val qrCodeDelegate: QRCodeDelegate,
+    @Mock private val actionComponentEventHandler: ActionComponentEventHandler,
 ) {
 
     private lateinit var component: QRCodeComponent
@@ -45,7 +47,7 @@ internal class QRCodeComponentTest(
         Logger.setLogcatLevel(Logger.NONE)
 
         whenever(qrCodeDelegate.viewFlow) doReturn MutableStateFlow(QrCodeComponentViewType.QR_CODE)
-        component = QRCodeComponent(qrCodeDelegate)
+        component = QRCodeComponent(qrCodeDelegate, actionComponentEventHandler)
     }
 
     @Test
@@ -89,7 +91,7 @@ internal class QRCodeComponentTest(
     fun `when delegate view flow emits a value then component view flow should match that value`() = runTest {
         val delegateViewFlow = MutableStateFlow(QrCodeComponentViewType.QR_CODE)
         whenever(qrCodeDelegate.viewFlow) doReturn delegateViewFlow
-        component = QRCodeComponent(qrCodeDelegate)
+        component = QRCodeComponent(qrCodeDelegate, actionComponentEventHandler)
 
         component.viewFlow.test {
             assertEquals(QrCodeComponentViewType.QR_CODE, awaitItem())

--- a/redirect/src/main/java/com/adyen/checkout/redirect/RedirectComponent.kt
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/RedirectComponent.kt
@@ -39,11 +39,11 @@ class RedirectComponent internal constructor(
         delegate.initialize(viewModelScope)
     }
 
-    override fun observe(lifecycleOwner: LifecycleOwner, callback: (ActionComponentEvent) -> Unit) {
+    internal fun observe(lifecycleOwner: LifecycleOwner, callback: (ActionComponentEvent) -> Unit) {
         delegate.observe(lifecycleOwner, viewModelScope, callback)
     }
 
-    override fun removeObserver() {
+    internal fun removeObserver() {
         delegate.removeObserver()
     }
 

--- a/redirect/src/main/java/com/adyen/checkout/redirect/RedirectComponent.kt
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/RedirectComponent.kt
@@ -16,6 +16,7 @@ import androidx.lifecycle.viewModelScope
 import com.adyen.checkout.components.ActionComponent
 import com.adyen.checkout.components.ActionComponentEvent
 import com.adyen.checkout.components.ActionComponentProvider
+import com.adyen.checkout.components.base.ActionComponentEventHandler
 import com.adyen.checkout.components.base.IntentHandlingComponent
 import com.adyen.checkout.components.model.payments.response.Action
 import com.adyen.checkout.components.ui.ViewableComponent
@@ -25,7 +26,8 @@ import com.adyen.checkout.core.log.Logger
 import kotlinx.coroutines.flow.Flow
 
 class RedirectComponent internal constructor(
-    override val delegate: RedirectDelegate
+    override val delegate: RedirectDelegate,
+    internal val actionComponentEventHandler: ActionComponentEventHandler,
 ) : ViewModel(),
     ActionComponent,
     IntentHandlingComponent,

--- a/redirect/src/test/java/com/adyen/checkout/redirect/RedirectComponentTest.kt
+++ b/redirect/src/test/java/com/adyen/checkout/redirect/RedirectComponentTest.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.viewModelScope
 import app.cash.turbine.test
 import com.adyen.checkout.components.ActionComponentEvent
+import com.adyen.checkout.components.base.ActionComponentEventHandler
 import com.adyen.checkout.components.model.payments.response.RedirectAction
 import com.adyen.checkout.components.test.TestComponentViewType
 import com.adyen.checkout.core.log.Logger
@@ -37,6 +38,7 @@ import org.mockito.kotlin.whenever
 @ExtendWith(MockitoExtension::class, TestDispatcherExtension::class)
 internal class RedirectComponentTest(
     @Mock private val redirectDelegate: RedirectDelegate,
+    @Mock private val actionComponentEventHandler: ActionComponentEventHandler,
 ) {
 
     private lateinit var component: RedirectComponent
@@ -46,7 +48,7 @@ internal class RedirectComponentTest(
         Logger.setLogcatLevel(Logger.NONE)
 
         whenever(redirectDelegate.viewFlow) doReturn MutableStateFlow(RedirectComponentViewType)
-        component = RedirectComponent(redirectDelegate)
+        component = RedirectComponent(redirectDelegate, actionComponentEventHandler)
     }
 
     @Test
@@ -90,7 +92,7 @@ internal class RedirectComponentTest(
     fun `when delegate view flow emits a value then component view flow should match that value`() = runTest {
         val delegateViewFlow = MutableStateFlow(TestComponentViewType.VIEW_TYPE_1)
         whenever(redirectDelegate.viewFlow) doReturn delegateViewFlow
-        component = RedirectComponent(redirectDelegate)
+        component = RedirectComponent(redirectDelegate, actionComponentEventHandler)
 
         component.viewFlow.test {
             assertEquals(TestComponentViewType.VIEW_TYPE_1, awaitItem())

--- a/voucher/src/main/java/com/adyen/checkout/voucher/VoucherComponent.kt
+++ b/voucher/src/main/java/com/adyen/checkout/voucher/VoucherComponent.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.viewModelScope
 import com.adyen.checkout.components.ActionComponent
 import com.adyen.checkout.components.ActionComponentEvent
 import com.adyen.checkout.components.ActionComponentProvider
+import com.adyen.checkout.components.base.ActionComponentEventHandler
 import com.adyen.checkout.components.model.payments.response.Action
 import com.adyen.checkout.components.ui.ViewableComponent
 import com.adyen.checkout.components.ui.view.ComponentViewType
@@ -24,6 +25,7 @@ import kotlinx.coroutines.flow.Flow
 
 class VoucherComponent internal constructor(
     override val delegate: VoucherDelegate,
+    internal val actionComponentEventHandler: ActionComponentEventHandler,
 ) : ViewModel(),
     ActionComponent,
     ViewableComponent {

--- a/voucher/src/main/java/com/adyen/checkout/voucher/VoucherComponent.kt
+++ b/voucher/src/main/java/com/adyen/checkout/voucher/VoucherComponent.kt
@@ -36,11 +36,11 @@ class VoucherComponent internal constructor(
         delegate.initialize(viewModelScope)
     }
 
-    override fun observe(lifecycleOwner: LifecycleOwner, callback: (ActionComponentEvent) -> Unit) {
+    internal fun observe(lifecycleOwner: LifecycleOwner, callback: (ActionComponentEvent) -> Unit) {
         delegate.observe(lifecycleOwner, viewModelScope, callback)
     }
 
-    override fun removeObserver() {
+    internal fun removeObserver() {
         delegate.removeObserver()
     }
 

--- a/voucher/src/main/java/com/adyen/checkout/voucher/VoucherComponentProvider.kt
+++ b/voucher/src/main/java/com/adyen/checkout/voucher/VoucherComponentProvider.kt
@@ -11,12 +11,15 @@ package com.adyen.checkout.voucher
 import android.app.Application
 import android.os.Bundle
 import androidx.annotation.RestrictTo
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
 import com.adyen.checkout.components.ActionComponentProvider
+import com.adyen.checkout.components.base.ActionComponentCallback
 import com.adyen.checkout.components.base.ComponentParams
+import com.adyen.checkout.components.base.DefaultActionComponentEventHandler
 import com.adyen.checkout.components.base.GenericComponentParamsMapper
 import com.adyen.checkout.components.base.lifecycle.get
 import com.adyen.checkout.components.base.lifecycle.viewModelFactory
@@ -32,30 +35,27 @@ class VoucherComponentProvider(
 
     private val componentParamsMapper = GenericComponentParamsMapper(overrideComponentParams)
 
-    override fun <T> get(
-        owner: T,
-        application: Application,
-        configuration: VoucherConfiguration,
-        key: String?,
-    ): VoucherComponent where T : SavedStateRegistryOwner, T : ViewModelStoreOwner {
-        return get(owner, owner, application, configuration, null, key)
-    }
-
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,
         viewModelStoreOwner: ViewModelStoreOwner,
+        lifecycleOwner: LifecycleOwner,
         application: Application,
         configuration: VoucherConfiguration,
+        callback: ActionComponentCallback,
         defaultArgs: Bundle?,
         key: String?,
     ): VoucherComponent {
         val voucherFactory = viewModelFactory(savedStateRegistryOwner, defaultArgs) { savedStateHandle ->
             val voucherDelegate = getDelegate(configuration, savedStateHandle, application)
             VoucherComponent(
-                voucherDelegate,
+                delegate = voucherDelegate,
+                actionComponentEventHandler = DefaultActionComponentEventHandler(callback),
             )
         }
         return ViewModelProvider(viewModelStoreOwner, voucherFactory)[key, VoucherComponent::class.java]
+            .also { component ->
+                component.observe(lifecycleOwner, component.actionComponentEventHandler::onActionComponentEvent)
+            }
     }
 
     override fun getDelegate(

--- a/voucher/src/test/java/com/adyen/checkout/voucher/VoucherComponentTest.kt
+++ b/voucher/src/test/java/com/adyen/checkout/voucher/VoucherComponentTest.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.viewModelScope
 import app.cash.turbine.test
 import com.adyen.checkout.components.ActionComponentEvent
+import com.adyen.checkout.components.base.ActionComponentEventHandler
 import com.adyen.checkout.components.model.payments.response.VoucherAction
 import com.adyen.checkout.components.test.TestComponentViewType
 import com.adyen.checkout.core.log.Logger
@@ -36,6 +37,7 @@ import org.mockito.kotlin.whenever
 @ExtendWith(MockitoExtension::class, TestDispatcherExtension::class)
 internal class VoucherComponentTest(
     @Mock private val voucherDelegate: VoucherDelegate,
+    @Mock private val actionComponentEventHandler: ActionComponentEventHandler,
 ) {
 
     private lateinit var component: VoucherComponent
@@ -45,7 +47,7 @@ internal class VoucherComponentTest(
         Logger.setLogcatLevel(Logger.NONE)
 
         whenever(voucherDelegate.viewFlow) doReturn MutableStateFlow(VoucherComponentViewType)
-        component = VoucherComponent(voucherDelegate)
+        component = VoucherComponent(voucherDelegate, actionComponentEventHandler)
     }
 
     @Test
@@ -89,7 +91,7 @@ internal class VoucherComponentTest(
     fun `when delegate view flow emits a value then component view flow should match that value`() = runTest {
         val delegateViewFlow = MutableStateFlow(TestComponentViewType.VIEW_TYPE_1)
         whenever(voucherDelegate.viewFlow) doReturn delegateViewFlow
-        component = VoucherComponent(voucherDelegate)
+        component = VoucherComponent(voucherDelegate, actionComponentEventHandler)
 
         component.viewFlow.test {
             assertEquals(TestComponentViewType.VIEW_TYPE_1, awaitItem())

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionComponent.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionComponent.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.viewModelScope
 import com.adyen.checkout.components.ActionComponent
 import com.adyen.checkout.components.ActionComponentEvent
 import com.adyen.checkout.components.ActionComponentProvider
+import com.adyen.checkout.components.base.ActionComponentEventHandler
 import com.adyen.checkout.components.base.IntentHandlingComponent
 import com.adyen.checkout.components.model.payments.response.Action
 import com.adyen.checkout.components.ui.ViewableComponent
@@ -25,6 +26,7 @@ import kotlinx.coroutines.flow.Flow
 
 class WeChatPayActionComponent internal constructor(
     override val delegate: WeChatDelegate,
+    internal val actionComponentEventHandler: ActionComponentEventHandler,
 ) : ViewModel(),
     ActionComponent,
     IntentHandlingComponent,

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionComponent.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionComponent.kt
@@ -38,11 +38,11 @@ class WeChatPayActionComponent internal constructor(
         delegate.initialize(viewModelScope)
     }
 
-    override fun observe(lifecycleOwner: LifecycleOwner, callback: (ActionComponentEvent) -> Unit) {
+    internal fun observe(lifecycleOwner: LifecycleOwner, callback: (ActionComponentEvent) -> Unit) {
         delegate.observe(lifecycleOwner, viewModelScope, callback)
     }
 
-    override fun removeObserver() {
+    internal fun removeObserver() {
         delegate.removeObserver()
     }
 

--- a/wechatpay/src/test/java/com/adyen/checkout/wechatpay/WeChatPayActionComponentTest.kt
+++ b/wechatpay/src/test/java/com/adyen/checkout/wechatpay/WeChatPayActionComponentTest.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.viewModelScope
 import app.cash.turbine.test
 import com.adyen.checkout.components.ActionComponentEvent
+import com.adyen.checkout.components.base.ActionComponentEventHandler
 import com.adyen.checkout.components.model.payments.response.SdkAction
 import com.adyen.checkout.components.model.payments.response.SdkData
 import com.adyen.checkout.components.test.TestComponentViewType
@@ -38,6 +39,7 @@ import org.mockito.kotlin.whenever
 @ExtendWith(MockitoExtension::class, TestDispatcherExtension::class)
 internal class WeChatPayActionComponentTest(
     @Mock private val weChatDelegate: WeChatDelegate,
+    @Mock private val actionComponentEventHandler: ActionComponentEventHandler,
 ) {
 
     private lateinit var component: WeChatPayActionComponent
@@ -47,7 +49,7 @@ internal class WeChatPayActionComponentTest(
         Logger.setLogcatLevel(Logger.NONE)
 
         whenever(weChatDelegate.viewFlow) doReturn MutableStateFlow(WeChatComponentViewType)
-        component = WeChatPayActionComponent(weChatDelegate)
+        component = WeChatPayActionComponent(weChatDelegate, actionComponentEventHandler)
     }
 
     @Test
@@ -91,7 +93,7 @@ internal class WeChatPayActionComponentTest(
     fun `when delegate view flow emits a value then component view flow should match that value`() = runTest {
         val delegateViewFlow = MutableStateFlow(TestComponentViewType.VIEW_TYPE_1)
         whenever(weChatDelegate.viewFlow) doReturn delegateViewFlow
-        component = WeChatPayActionComponent(weChatDelegate)
+        component = WeChatPayActionComponent(weChatDelegate, actionComponentEventHandler)
 
         component.viewFlow.test {
             assertEquals(TestComponentViewType.VIEW_TYPE_1, awaitItem())


### PR DESCRIPTION
## Description
Merchants don't have to call observe on action components anymore. Events are propagated through `ActionComponentCallback`

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-699
