### PR TITLE
Cancel button in redirect view not working in components

### DIFF
--- a/action/src/main/java/com/adyen/checkout/action/DefaultGenericActionDelegate.kt
+++ b/action/src/main/java/com/adyen/checkout/action/DefaultGenericActionDelegate.kt
@@ -179,6 +179,10 @@ internal class DefaultGenericActionDelegate(
         delegate.refreshStatus()
     }
 
+    override fun onError(e: CheckoutException) {
+        delegate.onError(e)
+    }
+
     override fun onCleared() {
         Logger.d(TAG, "onCleared")
         removeObserver()


### PR DESCRIPTION
## Description

The cancel button in the redirect view does not work with standalone components. `delegate.onError` gets called from `PaymentInProgressView` but the delegate there is the `GenericActionDelegate` which does not implement `onError`.


## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-720
