### PR TITLE
Remove non suspending methods from PaymentsRepository

### DIFF
--- a/example-app/src/main/java/com/adyen/checkout/example/repositories/PaymentsRepository.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/repositories/PaymentsRepository.kt
@@ -23,38 +23,30 @@ import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import org.json.JSONObject
 
 interface PaymentsRepository {
-    suspend fun getSessionAsync(sessionRequest: SessionRequest): SessionModel?
+    suspend fun createSession(sessionRequest: SessionRequest): SessionModel?
     suspend fun getPaymentMethods(paymentMethodsRequest: PaymentMethodsRequest): PaymentMethodsApiResponse?
-    fun paymentsRequest(paymentsRequest: PaymentsRequest): JSONObject?
-    suspend fun paymentsRequestAsync(paymentsRequest: PaymentsRequest): JSONObject?
-    fun detailsRequest(detailsRequest: JSONObject): JSONObject?
-    suspend fun detailsRequestAsync(detailsRequest: JSONObject): JSONObject?
-    suspend fun balanceRequestAsync(request: BalanceRequest): JSONObject?
-    suspend fun createOrderAsync(orderRequest: CreateOrderRequest): JSONObject?
-    suspend fun cancelOrderAsync(request: CancelOrderRequest): JSONObject?
+    suspend fun makePaymentsRequest(paymentsRequest: PaymentsRequest): JSONObject?
+    suspend fun makeDetailsRequest(detailsRequest: JSONObject): JSONObject?
+    suspend fun getBalance(request: BalanceRequest): JSONObject?
+    suspend fun createOrder(orderRequest: CreateOrderRequest): JSONObject?
+    suspend fun cancelOrder(request: CancelOrderRequest): JSONObject?
 }
 
 @Suppress("TooManyFunctions")
 internal class PaymentsRepositoryImpl(private val checkoutApiService: CheckoutApiService) : PaymentsRepository {
 
-    override suspend fun getSessionAsync(sessionRequest: SessionRequest): SessionModel? {
-        return safeApiCall { checkoutApiService.sessionsAsync(sessionRequest) }
+    override suspend fun createSession(sessionRequest: SessionRequest): SessionModel? = safeApiCall {
+        checkoutApiService.sessionsAsync(sessionRequest)
     }
 
-    override suspend fun getPaymentMethods(paymentMethodsRequest: PaymentMethodsRequest): PaymentMethodsApiResponse? {
-        return safeApiCall(
-            call = { checkoutApiService.paymentMethodsAsync(paymentMethodsRequest) }
-        )
+    override suspend fun getPaymentMethods(
+        paymentMethodsRequest: PaymentMethodsRequest
+    ): PaymentMethodsApiResponse? = safeApiCall {
+        checkoutApiService.paymentMethodsAsync(paymentMethodsRequest)
     }
 
-    override fun paymentsRequest(paymentsRequest: PaymentsRequest): JSONObject? {
-        return checkoutApiService.payments(paymentsRequest.combineToJSONObject()).execute().body()
-    }
-
-    override suspend fun paymentsRequestAsync(paymentsRequest: PaymentsRequest): JSONObject? {
-        return safeApiCall(
-            call = { checkoutApiService.paymentsAsync(paymentsRequest.combineToJSONObject()) }
-        )
+    override suspend fun makePaymentsRequest(paymentsRequest: PaymentsRequest): JSONObject? = safeApiCall {
+        checkoutApiService.paymentsAsync(paymentsRequest.combineToJSONObject())
     }
 
     private fun PaymentsRequest.combineToJSONObject(): JSONObject {
@@ -77,31 +69,19 @@ internal class PaymentsRepositoryImpl(private val checkoutApiService: CheckoutAp
         return this
     }
 
-    override fun detailsRequest(detailsRequest: JSONObject): JSONObject? {
-        return checkoutApiService.details(detailsRequest).execute().body()
+    override suspend fun makeDetailsRequest(detailsRequest: JSONObject): JSONObject? = safeApiCall {
+        checkoutApiService.detailsAsync(detailsRequest)
     }
 
-    override suspend fun detailsRequestAsync(detailsRequest: JSONObject): JSONObject? {
-        return safeApiCall(
-            call = { checkoutApiService.detailsAsync(detailsRequest) }
-        )
+    override suspend fun getBalance(request: BalanceRequest): JSONObject? = safeApiCall {
+        checkoutApiService.checkBalanceAsync(request)
     }
 
-    override suspend fun balanceRequestAsync(request: BalanceRequest): JSONObject? {
-        return safeApiCall(
-            call = { checkoutApiService.checkBalanceAsync(request) }
-        )
+    override suspend fun createOrder(orderRequest: CreateOrderRequest): JSONObject? = safeApiCall {
+        checkoutApiService.createOrderAsync(orderRequest)
     }
 
-    override suspend fun createOrderAsync(orderRequest: CreateOrderRequest): JSONObject? {
-        return safeApiCall(
-            call = { checkoutApiService.createOrderAsync(orderRequest) }
-        )
-    }
-
-    override suspend fun cancelOrderAsync(request: CancelOrderRequest): JSONObject? {
-        return safeApiCall(
-            call = { checkoutApiService.cancelOrderAsync(request) }
-        )
+    override suspend fun cancelOrder(request: CancelOrderRequest): JSONObject? = safeApiCall {
+        checkoutApiService.cancelOrderAsync(request)
     }
 }

--- a/example-app/src/main/java/com/adyen/checkout/example/repositories/RecurringRepository.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/repositories/RecurringRepository.kt
@@ -20,6 +20,9 @@ internal class RecurringRepositoryImpl(
     private val recurringApiService: RecurringApiService
 ) : RecurringRepository {
 
-    override suspend fun removeStoredPaymentMethod(request: RemoveStoredPaymentMethodRequest): JSONObject? =
-        safeApiCall { recurringApiService.removeStoredPaymentMethodAsync(request) }
+    override suspend fun removeStoredPaymentMethod(
+        request: RemoveStoredPaymentMethodRequest
+    ): JSONObject? = safeApiCall {
+        recurringApiService.removeStoredPaymentMethodAsync(request)
+    }
 }

--- a/example-app/src/main/java/com/adyen/checkout/example/service/ExampleAdvancedDropInService.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/service/ExampleAdvancedDropInService.kt
@@ -87,7 +87,7 @@ class ExampleAdvancedDropInService : DropInService() {
             )
 
             Logger.v(TAG, "paymentComponentJson - ${paymentComponentJson.toStringPretty()}")
-            val response = paymentsRepository.paymentsRequestAsync(paymentRequest)
+            val response = paymentsRepository.makePaymentsRequest(paymentRequest)
 
             val result = handleResponse(response) ?: return@launch
             sendResult(result)
@@ -119,7 +119,7 @@ class ExampleAdvancedDropInService : DropInService() {
 
             Logger.v(TAG, "payments/details/ - ${actionComponentJson.toStringPretty()}")
 
-            val response = paymentsRepository.detailsRequestAsync(actionComponentJson)
+            val response = paymentsRepository.makeDetailsRequest(actionComponentJson)
 
             val result = handleResponse(response) ?: return@launch
             sendResult(result)
@@ -221,7 +221,7 @@ class ExampleAdvancedDropInService : DropInService() {
                 keyValueStorage.getMerchantAccount()
             )
 
-            val response = paymentsRepository.balanceRequestAsync(request)
+            val response = paymentsRepository.getBalance(request)
             val result = handleBalanceResponse(response)
             sendBalanceResult(result)
         }
@@ -252,7 +252,7 @@ class ExampleAdvancedDropInService : DropInService() {
                 keyValueStorage.getMerchantAccount()
             )
 
-            val response = paymentsRepository.createOrderAsync(paymentRequest)
+            val response = paymentsRepository.createOrder(paymentRequest)
 
             val result = handleOrderResponse(response)
             sendOrderResult(result)
@@ -279,7 +279,7 @@ class ExampleAdvancedDropInService : DropInService() {
                 orderJson,
                 keyValueStorage.getMerchantAccount()
             )
-            val response = paymentsRepository.cancelOrderAsync(request)
+            val response = paymentsRepository.cancelOrder(request)
 
             val result = handleCancelOrderResponse(response, shouldUpdatePaymentMethods) ?: return@launch
             sendResult(result)

--- a/example-app/src/main/java/com/adyen/checkout/example/service/ExampleDropInService.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/service/ExampleDropInService.kt
@@ -74,7 +74,7 @@ class ExampleDropInService : DropInService() {
             )
 
             Logger.v(TAG, "paymentComponentJson - ${paymentComponentJson.toStringPretty()}")
-            val response = paymentsRepository.paymentsRequestAsync(paymentRequest)
+            val response = paymentsRepository.makePaymentsRequest(paymentRequest)
 
             val result = handleResponse(response)
             sendResult(result)
@@ -98,7 +98,7 @@ class ExampleDropInService : DropInService() {
 
             Logger.v(TAG, "payments/details/ - ${actionComponentJson.toStringPretty()}")
 
-            val response = paymentsRepository.detailsRequestAsync(actionComponentJson)
+            val response = paymentsRepository.makeDetailsRequest(actionComponentJson)
 
             val result = handleResponse(response)
             sendResult(result)

--- a/example-app/src/main/java/com/adyen/checkout/example/service/ExampleSessionsDropInService.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/service/ExampleSessionsDropInService.kt
@@ -67,7 +67,7 @@ class ExampleSessionsDropInService : SessionDropInService() {
                 )
 
                 Logger.v(TAG, "paymentComponentJson - ${paymentComponentJson.toStringPretty()}")
-                val response = paymentsRepository.paymentsRequestAsync(paymentRequest)
+                val response = paymentsRepository.makePaymentsRequest(paymentRequest)
 
                 val result = handleResponse(response)
                 sendResult(result)
@@ -85,7 +85,7 @@ class ExampleSessionsDropInService : SessionDropInService() {
             launch(Dispatchers.IO) {
                 Logger.d(TAG, "onDetailsCallRequested")
 
-                val response = paymentsRepository.detailsRequestAsync(
+                val response = paymentsRepository.makeDetailsRequest(
                     ActionComponentData.SERIALIZER.serialize(actionComponentData)
                 )
 

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/bacs/BacsViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/bacs/BacsViewModel.kt
@@ -111,7 +111,7 @@ internal class BacsViewModel @Inject constructor(
     private fun sendPaymentDetails(actionComponentData: ActionComponentData) {
         viewModelScope.launch(Dispatchers.IO) {
             val json = ActionComponentData.SERIALIZER.serialize(actionComponentData)
-            handlePaymentResponse(paymentsRepository.detailsRequestAsync(json))
+            handlePaymentResponse(paymentsRepository.makeDetailsRequest(json))
         }
     }
 
@@ -150,7 +150,7 @@ internal class BacsViewModel @Inject constructor(
                 isExecuteThreeD = keyValueStorage.isExecuteThreeD()
             )
 
-            handlePaymentResponse(paymentsRepository.paymentsRequestAsync(paymentRequest))
+            handlePaymentResponse(paymentsRepository.makePaymentsRequest(paymentRequest))
         }
     }
 }

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/blik/BlikViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/blik/BlikViewModel.kt
@@ -128,7 +128,7 @@ class BlikViewModel @Inject constructor(
                 isExecuteThreeD = keyValueStorage.isExecuteThreeD()
             )
 
-            handlePaymentResponse(paymentsRepository.paymentsRequestAsync(paymentRequest))
+            handlePaymentResponse(paymentsRepository.makePaymentsRequest(paymentRequest))
         }
     }
 
@@ -147,7 +147,7 @@ class BlikViewModel @Inject constructor(
     private fun sendPaymentDetails(actionComponentData: ActionComponentData) {
         viewModelScope.launch(Dispatchers.IO) {
             val json = ActionComponentData.SERIALIZER.serialize(actionComponentData)
-            handlePaymentResponse(paymentsRepository.detailsRequestAsync(json))
+            handlePaymentResponse(paymentsRepository.makeDetailsRequest(json))
         }
     }
 

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/card/CardViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/card/CardViewModel.kt
@@ -108,7 +108,7 @@ internal class CardViewModel @Inject constructor(
                 isExecuteThreeD = keyValueStorage.isExecuteThreeD()
             )
 
-            handlePaymentResponse(paymentsRepository.paymentsRequestAsync(paymentRequest))
+            handlePaymentResponse(paymentsRepository.makePaymentsRequest(paymentRequest))
         }
     }
 
@@ -131,7 +131,7 @@ internal class CardViewModel @Inject constructor(
     private fun sendPaymentDetails(actionComponentData: ActionComponentData) {
         viewModelScope.launch(Dispatchers.IO) {
             val json = ActionComponentData.SERIALIZER.serialize(actionComponentData)
-            handlePaymentResponse(paymentsRepository.detailsRequestAsync(json))
+            handlePaymentResponse(paymentsRepository.makeDetailsRequest(json))
         }
     }
 

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/card/SessionsCardViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/card/SessionsCardViewModel.kt
@@ -86,7 +86,7 @@ internal class SessionsCardViewModel @Inject constructor(
     }
 
     private suspend fun getSession(paymentMethodType: String): CheckoutSession? {
-        val sessionModel = paymentsRepository.getSessionAsync(
+        val sessionModel = paymentsRepository.createSession(
             getSessionRequest(
                 merchantAccount = keyValueStorage.getMerchantAccount(),
                 shopperReference = keyValueStorage.getShopperReference(),

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/instant/InstantViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/instant/InstantViewModel.kt
@@ -113,7 +113,7 @@ internal class InstantViewModel @Inject constructor(
                 isExecuteThreeD = keyValueStorage.isExecuteThreeD()
             )
 
-            handlePaymentResponse(paymentsRepository.paymentsRequestAsync(paymentRequest))
+            handlePaymentResponse(paymentsRepository.makePaymentsRequest(paymentRequest))
         }
     }
 
@@ -133,7 +133,7 @@ internal class InstantViewModel @Inject constructor(
     private fun sendPaymentDetails(actionComponentData: ActionComponentData) {
         viewModelScope.launch(Dispatchers.IO) {
             val json = ActionComponentData.SERIALIZER.serialize(actionComponentData)
-            handlePaymentResponse(paymentsRepository.detailsRequestAsync(json))
+            handlePaymentResponse(paymentsRepository.makeDetailsRequest(json))
         }
     }
 

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/main/MainViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/main/MainViewModel.kt
@@ -123,7 +123,7 @@ internal class MainViewModel @Inject constructor(
     )
 
     private suspend fun getSession(dropInConfiguration: DropInConfiguration): CheckoutSession? {
-        val sessionModel = paymentsRepository.getSessionAsync(
+        val sessionModel = paymentsRepository.createSession(
             getSessionRequest(
                 merchantAccount = keyValueStorage.getMerchantAccount(),
                 shopperReference = keyValueStorage.getShopperReference(),


### PR DESCRIPTION
## Description
Remove non suspending methods from `PaymentsRepository` after the refactor that removes support for synchronous API calls in `DropInService`.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-716
