### PR TITLE
Remove hard-coded brand support on card component (V5)

### DIFF
--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcComponent.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcComponent.kt
@@ -102,6 +102,6 @@ class BcmcComponent internal constructor(
         @JvmField
         val PAYMENT_METHOD_TYPES = listOf(PaymentMethodTypes.BCMC)
 
-        internal val SUPPORTED_CARD_TYPE = CardType(cardBrand = CardBrand.BCMC)
+        internal val SUPPORTED_CARD_TYPE = CardBrand(cardType = CardType.BCMC)
     }
 }

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/DefaultBcmcDelegate.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/DefaultBcmcDelegate.kt
@@ -13,7 +13,7 @@ import androidx.lifecycle.LifecycleOwner
 import com.adyen.checkout.card.CardValidationMapper
 import com.adyen.checkout.card.R
 import com.adyen.checkout.card.api.model.Brand
-import com.adyen.checkout.card.data.CardType
+import com.adyen.checkout.card.data.CardBrand
 import com.adyen.checkout.card.data.ExpiryDate
 import com.adyen.checkout.card.util.CardValidationUtils
 import com.adyen.checkout.components.PaymentComponentEvent
@@ -272,7 +272,7 @@ internal class DefaultBcmcDelegate(
 
     override fun isCardNumberSupported(cardNumber: String?): Boolean {
         if (cardNumber.isNullOrEmpty()) return false
-        return CardType.estimate(cardNumber).contains(BcmcComponent.SUPPORTED_CARD_TYPE)
+        return CardBrand.estimate(cardNumber).contains(BcmcComponent.SUPPORTED_CARD_TYPE)
     }
 
     override fun isConfirmationRequired(): Boolean = _viewFlow.value is ButtonComponentViewType

--- a/card/src/main/java/com/adyen/checkout/card/CardComponentParams.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponentParams.kt
@@ -8,14 +8,14 @@
 
 package com.adyen.checkout.card
 
-import com.adyen.checkout.card.data.CardType
+import com.adyen.checkout.card.data.CardBrand
 import com.adyen.checkout.components.base.ButtonParams
 import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.model.payments.Amount
 import com.adyen.checkout.components.ui.AddressParams
 import com.adyen.checkout.core.api.Environment
-import java.util.Locale
 import kotlinx.parcelize.Parcelize
+import java.util.Locale
 
 @Parcelize
 internal data class CardComponentParams(
@@ -27,7 +27,7 @@ internal data class CardComponentParams(
     override val amount: Amount,
     override val isSubmitButtonVisible: Boolean,
     val isHolderNameRequired: Boolean,
-    val supportedCardTypes: List<CardType>,
+    val supportedCardBrands: List<CardBrand>,
     val shopperReference: String?,
     val isStorePaymentFieldVisible: Boolean,
     val isHideCvc: Boolean,

--- a/card/src/main/java/com/adyen/checkout/card/CardComponentParamsMapper.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponentParamsMapper.kt
@@ -8,7 +8,7 @@
 
 package com.adyen.checkout.card
 
-import com.adyen.checkout.card.data.CardType
+import com.adyen.checkout.card.data.CardBrand
 import com.adyen.checkout.card.data.RestrictedCardType
 import com.adyen.checkout.components.base.ComponentParams
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
@@ -25,23 +25,23 @@ internal class CardComponentParamsMapper(
         cardConfiguration: CardConfiguration,
         paymentMethod: PaymentMethod,
     ): CardComponentParams {
-        val supportedCardTypes = cardConfiguration.getSupportedCardTypes(paymentMethod)
+        val supportedCardBrands = cardConfiguration.getSupportedCardBrands(paymentMethod)
         return cardConfiguration
-            .mapToParamsInternal(supportedCardTypes)
+            .mapToParamsInternal(supportedCardBrands)
             .override(overrideComponentParams)
     }
 
     fun mapToParamsStored(
         cardConfiguration: CardConfiguration,
     ): CardComponentParams {
-        val supportedCardTypes = cardConfiguration.getSupportedCardTypesStored()
+        val supportedCardBrands = cardConfiguration.getSupportedCardBrandsStored()
         return cardConfiguration
-            .mapToParamsInternal(supportedCardTypes)
+            .mapToParamsInternal(supportedCardBrands)
             .override(overrideComponentParams)
     }
 
     private fun CardConfiguration.mapToParamsInternal(
-        supportedCardTypes: List<CardType>,
+        supportedCardBrands: List<CardBrand>,
     ): CardComponentParams {
         return CardComponentParams(
             shopperLocale = shopperLocale,
@@ -52,7 +52,7 @@ internal class CardComponentParamsMapper(
             amount = amount,
             isHolderNameRequired = isHolderNameRequired ?: false,
             isSubmitButtonVisible = isSubmitButtonVisible ?: true,
-            supportedCardTypes = supportedCardTypes,
+            supportedCardBrands = supportedCardBrands,
             shopperReference = shopperReference,
             isStorePaymentFieldVisible = isStorePaymentFieldVisible ?: true,
             isHideCvc = isHideCvc ?: false,
@@ -69,18 +69,18 @@ internal class CardComponentParamsMapper(
      * Priority is: Custom -> PaymentMethod.brands -> Default
      * remove restricted card type
      */
-    private fun CardConfiguration.getSupportedCardTypes(
+    private fun CardConfiguration.getSupportedCardBrands(
         paymentMethod: PaymentMethod
-    ): List<CardType> {
+    ): List<CardBrand> {
         return when {
-            !supportedCardTypes.isNullOrEmpty() -> {
+            !supportedCardBrands.isNullOrEmpty() -> {
                 Logger.v(TAG, "Reading supportedCardTypes from configuration")
-                supportedCardTypes
+                supportedCardBrands
             }
             paymentMethod.brands.orEmpty().isNotEmpty() -> {
                 Logger.v(TAG, "Reading supportedCardTypes from API brands")
                 paymentMethod.brands.orEmpty().map {
-                    CardType(txVariant = it)
+                    CardBrand(txVariant = it)
                 }
             }
             else -> {
@@ -90,11 +90,11 @@ internal class CardComponentParamsMapper(
         }.removeRestrictedCards()
     }
 
-    private fun CardConfiguration.getSupportedCardTypesStored(): List<CardType> {
-        return supportedCardTypes.orEmpty().removeRestrictedCards()
+    private fun CardConfiguration.getSupportedCardBrandsStored(): List<CardBrand> {
+        return supportedCardBrands.orEmpty().removeRestrictedCards()
     }
 
-    private fun List<CardType>.removeRestrictedCards(): List<CardType> {
+    private fun List<CardBrand>.removeRestrictedCards(): List<CardBrand> {
         return this.filter { !RestrictedCardType.isRestrictedCardType(it.txVariant) }
     }
 

--- a/card/src/main/java/com/adyen/checkout/card/CardComponentState.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponentState.kt
@@ -7,7 +7,7 @@
  */
 package com.adyen.checkout.card
 
-import com.adyen.checkout.card.data.CardType
+import com.adyen.checkout.card.data.CardBrand
 import com.adyen.checkout.components.PaymentComponentState
 import com.adyen.checkout.components.model.payments.request.CardPaymentMethod
 import com.adyen.checkout.components.model.payments.request.PaymentComponentData
@@ -19,7 +19,7 @@ class CardComponentState(
     paymentComponentData: PaymentComponentData<CardPaymentMethod>,
     isInputValid: Boolean,
     isReady: Boolean,
-    val cardType: CardType?,
+    val cardBrand: CardBrand?,
     val binValue: String,
     val lastFourDigits: String?,
 ) : PaymentComponentState<CardPaymentMethod>(paymentComponentData, isInputValid, isReady)

--- a/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
@@ -34,7 +34,7 @@ class CardConfiguration private constructor(
     override val amount: Amount,
     override val isSubmitButtonVisible: Boolean?,
     val isHolderNameRequired: Boolean?,
-    val supportedCardTypes: List<CardType>?,
+    val supportedCardBrands: List<CardBrand>?,
     val shopperReference: String?,
     val isStorePaymentFieldVisible: Boolean?,
     val isHideCvc: Boolean?,
@@ -53,7 +53,7 @@ class CardConfiguration private constructor(
     class Builder :
         ActionHandlingPaymentMethodConfigurationBuilder<CardConfiguration, Builder>,
         ButtonConfigurationBuilder {
-        private var supportedCardTypes: List<CardType>? = null
+        private var supportedCardBrands: List<CardBrand>? = null
         private var holderNameRequired: Boolean? = null
         private var isStorePaymentFieldVisible: Boolean? = null
         private var shopperReference: String? = null
@@ -96,11 +96,11 @@ class CardConfiguration private constructor(
          *
          * Defaults to [PaymentMethod.brands] if it exists, or [DEFAULT_SUPPORTED_CARDS_LIST] otherwise.
          *
-         * @param supportCardTypes array of [CardType]
+         * @param supportCardBrands array of [CardBrand]
          * @return [CardConfiguration.Builder]
          */
-        fun setSupportedCardTypes(vararg supportCardTypes: CardType): Builder {
-            supportedCardTypes = listOf(*supportCardTypes)
+        fun setSupportedCardTypes(vararg supportCardBrands: CardBrand): Builder {
+            supportedCardBrands = listOf(*supportCardBrands)
             return this
         }
 
@@ -250,7 +250,7 @@ class CardConfiguration private constructor(
                 amount = amount,
                 isHolderNameRequired = holderNameRequired,
                 isSubmitButtonVisible = isSubmitButtonVisible,
-                supportedCardTypes = supportedCardTypes,
+                supportedCardBrands = supportedCardBrands,
                 shopperReference = shopperReference,
                 isStorePaymentFieldVisible = isStorePaymentFieldVisible,
                 isHideCvc = isHideCvc,
@@ -265,10 +265,10 @@ class CardConfiguration private constructor(
     }
 
     companion object {
-        val DEFAULT_SUPPORTED_CARDS_LIST: List<CardType> = listOf(
-            CardType(cardBrand = CardBrand.VISA),
-            CardType(cardBrand = CardBrand.AMERICAN_EXPRESS),
-            CardType(cardBrand = CardBrand.MASTERCARD)
+        val DEFAULT_SUPPORTED_CARDS_LIST: List<CardBrand> = listOf(
+            CardBrand(cardType = CardType.VISA),
+            CardBrand(cardType = CardType.AMERICAN_EXPRESS),
+            CardBrand(cardType = CardType.MASTERCARD)
         )
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
@@ -96,11 +96,26 @@ class CardConfiguration private constructor(
          *
          * Defaults to [PaymentMethod.brands] if it exists, or [DEFAULT_SUPPORTED_CARDS_LIST] otherwise.
          *
+         * Use this method when adding supported types that are not inside the [CardType] enum.
+         *
          * @param supportCardBrands array of [CardBrand]
          * @return [CardConfiguration.Builder]
          */
         fun setSupportedCardTypes(vararg supportCardBrands: CardBrand): Builder {
             supportedCardBrands = listOf(*supportCardBrands)
+            return this
+        }
+
+        /**
+         * Set the supported card types for this payment. Supported types will be shown as user inputs the card number.
+         *
+         * Defaults to [PaymentMethod.brands] if it exists, or [DEFAULT_SUPPORTED_CARDS_LIST] otherwise.
+         *
+         * @param supportCardTypes array of [CardType]
+         * @return [CardConfiguration.Builder]
+         */
+        fun setSupportedCardTypes(vararg supportCardTypes: CardType): Builder {
+            supportedCardBrands = listOf(*supportCardTypes).map { CardBrand(cardType = it) }
             return this
         }
 

--- a/card/src/main/java/com/adyen/checkout/card/CardListAdapter.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardListAdapter.kt
@@ -38,7 +38,7 @@ internal class CardListAdapter : ListAdapter<CardListItem, ImageViewHolder>(Card
             binding.imageViewBrandLogo.alpha = alpha
             binding.imageViewBrandLogo.loadLogo(
                 environment = card.environment,
-                txVariant = card.cardType.txVariant,
+                txVariant = card.cardBrand.txVariant,
             )
         }
     }
@@ -50,7 +50,7 @@ internal class CardListAdapter : ListAdapter<CardListItem, ImageViewHolder>(Card
 
     object CardDiffCallback : DiffUtil.ItemCallback<CardListItem>() {
         override fun areItemsTheSame(oldItem: CardListItem, newItem: CardListItem): Boolean =
-            oldItem.cardType.txVariant == newItem.cardType.txVariant
+            oldItem.cardBrand.txVariant == newItem.cardBrand.txVariant
 
         override fun areContentsTheSame(oldItem: CardListItem, newItem: CardListItem): Boolean =
             oldItem == newItem

--- a/card/src/main/java/com/adyen/checkout/card/CardView.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardView.kt
@@ -283,14 +283,14 @@ internal class CardView @JvmOverloads constructor(
             binding.cardBrandLogoImageViewPrimary.strokeWidth = RoundCornerImageView.DEFAULT_STROKE_WIDTH
             binding.cardBrandLogoImageViewPrimary.loadLogo(
                 environment = cardDelegate.componentParams.environment,
-                txVariant = detectedCardTypes[0].cardType.txVariant,
+                txVariant = detectedCardTypes[0].cardBrand.txVariant,
                 placeholder = R.drawable.ic_card,
                 errorFallback = R.drawable.ic_card,
             )
             setDualBrandedCardImages(detectedCardTypes, cardOutputData.cardNumberState.validation)
 
             // TODO: 29/01/2021 get this logic from OutputData
-            val isAmex = detectedCardTypes.any { it.cardType == CardType(cardBrand = CardBrand.AMERICAN_EXPRESS) }
+            val isAmex = detectedCardTypes.any { it.cardBrand == CardBrand(cardType = CardType.AMERICAN_EXPRESS) }
             binding.editTextCardNumber.setAmexCardFormat(isAmex)
 
             if (detectedCardTypes.size == 1 &&
@@ -316,7 +316,7 @@ internal class CardView @JvmOverloads constructor(
                 binding.cardBrandLogoImageViewSecondary.strokeWidth = RoundCornerImageView.DEFAULT_STROKE_WIDTH
                 binding.cardBrandLogoImageViewSecondary.loadLogo(
                     environment = cardDelegate.componentParams.environment,
-                    txVariant = detectedCardType.cardType.txVariant,
+                    txVariant = detectedCardType.cardBrand.txVariant,
                     placeholder = R.drawable.ic_card,
                     errorFallback = R.drawable.ic_card,
                 )

--- a/card/src/main/java/com/adyen/checkout/card/InstallmentConfiguration.kt
+++ b/card/src/main/java/com/adyen/checkout/card/InstallmentConfiguration.kt
@@ -9,19 +9,19 @@
 package com.adyen.checkout.card
 
 import android.os.Parcelable
-import com.adyen.checkout.card.data.CardType
+import com.adyen.checkout.card.data.CardBrand
 import com.adyen.checkout.card.util.InstallmentUtils
 import com.adyen.checkout.core.exception.CheckoutException
 import kotlinx.parcelize.Parcelize
 
 /**
  * Configuration class for Installments in Card Component. This class can be used
- * to define installment options for all cards or specific [CardType]. [defaultOptions]
+ * to define installment options for all cards or specific [CardBrand]. [defaultOptions]
  * and [cardBasedOptions] can be combined together. In that case [InstallmentOptions] from
  * [cardBasedOptions] will override the option defined in [defaultOptions].
  *
  * Note: [cardBasedOptions] should contain only one [InstallmentOptions.CardBasedInstallmentOptions]
- * instance for a [CardType].
+ * instance for a [CardBrand].
  *
  * @param defaultOptions Installment Options to be used for all card types.
  * @param cardBasedOptions Installment Options to be used for specific card types.
@@ -61,13 +61,13 @@ sealed class InstallmentOptions : Parcelable {
     /**
      * @param values see [InstallmentOptions.values]
      * @param includeRevolving see [InstallmentOptions.includeRevolving]
-     * @param cardType a [CardType] to apply the given options
+     * @param cardBrand a [CardBrand] to apply the given options
      */
     @Parcelize
     data class CardBasedInstallmentOptions(
         override val values: List<Int>,
         override val includeRevolving: Boolean,
-        val cardType: CardType
+        val cardBrand: CardBrand
     ) : InstallmentOptions() {
 
         /**
@@ -75,8 +75,8 @@ sealed class InstallmentOptions : Parcelable {
          *
          * Creates a [DefaultInstallmentOptions] instance with values in range [2, maxInstallments]
          */
-        constructor(maxInstallments: Int, includeRevolving: Boolean, cardType: CardType) :
-            this((STARTING_INSTALLMENT_VALUE..maxInstallments).toList(), includeRevolving, cardType)
+        constructor(maxInstallments: Int, includeRevolving: Boolean, cardBrand: CardBrand) :
+            this((STARTING_INSTALLMENT_VALUE..maxInstallments).toList(), includeRevolving, cardBrand)
     }
 
     /**

--- a/card/src/main/java/com/adyen/checkout/card/StoredCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/StoredCardDelegate.kt
@@ -66,9 +66,9 @@ internal class StoredCardDelegate(
     private val submitHandler: SubmitHandler<CardComponentState>,
 ) : CardDelegate {
 
-    private val noCvcBrands: Set<CardType> = hashSetOf(CardType(cardBrand = CardBrand.BCMC))
+    private val noCvcBrands: Set<CardBrand> = hashSetOf(CardBrand(cardType = CardType.BCMC))
 
-    private val cardType = CardType(txVariant = storedPaymentMethod.brand.orEmpty())
+    private val cardType = CardBrand(txVariant = storedPaymentMethod.brand.orEmpty())
     private val storedDetectedCardTypes = DetectedCardType(
         cardType,
         isReliable = true,
@@ -223,7 +223,7 @@ internal class StoredCardDelegate(
     ): CardComponentState {
         val cardNumber = outputData.cardNumberState.value
 
-        val firstCardType = outputData.detectedCardTypes.firstOrNull()?.cardType
+        val firstCardBrand = outputData.detectedCardTypes.firstOrNull()?.cardBrand
 
         val publicKey = publicKey
 
@@ -233,7 +233,7 @@ internal class StoredCardDelegate(
                 paymentComponentData = PaymentComponentData(),
                 isInputValid = outputData.isValid,
                 isReady = publicKey != null,
-                cardType = firstCardType,
+                cardBrand = firstCardBrand,
                 binValue = "",
                 lastFourDigits = null
             )
@@ -259,7 +259,7 @@ internal class StoredCardDelegate(
                 paymentComponentData = PaymentComponentData(),
                 isInputValid = false,
                 isReady = true,
-                cardType = firstCardType,
+                cardBrand = firstCardBrand,
                 binValue = "",
                 lastFourDigits = null
             )
@@ -268,7 +268,7 @@ internal class StoredCardDelegate(
         return mapComponentState(
             encryptedCard,
             cardNumber,
-            firstCardType,
+            firstCardBrand,
         )
     }
 
@@ -281,14 +281,14 @@ internal class StoredCardDelegate(
         return storedPaymentMethod.type ?: PaymentMethodTypes.UNKNOWN
     }
 
-    private fun validateSecurityCode(securityCode: String, cardType: DetectedCardType): FieldState<String> {
-        return if (componentParams.isHideCvcStoredCard || noCvcBrands.contains(cardType.cardType)) {
+    private fun validateSecurityCode(securityCode: String, detectedCardType: DetectedCardType): FieldState<String> {
+        return if (componentParams.isHideCvcStoredCard || noCvcBrands.contains(detectedCardType.cardBrand)) {
             FieldState(
                 securityCode,
                 Validation.Valid
             )
         } else {
-            CardValidationUtils.validateSecurityCode(securityCode, cardType)
+            CardValidationUtils.validateSecurityCode(securityCode, detectedCardType)
         }
     }
 
@@ -299,7 +299,7 @@ internal class StoredCardDelegate(
     private fun mapComponentState(
         encryptedCard: EncryptedCard,
         cardNumber: String,
-        firstCardType: CardType?,
+        firstCardBrand: CardBrand?,
     ): CardComponentState {
         val cardPaymentMethod = CardPaymentMethod().apply {
             type = CardPaymentMethod.PAYMENT_METHOD_TYPE
@@ -330,7 +330,7 @@ internal class StoredCardDelegate(
             paymentComponentData = paymentComponentData,
             isInputValid = true,
             isReady = true,
-            cardType = firstCardType,
+            cardBrand = firstCardBrand,
             binValue = "",
             lastFourDigits = lastFour
         )

--- a/card/src/main/java/com/adyen/checkout/card/data/CardBrand.kt
+++ b/card/src/main/java/com/adyen/checkout/card/data/CardBrand.kt
@@ -12,29 +12,29 @@ import kotlinx.parcelize.Parcelize
 import java.util.regex.Pattern
 
 @Parcelize
-data class CardType constructor(val txVariant: String) : Parcelable {
+data class CardBrand constructor(val txVariant: String) : Parcelable {
 
     /**
-     * Use this constructor when defining the supported card brand predefined inside [CardBrand] enum
+     * Use this constructor when defining the supported card brand predefined inside [CardType] enum
      * inside your component
      */
-    constructor(cardBrand: CardBrand) : this(txVariant = cardBrand.txVariant)
+    constructor(cardType: CardType) : this(txVariant = cardType.txVariant)
 
     companion object {
         /**
-         * Estimate all potential [CardTypes][CardType] for a given card number.
+         * Estimate all potential [CardBrands][CardBrand] for a given card number.
          *
          * @param cardNumber The potential card number.
-         * @return All matching [CardTypes][CardType] if the number was valid, otherwise an empty [List].
+         * @return All matching [CardBrands][CardBrand] if the number was valid, otherwise an empty [List].
          */
-        fun estimate(cardNumber: String): List<CardType> {
-            return CardBrand.values().filter { it.isEstimateFor(cardNumber) }.map { CardType(cardBrand = it) }
+        fun estimate(cardNumber: String): List<CardBrand> {
+            return CardType.values().filter { it.isEstimateFor(cardNumber) }.map { CardBrand(cardType = it) }
         }
     }
 }
 
 @Suppress("unused", "SpellCheckingInspection")
-enum class CardBrand(val txVariant: String, private val mPattern: Pattern) {
+enum class CardType(val txVariant: String, private val mPattern: Pattern) {
 
     AMERICAN_EXPRESS("amex", Pattern.compile("^3[47][0-9]{0,13}$")),
     ARGENCARD("argencard", Pattern.compile("^(50)(1)\\d*$")),
@@ -80,18 +80,18 @@ enum class CardBrand(val txVariant: String, private val mPattern: Pattern) {
     companion object {
 
         /**
-         * Get [CardBrand] from the brand name as it appears in the Checkout API.
+         * Get [CardType] from the brand name as it appears in the Checkout API.
          */
-        fun getByBrandName(brand: String): CardBrand? {
+        fun getByBrandName(brand: String): CardType? {
             return values().firstOrNull { it.txVariant == brand }
         }
     }
 
     /**
-     * Returns whether a given card number is estimated for this [CardBrand].
+     * Returns whether a given card number is estimated for this [CardType].
      *
      * @param cardNumber The card number to make an estimation for.
-     * @return Whether the [CardBrand] is an estimation for a given card number.
+     * @return Whether the [CardType] is an estimation for a given card number.
      */
     internal fun isEstimateFor(cardNumber: String): Boolean {
         val normalizedCardNumber = cardNumber.replace("\\s".toRegex(), "")

--- a/card/src/main/java/com/adyen/checkout/card/data/DetectedCardType.kt
+++ b/card/src/main/java/com/adyen/checkout/card/data/DetectedCardType.kt
@@ -11,7 +11,7 @@ package com.adyen.checkout.card.data
 import com.adyen.checkout.card.api.model.Brand
 
 data class DetectedCardType(
-    val cardType: CardType,
+    val cardBrand: CardBrand,
     val isReliable: Boolean,
     val enableLuhnCheck: Boolean,
     val cvcPolicy: Brand.FieldPolicy,

--- a/card/src/main/java/com/adyen/checkout/card/repository/DetectCardTypeRepository.kt
+++ b/card/src/main/java/com/adyen/checkout/card/repository/DetectCardTypeRepository.kt
@@ -8,7 +8,7 @@
 
 package com.adyen.checkout.card.repository
 
-import com.adyen.checkout.card.data.CardType
+import com.adyen.checkout.card.data.CardBrand
 import com.adyen.checkout.card.data.DetectedCardType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -21,7 +21,7 @@ interface DetectCardTypeRepository {
     fun detectCardType(
         cardNumber: String,
         publicKey: String?,
-        supportedCardTypes: List<CardType>,
+        supportedCardBrands: List<CardBrand>,
         clientKey: String,
         coroutineScope: CoroutineScope,
     )

--- a/card/src/main/java/com/adyen/checkout/card/test/TestDetectCardTypeRepository.kt
+++ b/card/src/main/java/com/adyen/checkout/card/test/TestDetectCardTypeRepository.kt
@@ -40,15 +40,15 @@ internal class TestDetectCardTypeRepository : DetectCardTypeRepository {
     override fun detectCardType(
         cardNumber: String,
         publicKey: String?,
-        supportedCardTypes: List<CardType>,
+        supportedCardBrands: List<CardBrand>,
         clientKey: String,
         coroutineScope: CoroutineScope,
     ) {
         val detectedCardTypes = when (detectionResult) {
             ERROR -> null
-            DETECTED_LOCALLY -> getDetectedCardTypesLocal(supportedCardTypes)
-            FETCHED_FROM_NETWORK -> getDetectedCardTypesNetwork(supportedCardTypes)
-            DUAL_BRANDED -> getDetectedCardTypesDualBranded(supportedCardTypes)
+            DETECTED_LOCALLY -> getDetectedCardTypesLocal(supportedCardBrands)
+            FETCHED_FROM_NETWORK -> getDetectedCardTypesNetwork(supportedCardBrands)
+            DUAL_BRANDED -> getDetectedCardTypesDualBranded(supportedCardBrands)
             EMPTY -> emptyList()
         } ?: return
 
@@ -63,56 +63,56 @@ internal class TestDetectCardTypeRepository : DetectCardTypeRepository {
         EMPTY,
     }
 
-    fun getDetectedCardTypesLocal(supportedCardTypes: List<CardType>): List<DetectedCardType> {
-        val cardType = CardType(cardBrand = CardBrand.VISA)
+    fun getDetectedCardTypesLocal(supportedCardTypes: List<CardBrand>): List<DetectedCardType> {
+        val cardBrand = CardBrand(cardType = CardType.VISA)
         return listOf(
             DetectedCardType(
-                cardType = cardType,
+                cardBrand = cardBrand,
                 isReliable = false,
                 enableLuhnCheck = true,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
                 expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
-                isSupported = supportedCardTypes.contains(cardType),
+                isSupported = supportedCardTypes.contains(cardBrand),
                 panLength = null,
             )
         )
     }
 
-    fun getDetectedCardTypesNetwork(supportedCardTypes: List<CardType>): List<DetectedCardType> {
-        val cardType = CardType(cardBrand = CardBrand.MASTERCARD)
+    fun getDetectedCardTypesNetwork(supportedCardTypes: List<CardBrand>): List<DetectedCardType> {
+        val cardBrand = CardBrand(cardType = CardType.MASTERCARD)
         return listOf(
             DetectedCardType(
-                cardType = cardType,
+                cardBrand = cardBrand,
                 isReliable = true,
                 enableLuhnCheck = true,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
                 expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
-                isSupported = supportedCardTypes.contains(cardType),
+                isSupported = supportedCardTypes.contains(cardBrand),
                 panLength = 16,
             )
         )
     }
 
-    fun getDetectedCardTypesDualBranded(supportedCardTypes: List<CardType>): List<DetectedCardType> {
-        val cardTypeFirst = CardType(cardBrand = CardBrand.BCMC)
-        val cardTypeSecond = CardType(cardBrand = CardBrand.MAESTRO)
+    fun getDetectedCardTypesDualBranded(supportedCardBrands: List<CardBrand>): List<DetectedCardType> {
+        val cardBrandFirst = CardBrand(cardType = CardType.BCMC)
+        val cardBrandSecond = CardBrand(cardType = CardType.MAESTRO)
         return listOf(
             DetectedCardType(
-                cardType = cardTypeFirst,
+                cardBrand = cardBrandFirst,
                 isReliable = true,
                 enableLuhnCheck = true,
                 cvcPolicy = Brand.FieldPolicy.HIDDEN,
                 expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
-                isSupported = supportedCardTypes.contains(cardTypeFirst),
+                isSupported = supportedCardBrands.contains(cardBrandFirst),
                 panLength = 16,
             ),
             DetectedCardType(
-                cardType = cardTypeSecond,
+                cardBrand = cardBrandSecond,
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.OPTIONAL,
                 expiryDatePolicy = Brand.FieldPolicy.HIDDEN,
-                isSupported = supportedCardTypes.contains(cardTypeSecond),
+                isSupported = supportedCardBrands.contains(cardBrandSecond),
                 panLength = 16,
             )
         )

--- a/card/src/main/java/com/adyen/checkout/card/ui/model/CardListItem.kt
+++ b/card/src/main/java/com/adyen/checkout/card/ui/model/CardListItem.kt
@@ -8,11 +8,11 @@
 
 package com.adyen.checkout.card.ui.model
 
-import com.adyen.checkout.card.data.CardType
+import com.adyen.checkout.card.data.CardBrand
 import com.adyen.checkout.core.api.Environment
 
 data class CardListItem(
-    val cardType: CardType,
+    val cardBrand: CardBrand,
     val isDetected: Boolean,
     // We need the environment to load the logo
     val environment: Environment,

--- a/card/src/main/java/com/adyen/checkout/card/util/CardValidationUtils.kt
+++ b/card/src/main/java/com/adyen/checkout/card/util/CardValidationUtils.kt
@@ -122,16 +122,16 @@ object CardValidationUtils {
     /**
      * Validate Security Code.
      */
-    fun validateSecurityCode(securityCode: String, cardType: DetectedCardType?): FieldState<String> {
+    fun validateSecurityCode(securityCode: String, detectedCardType: DetectedCardType?): FieldState<String> {
         val normalizedSecurityCode = StringUtil.normalize(securityCode)
         val length = normalizedSecurityCode.length
         val invalidState = Validation.Invalid(R.string.checkout_security_code_not_valid)
         val validation = when {
             !StringUtil.isDigitsAndSeparatorsOnly(normalizedSecurityCode) -> invalidState
-            cardType?.cvcPolicy == Brand.FieldPolicy.OPTIONAL && length == 0 -> Validation.Valid
-            cardType?.cardType == CardType(cardBrand = CardBrand.AMERICAN_EXPRESS) &&
+            detectedCardType?.cvcPolicy == Brand.FieldPolicy.OPTIONAL && length == 0 -> Validation.Valid
+            detectedCardType?.cardBrand == CardBrand(cardType = CardType.AMERICAN_EXPRESS) &&
                 length == AMEX_SECURITY_CODE_SIZE -> Validation.Valid
-            cardType?.cardType != CardType(cardBrand = CardBrand.AMERICAN_EXPRESS) &&
+            detectedCardType?.cardBrand != CardBrand(cardType = CardType.AMERICAN_EXPRESS) &&
                 length == GENERAL_CARD_SECURITY_CODE_SIZE -> Validation.Valid
             else -> invalidState
         }

--- a/card/src/main/java/com/adyen/checkout/card/util/DualBrandedCardUtils.kt
+++ b/card/src/main/java/com/adyen/checkout/card/util/DualBrandedCardUtils.kt
@@ -10,20 +10,20 @@ object DualBrandedCardUtils {
         return if (cards.size <= 1) {
             cards
         } else {
-            val hasCarteBancaire = cards.any { it.cardType == CardType(cardBrand = CardBrand.CARTEBANCAIRE) }
-            val hasVisa = cards.any { it.cardType == CardType(cardBrand = CardBrand.VISA) }
+            val hasCarteBancaire = cards.any { it.cardBrand == CardBrand(cardType = CardType.CARTEBANCAIRE) }
+            val hasVisa = cards.any { it.cardBrand == CardBrand(cardType = CardType.VISA) }
             val hasPlcc = cards.any {
-                it.cardType.txVariant.contains("plcc") ||
-                    it.cardType.txVariant.contains("cbcc")
+                it.cardBrand.txVariant.contains("plcc") ||
+                    it.cardBrand.txVariant.contains("cbcc")
             }
 
             when {
                 hasCarteBancaire && hasVisa -> cards.sortedByDescending {
-                    it.cardType == CardType(cardBrand = CardBrand.VISA)
+                    it.cardBrand == CardBrand(cardType = CardType.VISA)
                 }
                 hasPlcc -> cards.sortedByDescending {
-                    it.cardType.txVariant.contains("plcc") ||
-                        it.cardType.txVariant.contains("cbcc")
+                    it.cardBrand.txVariant.contains("plcc") ||
+                        it.cardBrand.txVariant.contains("cbcc")
                 }
                 else -> cards
             }

--- a/card/src/main/java/com/adyen/checkout/card/util/InstallmentUtils.kt
+++ b/card/src/main/java/com/adyen/checkout/card/util/InstallmentUtils.kt
@@ -14,7 +14,7 @@ import com.adyen.checkout.card.InstallmentModel
 import com.adyen.checkout.card.InstallmentOption
 import com.adyen.checkout.card.InstallmentOptions
 import com.adyen.checkout.card.R
-import com.adyen.checkout.card.data.CardType
+import com.adyen.checkout.card.data.CardBrand
 import com.adyen.checkout.components.model.payments.request.Installments
 
 private const val REVOLVING_INSTALLMENT_VALUE = 1
@@ -26,18 +26,18 @@ internal object InstallmentUtils {
      */
     fun makeInstallmentOptions(
         configuration: InstallmentConfiguration?,
-        cardType: CardType?,
+        cardBrand: CardBrand?,
         isCardTypeReliable: Boolean
     ): List<InstallmentModel> {
         val hasCardBasedInstallmentOptions = configuration?.cardBasedOptions != null
         val hasDefaultInstallmentOptions = configuration?.defaultOptions != null
         val hasOptionsForCardType = hasCardBasedInstallmentOptions &&
             isCardTypeReliable &&
-            (configuration?.cardBasedOptions?.any { it.cardType == cardType } ?: false)
+            (configuration?.cardBasedOptions?.any { it.cardBrand == cardBrand } ?: false)
 
         return when {
             hasOptionsForCardType -> {
-                makeInstallmentModelList(configuration?.cardBasedOptions?.firstOrNull { it.cardType == cardType })
+                makeInstallmentModelList(configuration?.cardBasedOptions?.firstOrNull { it.cardBrand == cardBrand })
             }
             hasDefaultInstallmentOptions -> {
                 makeInstallmentModelList(configuration?.defaultOptions)
@@ -108,7 +108,7 @@ internal object InstallmentUtils {
         cardBasedInstallmentOptions: List<InstallmentOptions.CardBasedInstallmentOptions>?
     ): Boolean {
         val hasMultipleOptionsForSameCard = cardBasedInstallmentOptions
-            ?.groupBy { it.cardType }
+            ?.groupBy { it.cardBrand }
             ?.values
             ?.any { it.size > 1 } ?: false
         return !hasMultipleOptionsForSameCard

--- a/card/src/test/java/com/adyen/checkout/card/CardComponentParamsMapperTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/CardComponentParamsMapperTest.kt
@@ -54,7 +54,7 @@ internal class CardComponentParamsMapperTest {
             clientKey = TEST_CLIENT_KEY_2
         )
             .setHolderNameRequired(true)
-            .setSupportedCardTypes(CardType(cardBrand = CardBrand.DINERS), CardType(cardBrand = CardBrand.MAESTRO))
+            .setSupportedCardTypes(CardType.DINERS, CardType.MAESTRO)
             .setShopperReference(shopperReference)
             .setShowStorePaymentField(false)
             .setHideCvc(true)
@@ -73,9 +73,9 @@ internal class CardComponentParamsMapperTest {
             environment = Environment.APSE,
             clientKey = TEST_CLIENT_KEY_2,
             isHolderNameRequired = true,
-            supportedCardTypes = listOf(
-                CardType(cardBrand = CardBrand.DINERS),
-                CardType(cardBrand = CardBrand.MAESTRO)
+            supportedCardBrands = listOf(
+                CardBrand(cardType = CardType.DINERS),
+                CardBrand(cardType = CardType.MAESTRO)
             ),
             shopperReference = shopperReference,
             isStorePaymentFieldVisible = false,
@@ -129,20 +129,20 @@ internal class CardComponentParamsMapperTest {
     @Test
     fun `when supported card types are set in the card configuration then they should be used in the params`() {
         val cardConfiguration = getCardConfigurationBuilder()
-            .setSupportedCardTypes(CardType(cardBrand = CardBrand.MAESTRO), CardType(cardBrand = CardBrand.BCMC))
+            .setSupportedCardTypes(CardType.MAESTRO, CardType.BCMC)
             .build()
 
         val paymentMethod = PaymentMethod(
             brands = listOf(
-                CardBrand.VISA.txVariant,
-                CardBrand.MASTERCARD.txVariant
+                CardType.VISA.txVariant,
+                CardType.MASTERCARD.txVariant
             )
         )
 
         val params = CardComponentParamsMapper(null).mapToParamsDefault(cardConfiguration, paymentMethod)
 
         val expected = getCardComponentParams(
-            supportedCardTypes = listOf(CardType(cardBrand = CardBrand.MAESTRO), CardType(cardBrand = CardBrand.BCMC))
+            supportedCardBrands = listOf(CardBrand(cardType = CardType.MAESTRO), CardBrand(cardType = CardType.BCMC))
         )
 
         assertEquals(expected, params)
@@ -155,14 +155,14 @@ internal class CardComponentParamsMapperTest {
             PaymentMethod(
                 brands = listOf(
                     RestrictedCardType.NYCE.txVariant,
-                    CardBrand.MASTERCARD.txVariant
+                    CardType.MASTERCARD.txVariant
                 )
             )
 
         val params = CardComponentParamsMapper(null).mapToParamsDefault(cardConfiguration, paymentMethod)
 
         val expected = getCardComponentParams(
-            supportedCardTypes = listOf(CardType(cardBrand = CardBrand.MASTERCARD))
+            supportedCardBrands = listOf(CardBrand(cardType = CardType.MASTERCARD))
         )
 
         assertEquals(expected, params)
@@ -175,17 +175,17 @@ internal class CardComponentParamsMapperTest {
 
         val paymentMethod = PaymentMethod(
             brands = listOf(
-                CardBrand.VISA.txVariant,
-                CardBrand.MASTERCARD.txVariant
+                CardType.VISA.txVariant,
+                CardType.MASTERCARD.txVariant
             )
         )
 
         val params = CardComponentParamsMapper(null).mapToParamsDefault(cardConfiguration, paymentMethod)
 
         val expected = getCardComponentParams(
-            supportedCardTypes = listOf(
-                CardType(cardBrand = CardBrand.VISA),
-                CardType(cardBrand = CardBrand.MASTERCARD)
+            supportedCardBrands = listOf(
+                CardBrand(cardType = CardType.VISA),
+                CardBrand(cardType = CardType.MASTERCARD)
             )
         )
 
@@ -200,7 +200,7 @@ internal class CardComponentParamsMapperTest {
         val params = CardComponentParamsMapper(null).mapToParamsDefault(cardConfiguration, PaymentMethod())
 
         val expected = getCardComponentParams(
-            supportedCardTypes = CardConfiguration.DEFAULT_SUPPORTED_CARDS_LIST
+            supportedCardBrands = CardConfiguration.DEFAULT_SUPPORTED_CARDS_LIST
         )
 
         assertEquals(expected, params)
@@ -221,7 +221,7 @@ internal class CardComponentParamsMapperTest {
         amount: Amount = Amount.EMPTY,
         isHolderNameRequired: Boolean = false,
         isSubmitButtonVisible: Boolean = true,
-        supportedCardTypes: List<CardType> = CardConfiguration.DEFAULT_SUPPORTED_CARDS_LIST,
+        supportedCardBrands: List<CardBrand> = CardConfiguration.DEFAULT_SUPPORTED_CARDS_LIST,
         shopperReference: String? = null,
         isStorePaymentFieldVisible: Boolean = true,
         isHideCvc: Boolean = false,
@@ -238,7 +238,7 @@ internal class CardComponentParamsMapperTest {
         isCreatedByDropIn = isCreatedByDropIn,
         isHolderNameRequired = isHolderNameRequired,
         isSubmitButtonVisible = isSubmitButtonVisible,
-        supportedCardTypes = supportedCardTypes,
+        supportedCardBrands = supportedCardBrands,
         shopperReference = shopperReference,
         isStorePaymentFieldVisible = isStorePaymentFieldVisible,
         isHideCvc = isHideCvc,

--- a/card/src/test/java/com/adyen/checkout/card/CardTypeTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/CardTypeTest.kt
@@ -20,8 +20,8 @@ class CardTypeTest {
 
     @Test
     fun `test if card number is not part of predefined card brand enum`() {
-        val sodexoCard = CardType(txVariant = "sodexo")
-        val cardTypes = CardType.estimate(SODEXO_CARD_NUMBER)
+        val sodexoCard = CardBrand(txVariant = "sodexo")
+        val cardTypes = CardBrand.estimate(SODEXO_CARD_NUMBER)
 
         val isPredefinedBrand = cardTypes.contains(sodexoCard)
 
@@ -30,8 +30,8 @@ class CardTypeTest {
 
     @Test
     fun `test if card number is part of predefined card brand enum`() {
-        val amexCard = CardType(cardBrand = CardBrand.AMERICAN_EXPRESS)
-        val cardTypes = CardType.estimate(AMEX_CARD_NUMBER)
+        val amexCard = CardBrand(cardType = CardType.AMERICAN_EXPRESS)
+        val cardTypes = CardBrand.estimate(AMEX_CARD_NUMBER)
 
         val isPredefinedBrand = cardTypes.contains(amexCard)
 
@@ -40,18 +40,18 @@ class CardTypeTest {
 
     @Test
     fun `test if card brand is not part of predefined card brand enum`() {
-        val sodexoCard = CardType(txVariant = "sodexo")
+        val sodexoCard = CardBrand(txVariant = "sodexo")
 
-        val result = CardBrand.getByBrandName(sodexoCard.txVariant)
+        val result = CardType.getByBrandName(sodexoCard.txVariant)
 
         assertNull(result)
     }
 
     @Test
     fun `test if card brand is part of predefined card brand enum`() {
-        val amexCard = CardType(txVariant = "amex")
+        val amexCard = CardBrand(txVariant = "amex")
 
-        val result = CardBrand.getByBrandName(amexCard.txVariant)
+        val result = CardType.getByBrandName(amexCard.txVariant)
 
         assertNotNull(result)
     }

--- a/card/src/test/java/com/adyen/checkout/card/DefaultCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/DefaultCardDelegateTest.kt
@@ -266,10 +266,10 @@ internal class DefaultCardDelegateTest(
 
         @Test
         fun `When a card brand is detected, isCardListVisible should be false`() = runTest {
-            val supportedCardTypes = listOf(CardType(cardBrand = CardBrand.VISA))
+            val supportedCardBrands = listOf(CardBrand(cardType = CardType.VISA))
             delegate = createCardDelegate(
                 configuration = getDefaultCardConfigurationBuilder()
-                    .setSupportedCardTypes(*supportedCardTypes.toTypedArray())
+                    .setSupportedCardTypes(*supportedCardBrands.toTypedArray())
                     .build()
             )
             delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
@@ -285,10 +285,10 @@ internal class DefaultCardDelegateTest(
 
         @Test
         fun `When a card brand is not detected, isCardListVisible should be true`() = runTest {
-            val supportedCardTypes = listOf(CardType(cardBrand = CardBrand.VISA))
+            val supportedCardBrands = listOf(CardBrand(cardType = CardType.VISA))
             delegate = createCardDelegate(
                 configuration = getDefaultCardConfigurationBuilder()
-                    .setSupportedCardTypes(*supportedCardTypes.toTypedArray())
+                    .setSupportedCardTypes(*supportedCardBrands.toTypedArray())
                     .build()
             )
             delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
@@ -304,11 +304,11 @@ internal class DefaultCardDelegateTest(
         }
 
         @Test
-        fun `When the supported cardlist is empty, isCardListVisible should be true`() = runTest {
-            val supportedCardTypes = emptyList<CardType>()
+        fun `When the supported card list is empty, isCardListVisible should be true`() = runTest {
+            val supportedCardBrands = emptyList<CardBrand>()
             delegate = createCardDelegate(
                 configuration = getDefaultCardConfigurationBuilder()
-                    .setSupportedCardTypes(*supportedCardTypes.toTypedArray())
+                    .setSupportedCardTypes(*supportedCardBrands.toTypedArray())
                     .build()
             )
             delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
@@ -325,14 +325,14 @@ internal class DefaultCardDelegateTest(
 
         @Test
         fun `detect card type repository returns supported cards, then output data should contain them`() = runTest {
-            val supportedCardTypes = listOf(
-                CardType(cardBrand = CardBrand.VISA),
-                CardType(cardBrand = CardBrand.MASTERCARD),
-                CardType(cardBrand = CardBrand.AMERICAN_EXPRESS)
+            val supportedCardBrands = listOf(
+                CardBrand(cardType = CardType.VISA),
+                CardBrand(cardType = CardType.MASTERCARD),
+                CardBrand(cardType = CardType.AMERICAN_EXPRESS)
             )
             delegate = createCardDelegate(
                 configuration = getDefaultCardConfigurationBuilder()
-                    .setSupportedCardTypes(*supportedCardTypes.toTypedArray())
+                    .setSupportedCardTypes(*supportedCardBrands.toTypedArray())
                     .build()
             )
             detectCardTypeRepository.detectionResult =
@@ -343,8 +343,7 @@ internal class DefaultCardDelegateTest(
             delegate.outputDataFlow.test {
                 delegate.updateInputData { /* Empty to trigger an update */ }
 
-                val expectedDetectedCardTypes =
-                    detectCardTypeRepository.getDetectedCardTypesLocal(supportedCardTypes)
+                val expectedDetectedCardTypes = detectCardTypeRepository.getDetectedCardTypesLocal(supportedCardBrands)
 
                 with(expectMostRecentItem()) {
                     assertEquals(expectedDetectedCardTypes, detectedCardTypes)
@@ -356,8 +355,8 @@ internal class DefaultCardDelegateTest(
         @Test
         fun `detect card type repository returns unsupported cards, then output data should filter them`() = runTest {
             val supportedCardTypes = listOf(
-                CardType(cardBrand = CardBrand.VISA),
-                CardType(cardBrand = CardBrand.AMERICAN_EXPRESS)
+                CardBrand(cardType = CardType.VISA),
+                CardBrand(cardType = CardType.AMERICAN_EXPRESS)
             )
             delegate = createCardDelegate(
                 configuration = getDefaultCardConfigurationBuilder()
@@ -384,13 +383,13 @@ internal class DefaultCardDelegateTest(
 
         @Test
         fun `detect card type repository returns dual branded cards, then output data should be good`() = runTest {
-            val supportedCardTypes = listOf(
-                CardType(cardBrand = CardBrand.BCMC),
-                CardType(cardBrand = CardBrand.MAESTRO)
+            val supportedCardBrands = listOf(
+                CardBrand(cardType = CardType.BCMC),
+                CardBrand(cardType = CardType.MAESTRO)
             )
             delegate = createCardDelegate(
                 configuration = getDefaultCardConfigurationBuilder()
-                    .setSupportedCardTypes(*supportedCardTypes.toTypedArray())
+                    .setSupportedCardTypes(*supportedCardBrands.toTypedArray())
                     .build()
             )
             detectCardTypeRepository.detectionResult = TestDetectCardTypeRepository.TestDetectedCardType.DUAL_BRANDED
@@ -406,7 +405,7 @@ internal class DefaultCardDelegateTest(
                 }
 
                 val expectedDetectedCardTypes = DetectedCardTypesUtils.filterDetectedCardTypes(
-                    detectedCardTypes = detectCardTypeRepository.getDetectedCardTypesDualBranded(supportedCardTypes),
+                    detectedCardTypes = detectCardTypeRepository.getDetectedCardTypesDualBranded(supportedCardBrands),
                     selectedCardIndex = 1,
                 )
 
@@ -498,11 +497,11 @@ internal class DefaultCardDelegateTest(
         @Test
         fun `input data with custom config is valid, then output data should be good`() = runTest {
             val cardBrands = listOf(
-                CardListItem(CardType(cardBrand = CardBrand.VISA), true, Environment.TEST),
-                CardListItem(CardType(cardBrand = CardBrand.MASTERCARD), false, Environment.TEST),
-                CardListItem(CardType(cardBrand = CardBrand.AMERICAN_EXPRESS), false, Environment.TEST)
+                CardListItem(CardBrand(cardType = CardType.VISA), true, Environment.TEST),
+                CardListItem(CardBrand(cardType = CardType.MASTERCARD), false, Environment.TEST),
+                CardListItem(CardBrand(cardType = CardType.AMERICAN_EXPRESS), false, Environment.TEST)
             )
-            val supportedCardTypes = cardBrands.map { it.cardType }
+            val supportedCardBrands = cardBrands.map { it.cardBrand }
             val installmentConfiguration = InstallmentConfiguration(
                 InstallmentOptions.DefaultInstallmentOptions(
                     maxInstallments = 3,
@@ -521,7 +520,7 @@ internal class DefaultCardDelegateTest(
                     .setHolderNameRequired(true)
                     .setAddressConfiguration(addressConfiguration)
                     .setKcpAuthVisibility(KCPAuthVisibility.SHOW)
-                    .setSupportedCardTypes(*supportedCardTypes.toTypedArray())
+                    .setSupportedCardTypes(*supportedCardBrands.toTypedArray())
                     .setShowStorePaymentField(false)
                     .build()
             )
@@ -582,11 +581,11 @@ internal class DefaultCardDelegateTest(
                     stateOptions = AddressFormUtils.initializeStateOptions(TestAddressRepository.STATES)
                 )
 
-                val expectedDetectedCardTypes = detectCardTypeRepository.getDetectedCardTypesLocal(supportedCardTypes)
+                val expectedDetectedCardTypes = detectCardTypeRepository.getDetectedCardTypesLocal(supportedCardBrands)
 
                 val expectedInstallmentOptions = InstallmentUtils.makeInstallmentOptions(
                     installmentConfiguration,
-                    expectedDetectedCardTypes.first().cardType,
+                    expectedDetectedCardTypes.first().cardBrand,
                     true
                 )
 
@@ -713,7 +712,7 @@ internal class DefaultCardDelegateTest(
                 assertTrue(componentState.isValid)
                 assertEquals(TEST_CARD_NUMBER.takeLast(4), componentState.lastFourDigits)
                 assertEquals(TEST_CARD_NUMBER.take(8), componentState.binValue)
-                assertEquals(CardType(cardBrand = CardBrand.VISA), componentState.cardType)
+                assertEquals(CardBrand(cardType = CardType.VISA), componentState.cardBrand)
 
                 val paymentComponentData = componentState.data
                 with(paymentComponentData) {
@@ -780,7 +779,7 @@ internal class DefaultCardDelegateTest(
                     createDetectedCardType(),
                     createDetectedCardType().copy(
                         isSelected = true,
-                        cardType = CardType(cardBrand = CardBrand.VISA)
+                        cardBrand = CardBrand(cardType = CardType.VISA)
                     )
                 )
 
@@ -801,9 +800,9 @@ internal class DefaultCardDelegateTest(
                         addressUIState = addressUIState,
                         installmentOptions = listOf(installmentModel),
                         cardBrands = listOf(
-                            CardListItem(CardType(cardBrand = CardBrand.VISA), false, Environment.TEST),
-                            CardListItem(CardType(cardBrand = CardBrand.MASTERCARD), false, Environment.TEST),
-                            CardListItem(CardType(cardBrand = CardBrand.AMERICAN_EXPRESS), false, Environment.TEST)
+                            CardListItem(CardBrand(cardType = CardType.VISA), false, Environment.TEST),
+                            CardListItem(CardBrand(cardType = CardType.MASTERCARD), false, Environment.TEST),
+                            CardListItem(CardBrand(cardType = CardType.AMERICAN_EXPRESS), false, Environment.TEST)
                         ),
                     )
                 )
@@ -816,7 +815,7 @@ internal class DefaultCardDelegateTest(
                 assertTrue(componentState.isValid)
                 assertEquals(TEST_CARD_NUMBER.takeLast(4), componentState.lastFourDigits)
                 assertEquals(TEST_CARD_NUMBER.take(8), componentState.binValue)
-                assertEquals(CardType(cardBrand = CardBrand.VISA), componentState.cardType)
+                assertEquals(CardBrand(cardType = CardType.VISA), componentState.cardBrand)
 
                 val paymentComponentData = componentState.data
                 with(paymentComponentData) {
@@ -844,7 +843,7 @@ internal class DefaultCardDelegateTest(
                     assertEquals("12", encryptedPassword)
                     assertEquals("funding_source_1", fundingSource)
                     assertEquals(PaymentMethodTypes.SCHEME, type)
-                    assertEquals(CardBrand.VISA.txVariant, brand)
+                    assertEquals(CardType.VISA.txVariant, brand)
                     assertNull(storedPaymentMethodId)
                     assertEquals("2.2.11", threeDS2SdkVersion)
                 }
@@ -973,7 +972,7 @@ internal class DefaultCardDelegateTest(
     private fun getDefaultCardConfigurationBuilder(): CardConfiguration.Builder {
         return CardConfiguration
             .Builder(Locale.US, Environment.TEST, TEST_CLIENT_KEY)
-            .setSupportedCardTypes(CardType(cardBrand = CardBrand.VISA))
+            .setSupportedCardTypes(CardType.VISA)
     }
 
     private fun getCustomCardConfigurationBuilder(): CardConfiguration.Builder {
@@ -993,11 +992,7 @@ internal class DefaultCardDelegateTest(
             .setAddressConfiguration(AddressConfiguration.FullAddress())
             .setKcpAuthVisibility(KCPAuthVisibility.SHOW)
             .setShowStorePaymentField(false)
-            .setSupportedCardTypes(
-                CardType(cardBrand = CardBrand.VISA),
-                CardType(cardBrand = CardBrand.MASTERCARD),
-                CardType(cardBrand = CardBrand.AMERICAN_EXPRESS)
-            )
+            .setSupportedCardTypes(CardType.VISA, CardType.MASTERCARD, CardType.AMERICAN_EXPRESS)
     }
 
     private fun createOutputData(
@@ -1016,7 +1011,7 @@ internal class DefaultCardDelegateTest(
         holderNameUIState: InputFieldUIState = InputFieldUIState.HIDDEN,
         showStorePaymentField: Boolean = true,
         detectedCardTypes: List<DetectedCardType> =
-            detectCardTypeRepository.getDetectedCardTypesLocal(listOf(CardType(cardBrand = CardBrand.VISA))),
+            detectCardTypeRepository.getDetectedCardTypesLocal(listOf(CardBrand(cardType = CardType.VISA))),
         isSocialSecurityNumberRequired: Boolean = false,
         isKCPAuthRequired: Boolean = false,
         addressUIState: AddressFormUIState = AddressFormUIState.NONE,
@@ -1025,7 +1020,7 @@ internal class DefaultCardDelegateTest(
         @StringRes kcpBirthDateOrTaxNumberHint: Int = R.string.checkout_kcp_birth_date_or_tax_number_hint,
         cardBrands: List<CardListItem> = listOf(
             CardListItem(
-                CardType(cardBrand = CardBrand.VISA),
+                CardBrand(cardType = CardType.VISA),
                 true,
                 Environment.TEST
             )
@@ -1061,7 +1056,7 @@ internal class DefaultCardDelegateTest(
     }
 
     private fun createDetectedCardType(
-        cardType: CardType = CardType(cardBrand = CardBrand.MASTERCARD),
+        cardBrand: CardBrand = CardBrand(cardType = CardType.MASTERCARD),
         isReliable: Boolean = true,
         enableLuhnCheck: Boolean = true,
         cvcPolicy: Brand.FieldPolicy = Brand.FieldPolicy.REQUIRED,
@@ -1071,7 +1066,7 @@ internal class DefaultCardDelegateTest(
         isSelected: Boolean = false,
     ): DetectedCardType {
         return DetectedCardType(
-            cardType = cardType,
+            cardBrand = cardBrand,
             isReliable = isReliable,
             enableLuhnCheck = enableLuhnCheck,
             cvcPolicy = cvcPolicy,

--- a/card/src/test/java/com/adyen/checkout/card/DualBrandedCardUtilsTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/DualBrandedCardUtilsTest.kt
@@ -20,7 +20,7 @@ internal class DualBrandedCardUtilsTest {
     fun testDualBrandSortingSingleItemList() {
         val detectedCards = listOf(
             DetectedCardType(
-                cardType = CardType(cardBrand = CardBrand.CARTEBANCAIRE),
+                cardBrand = CardBrand(cardType = CardType.CARTEBANCAIRE),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -36,7 +36,7 @@ internal class DualBrandedCardUtilsTest {
     fun testDualBrandVisaAndCarteBancaire() {
         val detectedCards = listOf(
             DetectedCardType(
-                cardType = CardType(cardBrand = CardBrand.CARTEBANCAIRE),
+                cardBrand = CardBrand(cardType = CardType.CARTEBANCAIRE),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -45,7 +45,7 @@ internal class DualBrandedCardUtilsTest {
                 panLength = null,
             ),
             DetectedCardType(
-                cardType = CardType(cardBrand = CardBrand.VISA),
+                cardBrand = CardBrand(cardType = CardType.VISA),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -57,7 +57,7 @@ internal class DualBrandedCardUtilsTest {
 
         val sortedCards = listOf(
             DetectedCardType(
-                cardType = CardType(cardBrand = CardBrand.VISA),
+                cardBrand = CardBrand(cardType = CardType.VISA),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -66,7 +66,7 @@ internal class DualBrandedCardUtilsTest {
                 panLength = null,
             ),
             DetectedCardType(
-                cardType = CardType(cardBrand = CardBrand.CARTEBANCAIRE),
+                cardBrand = CardBrand(cardType = CardType.CARTEBANCAIRE),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -83,7 +83,7 @@ internal class DualBrandedCardUtilsTest {
     fun testDualBrandVisaAndCarteBancaireAlreadySorted() {
         val detectedCards = listOf(
             DetectedCardType(
-                cardType = CardType(cardBrand = CardBrand.VISA),
+                cardBrand = CardBrand(cardType = CardType.VISA),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -92,7 +92,7 @@ internal class DualBrandedCardUtilsTest {
                 panLength = null,
             ),
             DetectedCardType(
-                cardType = CardType(cardBrand = CardBrand.CARTEBANCAIRE),
+                cardBrand = CardBrand(cardType = CardType.CARTEBANCAIRE),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -104,7 +104,7 @@ internal class DualBrandedCardUtilsTest {
 
         val sortedCards = listOf(
             DetectedCardType(
-                cardType = CardType(cardBrand = CardBrand.VISA),
+                cardBrand = CardBrand(cardType = CardType.VISA),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -113,7 +113,7 @@ internal class DualBrandedCardUtilsTest {
                 panLength = null,
             ),
             DetectedCardType(
-                cardType = CardType(cardBrand = CardBrand.CARTEBANCAIRE),
+                cardBrand = CardBrand(cardType = CardType.CARTEBANCAIRE),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -130,7 +130,7 @@ internal class DualBrandedCardUtilsTest {
     fun testDualBrandPlccAndMasterCard() {
         val detectedCards = listOf(
             DetectedCardType(
-                cardType = CardType(cardBrand = CardBrand.MASTERCARD),
+                cardBrand = CardBrand(cardType = CardType.MASTERCARD),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -139,7 +139,7 @@ internal class DualBrandedCardUtilsTest {
                 panLength = null,
             ),
             DetectedCardType(
-                cardType = CardType(txVariant = "plcc_mastercard"),
+                cardBrand = CardBrand(txVariant = "plcc_mastercard"),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -151,7 +151,7 @@ internal class DualBrandedCardUtilsTest {
 
         val sortedCards = listOf(
             DetectedCardType(
-                cardType = CardType(txVariant = "plcc_mastercard"),
+                cardBrand = CardBrand(txVariant = "plcc_mastercard"),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -160,7 +160,7 @@ internal class DualBrandedCardUtilsTest {
                 panLength = null,
             ),
             DetectedCardType(
-                cardType = CardType(cardBrand = CardBrand.MASTERCARD),
+                cardBrand = CardBrand(cardType = CardType.MASTERCARD),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -177,7 +177,7 @@ internal class DualBrandedCardUtilsTest {
     fun testDualBrandPlccAndMasterCardAlreadySorted() {
         val detectedCards = listOf(
             DetectedCardType(
-                cardType = CardType(txVariant = "plcc_mastercard"),
+                cardBrand = CardBrand(txVariant = "plcc_mastercard"),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -186,7 +186,7 @@ internal class DualBrandedCardUtilsTest {
                 panLength = null,
             ),
             DetectedCardType(
-                cardType = CardType(cardBrand = CardBrand.MASTERCARD),
+                cardBrand = CardBrand(cardType = CardType.MASTERCARD),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -198,7 +198,7 @@ internal class DualBrandedCardUtilsTest {
 
         val sortedCards = listOf(
             DetectedCardType(
-                cardType = CardType(txVariant = "plcc_mastercard"),
+                cardBrand = CardBrand(txVariant = "plcc_mastercard"),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,
@@ -207,7 +207,7 @@ internal class DualBrandedCardUtilsTest {
                 panLength = null,
             ),
             DetectedCardType(
-                cardType = CardType(cardBrand = CardBrand.MASTERCARD),
+                cardBrand = CardBrand(cardType = CardType.MASTERCARD),
                 isReliable = true,
                 enableLuhnCheck = false,
                 cvcPolicy = Brand.FieldPolicy.REQUIRED,

--- a/card/src/test/java/com/adyen/checkout/card/StoredCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/StoredCardDelegateTest.kt
@@ -177,7 +177,7 @@ internal class StoredCardDelegateTest(
         fun `security code is empty with a no cvc card, then output data should be valid`() = runTest {
             delegate = createCardDelegate(
                 storedPaymentMethod = getStoredPaymentMethod(
-                    brand = CardBrand.BCMC.txVariant,
+                    brand = CardType.BCMC.txVariant,
                 )
             )
 
@@ -261,7 +261,7 @@ internal class StoredCardDelegateTest(
                     assertTrue(isValid)
                     assertEquals(TEST_CARD_LAST_FOUR, lastFourDigits)
                     assertEquals("", binValue)
-                    assertEquals(CardType(cardBrand = CardBrand.MASTERCARD), cardType)
+                    assertEquals(CardBrand(cardType = CardType.MASTERCARD), cardBrand)
                 }
 
                 val paymentComponentData = componentState.data
@@ -416,11 +416,7 @@ internal class StoredCardDelegateTest(
             .setHolderNameRequired(true)
             .setAddressConfiguration(AddressConfiguration.FullAddress())
             .setKcpAuthVisibility(KCPAuthVisibility.SHOW)
-            .setSupportedCardTypes(
-                CardType(cardBrand = CardBrand.VISA),
-                CardType(cardBrand = CardBrand.MASTERCARD),
-                CardType(cardBrand = CardBrand.AMERICAN_EXPRESS)
-            )
+            .setSupportedCardTypes(CardType.VISA, CardType.MASTERCARD, CardType.AMERICAN_EXPRESS)
     }
 
     private fun createOutputData(
@@ -475,7 +471,7 @@ internal class StoredCardDelegateTest(
     }
 
     private fun createDetectedCardType(
-        cardType: CardType = TEST_CARD_TYPE,
+        cardBrand: CardBrand = TEST_CARD_TYPE,
         isReliable: Boolean = true,
         enableLuhnCheck: Boolean = true,
         cvcPolicy: Brand.FieldPolicy = Brand.FieldPolicy.REQUIRED,
@@ -485,7 +481,7 @@ internal class StoredCardDelegateTest(
         isSelected: Boolean = false,
     ): DetectedCardType {
         return DetectedCardType(
-            cardType = cardType,
+            cardBrand = cardBrand,
             isReliable = isReliable,
             enableLuhnCheck = enableLuhnCheck,
             cvcPolicy = cvcPolicy,
@@ -502,7 +498,7 @@ internal class StoredCardDelegateTest(
         private val TEST_EXPIRY_DATE = ExpiryDate(3, 2030)
         private const val TEST_SECURITY_CODE = "737"
         private const val TEST_STORED_PM_ID = "1337"
-        private val TEST_CARD_TYPE = CardType(cardBrand = CardBrand.MASTERCARD)
+        private val TEST_CARD_TYPE = CardBrand(cardType = CardType.MASTERCARD)
         private val TEST_ORDER = OrderRequest("PSP", "ORDER_DATA")
     }
 }

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/card/SessionsCardTakenOverViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/card/SessionsCardTakenOverViewModel.kt
@@ -148,7 +148,7 @@ internal class SessionsCardTakenOverViewModel @Inject constructor(
 
     override fun onSubmit(state: CardComponentState): Boolean {
         // for this example we will only take over the flow if the brand is MASTERCARD
-        if (state.cardType != CardType(CardBrand.MASTERCARD)) return false
+        if (state.cardBrand != CardBrand(CardType.MASTERCARD)) return false
 
         isFlowTakenOver = true
         makePayment(state.data)


### PR DESCRIPTION
## Description
- Rename `CardType -> CardBrand` and `CardBrand -> CardType` 
- Add a new method inside `CardConfiguration` `setSupportedCardType(CardBrand)` so now we have two methods one with `CardBrand` and another one with `CardType` to make it easy for migration from V4 to V5 
PS: `CardBrand` is the source of truth internally when adding `SupportCardTypes`.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-708
