### PR TITLE
Release 4.10.0 🎉

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ If you are upgrading from 3.x.x to a current release, check out our [migration g
 Import the Component module for the Payment Method you want to use by adding it to your `build.gradle` file.
 For example, for the Drop-in solution you should add:
 ```groovy
-implementation "com.adyen.checkout:drop-in:4.9.1"
+implementation "com.adyen.checkout:drop-in:4.10.0"
 ```
 For a Credit Card component you should add:
 ```groovy
-implementation "com.adyen.checkout:card:4.9.1"
+implementation "com.adyen.checkout:card:4.10.0"
 ```
 
 ### Client Key

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,7 @@
 [//]: # ( - Configurations public constructor are deprecated, please use each Configuration's builder to make a Configuration object)
 
 # New
+* The `CardComponentState.binValue` now reports 8 digit bins in case of card numbers with 16 or more digits.
 * We added `CardBrand`, along with `CardType`, to use when adding new card brands through `CardConfiguration`.
 * In `CardConfiguration` when adding supported card types you can now add new supported card types which are not part of `CardType`.
   example:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,4 +26,4 @@ CardConfiguration.Builder([SHOPPER_LOCALE], [ENVIRONMENT], [CLIENT_KEY])
 
 ## Deprecated
 * The `CardType.UNKNOWN` property. Use `CardBrand(txVariant = "[CARD_BRAND]")` instead.
-* The `CardType.setTxVariant()` method. No longer needed as it was used with `CardType.UNKNOWN`
+* The `CardType.setTxVariant()` method. No longer needed as it was used with `CardType.UNKNOWN`.

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ allprojects {
     // just for example app, don't need to increment
     ext.version_code = 1
     // The version_name format is "major.minor.patch(-(alpha|beta|rc)[0-9]{2}){0,1}" (e.g. 3.0.0, 3.1.1-alpha04 or 3.1.4-rc01 etc).
-    ext.version_name = "4.9.1"
+    ext.version_name = "4.10.0"
 
     // Code quality
     ext.ktlint_version = '0.40.0'

--- a/example-app/build.gradle
+++ b/example-app/build.gradle
@@ -72,7 +72,7 @@ android {
 dependencies {
     // Checkout
     implementation project(':drop-in')
-//    implementation "com.adyen.checkout:drop-in:4.9.1"
+//    implementation "com.adyen.checkout:drop-in:4.10.0"
 
     // Dependencies
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinx_version"


### PR DESCRIPTION
## Release Notes

# New
* The `CardComponentState.binValue` now reports 8 digit bins in case of card numbers with 16 or more digits.
* We added `CardBrand`, along with `CardType`, to use when adding new card brands through `CardConfiguration`.
* In `CardConfiguration` when adding supported card types you can now add new supported card types which are not part of `CardType`.
  example:

```kotlin
CardConfiguration.Builder([SHOPPER_LOCALE], [ENVIRONMENT], [CLIENT_KEY])
.setSupportedCardTypes(CardBrand(txVariant = "[CARD_BRAND1]"), CardBrand(txVariant = "[CARD_BRAND2]"))
.build()
```

## Fixed
* Undefined supported card types now works correctly for card component/drop-in.
  `CardType.UNKNOWN` was not working correctly when there were supported card brands coming from `/paymentMethods`, under `scheme` payment method,
  which are not part of `CardType` predefined brands, so we had to add `CardBrand` to make these undefined supported card types work.

## Deprecated
* The `CardType.UNKNOWN` property. Use `CardBrand(txVariant = "[CARD_BRAND]")` instead.
* The `CardType.setTxVariant()` method. No longer needed as it was used with `CardType.UNKNOWN`
