### PR TITLE
Remove hard-coded brand support on card component/drop-in Android SDK

### DIFF
--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcComponent.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcComponent.kt
@@ -14,6 +14,7 @@ import com.adyen.checkout.action.ActionHandlingComponent
 import com.adyen.checkout.action.DefaultActionHandlingComponent
 import com.adyen.checkout.action.GenericActionDelegate
 import com.adyen.checkout.bcmc.BcmcComponent.Companion.PROVIDER
+import com.adyen.checkout.card.data.CardBrand
 import com.adyen.checkout.card.data.CardType
 import com.adyen.checkout.components.ButtonComponent
 import com.adyen.checkout.components.PaymentComponent
@@ -93,6 +94,6 @@ class BcmcComponent internal constructor(
         @JvmField
         val PAYMENT_METHOD_TYPES = arrayOf(PaymentMethodTypes.BCMC)
 
-        internal val SUPPORTED_CARD_TYPE = CardType.BCMC
+        internal val SUPPORTED_CARD_TYPE = CardType(cardBrand = CardBrand.BCMC)
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/CardComponentParamsMapper.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponentParamsMapper.kt
@@ -80,7 +80,7 @@ internal class CardComponentParamsMapper(
             paymentMethod.brands.orEmpty().isNotEmpty() -> {
                 Logger.v(TAG, "Reading supportedCardTypes from API brands")
                 paymentMethod.brands.orEmpty().map {
-                    CardType.getByBrandName(it)
+                    CardType(txVariant = it)
                 }
             }
             else -> {

--- a/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.card
 import android.content.Context
 import com.adyen.checkout.action.ActionHandlingPaymentMethodConfigurationBuilder
 import com.adyen.checkout.action.GenericActionConfiguration
+import com.adyen.checkout.card.data.CardBrand
 import com.adyen.checkout.card.data.CardType
 import com.adyen.checkout.components.base.ButtonConfiguration
 import com.adyen.checkout.components.base.ButtonConfigurationBuilder
@@ -265,9 +266,9 @@ class CardConfiguration private constructor(
 
     companion object {
         val DEFAULT_SUPPORTED_CARDS_LIST: List<CardType> = listOf(
-            CardType.VISA,
-            CardType.AMERICAN_EXPRESS,
-            CardType.MASTERCARD
+            CardType(cardBrand = CardBrand.VISA),
+            CardType(cardBrand = CardBrand.AMERICAN_EXPRESS),
+            CardType(cardBrand = CardBrand.MASTERCARD)
         )
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/CardView.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardView.kt
@@ -20,6 +20,7 @@ import android.widget.AdapterView
 import android.widget.LinearLayout
 import androidx.annotation.StringRes
 import androidx.core.view.isVisible
+import com.adyen.checkout.card.data.CardBrand
 import com.adyen.checkout.card.data.CardType
 import com.adyen.checkout.card.data.DetectedCardType
 import com.adyen.checkout.card.data.ExpiryDate
@@ -289,7 +290,7 @@ internal class CardView @JvmOverloads constructor(
             setDualBrandedCardImages(detectedCardTypes, cardOutputData.cardNumberState.validation)
 
             // TODO: 29/01/2021 get this logic from OutputData
-            val isAmex = detectedCardTypes.any { it.cardType == CardType.AMERICAN_EXPRESS }
+            val isAmex = detectedCardTypes.any { it.cardType == CardType(cardBrand = CardBrand.AMERICAN_EXPRESS) }
             binding.editTextCardNumber.setAmexCardFormat(isAmex)
 
             if (detectedCardTypes.size == 1 &&

--- a/card/src/main/java/com/adyen/checkout/card/StoredCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/StoredCardDelegate.kt
@@ -11,6 +11,7 @@ package com.adyen.checkout.card
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LifecycleOwner
 import com.adyen.checkout.card.api.model.Brand
+import com.adyen.checkout.card.data.CardBrand
 import com.adyen.checkout.card.data.CardType
 import com.adyen.checkout.card.data.DetectedCardType
 import com.adyen.checkout.card.data.ExpiryDate
@@ -65,9 +66,9 @@ internal class StoredCardDelegate(
     private val submitHandler: SubmitHandler
 ) : CardDelegate {
 
-    private val noCvcBrands: Set<CardType> = hashSetOf(CardType.BCMC)
+    private val noCvcBrands: Set<CardType> = hashSetOf(CardType(cardBrand = CardBrand.BCMC))
 
-    private val cardType = CardType.getByBrandName(storedPaymentMethod.brand.orEmpty())
+    private val cardType = CardType(txVariant = storedPaymentMethod.brand.orEmpty())
     private val storedDetectedCardTypes = DetectedCardType(
         cardType,
         isReliable = true,

--- a/card/src/main/java/com/adyen/checkout/card/repository/DefaultDetectCardTypeRepository.kt
+++ b/card/src/main/java/com/adyen/checkout/card/repository/DefaultDetectCardTypeRepository.kt
@@ -12,6 +12,7 @@ import com.adyen.checkout.card.api.BinLookupService
 import com.adyen.checkout.card.api.model.BinLookupRequest
 import com.adyen.checkout.card.api.model.BinLookupResponse
 import com.adyen.checkout.card.api.model.Brand
+import com.adyen.checkout.card.data.CardBrand
 import com.adyen.checkout.card.data.CardType
 import com.adyen.checkout.card.data.DetectedCardType
 import com.adyen.checkout.components.channel.bufferedChannel
@@ -179,7 +180,7 @@ internal class DefaultDetectCardTypeRepository(
         // Any null or unmapped values are ignored, a null response becomes an empty list
         return binLookupResponse.brands.orEmpty().mapNotNull { brandResponse ->
             if (brandResponse.brand == null) return@mapNotNull null
-            val cardType = CardType.getByBrandName(brandResponse.brand)
+            val cardType = CardType(txVariant = brandResponse.brand)
             DetectedCardType(
                 cardType = cardType,
                 isReliable = true,
@@ -196,7 +197,7 @@ internal class DefaultDetectCardTypeRepository(
 
     companion object {
         private val TAG = LogUtil.getTag()
-        private val NO_CVC_BRANDS: Set<CardType> = hashSetOf(CardType.BCMC)
+        private val NO_CVC_BRANDS: Set<CardType> = hashSetOf(CardType(cardBrand = CardBrand.BCMC))
 
         private const val REQUIRED_BIN_SIZE = 11
     }

--- a/card/src/main/java/com/adyen/checkout/card/test/TestDetectCardTypeRepository.kt
+++ b/card/src/main/java/com/adyen/checkout/card/test/TestDetectCardTypeRepository.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.card.test
 
 import androidx.annotation.RestrictTo
 import com.adyen.checkout.card.api.model.Brand
+import com.adyen.checkout.card.data.CardBrand
 import com.adyen.checkout.card.data.CardType
 import com.adyen.checkout.card.data.DetectedCardType
 import com.adyen.checkout.card.repository.DetectCardTypeRepository
@@ -63,7 +64,7 @@ internal class TestDetectCardTypeRepository : DetectCardTypeRepository {
     }
 
     fun getDetectedCardTypesLocal(supportedCardTypes: List<CardType>): List<DetectedCardType> {
-        val cardType = CardType.VISA
+        val cardType = CardType(cardBrand = CardBrand.VISA)
         return listOf(
             DetectedCardType(
                 cardType = cardType,
@@ -78,7 +79,7 @@ internal class TestDetectCardTypeRepository : DetectCardTypeRepository {
     }
 
     fun getDetectedCardTypesNetwork(supportedCardTypes: List<CardType>): List<DetectedCardType> {
-        val cardType = CardType.MASTERCARD
+        val cardType = CardType(cardBrand = CardBrand.MASTERCARD)
         return listOf(
             DetectedCardType(
                 cardType = cardType,
@@ -93,8 +94,8 @@ internal class TestDetectCardTypeRepository : DetectCardTypeRepository {
     }
 
     fun getDetectedCardTypesDualBranded(supportedCardTypes: List<CardType>): List<DetectedCardType> {
-        val cardTypeFirst = CardType.BCMC
-        val cardTypeSecond = CardType.MAESTRO
+        val cardTypeFirst = CardType(cardBrand = CardBrand.BCMC)
+        val cardTypeSecond = CardType(cardBrand = CardBrand.MAESTRO)
         return listOf(
             DetectedCardType(
                 cardType = cardTypeFirst,

--- a/card/src/main/java/com/adyen/checkout/card/util/CardValidationUtils.kt
+++ b/card/src/main/java/com/adyen/checkout/card/util/CardValidationUtils.kt
@@ -9,6 +9,7 @@ package com.adyen.checkout.card.util
 
 import com.adyen.checkout.card.R
 import com.adyen.checkout.card.api.model.Brand
+import com.adyen.checkout.card.data.CardBrand
 import com.adyen.checkout.card.data.CardType
 import com.adyen.checkout.card.data.DetectedCardType
 import com.adyen.checkout.card.data.ExpiryDate
@@ -128,8 +129,9 @@ object CardValidationUtils {
         val validation = when {
             !StringUtil.isDigitsAndSeparatorsOnly(normalizedSecurityCode) -> invalidState
             cardType?.cvcPolicy == Brand.FieldPolicy.OPTIONAL && length == 0 -> Validation.Valid
-            cardType?.cardType == CardType.AMERICAN_EXPRESS && length == AMEX_SECURITY_CODE_SIZE -> Validation.Valid
-            cardType?.cardType != CardType.AMERICAN_EXPRESS &&
+            cardType?.cardType == CardType(cardBrand = CardBrand.AMERICAN_EXPRESS) &&
+                length == AMEX_SECURITY_CODE_SIZE -> Validation.Valid
+            cardType?.cardType != CardType(cardBrand = CardBrand.AMERICAN_EXPRESS) &&
                 length == GENERAL_CARD_SECURITY_CODE_SIZE -> Validation.Valid
             else -> invalidState
         }

--- a/card/src/main/java/com/adyen/checkout/card/util/DualBrandedCardUtils.kt
+++ b/card/src/main/java/com/adyen/checkout/card/util/DualBrandedCardUtils.kt
@@ -1,5 +1,6 @@
 package com.adyen.checkout.card.util
 
+import com.adyen.checkout.card.data.CardBrand
 import com.adyen.checkout.card.data.CardType
 import com.adyen.checkout.card.data.DetectedCardType
 
@@ -9,17 +10,17 @@ object DualBrandedCardUtils {
         return if (cards.size <= 1) {
             cards
         } else {
-            val hasCarteBancaire = cards.any { it.cardType == CardType.CARTEBANCAIRE }
-            val hasVisa = cards.any { it.cardType == CardType.VISA }
+            val hasCarteBancaire = cards.any { it.cardType == CardType(cardBrand = CardBrand.CARTEBANCAIRE) }
+            val hasVisa = cards.any { it.cardType == CardType(cardBrand = CardBrand.VISA) }
             val hasPlcc = cards.any {
-                it.cardType == CardType.UNKNOWN && (
-                    it.cardType.txVariant.contains("plcc") ||
-                        it.cardType.txVariant.contains("cbcc")
-                    )
+                it.cardType.txVariant.contains("plcc") ||
+                    it.cardType.txVariant.contains("cbcc")
             }
 
             when {
-                hasCarteBancaire && hasVisa -> cards.sortedByDescending { it.cardType == CardType.VISA }
+                hasCarteBancaire && hasVisa -> cards.sortedByDescending {
+                    it.cardType == CardType(cardBrand = CardBrand.VISA)
+                }
                 hasPlcc -> cards.sortedByDescending {
                     it.cardType.txVariant.contains("plcc") ||
                         it.cardType.txVariant.contains("cbcc")

--- a/card/src/test/java/com/adyen/checkout/card/CardComponentParamsMapperTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/CardComponentParamsMapperTest.kt
@@ -8,6 +8,7 @@
 
 package com.adyen.checkout.card
 
+import com.adyen.checkout.card.data.CardBrand
 import com.adyen.checkout.card.data.CardType
 import com.adyen.checkout.card.data.RestrictedCardType
 import com.adyen.checkout.components.base.GenericComponentParams
@@ -53,7 +54,7 @@ internal class CardComponentParamsMapperTest {
             clientKey = TEST_CLIENT_KEY_2
         )
             .setHolderNameRequired(true)
-            .setSupportedCardTypes(CardType.DINERS, CardType.MAESTRO)
+            .setSupportedCardTypes(CardType(cardBrand = CardBrand.DINERS), CardType(cardBrand = CardBrand.MAESTRO))
             .setShopperReference(shopperReference)
             .setShowStorePaymentField(false)
             .setHideCvc(true)
@@ -72,7 +73,10 @@ internal class CardComponentParamsMapperTest {
             environment = Environment.APSE,
             clientKey = TEST_CLIENT_KEY_2,
             isHolderNameRequired = true,
-            supportedCardTypes = listOf(CardType.DINERS, CardType.MAESTRO),
+            supportedCardTypes = listOf(
+                CardType(cardBrand = CardBrand.DINERS),
+                CardType(cardBrand = CardBrand.MAESTRO)
+            ),
             shopperReference = shopperReference,
             isStorePaymentFieldVisible = false,
             isSubmitButtonVisible = false,
@@ -125,15 +129,20 @@ internal class CardComponentParamsMapperTest {
     @Test
     fun `when supported card types are set in the card configuration then they should be used in the params`() {
         val cardConfiguration = getCardConfigurationBuilder()
-            .setSupportedCardTypes(CardType.MAESTRO, CardType.BCMC)
+            .setSupportedCardTypes(CardType(cardBrand = CardBrand.MAESTRO), CardType(cardBrand = CardBrand.BCMC))
             .build()
 
-        val paymentMethod = PaymentMethod(brands = listOf(CardType.VISA.txVariant, CardType.MASTERCARD.txVariant))
+        val paymentMethod = PaymentMethod(
+            brands = listOf(
+                CardBrand.VISA.txVariant,
+                CardBrand.MASTERCARD.txVariant
+            )
+        )
 
         val params = CardComponentParamsMapper(null).mapToParamsDefault(cardConfiguration, paymentMethod)
 
         val expected = getCardComponentParams(
-            supportedCardTypes = listOf(CardType.MAESTRO, CardType.BCMC)
+            supportedCardTypes = listOf(CardType(cardBrand = CardBrand.MAESTRO), CardType(cardBrand = CardBrand.BCMC))
         )
 
         assertEquals(expected, params)
@@ -143,12 +152,17 @@ internal class CardComponentParamsMapperTest {
     fun `when there are any restricted card brand in payment method,they are removed from the params`() {
         val cardConfiguration = getCardConfigurationBuilder().build()
         val paymentMethod =
-            PaymentMethod(brands = listOf(RestrictedCardType.NYCE.txVariant, CardType.MASTERCARD.txVariant))
+            PaymentMethod(
+                brands = listOf(
+                    RestrictedCardType.NYCE.txVariant,
+                    CardBrand.MASTERCARD.txVariant
+                )
+            )
 
         val params = CardComponentParamsMapper(null).mapToParamsDefault(cardConfiguration, paymentMethod)
 
         val expected = getCardComponentParams(
-            supportedCardTypes = listOf(CardType.MASTERCARD)
+            supportedCardTypes = listOf(CardType(cardBrand = CardBrand.MASTERCARD))
         )
 
         assertEquals(expected, params)
@@ -159,12 +173,20 @@ internal class CardComponentParamsMapperTest {
         val cardConfiguration = getCardConfigurationBuilder()
             .build()
 
-        val paymentMethod = PaymentMethod(brands = listOf(CardType.VISA.txVariant, CardType.MASTERCARD.txVariant))
+        val paymentMethod = PaymentMethod(
+            brands = listOf(
+                CardBrand.VISA.txVariant,
+                CardBrand.MASTERCARD.txVariant
+            )
+        )
 
         val params = CardComponentParamsMapper(null).mapToParamsDefault(cardConfiguration, paymentMethod)
 
         val expected = getCardComponentParams(
-            supportedCardTypes = listOf(CardType.VISA, CardType.MASTERCARD)
+            supportedCardTypes = listOf(
+                CardType(cardBrand = CardBrand.VISA),
+                CardType(cardBrand = CardBrand.MASTERCARD)
+            )
         )
 
         assertEquals(expected, params)

--- a/card/src/test/java/com/adyen/checkout/card/CardTypeTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/CardTypeTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by atef on 25/1/2023.
+ */
+
+package com.adyen.checkout.card
+
+import com.adyen.checkout.card.data.CardBrand
+import com.adyen.checkout.card.data.CardType
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CardTypeTest {
+
+    @Test
+    fun `test if card number is not part of predefined card brand enum`() {
+        val sodexoCard = CardType(txVariant = "sodexo")
+        val cardTypes = CardType.estimate(SODEXO_CARD_NUMBER)
+
+        val isPredefinedBrand = cardTypes.contains(sodexoCard)
+
+        assertFalse(isPredefinedBrand)
+    }
+
+    @Test
+    fun `test if card number is part of predefined card brand enum`() {
+        val amexCard = CardType(cardBrand = CardBrand.AMERICAN_EXPRESS)
+        val cardTypes = CardType.estimate(AMEX_CARD_NUMBER)
+
+        val isPredefinedBrand = cardTypes.contains(amexCard)
+
+        assertTrue(isPredefinedBrand)
+    }
+
+    @Test
+    fun `test if card brand is not part of predefined card brand enum`() {
+        val sodexoCard = CardType(txVariant = "sodexo")
+
+        val result = CardBrand.getByBrandName(sodexoCard.txVariant)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `test if card brand is part of predefined card brand enum`() {
+        val amexCard = CardType(txVariant = "amex")
+
+        val result = CardBrand.getByBrandName(amexCard.txVariant)
+
+        assertNotNull(result)
+    }
+
+    companion object {
+        private const val SODEXO_CARD_NUMBER = "6033890257034050"
+        private const val AMEX_CARD_NUMBER = "370000000000002"
+    }
+}

--- a/card/src/test/java/com/adyen/checkout/card/DefaultCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/DefaultCardDelegateTest.kt
@@ -14,6 +14,7 @@ import app.cash.turbine.testIn
 import com.adyen.checkout.card.DefaultCardDelegate.Companion.BIN_VALUE_EXTENDED_LENGTH
 import com.adyen.checkout.card.DefaultCardDelegate.Companion.BIN_VALUE_LENGTH
 import com.adyen.checkout.card.api.model.Brand
+import com.adyen.checkout.card.data.CardBrand
 import com.adyen.checkout.card.data.CardType
 import com.adyen.checkout.card.data.DetectedCardType
 import com.adyen.checkout.card.data.ExpiryDate
@@ -263,7 +264,7 @@ internal class DefaultCardDelegateTest(
 
         @Test
         fun `When a card brand is detected, isCardListVisible should be false`() = runTest {
-            val supportedCardTypes = listOf(CardType.VISA)
+            val supportedCardTypes = listOf(CardType(cardBrand = CardBrand.VISA))
             delegate = createCardDelegate(
                 configuration = getDefaultCardConfigurationBuilder()
                     .setSupportedCardTypes(*supportedCardTypes.toTypedArray())
@@ -282,7 +283,7 @@ internal class DefaultCardDelegateTest(
 
         @Test
         fun `When a card brand is not detected, isCardListVisible should be true`() = runTest {
-            val supportedCardTypes = listOf(CardType.VISA)
+            val supportedCardTypes = listOf(CardType(cardBrand = CardBrand.VISA))
             delegate = createCardDelegate(
                 configuration = getDefaultCardConfigurationBuilder()
                     .setSupportedCardTypes(*supportedCardTypes.toTypedArray())
@@ -322,7 +323,11 @@ internal class DefaultCardDelegateTest(
 
         @Test
         fun `detect card type repository returns supported cards, then output data should contain them`() = runTest {
-            val supportedCardTypes = listOf(CardType.VISA, CardType.MASTERCARD, CardType.AMERICAN_EXPRESS)
+            val supportedCardTypes = listOf(
+                CardType(cardBrand = CardBrand.VISA),
+                CardType(cardBrand = CardBrand.MASTERCARD),
+                CardType(cardBrand = CardBrand.AMERICAN_EXPRESS)
+            )
             delegate = createCardDelegate(
                 configuration = getDefaultCardConfigurationBuilder()
                     .setSupportedCardTypes(*supportedCardTypes.toTypedArray())
@@ -348,7 +353,10 @@ internal class DefaultCardDelegateTest(
 
         @Test
         fun `detect card type repository returns unsupported cards, then output data should filter them`() = runTest {
-            val supportedCardTypes = listOf(CardType.VISA, CardType.AMERICAN_EXPRESS)
+            val supportedCardTypes = listOf(
+                CardType(cardBrand = CardBrand.VISA),
+                CardType(cardBrand = CardBrand.AMERICAN_EXPRESS)
+            )
             delegate = createCardDelegate(
                 configuration = getDefaultCardConfigurationBuilder()
                     .setSupportedCardTypes(*supportedCardTypes.toTypedArray())
@@ -374,7 +382,10 @@ internal class DefaultCardDelegateTest(
 
         @Test
         fun `detect card type repository returns dual branded cards, then output data should be good`() = runTest {
-            val supportedCardTypes = listOf(CardType.BCMC, CardType.MAESTRO)
+            val supportedCardTypes = listOf(
+                CardType(cardBrand = CardBrand.BCMC),
+                CardType(cardBrand = CardBrand.MAESTRO)
+            )
             delegate = createCardDelegate(
                 configuration = getDefaultCardConfigurationBuilder()
                     .setSupportedCardTypes(*supportedCardTypes.toTypedArray())
@@ -485,9 +496,9 @@ internal class DefaultCardDelegateTest(
         @Test
         fun `input data with custom config is valid, then output data should be good`() = runTest {
             val cardBrands = listOf(
-                CardListItem(CardType.VISA, true, Environment.TEST),
-                CardListItem(CardType.MASTERCARD, false, Environment.TEST),
-                CardListItem(CardType.AMERICAN_EXPRESS, false, Environment.TEST)
+                CardListItem(CardType(cardBrand = CardBrand.VISA), true, Environment.TEST),
+                CardListItem(CardType(cardBrand = CardBrand.MASTERCARD), false, Environment.TEST),
+                CardListItem(CardType(cardBrand = CardBrand.AMERICAN_EXPRESS), false, Environment.TEST)
             )
             val supportedCardTypes = cardBrands.map { it.cardType }
             val installmentConfiguration = InstallmentConfiguration(
@@ -699,7 +710,7 @@ internal class DefaultCardDelegateTest(
                 assertTrue(componentState.isValid)
                 assertEquals(TEST_CARD_NUMBER.takeLast(4), componentState.lastFourDigits)
                 assertEquals(TEST_CARD_NUMBER.take(8), componentState.binValue)
-                assertEquals(CardType.VISA, componentState.cardType)
+                assertEquals(CardType(cardBrand = CardBrand.VISA), componentState.cardType)
 
                 val paymentComponentData = componentState.data
                 with(paymentComponentData) {
@@ -766,7 +777,7 @@ internal class DefaultCardDelegateTest(
                     createDetectedCardType(),
                     createDetectedCardType().copy(
                         isSelected = true,
-                        cardType = CardType.VISA
+                        cardType = CardType(cardBrand = CardBrand.VISA)
                     )
                 )
 
@@ -787,9 +798,9 @@ internal class DefaultCardDelegateTest(
                         addressUIState = addressUIState,
                         installmentOptions = listOf(installmentModel),
                         cardBrands = listOf(
-                            CardListItem(CardType.VISA, false, Environment.TEST),
-                            CardListItem(CardType.MASTERCARD, false, Environment.TEST),
-                            CardListItem(CardType.AMERICAN_EXPRESS, false, Environment.TEST)
+                            CardListItem(CardType(cardBrand = CardBrand.VISA), false, Environment.TEST),
+                            CardListItem(CardType(cardBrand = CardBrand.MASTERCARD), false, Environment.TEST),
+                            CardListItem(CardType(cardBrand = CardBrand.AMERICAN_EXPRESS), false, Environment.TEST)
                         ),
                     )
                 )
@@ -802,7 +813,7 @@ internal class DefaultCardDelegateTest(
                 assertTrue(componentState.isValid)
                 assertEquals(TEST_CARD_NUMBER.takeLast(4), componentState.lastFourDigits)
                 assertEquals(TEST_CARD_NUMBER.take(8), componentState.binValue)
-                assertEquals(CardType.VISA, componentState.cardType)
+                assertEquals(CardType(cardBrand = CardBrand.VISA), componentState.cardType)
 
                 val paymentComponentData = componentState.data
                 with(paymentComponentData) {
@@ -830,7 +841,7 @@ internal class DefaultCardDelegateTest(
                     assertEquals("12", encryptedPassword)
                     assertEquals("funding_source_1", fundingSource)
                     assertEquals(PaymentMethodTypes.SCHEME, type)
-                    assertEquals(CardType.VISA.txVariant, brand)
+                    assertEquals(CardBrand.VISA.txVariant, brand)
                     assertNull(storedPaymentMethodId)
                     assertEquals("2.2.11", threeDS2SdkVersion)
                 }
@@ -929,7 +940,7 @@ internal class DefaultCardDelegateTest(
     private fun getDefaultCardConfigurationBuilder(): CardConfiguration.Builder {
         return CardConfiguration
             .Builder(Locale.US, Environment.TEST, TEST_CLIENT_KEY)
-            .setSupportedCardTypes(CardType.VISA)
+            .setSupportedCardTypes(CardType(cardBrand = CardBrand.VISA))
     }
 
     private fun getCustomCardConfigurationBuilder(): CardConfiguration.Builder {
@@ -949,7 +960,11 @@ internal class DefaultCardDelegateTest(
             .setAddressConfiguration(AddressConfiguration.FullAddress())
             .setKcpAuthVisibility(KCPAuthVisibility.SHOW)
             .setShowStorePaymentField(false)
-            .setSupportedCardTypes(CardType.VISA, CardType.MASTERCARD, CardType.AMERICAN_EXPRESS)
+            .setSupportedCardTypes(
+                CardType(cardBrand = CardBrand.VISA),
+                CardType(cardBrand = CardBrand.MASTERCARD),
+                CardType(cardBrand = CardBrand.AMERICAN_EXPRESS)
+            )
     }
 
     private fun createOutputData(
@@ -968,14 +983,20 @@ internal class DefaultCardDelegateTest(
         holderNameUIState: InputFieldUIState = InputFieldUIState.HIDDEN,
         showStorePaymentField: Boolean = true,
         detectedCardTypes: List<DetectedCardType> =
-            detectCardTypeRepository.getDetectedCardTypesLocal(listOf(CardType.VISA)),
+            detectCardTypeRepository.getDetectedCardTypesLocal(listOf(CardType(cardBrand = CardBrand.VISA))),
         isSocialSecurityNumberRequired: Boolean = false,
         isKCPAuthRequired: Boolean = false,
         addressUIState: AddressFormUIState = AddressFormUIState.NONE,
         installmentOptions: List<InstallmentModel> = emptyList(),
         isDualBranded: Boolean = false,
         @StringRes kcpBirthDateOrTaxNumberHint: Int = R.string.checkout_kcp_birth_date_or_tax_number_hint,
-        cardBrands: List<CardListItem> = listOf(CardListItem(CardType.VISA, true, Environment.TEST)),
+        cardBrands: List<CardListItem> = listOf(
+            CardListItem(
+                CardType(cardBrand = CardBrand.VISA),
+                true,
+                Environment.TEST
+            )
+        ),
         isCardListVisible: Boolean = true
     ): CardOutputData {
         return CardOutputData(
@@ -1007,7 +1028,7 @@ internal class DefaultCardDelegateTest(
     }
 
     private fun createDetectedCardType(
-        cardType: CardType = CardType.MASTERCARD,
+        cardType: CardType = CardType(cardBrand = CardBrand.MASTERCARD),
         isReliable: Boolean = true,
         enableLuhnCheck: Boolean = true,
         cvcPolicy: Brand.FieldPolicy = Brand.FieldPolicy.REQUIRED,

--- a/card/src/test/java/com/adyen/checkout/card/DualBrandedCardUtilsTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/DualBrandedCardUtilsTest.kt
@@ -1,6 +1,7 @@
 package com.adyen.checkout.card
 
 import com.adyen.checkout.card.api.model.Brand
+import com.adyen.checkout.card.data.CardBrand
 import com.adyen.checkout.card.data.CardType
 import com.adyen.checkout.card.data.DetectedCardType
 import com.adyen.checkout.card.util.DualBrandedCardUtils
@@ -19,7 +20,7 @@ internal class DualBrandedCardUtilsTest {
     fun testDualBrandSortingSingleItemList() {
         val detectedCards = listOf(
             DetectedCardType(
-                cardType = CardType.CARTEBANCAIRE,
+                cardType = CardType(cardBrand = CardBrand.CARTEBANCAIRE),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -35,7 +36,7 @@ internal class DualBrandedCardUtilsTest {
     fun testDualBrandVisaAndCarteBancaire() {
         val detectedCards = listOf(
             DetectedCardType(
-                cardType = CardType.CARTEBANCAIRE,
+                cardType = CardType(cardBrand = CardBrand.CARTEBANCAIRE),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -44,7 +45,7 @@ internal class DualBrandedCardUtilsTest {
                 panLength = null,
             ),
             DetectedCardType(
-                cardType = CardType.VISA,
+                cardType = CardType(cardBrand = CardBrand.VISA),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -56,7 +57,7 @@ internal class DualBrandedCardUtilsTest {
 
         val sortedCards = listOf(
             DetectedCardType(
-                cardType = CardType.VISA,
+                cardType = CardType(cardBrand = CardBrand.VISA),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -65,7 +66,7 @@ internal class DualBrandedCardUtilsTest {
                 panLength = null,
             ),
             DetectedCardType(
-                cardType = CardType.CARTEBANCAIRE,
+                cardType = CardType(cardBrand = CardBrand.CARTEBANCAIRE),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -82,7 +83,7 @@ internal class DualBrandedCardUtilsTest {
     fun testDualBrandVisaAndCarteBancaireAlreadySorted() {
         val detectedCards = listOf(
             DetectedCardType(
-                cardType = CardType.VISA,
+                cardType = CardType(cardBrand = CardBrand.VISA),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -91,7 +92,7 @@ internal class DualBrandedCardUtilsTest {
                 panLength = null,
             ),
             DetectedCardType(
-                cardType = CardType.CARTEBANCAIRE,
+                cardType = CardType(cardBrand = CardBrand.CARTEBANCAIRE),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -103,7 +104,7 @@ internal class DualBrandedCardUtilsTest {
 
         val sortedCards = listOf(
             DetectedCardType(
-                cardType = CardType.VISA,
+                cardType = CardType(cardBrand = CardBrand.VISA),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -112,7 +113,7 @@ internal class DualBrandedCardUtilsTest {
                 panLength = null,
             ),
             DetectedCardType(
-                cardType = CardType.CARTEBANCAIRE,
+                cardType = CardType(cardBrand = CardBrand.CARTEBANCAIRE),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -129,7 +130,7 @@ internal class DualBrandedCardUtilsTest {
     fun testDualBrandPlccAndMasterCard() {
         val detectedCards = listOf(
             DetectedCardType(
-                cardType = CardType.MASTERCARD,
+                cardType = CardType(cardBrand = CardBrand.MASTERCARD),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -138,7 +139,7 @@ internal class DualBrandedCardUtilsTest {
                 panLength = null,
             ),
             DetectedCardType(
-                cardType = CardType.UNKNOWN.apply { txVariant = "plcc_mastercard" },
+                cardType = CardType(txVariant = "plcc_mastercard"),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -150,7 +151,7 @@ internal class DualBrandedCardUtilsTest {
 
         val sortedCards = listOf(
             DetectedCardType(
-                cardType = CardType.UNKNOWN.apply { txVariant = "plcc_mastercard" },
+                cardType = CardType(txVariant = "plcc_mastercard"),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -159,7 +160,7 @@ internal class DualBrandedCardUtilsTest {
                 panLength = null,
             ),
             DetectedCardType(
-                cardType = CardType.MASTERCARD,
+                cardType = CardType(cardBrand = CardBrand.MASTERCARD),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -176,7 +177,7 @@ internal class DualBrandedCardUtilsTest {
     fun testDualBrandPlccAndMasterCardAlreadySorted() {
         val detectedCards = listOf(
             DetectedCardType(
-                cardType = CardType.UNKNOWN.apply { txVariant = "plcc_mastercard" },
+                cardType = CardType(txVariant = "plcc_mastercard"),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -185,7 +186,7 @@ internal class DualBrandedCardUtilsTest {
                 panLength = null,
             ),
             DetectedCardType(
-                cardType = CardType.MASTERCARD,
+                cardType = CardType(cardBrand = CardBrand.MASTERCARD),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -197,7 +198,7 @@ internal class DualBrandedCardUtilsTest {
 
         val sortedCards = listOf(
             DetectedCardType(
-                cardType = CardType.UNKNOWN.apply { txVariant = "plcc_mastercard" },
+                cardType = CardType(txVariant = "plcc_mastercard"),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -206,7 +207,7 @@ internal class DualBrandedCardUtilsTest {
                 panLength = null,
             ),
             DetectedCardType(
-                cardType = CardType.MASTERCARD,
+                cardType = CardType(cardBrand = CardBrand.MASTERCARD),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,

--- a/card/src/test/java/com/adyen/checkout/card/StoredCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/StoredCardDelegateTest.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.card
 
 import app.cash.turbine.test
 import com.adyen.checkout.card.api.model.Brand
+import com.adyen.checkout.card.data.CardBrand
 import com.adyen.checkout.card.data.CardType
 import com.adyen.checkout.card.data.DetectedCardType
 import com.adyen.checkout.card.data.ExpiryDate
@@ -174,7 +175,7 @@ internal class StoredCardDelegateTest(
         fun `security code is empty with a no cvc card, then output data should be valid`() = runTest {
             delegate = createCardDelegate(
                 storedPaymentMethod = getStoredPaymentMethod(
-                    brand = CardType.BCMC.txVariant,
+                    brand = CardBrand.BCMC.txVariant,
                 )
             )
 
@@ -258,7 +259,7 @@ internal class StoredCardDelegateTest(
                     assertTrue(isValid)
                     assertEquals(TEST_CARD_LAST_FOUR, lastFourDigits)
                     assertEquals("", binValue)
-                    assertEquals(CardType.MASTERCARD, cardType)
+                    assertEquals(CardType(cardBrand = CardBrand.MASTERCARD), cardType)
                 }
 
                 val paymentComponentData = componentState.data
@@ -383,7 +384,11 @@ internal class StoredCardDelegateTest(
             .setHolderNameRequired(true)
             .setAddressConfiguration(AddressConfiguration.FullAddress())
             .setKcpAuthVisibility(KCPAuthVisibility.SHOW)
-            .setSupportedCardTypes(CardType.VISA, CardType.MASTERCARD, CardType.AMERICAN_EXPRESS)
+            .setSupportedCardTypes(
+                CardType(cardBrand = CardBrand.VISA),
+                CardType(cardBrand = CardBrand.MASTERCARD),
+                CardType(cardBrand = CardBrand.AMERICAN_EXPRESS)
+            )
     }
 
     private fun createOutputData(
@@ -465,6 +470,6 @@ internal class StoredCardDelegateTest(
         private val TEST_EXPIRY_DATE = ExpiryDate(3, 2030)
         private const val TEST_SECURITY_CODE = "737"
         private const val TEST_STORED_PM_ID = "1337"
-        private val TEST_CARD_TYPE = CardType.MASTERCARD
+        private val TEST_CARD_TYPE = CardType(cardBrand = CardBrand.MASTERCARD)
     }
 }


### PR DESCRIPTION
## Description
- Fix supported card brands that are not part of predefined types inside `CardType.CardBrand` enum.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-708
