### PR TITLE
Remove hard-coded brand support on card component/drop-in Android SDK (V4)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,22 @@
 [//]: # ( # Deprecated)
 [//]: # ( - Configurations public constructor are deprecated, please use each Configuration's builder to make a Configuration object)
 
+# New
+* We added `CardBrand`, along with `CardType`, to use when adding new card brands through `CardConfiguration`.
+* In `CardConfiguration` when adding supported card types you can now add new supported card types which are not part of `CardType`.
+  example:
+
+```kotlin
+CardConfiguration.Builder([SHOPPER_LOCALE], [ENVIRONMENT], [CLIENT_KEY])
+.setSupportedCardTypes(CardBrand(txVariant = "[CARD_BRAND1]"), CardBrand(txVariant = "[CARD_BRAND2]"))
+.build()
+```
+
 ## Fixed
-- For cards, when the shopper enters a card number and a dual branded card is detected, a brand is no longer selected by default.
-- Drop-in no longer crashes when navigating back after the shopper removes all stored payment methods.
+* Undefined supported card types now works correctly for card component/drop-in.
+  `CardType.UNKNOWN` was not working correctly when there were supported card brands coming from `/paymentMethods`, under `scheme` payment method,
+  which are not part of `CardType` predefined brands, so we had to add `CardBrand` to make these undefined supported card types work.
+
+## Deprecated
+* The `CardType.UNKNOWN` property. Use `CardBrand(txVariant = "[CARD_BRAND]")` instead.
+* The `CardType.setTxVariant()` method. No longer needed as it was used with `CardType.UNKNOWN`

--- a/card/src/main/java/com/adyen/checkout/card/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponent.kt
@@ -229,7 +229,7 @@ class CardComponent private constructor(
             addressFormUIState,
             cardDelegate.getInstallmentOptions(
                 configuration.installmentConfiguration,
-                selectedOrFirstCardType?.cardType,
+                selectedOrFirstCardType?.cardBrand?.cardType,
                 isReliable
             ),
             countryOptions,
@@ -339,7 +339,7 @@ class CardComponent private constructor(
 
         val cardNumber = stateOutputData.cardNumberState.value
 
-        val firstCardType = stateOutputData.detectedCardTypes.firstOrNull()?.cardType
+        val firstCardType = stateOutputData.detectedCardTypes.firstOrNull()?.cardBrand?.cardType
 
         val binValue = if (
             stateOutputData.cardNumberState.validation.isValid() &&
@@ -440,7 +440,7 @@ class CardComponent private constructor(
         }
 
         if (isDualBrandedFlow(stateOutputData)) {
-            cardPaymentMethod.brand = stateOutputData.detectedCardTypes.firstOrNull { it.isSelected }?.cardType?.txVariant
+            cardPaymentMethod.brand = stateOutputData.detectedCardTypes.firstOrNull { it.isSelected }?.cardBrand?.txVariant
         }
 
         cardPaymentMethod.fundingSource = cardDelegate.getFundingSource()

--- a/card/src/main/java/com/adyen/checkout/card/CardComponentProvider.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponentProvider.kt
@@ -11,7 +11,7 @@ import android.os.Bundle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
-import com.adyen.checkout.card.data.CardType
+import com.adyen.checkout.card.data.CardBrand
 import com.adyen.checkout.card.repository.AddressRepository
 import com.adyen.checkout.card.repository.BinLookupRepository
 import com.adyen.checkout.components.StoredPaymentComponentProvider
@@ -101,30 +101,28 @@ class CardComponentProvider : StoredPaymentComponentProvider<CardComponent, Card
      * @return The Configuration object with possibly adjusted values.
      */
     private fun checkSupportedCardTypes(paymentMethod: PaymentMethod, cardConfiguration: CardConfiguration): CardConfiguration {
-        if (cardConfiguration.supportedCardTypes.isNotEmpty()) {
+        if (cardConfiguration.supportedCardBrands.isNotEmpty()) {
             return cardConfiguration
         }
 
         val brands = paymentMethod.brands
-        var supportedCardTypes = CardConfiguration.DEFAULT_SUPPORTED_CARDS_LIST
+        var supportedCardBrands = CardConfiguration.DEFAULT_SUPPORTED_CARDS_LIST.map {
+            CardBrand(it)
+        }
 
-        // Get card types from brands in PaymentMethod object
+        // Get card brands from brands in PaymentMethod object
         if (!brands.isNullOrEmpty()) {
-            supportedCardTypes = arrayListOf()
+            supportedCardBrands = arrayListOf()
             for (brand in brands) {
-                val brandType = CardType.getByBrandName(brand)
-                if (brandType != null) {
-                    supportedCardTypes.add(brandType)
-                } else {
-                    Logger.e(TAG, "Failed to get card type for brand: $brand")
-                }
+                val cardBrand = CardBrand(brand)
+                supportedCardBrands.add(cardBrand)
             }
         } else {
             Logger.d(TAG, "Falling back to DEFAULT_SUPPORTED_CARDS_LIST")
         }
         @Suppress("SpreadOperator")
         return cardConfiguration.newBuilder()
-            .setSupportedCardTypes(*supportedCardTypes.toTypedArray())
+            .setSupportedCardTypes(*supportedCardBrands.toTypedArray())
             .build()
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/CardConfiguration.java
+++ b/card/src/main/java/com/adyen/checkout/card/CardConfiguration.java
@@ -15,6 +15,7 @@ import android.os.Parcelable;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.adyen.checkout.card.data.CardBrand;
 import com.adyen.checkout.card.data.CardType;
 import com.adyen.checkout.components.base.AddressVisibility;
 import com.adyen.checkout.components.base.BaseConfigurationBuilder;
@@ -22,6 +23,7 @@ import com.adyen.checkout.components.base.Configuration;
 import com.adyen.checkout.core.api.Environment;
 import com.adyen.checkout.core.util.ParcelUtils;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -41,6 +43,7 @@ public class CardConfiguration extends Configuration {
     private final String mShopperReference;
     private final boolean mHolderNameRequired;
     private final List<CardType> mSupportedCardTypes;
+    private final List<CardBrand> mSupportedCardBrands;
     private final boolean mShowStorePaymentField;
     private final boolean mHideCvc;
     private final boolean mHideCvcStoredCard;
@@ -70,6 +73,7 @@ public class CardConfiguration extends Configuration {
 
         mHolderNameRequired = builder.mBuilderHolderNameRequired;
         mSupportedCardTypes = builder.mBuilderSupportedCardTypes;
+        mSupportedCardBrands = builder.mBuilderSupportedCardBrands;
         mShopperReference = builder.mShopperReference;
         mShowStorePaymentField = builder.mBuilderShowStorePaymentField;
         mHideCvc = builder.mBuilderHideCvc;
@@ -86,6 +90,7 @@ public class CardConfiguration extends Configuration {
         mShopperReference = in.readString();
         mHolderNameRequired = ParcelUtils.readBoolean(in);
         mSupportedCardTypes = in.readArrayList(CardType.class.getClassLoader());
+        mSupportedCardBrands = in.readArrayList(CardBrand.class.getClassLoader());
         mShowStorePaymentField = ParcelUtils.readBoolean(in);
         mHideCvc = ParcelUtils.readBoolean(in);
         mHideCvcStoredCard = ParcelUtils.readBoolean(in);
@@ -102,6 +107,7 @@ public class CardConfiguration extends Configuration {
         dest.writeString(mShopperReference);
         ParcelUtils.writeBoolean(dest, mHolderNameRequired);
         dest.writeList(mSupportedCardTypes);
+        dest.writeList(mSupportedCardBrands);
         ParcelUtils.writeBoolean(dest, mShowStorePaymentField);
         ParcelUtils.writeBoolean(dest, mHideCvc);
         ParcelUtils.writeBoolean(dest, mHideCvcStoredCard);
@@ -120,6 +126,15 @@ public class CardConfiguration extends Configuration {
     @NonNull
     public List<CardType> getSupportedCardTypes() {
         return mSupportedCardTypes;
+    }
+
+    /**
+     * The list of {@link CardBrand} that this payment supports. Used to predict the card type of the
+     * @return The list of {@link CardBrand}.
+     */
+    @NonNull
+    public List<CardBrand> getSupportedCardBrands() {
+        return mSupportedCardBrands;
     }
 
     /**
@@ -190,6 +205,8 @@ public class CardConfiguration extends Configuration {
     public static final class Builder extends BaseConfigurationBuilder<CardConfiguration> {
 
         private List<CardType> mBuilderSupportedCardTypes = Collections.emptyList();
+
+        private List<CardBrand> mBuilderSupportedCardBrands = new ArrayList<>();
         private boolean mBuilderHolderNameRequired;
         private boolean mBuilderShowStorePaymentField = true;
         private String mShopperReference;
@@ -207,6 +224,7 @@ public class CardConfiguration extends Configuration {
         public Builder(@NonNull CardConfiguration cardConfiguration) {
             super(cardConfiguration);
             mBuilderSupportedCardTypes = cardConfiguration.getSupportedCardTypes();
+            mBuilderSupportedCardBrands = cardConfiguration.getSupportedCardBrands();
             mBuilderHolderNameRequired = cardConfiguration.isHolderNameRequired();
             mBuilderShowStorePaymentField = cardConfiguration.isStorePaymentFieldVisible();
             mShopperReference = cardConfiguration.getShopperReference();
@@ -265,6 +283,25 @@ public class CardConfiguration extends Configuration {
         @NonNull
         public Builder setSupportedCardTypes(@NonNull CardType... supportCardTypes) {
             mBuilderSupportedCardTypes = Arrays.asList(supportCardTypes);
+            final List<CardBrand> cardBrands = new ArrayList<>();
+            for (CardType cardType : mBuilderSupportedCardTypes) {
+                cardBrands.add(new CardBrand(cardType));
+            }
+            mBuilderSupportedCardBrands.clear();
+            mBuilderSupportedCardBrands.addAll(cardBrands);
+            return this;
+        }
+
+        /**
+         * Set the supported card types for this payment. Supported types will be shown as user inputs the card number.
+         * Use this method when adding supported card types that are not inside the {@link CardType} enum.
+         *
+         * @param supportCardBrands array of {@link CardBrand}
+         * @return {@link CardConfiguration.Builder}
+         */
+        @NonNull
+        public Builder setSupportedCardTypes(@NonNull CardBrand... supportCardBrands) {
+            mBuilderSupportedCardBrands = Arrays.asList(supportCardBrands);
             return this;
         }
 

--- a/card/src/main/java/com/adyen/checkout/card/CardListAdapter.java
+++ b/card/src/main/java/com/adyen/checkout/card/CardListAdapter.java
@@ -15,7 +15,7 @@ import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.adyen.checkout.card.data.CardType;
+import com.adyen.checkout.card.data.CardBrand;
 import com.adyen.checkout.components.api.ImageLoader;
 import com.adyen.checkout.components.ui.view.RoundCornerImageView;
 
@@ -24,14 +24,14 @@ import java.util.List;
 
 public class CardListAdapter extends RecyclerView.Adapter<CardListAdapter.ImageViewHolder> {
 
-    private final List<CardType> mSupportedCards;
-    private List<CardType> mFilteredCards = Collections.emptyList();
+    private final List<CardBrand> mSupportedCards;
+    private List<CardBrand> mFilteredCards = Collections.emptyList();
     private final ImageLoader mImageLoader;
 
     private static final float ACTIVE = 1f;
     private static final float NOT_ACTIVE = 0.2f;
 
-    public CardListAdapter(@NonNull ImageLoader imageLoader, @NonNull List<CardType> supportedCards) {
+    public CardListAdapter(@NonNull ImageLoader imageLoader, @NonNull List<CardBrand> supportedCards) {
         mImageLoader = imageLoader;
         mSupportedCards = supportedCards;
     }
@@ -48,7 +48,7 @@ public class CardListAdapter extends RecyclerView.Adapter<CardListAdapter.ImageV
 
     @Override
     public void onBindViewHolder(@NonNull ImageViewHolder imageViewHolder, int i) {
-        final CardType card = mSupportedCards.get(i);
+        final CardBrand card = mSupportedCards.get(i);
         imageViewHolder.mCardLogo.setAlpha(mFilteredCards.isEmpty() || mFilteredCards.contains(card) ? ACTIVE : NOT_ACTIVE);
         mImageLoader.load(card.getTxVariant(), imageViewHolder.mCardLogo);
     }
@@ -59,7 +59,7 @@ public class CardListAdapter extends RecyclerView.Adapter<CardListAdapter.ImageV
     }
 
 
-    public void setFilteredCard(@NonNull List<CardType> filteredCards) {
+    public void setFilteredCard(@NonNull List<CardBrand> filteredCards) {
         this.mFilteredCards = filteredCards;
         notifyDataSetChanged();
     }

--- a/card/src/main/java/com/adyen/checkout/card/CardView.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardView.kt
@@ -271,11 +271,11 @@ class CardView @JvmOverloads constructor(context: Context, attrs: AttributeSet? 
             val firstDetectedCardType = detectedCardTypes.first()
 
             binding.cardBrandLogoImageViewPrimary.setStrokeWidth(RoundCornerImageView.DEFAULT_STROKE_WIDTH)
-            mImageLoader?.load(firstDetectedCardType.cardType.txVariant, binding.cardBrandLogoImageViewPrimary, 0, R.drawable.ic_card)
+            mImageLoader?.load(firstDetectedCardType.cardBrand.txVariant, binding.cardBrandLogoImageViewPrimary, 0, R.drawable.ic_card)
             setDualBrandedCardImages(detectedCardTypes, cardOutputData.cardNumberState.validation)
 
             // TODO: 29/01/2021 get this logic from OutputData
-            val isAmex = detectedCardTypes.any { it.cardType == CardType.AMERICAN_EXPRESS }
+            val isAmex = detectedCardTypes.any { it.cardBrand.cardType == CardType.AMERICAN_EXPRESS }
             binding.editTextCardNumber.setAmexCardFormat(isAmex)
 
             if (detectedCardTypes.size == 1 &&
@@ -299,7 +299,7 @@ class CardView @JvmOverloads constructor(context: Context, attrs: AttributeSet? 
             detectedCardTypes.getOrNull(1)?.takeIf { it.isReliable }?.let {
                 binding.cardBrandLogoContainerSecondary.isVisible = true
                 binding.cardBrandLogoImageViewSecondary.setStrokeWidth(RoundCornerImageView.DEFAULT_STROKE_WIDTH)
-                mImageLoader?.load(it.cardType.txVariant, binding.cardBrandLogoImageViewSecondary, 0, R.drawable.ic_card)
+                mImageLoader?.load(it.cardBrand.txVariant, binding.cardBrandLogoImageViewSecondary, 0, R.drawable.ic_card)
                 initCardBrandLogoViews(detectedCardTypes.indexOfFirst { it.isSelected })
                 initBrandSelectionListeners()
             } ?: run {

--- a/card/src/main/java/com/adyen/checkout/card/NewCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/NewCardDelegate.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.card
 
 import com.adyen.checkout.card.api.model.AddressItem
 import com.adyen.checkout.card.api.model.Brand
+import com.adyen.checkout.card.data.CardBrand
 import com.adyen.checkout.card.data.CardType
 import com.adyen.checkout.card.data.DetectedCardType
 import com.adyen.checkout.card.data.ExpiryDate
@@ -219,23 +220,23 @@ class NewCardDelegate(
         if (cardNumber.isEmpty()) {
             return emptyList()
         }
-        val supportedCardTypes = cardConfiguration.supportedCardTypes
-        val estimateCardTypes = CardType.estimate(cardNumber)
-        return estimateCardTypes.map { localDetectedCard(it, supportedCardTypes) }
+        val supportedCardBrands = cardConfiguration.supportedCardBrands
+        val estimateCardBrands = CardType.estimate(cardNumber).map { CardBrand(it) }
+        return estimateCardBrands.map { localDetectedCard(it, supportedCardBrands) }
     }
 
-    private fun localDetectedCard(cardType: CardType, supportedCardTypes: List<CardType>): DetectedCardType {
+    private fun localDetectedCard(cardBrand: CardBrand, supportedCardBrands: List<CardBrand>): DetectedCardType {
         return DetectedCardType(
-            cardType,
+            cardBrand,
             isReliable = false,
             enableLuhnCheck = true,
             cvcPolicy = when {
-                noCvcBrands.contains(cardType) -> Brand.FieldPolicy.HIDDEN
+                noCvcBrands.contains(cardBrand.cardType) -> Brand.FieldPolicy.HIDDEN
                 else -> Brand.FieldPolicy.REQUIRED
             },
             expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
             panLength = null,
-            isSupported = supportedCardTypes.contains(cardType),
+            isSupported = supportedCardBrands.contains(cardBrand),
         )
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/data/CardBrand.kt
+++ b/card/src/main/java/com/adyen/checkout/card/data/CardBrand.kt
@@ -1,0 +1,39 @@
+package com.adyen.checkout.card.data
+
+import android.os.Parcel
+import android.os.Parcelable
+
+data class CardBrand(val txVariant: String) : Parcelable {
+
+    internal var cardType: CardType? = CardType.getByBrandName(txVariant)
+        private set
+
+    /**
+     * Use this constructor when defining the supported card type predefined inside [CardType] enum
+     * inside your component
+     */
+    constructor(cardType: CardType) : this(cardType.txVariant) {
+        this.cardType = cardType
+    }
+
+    private constructor(parcel: Parcel) : this(parcel.readString().orEmpty())
+
+    override fun describeContents(): Int = 0
+
+    override fun writeToParcel(parcel: Parcel, i: Int) {
+        parcel.writeString(txVariant)
+    }
+
+    companion object {
+        @JvmField
+        val CREATOR = object : Parcelable.Creator<CardBrand> {
+            override fun createFromParcel(parcel: Parcel): CardBrand {
+                return CardBrand(parcel)
+            }
+
+            override fun newArray(size: Int): Array<CardBrand?> {
+                return arrayOfNulls(size)
+            }
+        }
+    }
+}

--- a/card/src/main/java/com/adyen/checkout/card/data/CardType.java
+++ b/card/src/main/java/com/adyen/checkout/card/data/CardType.java
@@ -57,7 +57,13 @@ public enum CardType {
     UATP("uatp", Pattern.compile("^1[0-9]{0,14}$")),
     VISA("visa", Pattern.compile("^4[0-9]{0,18}$")),
     VISADANKORT("visadankort", Pattern.compile("^(4571)[0-9]{0,12}$")),
-    // UNKNOWN type is used for txVariants that are valid but not accounted for in this enum
+    /**
+     * UNKNOWN type is used for txVariants that are valid but not accounted for in this enum.
+     *
+     * @deprecated Was not working correctly when there were more than one card brand. Use
+     * {@link CardBrand} instead when adding supported card brand that isn't inside this enum.
+     */
+    @Deprecated
     UNKNOWN("", Pattern.compile("([1-9])+"));
 
     private String mTxVariant;
@@ -111,6 +117,10 @@ public enum CardType {
         return mTxVariant;
     }
 
+    /**
+     * @deprecated No longer needed as it was used with {@link CardType#UNKNOWN} which is deprecated.
+     */
+    @Deprecated
     public void setTxVariant(@NonNull String txVariant) {
         mTxVariant = txVariant;
     }

--- a/card/src/main/java/com/adyen/checkout/card/data/DetectedCardType.kt
+++ b/card/src/main/java/com/adyen/checkout/card/data/DetectedCardType.kt
@@ -11,7 +11,7 @@ package com.adyen.checkout.card.data
 import com.adyen.checkout.card.api.model.Brand
 
 data class DetectedCardType(
-    val cardType: CardType,
+    val cardBrand: CardBrand,
     val isReliable: Boolean,
     val enableLuhnCheck: Boolean,
     val cvcPolicy: Brand.FieldPolicy,

--- a/card/src/main/java/com/adyen/checkout/card/util/AddressValidationUtils.kt
+++ b/card/src/main/java/com/adyen/checkout/card/util/AddressValidationUtils.kt
@@ -103,7 +103,7 @@ object AddressValidationUtils {
                 if (detectedCardType == null) {
                     false
                 } else {
-                    policy.brands.contains(detectedCardType.cardType.txVariant)
+                    policy.brands.contains(detectedCardType.cardBrand.txVariant)
                 }
             }
         }

--- a/card/src/main/java/com/adyen/checkout/card/util/CardValidationUtils.kt
+++ b/card/src/main/java/com/adyen/checkout/card/util/CardValidationUtils.kt
@@ -15,8 +15,7 @@ import com.adyen.checkout.card.data.ExpiryDate
 import com.adyen.checkout.components.ui.FieldState
 import com.adyen.checkout.components.ui.Validation
 import com.adyen.checkout.core.util.StringUtil
-import java.util.Calendar
-import java.util.GregorianCalendar
+import java.util.*
 
 object CardValidationUtils {
 
@@ -109,8 +108,8 @@ object CardValidationUtils {
         val validation = when {
             !StringUtil.isDigitsAndSeparatorsOnly(normalizedSecurityCode) -> invalidState
             cardType?.cvcPolicy == Brand.FieldPolicy.OPTIONAL && length == 0 -> Validation.Valid
-            cardType?.cardType == CardType.AMERICAN_EXPRESS && length == AMEX_SECURITY_CODE_SIZE -> Validation.Valid
-            cardType?.cardType != CardType.AMERICAN_EXPRESS && length == GENERAL_CARD_SECURITY_CODE_SIZE -> Validation.Valid
+            cardType?.cardBrand?.cardType == CardType.AMERICAN_EXPRESS && length == AMEX_SECURITY_CODE_SIZE -> Validation.Valid
+            cardType?.cardBrand?.cardType != CardType.AMERICAN_EXPRESS && length == GENERAL_CARD_SECURITY_CODE_SIZE -> Validation.Valid
             else -> invalidState
         }
         return FieldState(normalizedSecurityCode, validation)

--- a/card/src/main/java/com/adyen/checkout/card/util/DualBrandedCardUtils.kt
+++ b/card/src/main/java/com/adyen/checkout/card/util/DualBrandedCardUtils.kt
@@ -9,16 +9,19 @@ object DualBrandedCardUtils {
         return if (cards.size <= 1) {
             cards
         } else {
-            val hasCarteBancaire = cards.any { it.cardType == CardType.CARTEBANCAIRE }
-            val hasVisa = cards.any { it.cardType == CardType.VISA }
+            val hasCarteBancaire = cards.any { it.cardBrand.cardType == CardType.CARTEBANCAIRE }
+            val hasVisa = cards.any { it.cardBrand.cardType == CardType.VISA }
             val hasPlcc = cards.any {
-                it.cardType == CardType.UNKNOWN &&
-                    (it.cardType.txVariant.contains("plcc") || it.cardType.txVariant.contains("cbcc"))
+                it.cardBrand.txVariant.contains("plcc") ||
+                    it.cardBrand.txVariant.contains("cbcc")
             }
 
             when {
-                hasCarteBancaire && hasVisa -> cards.sortedByDescending { it.cardType == CardType.VISA }
-                hasPlcc -> cards.sortedByDescending { it.cardType.txVariant.contains("plcc") || it.cardType.txVariant.contains("cbcc") }
+                hasCarteBancaire && hasVisa -> cards.sortedByDescending { it.cardBrand.cardType == CardType.VISA }
+                hasPlcc -> cards.sortedByDescending {
+                    it.cardBrand.txVariant.contains("plcc") ||
+                        it.cardBrand.txVariant.contains("cbcc")
+                }
                 else -> cards
             }
         }

--- a/card/src/test/java/com/adyen/checkout/card/CardBrandTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/CardBrandTest.kt
@@ -1,0 +1,55 @@
+package com.adyen.checkout.card
+
+import com.adyen.checkout.card.data.CardBrand
+import com.adyen.checkout.card.data.CardType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CardBrandTest {
+
+    @Test
+    fun `test if card number is not part of predefined card brand enum`() {
+        val sodexoCard = CardBrand(txVariant = "sodexo")
+        val cardTypes = CardType.estimate(SODEXO_CARD_NUMBER)
+
+        val isPredefinedBrand = cardTypes.contains(sodexoCard.cardType)
+
+        assertFalse(isPredefinedBrand)
+    }
+
+    @Test
+    fun `test if card number is part of predefined card brand enum`() {
+        val amexCard = CardBrand(CardType.AMERICAN_EXPRESS)
+        val cardTypes = CardType.estimate(AMEX_CARD_NUMBER)
+
+        val isPredefinedBrand = cardTypes.contains(amexCard.cardType)
+
+        assertTrue(isPredefinedBrand)
+    }
+
+    @Test
+    fun `test if card brand is not part of predefined card brand enum`() {
+        val sodexoCard = CardBrand(txVariant = "sodexo")
+
+        val result = CardType.getByBrandName(sodexoCard.txVariant)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `test if card brand is part of predefined card brand enum`() {
+        val amexCard = CardBrand(txVariant = "amex")
+
+        val result = CardType.getByBrandName(amexCard.txVariant)
+
+        assertEquals(result, CardType.AMERICAN_EXPRESS)
+    }
+
+    companion object {
+        private const val SODEXO_CARD_NUMBER = "6033890257034050"
+        private const val AMEX_CARD_NUMBER = "370000000000002"
+    }
+}

--- a/card/src/test/java/com/adyen/checkout/card/DualBrandedCardUtilsTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/DualBrandedCardUtilsTest.kt
@@ -1,6 +1,7 @@
 package com.adyen.checkout.card
 
 import com.adyen.checkout.card.api.model.Brand
+import com.adyen.checkout.card.data.CardBrand
 import com.adyen.checkout.card.data.CardType
 import com.adyen.checkout.card.data.DetectedCardType
 import com.adyen.checkout.card.util.DualBrandedCardUtils
@@ -19,7 +20,7 @@ class DualBrandedCardUtilsTest {
     fun testDualBrandSortingSingleItemList() {
         val detectedCards = listOf(
             DetectedCardType(
-                cardType = CardType.CARTEBANCAIRE,
+                cardBrand = CardBrand(CardType.CARTEBANCAIRE),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -35,7 +36,7 @@ class DualBrandedCardUtilsTest {
     fun testDualBrandVisaAndCarteBancaire() {
         val detectedCards = listOf(
             DetectedCardType(
-                cardType = CardType.CARTEBANCAIRE,
+                cardBrand = CardBrand(CardType.CARTEBANCAIRE),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -44,7 +45,7 @@ class DualBrandedCardUtilsTest {
                 isSupported = true
             ),
             DetectedCardType(
-                cardType = CardType.VISA,
+                cardBrand = CardBrand(CardType.VISA),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -56,7 +57,7 @@ class DualBrandedCardUtilsTest {
 
         val sortedCards = listOf(
             DetectedCardType(
-                cardType = CardType.VISA,
+                cardBrand = CardBrand(CardType.VISA),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -65,7 +66,7 @@ class DualBrandedCardUtilsTest {
                 isSupported = true
             ),
             DetectedCardType(
-                cardType = CardType.CARTEBANCAIRE,
+                cardBrand = CardBrand(CardType.CARTEBANCAIRE),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -82,7 +83,7 @@ class DualBrandedCardUtilsTest {
     fun testDualBrandVisaAndCarteBancaireAlreadySorted() {
         val detectedCards = listOf(
             DetectedCardType(
-                cardType = CardType.VISA,
+                cardBrand = CardBrand(CardType.VISA),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -91,7 +92,7 @@ class DualBrandedCardUtilsTest {
                 isSupported = true
             ),
             DetectedCardType(
-                cardType = CardType.CARTEBANCAIRE,
+                cardBrand = CardBrand(CardType.CARTEBANCAIRE),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -103,7 +104,7 @@ class DualBrandedCardUtilsTest {
 
         val sortedCards = listOf(
             DetectedCardType(
-                cardType = CardType.VISA,
+                cardBrand = CardBrand(CardType.VISA),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -112,7 +113,7 @@ class DualBrandedCardUtilsTest {
                 isSupported = true
             ),
             DetectedCardType(
-                cardType = CardType.CARTEBANCAIRE,
+                cardBrand = CardBrand(CardType.CARTEBANCAIRE),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -129,7 +130,7 @@ class DualBrandedCardUtilsTest {
     fun testDualBrandPlccAndMasterCard() {
         val detectedCards = listOf(
             DetectedCardType(
-                cardType = CardType.MASTERCARD,
+                cardBrand = CardBrand(CardType.MASTERCARD),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -138,7 +139,7 @@ class DualBrandedCardUtilsTest {
                 isSupported = true
             ),
             DetectedCardType(
-                cardType = CardType.UNKNOWN.apply { txVariant = "plcc_mastercard" },
+                cardBrand = CardBrand(txVariant = "plcc_mastercard"),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -150,7 +151,7 @@ class DualBrandedCardUtilsTest {
 
         val sortedCards = listOf(
             DetectedCardType(
-                cardType = CardType.UNKNOWN.apply { txVariant = "plcc_mastercard" },
+                cardBrand = CardBrand(txVariant = "plcc_mastercard"),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -159,7 +160,7 @@ class DualBrandedCardUtilsTest {
                 isSupported = true
             ),
             DetectedCardType(
-                cardType = CardType.MASTERCARD,
+                cardBrand = CardBrand(CardType.MASTERCARD),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -176,7 +177,7 @@ class DualBrandedCardUtilsTest {
     fun testDualBrandPlccAndMasterCardAlreadySorted() {
         val detectedCards = listOf(
             DetectedCardType(
-                cardType = CardType.UNKNOWN.apply { txVariant = "plcc_mastercard" },
+                cardBrand = CardBrand(txVariant = "plcc_mastercard"),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -185,7 +186,7 @@ class DualBrandedCardUtilsTest {
                 isSupported = true
             ),
             DetectedCardType(
-                cardType = CardType.MASTERCARD,
+                cardBrand = CardBrand(CardType.MASTERCARD),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -197,7 +198,7 @@ class DualBrandedCardUtilsTest {
 
         val sortedCards = listOf(
             DetectedCardType(
-                cardType = CardType.UNKNOWN.apply { txVariant = "plcc_mastercard" },
+                cardBrand = CardBrand(txVariant = "plcc_mastercard"),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -206,7 +207,7 @@ class DualBrandedCardUtilsTest {
                 isSupported = true
             ),
             DetectedCardType(
-                cardType = CardType.MASTERCARD,
+                cardBrand = CardBrand(CardType.MASTERCARD),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/CardComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/CardComponentDialogFragment.kt
@@ -16,7 +16,7 @@ import androidx.core.view.isVisible
 import com.adyen.checkout.card.CardComponent
 import com.adyen.checkout.card.CardComponentState
 import com.adyen.checkout.card.CardListAdapter
-import com.adyen.checkout.card.data.CardType
+import com.adyen.checkout.card.data.CardBrand
 import com.adyen.checkout.components.PaymentComponentState
 import com.adyen.checkout.components.api.ImageLoader
 import com.adyen.checkout.components.model.payments.request.PaymentMethodDetails
@@ -92,9 +92,9 @@ class CardComponentDialogFragment : BaseComponentDialogFragment() {
         }
 
         val supportedCards = if (cardComponent.isStoredPaymentMethod()) {
-            emptyList<CardType>()
+            emptyList<CardBrand>()
         } else {
-            cardComponent.configuration.supportedCardTypes
+            cardComponent.configuration.supportedCardBrands
         }
         cardListAdapter = CardListAdapter(
             ImageLoader.getInstance(requireContext(), component.configuration.environment),
@@ -108,7 +108,9 @@ class CardComponentDialogFragment : BaseComponentDialogFragment() {
         val cardComponentState = paymentComponentState as? CardComponentState
         if (cardComponentState?.cardType != null && !cardComponent.isStoredPaymentMethod()) {
             // TODO: 11/01/2021 pass list of cards from Bin Lookup
-            cardListAdapter.setFilteredCard(listOf(cardComponentState.cardType))
+            cardListAdapter.setFilteredCard(
+                listOf(CardBrand(txVariant = cardComponentState.cardType?.txVariant.orEmpty()))
+            )
         } else {
             cardListAdapter.setFilteredCard(emptyList())
         }


### PR DESCRIPTION
## Description

- Fix supported card brands that are not part of predefined types inside `CardBrand.CardType` enum.
- Add `SupportedCardBrands` inside `CardConfiguration`
- Add new method `CardConfiguration.setSupportedCardTypes` with new argument `CardBrand` to allow merchants to add more `supported` types that are not predefined inside `CardType` enum.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-708
