### PR TITLE
Add support for stored Blik payment method (v4)

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/CardComponentProvider.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponentProvider.kt
@@ -25,6 +25,7 @@ import com.adyen.checkout.core.log.Logger
 private val TAG = LogUtil.getTag()
 
 class CardComponentProvider : StoredPaymentComponentProvider<CardComponent, CardConfiguration> {
+
     override fun <T> get(
         owner: T,
         paymentMethod: PaymentMethod,
@@ -70,12 +71,32 @@ class CardComponentProvider : StoredPaymentComponentProvider<CardComponent, Card
         return get(owner, owner, storedPaymentMethod, configuration, null)
     }
 
+    override fun <T> get(
+        owner: T,
+        storedPaymentMethod: StoredPaymentMethod,
+        configuration: CardConfiguration,
+        key: String?
+    ): CardComponent where T : SavedStateRegistryOwner, T : ViewModelStoreOwner {
+        return get(owner, owner, storedPaymentMethod, configuration, null, key)
+    }
+
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,
         viewModelStoreOwner: ViewModelStoreOwner,
         storedPaymentMethod: StoredPaymentMethod,
         configuration: CardConfiguration,
         defaultArgs: Bundle?
+    ): CardComponent {
+        return get(savedStateRegistryOwner, viewModelStoreOwner, storedPaymentMethod, configuration, defaultArgs, null)
+    }
+
+    override fun get(
+        savedStateRegistryOwner: SavedStateRegistryOwner,
+        viewModelStoreOwner: ViewModelStoreOwner,
+        storedPaymentMethod: StoredPaymentMethod,
+        configuration: CardConfiguration,
+        defaultArgs: Bundle?,
+        key: String?
     ): CardComponent {
         val publicKeyRepository = PublicKeyRepository()
         val factory = viewModelFactory(savedStateRegistryOwner, defaultArgs) { savedStateHandle ->
@@ -89,7 +110,12 @@ class CardComponentProvider : StoredPaymentComponentProvider<CardComponent, Card
                 configuration
             )
         }
-        return ViewModelProvider(viewModelStoreOwner, factory).get(CardComponent::class.java)
+
+        return if (key == null) {
+            ViewModelProvider(viewModelStoreOwner, factory)[CardComponent::class.java]
+        } else {
+            ViewModelProvider(viewModelStoreOwner, factory)[key, CardComponent::class.java]
+        }
     }
 
     /**

--- a/components-core/src/main/java/com/adyen/checkout/components/StoredPaymentComponentProvider.java
+++ b/components-core/src/main/java/com/adyen/checkout/components/StoredPaymentComponentProvider.java
@@ -22,6 +22,7 @@ import com.adyen.checkout.components.model.paymentmethods.StoredPaymentMethod;
 import com.adyen.checkout.core.exception.CheckoutException;
 
 
+@SuppressWarnings("LambdaLast")
 public interface StoredPaymentComponentProvider<ComponentT extends PaymentComponent, ConfigurationT extends Configuration>
         extends PaymentComponentProvider<ComponentT, ConfigurationT> {
     /**
@@ -32,12 +33,28 @@ public interface StoredPaymentComponentProvider<ComponentT extends PaymentCompon
      * @param configuration       The Configuration of the component.
      * @return The Component
      */
-    @SuppressWarnings("LambdaLast")
     @NonNull
     <T extends SavedStateRegistryOwner & ViewModelStoreOwner> ComponentT get(
             @NonNull T owner,
             @NonNull StoredPaymentMethod storedPaymentMethod,
             @NonNull ConfigurationT configuration
+    ) throws CheckoutException;
+
+    /**
+     * Get a {@link PaymentComponent} with a stored payment method.
+     *
+     * @param owner               The Activity or Fragment to associate the lifecycle.
+     * @param storedPaymentMethod The corresponding  {@link StoredPaymentMethod} object.
+     * @param configuration       The Configuration of the component.
+     * @param key                 The key used to retrieve the component.
+     * @return The Component
+     */
+    @NonNull
+    <T extends SavedStateRegistryOwner & ViewModelStoreOwner> ComponentT get(
+            @NonNull T owner,
+            @NonNull StoredPaymentMethod storedPaymentMethod,
+            @NonNull ConfigurationT configuration,
+            @Nullable String key
     ) throws CheckoutException;
 
     /**
@@ -51,7 +68,6 @@ public interface StoredPaymentComponentProvider<ComponentT extends PaymentCompon
      *                                ViewModels} if there is no previously saved state or previously saved state misses a value by such key
      * @return The Component
      */
-    @SuppressWarnings("LambdaLast")
     @NonNull
     ComponentT get(
             @NonNull SavedStateRegistryOwner savedStateRegistryOwner,
@@ -59,5 +75,27 @@ public interface StoredPaymentComponentProvider<ComponentT extends PaymentCompon
             @NonNull StoredPaymentMethod storedPaymentMethod,
             @NonNull ConfigurationT configuration,
             @Nullable Bundle defaultArgs
+    ) throws CheckoutException;
+
+    /**
+     * Get a {@link PaymentComponent} with a stored payment method.
+     *
+     * @param savedStateRegistryOwner The owner of the SavedStateRegistry, normally an Activity or Fragment.
+     * @param viewModelStoreOwner     A scope that owns ViewModelStore, normally an Activity or Fragment.
+     * @param storedPaymentMethod     The corresponding  {@link StoredPaymentMethod} object.
+     * @param configuration           The Configuration of the component.
+     * @param defaultArgs             Values from this {@code Bundle} will be used as defaults by {@link SavedStateHandle} passed in {@link ViewModel
+     *                                ViewModels} if there is no previously saved state or previously saved state misses a value by such key
+     * @param key                     The key used to retrieve the component.
+     * @return The Component
+     */
+    @NonNull
+    ComponentT get(
+            @NonNull SavedStateRegistryOwner savedStateRegistryOwner,
+            @NonNull ViewModelStoreOwner viewModelStoreOwner,
+            @NonNull StoredPaymentMethod storedPaymentMethod,
+            @NonNull ConfigurationT configuration,
+            @Nullable Bundle defaultArgs,
+            @Nullable String key
     ) throws CheckoutException;
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/base/GenericStoredPaymentComponentProvider.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/base/GenericStoredPaymentComponentProvider.kt
@@ -31,12 +31,32 @@ class GenericStoredPaymentComponentProvider<
         return get(owner, owner, storedPaymentMethod, configuration, null)
     }
 
+    override fun <T> get(
+        owner: T,
+        storedPaymentMethod: StoredPaymentMethod,
+        configuration: ConfigurationT,
+        key: String?
+    ): BaseComponentT where T : ViewModelStoreOwner, T : SavedStateRegistryOwner {
+        return get(owner, owner, storedPaymentMethod, configuration, null, key)
+    }
+
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,
         viewModelStoreOwner: ViewModelStoreOwner,
         storedPaymentMethod: StoredPaymentMethod,
         configuration: ConfigurationT,
         defaultArgs: Bundle?
+    ): BaseComponentT {
+        return get(savedStateRegistryOwner, viewModelStoreOwner, storedPaymentMethod, configuration, defaultArgs, null)
+    }
+
+    override fun get(
+        savedStateRegistryOwner: SavedStateRegistryOwner,
+        viewModelStoreOwner: ViewModelStoreOwner,
+        storedPaymentMethod: StoredPaymentMethod,
+        configuration: ConfigurationT,
+        defaultArgs: Bundle?,
+        key: String?
     ): BaseComponentT {
         val genericStoredFactory: ViewModelProvider.Factory = viewModelFactory(savedStateRegistryOwner, defaultArgs) { savedStateHandle ->
             componentClass.getConstructor(
@@ -45,7 +65,11 @@ class GenericStoredPaymentComponentProvider<
                 configuration.javaClass
             ).newInstance(savedStateHandle, GenericStoredPaymentDelegate(storedPaymentMethod), configuration)
         }
-        return ViewModelProvider(viewModelStoreOwner, genericStoredFactory)[componentClass]
+        return if (key == null) {
+            ViewModelProvider(viewModelStoreOwner, genericStoredFactory)[componentClass]
+        } else {
+            ViewModelProvider(viewModelStoreOwner, genericStoredFactory)[key, componentClass]
+        }
     }
 
     override fun <T> get(

--- a/components-core/src/main/java/com/adyen/checkout/components/model/payments/Amount.java
+++ b/components-core/src/main/java/com/adyen/checkout/components/model/payments/Amount.java
@@ -13,6 +13,7 @@ import android.os.Parcel;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.adyen.checkout.components.util.CheckoutCurrency;
 import com.adyen.checkout.core.exception.ModelSerializationException;
 import com.adyen.checkout.core.model.JsonUtils;
 import com.adyen.checkout.core.model.ModelObject;
@@ -94,6 +95,10 @@ public class Amount extends ModelObject {
 
     public boolean isEmpty() {
         return EMPTY_CURRENCY.equals(currency) || value == EMPTY_VALUE;
+    }
+
+    public boolean isZero() {
+        return CheckoutCurrency.isSupported(currency) && value == 0L;
     }
 
     @Override

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ComponentParsingProvider.kt
@@ -257,11 +257,11 @@ internal fun getComponentFor(
     val component = when (storedPaymentMethod.type) {
         PaymentMethodTypes.SCHEME -> {
             val cardConfig: CardConfiguration = getConfigurationForPaymentMethod(PaymentMethodTypes.SCHEME, dropInConfiguration, amount)
-            CardComponent.PROVIDER.get(fragment, storedPaymentMethod, cardConfig)
+            CardComponent.PROVIDER.get(fragment, storedPaymentMethod, cardConfig, storedPaymentMethod.id)
         }
         PaymentMethodTypes.BLIK -> {
             val blikConfig: BlikConfiguration = getConfigurationForPaymentMethod(PaymentMethodTypes.BLIK, dropInConfiguration, amount)
-            BlikComponent.PROVIDER.get(fragment, storedPaymentMethod, blikConfig)
+            BlikComponent.PROVIDER.get(fragment, storedPaymentMethod, blikConfig, storedPaymentMethod.id)
         }
         else -> {
             throw CheckoutException("Unable to find stored component for type - ${storedPaymentMethod.type}")

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/PayButtonFormatter.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/PayButtonFormatter.kt
@@ -1,0 +1,36 @@
+package com.adyen.checkout.dropin.ui
+
+import android.content.Context
+import androidx.annotation.StringRes
+import com.adyen.checkout.components.model.payments.Amount
+import com.adyen.checkout.components.util.CurrencyUtils
+import com.adyen.checkout.dropin.R
+import java.util.Locale
+
+internal object PayButtonFormatter {
+
+    @Suppress("LongParameterList")
+    fun getPayButtonText(
+        amount: Amount,
+        locale: Locale,
+        localizedContext: Context,
+        @StringRes emptyAmountStringResId: Int = R.string.pay_button,
+        @StringRes zeroAmountStringResId: Int = R.string.confirm_preauthorization,
+        @StringRes positiveAmountStringResId: Int = R.string.pay_button_with_value,
+    ): String {
+        return when {
+            amount.isEmpty -> {
+                localizedContext.getString(emptyAmountStringResId)
+            }
+            amount.isZero -> {
+                localizedContext.getString(zeroAmountStringResId)
+            }
+            else -> {
+                localizedContext.getString(
+                    positiveAmountStringResId,
+                    CurrencyUtils.formatAmount(amount, locale)
+                )
+            }
+        }
+    }
+}

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/paymentmethods/PaymentMethodListDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/paymentmethods/PaymentMethodListDialogFragment.kt
@@ -237,6 +237,7 @@ class PaymentMethodListDialogFragment :
 
         component.observe(viewLifecycleOwner) { componentState ->
             if (componentState.isValid) {
+                component.removeObservers(viewLifecycleOwner)
                 protocol.requestPaymentsCall(componentState)
             }
         }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/viewmodel/PaymentMethodsListViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/viewmodel/PaymentMethodsListViewModel.kt
@@ -35,7 +35,7 @@ import com.adyen.checkout.dropin.ui.paymentmethods.StoredPaymentMethodModel
 import com.adyen.checkout.dropin.ui.stored.makeStoredModel
 
 @Suppress("TooManyFunctions")
-class PaymentMethodsListViewModel(
+internal class PaymentMethodsListViewModel(
     application: Application,
     private val paymentMethods: List<PaymentMethod>,
     storedPaymentMethods: List<StoredPaymentMethod>,

--- a/drop-in/src/main/res/template/values/strings.xml.tt
+++ b/drop-in/src/main/res/template/values/strings.xml.tt
@@ -9,6 +9,7 @@
 <resources>
     <string name="pay_button">%%payButton%%</string>
     <string name="pay_button_with_value">%%payAmountFormat%%</string>
+    <string name="confirm_preauthorization">%%confirmPreauthorization%%</string>
     <string name="payment_methods_header">%%paymentMethods.title%%</string>
     <string name="error_dialog_title">%%error.title%%</string>
     <string name="error_dialog_button">%%dismissButton%%</string>
@@ -33,6 +34,8 @@
     <string name="checkout_giftcard_remove_gift_cards_positive_button">%%storedPaymentMethod.disable.confirmButton%%</string>
     <string name="checkout_giftcard_remove_gift_cards_negative_button">%%storedPaymentMethod.disable.cancelButton%%</string>
     <string name="checkout_remove_stored_payment_method_body">%%storedPaymentMethod.disable.confirmation%%</string>
+    <string name="checkout_stored_payment_confirmation_message">%%oneClick.confirmationAlert.title%%</string>
+    <string name="checkout_stored_payment_confirmation_cancel_button">%%cancelButton%%</string>
     <!-- Untranslatable strings -->
     <string name="checkout_negative_amount" translatable="false">- %s</string>
 </resources>

--- a/drop-in/src/main/res/values-ar/strings.xml
+++ b/drop-in/src/main/res/values-ar/strings.xml
@@ -9,6 +9,7 @@
 <resources>
     <string name="pay_button">دفع</string>
     <string name="pay_button_with_value">دفع %s</string>
+    <string name="confirm_preauthorization">تأكيد التفويض المسبق</string>
     <string name="payment_methods_header">طرق الدفع</string>
     <string name="error_dialog_title">خطأ</string>
     <string name="error_dialog_button">موافق</string>
@@ -33,4 +34,6 @@
     <string name="checkout_giftcard_remove_gift_cards_positive_button">نعم، أرغب في إزالتها</string>
     <string name="checkout_giftcard_remove_gift_cards_negative_button">إلغاء</string>
     <string name="checkout_remove_stored_payment_method_body">إزالة طريقة الدفع المخزنة</string>
+    <string name="checkout_stored_payment_confirmation_message">تأكيد الدفع باستخدام %s</string>
+    <string name="checkout_stored_payment_confirmation_cancel_button">إلغاء</string>
 </resources>

--- a/drop-in/src/main/res/values-cs-rCZ/strings.xml
+++ b/drop-in/src/main/res/values-cs-rCZ/strings.xml
@@ -9,6 +9,7 @@
 <resources>
     <string name="pay_button">Zaplatit</string>
     <string name="pay_button_with_value">Zaplatit %s</string>
+    <string name="confirm_preauthorization">Potvrdit předautorizaci</string>
     <string name="payment_methods_header">Způsoby platby</string>
     <string name="error_dialog_title">Chyba</string>
     <string name="error_dialog_button">OK</string>
@@ -33,4 +34,6 @@
     <string name="checkout_giftcard_remove_gift_cards_positive_button">Ano, odebrat</string>
     <string name="checkout_giftcard_remove_gift_cards_negative_button">Zrušit</string>
     <string name="checkout_remove_stored_payment_method_body">Odebrat uložený způsob platby</string>
+    <string name="checkout_stored_payment_confirmation_message">Potvrdit %s platbu</string>
+    <string name="checkout_stored_payment_confirmation_cancel_button">Zrušit</string>
 </resources>

--- a/drop-in/src/main/res/values-da-rDK/strings.xml
+++ b/drop-in/src/main/res/values-da-rDK/strings.xml
@@ -9,6 +9,7 @@
 <resources>
     <string name="pay_button">Betal</string>
     <string name="pay_button_with_value">Betal %s</string>
+    <string name="confirm_preauthorization">Bekræft forhåndsgodkendelse</string>
     <string name="payment_methods_header">Betalingsmåder</string>
     <string name="error_dialog_title">Fejl</string>
     <string name="error_dialog_button">OK</string>
@@ -33,4 +34,6 @@
     <string name="checkout_giftcard_remove_gift_cards_positive_button">Ja, fjern</string>
     <string name="checkout_giftcard_remove_gift_cards_negative_button">Annuller</string>
     <string name="checkout_remove_stored_payment_method_body">Fjern gemt betalingsmåde</string>
+    <string name="checkout_stored_payment_confirmation_message">Bekræft %s-betaling</string>
+    <string name="checkout_stored_payment_confirmation_cancel_button">Annuller</string>
 </resources>

--- a/drop-in/src/main/res/values-de-rDE/strings.xml
+++ b/drop-in/src/main/res/values-de-rDE/strings.xml
@@ -9,6 +9,7 @@
 <resources>
     <string name="pay_button">Zahlen</string>
     <string name="pay_button_with_value">%s zahlen</string>
+    <string name="confirm_preauthorization">Vorautorisierung bestätigen</string>
     <string name="payment_methods_header">Zahlungsmethoden</string>
     <string name="error_dialog_title">Fehler</string>
     <string name="error_dialog_button">OK</string>
@@ -33,4 +34,6 @@
     <string name="checkout_giftcard_remove_gift_cards_positive_button">Ja, entfernen</string>
     <string name="checkout_giftcard_remove_gift_cards_negative_button">Abbrechen</string>
     <string name="checkout_remove_stored_payment_method_body">Gespeicherte Zahlungsmethode entfernen</string>
+    <string name="checkout_stored_payment_confirmation_message">Bestätige %s Zahlung</string>
+    <string name="checkout_stored_payment_confirmation_cancel_button">Abbrechen</string>
 </resources>

--- a/drop-in/src/main/res/values-el-rGR/strings.xml
+++ b/drop-in/src/main/res/values-el-rGR/strings.xml
@@ -9,6 +9,7 @@
 <resources>
     <string name="pay_button">Πληρωμή</string>
     <string name="pay_button_with_value">Πληρωμή %s</string>
+    <string name="confirm_preauthorization">Επιβεβαίωση προεξουσιοδότησης</string>
     <string name="payment_methods_header">Τρόποι πληρωμής</string>
     <string name="error_dialog_title">Σφάλμα</string>
     <string name="error_dialog_button">ΟΚ</string>
@@ -33,4 +34,6 @@
     <string name="checkout_giftcard_remove_gift_cards_positive_button">Ναι, αφαίρεση</string>
     <string name="checkout_giftcard_remove_gift_cards_negative_button">Άκυρο</string>
     <string name="checkout_remove_stored_payment_method_body">Αφαίρεση αποθηκευμένου τρόπου πληρωμής</string>
+    <string name="checkout_stored_payment_confirmation_message">Επιβεβαίωση πληρωμής μέσω %s</string>
+    <string name="checkout_stored_payment_confirmation_cancel_button">Άκυρο</string>
 </resources>

--- a/drop-in/src/main/res/values-es-rES/strings.xml
+++ b/drop-in/src/main/res/values-es-rES/strings.xml
@@ -9,6 +9,7 @@
 <resources>
     <string name="pay_button">Pagar</string>
     <string name="pay_button_with_value">Pagar %s</string>
+    <string name="confirm_preauthorization">Confirmar preautorización</string>
     <string name="payment_methods_header">Métodos de pago</string>
     <string name="error_dialog_title">Error</string>
     <string name="error_dialog_button">Okay</string>
@@ -33,4 +34,6 @@
     <string name="checkout_giftcard_remove_gift_cards_positive_button">Sí, eliminar</string>
     <string name="checkout_giftcard_remove_gift_cards_negative_button">Cancelar</string>
     <string name="checkout_remove_stored_payment_method_body">Eliminar método de pago almacenado</string>
+    <string name="checkout_stored_payment_confirmation_message">Confirmar pago de %s</string>
+    <string name="checkout_stored_payment_confirmation_cancel_button">Cancelar</string>
 </resources>

--- a/drop-in/src/main/res/values-fi-rFI/strings.xml
+++ b/drop-in/src/main/res/values-fi-rFI/strings.xml
@@ -9,6 +9,7 @@
 <resources>
     <string name="pay_button">Maksa</string>
     <string name="pay_button_with_value">Maksa %s</string>
+    <string name="confirm_preauthorization">Vahvista ennakkolupa</string>
     <string name="payment_methods_header">Maksutavat</string>
     <string name="error_dialog_title">Virhe</string>
     <string name="error_dialog_button">Ok</string>
@@ -33,4 +34,6 @@
     <string name="checkout_giftcard_remove_gift_cards_positive_button">Kyllä, poista</string>
     <string name="checkout_giftcard_remove_gift_cards_negative_button">Peruuta</string>
     <string name="checkout_remove_stored_payment_method_body">Poista tallennettu maksutapa</string>
+    <string name="checkout_stored_payment_confirmation_message">Vahvista %s maksu</string>
+    <string name="checkout_stored_payment_confirmation_cancel_button">Peruuta</string>
 </resources>

--- a/drop-in/src/main/res/values-fr-rFR/strings.xml
+++ b/drop-in/src/main/res/values-fr-rFR/strings.xml
@@ -9,6 +9,7 @@
 <resources>
     <string name="pay_button">Payer</string>
     <string name="pay_button_with_value">Payer %s</string>
+    <string name="confirm_preauthorization">Confirmer la pré-autorisation</string>
     <string name="payment_methods_header">Méthodes de paiement</string>
     <string name="error_dialog_title">Erreur</string>
     <string name="error_dialog_button">Ok</string>
@@ -33,4 +34,6 @@
     <string name="checkout_giftcard_remove_gift_cards_positive_button">Oui, supprimer</string>
     <string name="checkout_giftcard_remove_gift_cards_negative_button">Annuler</string>
     <string name="checkout_remove_stored_payment_method_body">Supprimer le mode de paiement enregistré</string>
+    <string name="checkout_stored_payment_confirmation_message">Confirmer paiement de %s</string>
+    <string name="checkout_stored_payment_confirmation_cancel_button">Annuler</string>
 </resources>

--- a/drop-in/src/main/res/values-hr-rHR/strings.xml
+++ b/drop-in/src/main/res/values-hr-rHR/strings.xml
@@ -9,6 +9,7 @@
 <resources>
     <string name="pay_button">Platiti</string>
     <string name="pay_button_with_value">Platiti %s</string>
+    <string name="confirm_preauthorization">Potvrdite prethodno odobrenje</string>
     <string name="payment_methods_header">Način plaćanja</string>
     <string name="error_dialog_title">Greška</string>
     <string name="error_dialog_button">U redu</string>
@@ -33,4 +34,6 @@
     <string name="checkout_giftcard_remove_gift_cards_positive_button">Da, ukloni</string>
     <string name="checkout_giftcard_remove_gift_cards_negative_button">Otkaži</string>
     <string name="checkout_remove_stored_payment_method_body">Uklonite pohranjeni način plaćanja</string>
+    <string name="checkout_stored_payment_confirmation_message">Potvrdite plaćanje: %s</string>
+    <string name="checkout_stored_payment_confirmation_cancel_button">Otkaži</string>
 </resources>

--- a/drop-in/src/main/res/values-hu-rHU/strings.xml
+++ b/drop-in/src/main/res/values-hu-rHU/strings.xml
@@ -9,6 +9,7 @@
 <resources>
     <string name="pay_button">Fizetés</string>
     <string name="pay_button_with_value">Fizetendő: %s</string>
+    <string name="confirm_preauthorization">Előzetes meghatalmazás jóváhagyása</string>
     <string name="payment_methods_header">Fizetési módok</string>
     <string name="error_dialog_title">Hiba</string>
     <string name="error_dialog_button">OK</string>
@@ -33,4 +34,6 @@
     <string name="checkout_giftcard_remove_gift_cards_positive_button">Igen, eltávolítom</string>
     <string name="checkout_giftcard_remove_gift_cards_negative_button">Mégse</string>
     <string name="checkout_remove_stored_payment_method_body">Tárolt fizetési mód eltávolítása</string>
+    <string name="checkout_stored_payment_confirmation_message">%s használatával történő fizetés jóváhagyása</string>
+    <string name="checkout_stored_payment_confirmation_cancel_button">Mégse</string>
 </resources>

--- a/drop-in/src/main/res/values-it-rIT/strings.xml
+++ b/drop-in/src/main/res/values-it-rIT/strings.xml
@@ -9,6 +9,7 @@
 <resources>
     <string name="pay_button">Paga</string>
     <string name="pay_button_with_value">Paga %s</string>
+    <string name="confirm_preauthorization">Conferma preautorizzazione</string>
     <string name="payment_methods_header">Metodo di Pagamento</string>
     <string name="error_dialog_title">Errore</string>
     <string name="error_dialog_button">OK</string>
@@ -33,4 +34,6 @@
     <string name="checkout_giftcard_remove_gift_cards_positive_button">Sì, rimuoverli</string>
     <string name="checkout_giftcard_remove_gift_cards_negative_button">Cancella</string>
     <string name="checkout_remove_stored_payment_method_body">Rimuovi il metodo di pagamento archiviato</string>
+    <string name="checkout_stored_payment_confirmation_message">Conferma il pagamento di %s</string>
+    <string name="checkout_stored_payment_confirmation_cancel_button">Annulla</string>
 </resources>

--- a/drop-in/src/main/res/values-ja-rJP/strings.xml
+++ b/drop-in/src/main/res/values-ja-rJP/strings.xml
@@ -9,6 +9,7 @@
 <resources>
     <string name="pay_button">支払う</string>
     <string name="pay_button_with_value">%sのお支払い</string>
+    <string name="confirm_preauthorization">事前承認を確認する</string>
     <string name="payment_methods_header">お支払い方法</string>
     <string name="error_dialog_title">エラー</string>
     <string name="error_dialog_button">OK</string>
@@ -33,4 +34,6 @@
     <string name="checkout_giftcard_remove_gift_cards_positive_button">はい、削除します</string>
     <string name="checkout_giftcard_remove_gift_cards_negative_button">キャンセル</string>
     <string name="checkout_remove_stored_payment_method_body">保存されている支払方法を削除する</string>
+    <string name="checkout_stored_payment_confirmation_message">%sのお支払いをご確認下さい</string>
+    <string name="checkout_stored_payment_confirmation_cancel_button">キャンセル</string>
 </resources>

--- a/drop-in/src/main/res/values-ko-rKR/strings.xml
+++ b/drop-in/src/main/res/values-ko-rKR/strings.xml
@@ -9,6 +9,7 @@
 <resources>
     <string name="pay_button">결제</string>
     <string name="pay_button_with_value">%s 결제</string>
+    <string name="confirm_preauthorization">사전 승인 확인</string>
     <string name="payment_methods_header">결제 수단</string>
     <string name="error_dialog_title">오류</string>
     <string name="error_dialog_button">확인</string>
@@ -33,4 +34,6 @@
     <string name="checkout_giftcard_remove_gift_cards_positive_button">예, 삭제합니다</string>
     <string name="checkout_giftcard_remove_gift_cards_negative_button">취소</string>
     <string name="checkout_remove_stored_payment_method_body">저장된 결제 수단 삭제</string>
+    <string name="checkout_stored_payment_confirmation_message">%s 결제 확인</string>
+    <string name="checkout_stored_payment_confirmation_cancel_button">취소</string>
 </resources>

--- a/drop-in/src/main/res/values-nb-rNO/strings.xml
+++ b/drop-in/src/main/res/values-nb-rNO/strings.xml
@@ -9,6 +9,7 @@
 <resources>
     <string name="pay_button">Betal</string>
     <string name="pay_button_with_value">Betal %s</string>
+    <string name="confirm_preauthorization">Bekreft forhåndsgodkjenning</string>
     <string name="payment_methods_header">Betalingsmetoder</string>
     <string name="error_dialog_title">Feil</string>
     <string name="error_dialog_button">Ok</string>
@@ -33,4 +34,6 @@
     <string name="checkout_giftcard_remove_gift_cards_positive_button">Ja, fjern</string>
     <string name="checkout_giftcard_remove_gift_cards_negative_button">Avbryt</string>
     <string name="checkout_remove_stored_payment_method_body">Fjern lagret betalingsmetode</string>
+    <string name="checkout_stored_payment_confirmation_message">Bekreft betaling med %s</string>
+    <string name="checkout_stored_payment_confirmation_cancel_button">Avbryt</string>
 </resources>

--- a/drop-in/src/main/res/values-nl-rNL/strings.xml
+++ b/drop-in/src/main/res/values-nl-rNL/strings.xml
@@ -9,6 +9,7 @@
 <resources>
     <string name="pay_button">Betaal</string>
     <string name="pay_button_with_value">%s betalen</string>
+    <string name="confirm_preauthorization">Preautorisatie bevestigen</string>
     <string name="payment_methods_header">Betaalmethodes</string>
     <string name="error_dialog_title">Fout</string>
     <string name="error_dialog_button">Oké</string>
@@ -33,4 +34,6 @@
     <string name="checkout_giftcard_remove_gift_cards_positive_button">Ja, verwijderen</string>
     <string name="checkout_giftcard_remove_gift_cards_negative_button">Annuleren</string>
     <string name="checkout_remove_stored_payment_method_body">Opgeslagen betalingsmethode verwijderen</string>
+    <string name="checkout_stored_payment_confirmation_message">Bevestig %s betaling</string>
+    <string name="checkout_stored_payment_confirmation_cancel_button">Annuleer</string>
 </resources>

--- a/drop-in/src/main/res/values-pl-rPL/strings.xml
+++ b/drop-in/src/main/res/values-pl-rPL/strings.xml
@@ -9,6 +9,7 @@
 <resources>
     <string name="pay_button">Zapłać</string>
     <string name="pay_button_with_value">Zapłać %s</string>
+    <string name="confirm_preauthorization">Potwierdź autoryzację wstępną</string>
     <string name="payment_methods_header">Metody płatności</string>
     <string name="error_dialog_title">Błąd</string>
     <string name="error_dialog_button">Ok</string>
@@ -33,4 +34,6 @@
     <string name="checkout_giftcard_remove_gift_cards_positive_button">Tak, usuń</string>
     <string name="checkout_giftcard_remove_gift_cards_negative_button">Anuluj</string>
     <string name="checkout_remove_stored_payment_method_body">Usuń zapisaną metodę płatności</string>
+    <string name="checkout_stored_payment_confirmation_message">Potwierdź płatność %s</string>
+    <string name="checkout_stored_payment_confirmation_cancel_button">Anuluj</string>
 </resources>

--- a/drop-in/src/main/res/values-pt-rBR/strings.xml
+++ b/drop-in/src/main/res/values-pt-rBR/strings.xml
@@ -9,6 +9,7 @@
 <resources>
     <string name="pay_button">Pagar</string>
     <string name="pay_button_with_value">Pagar %s</string>
+    <string name="confirm_preauthorization">Confirmar pré-autorização</string>
     <string name="payment_methods_header">Meios de pagamento</string>
     <string name="error_dialog_title">Erro</string>
     <string name="error_dialog_button">OK</string>
@@ -33,4 +34,6 @@
     <string name="checkout_giftcard_remove_gift_cards_positive_button">Sim, remover</string>
     <string name="checkout_giftcard_remove_gift_cards_negative_button">Cancelar</string>
     <string name="checkout_remove_stored_payment_method_body">Remover método de pagamento armazenado</string>
+    <string name="checkout_stored_payment_confirmation_message">Confirmar pagamento %s</string>
+    <string name="checkout_stored_payment_confirmation_cancel_button">Cancelar</string>
 </resources>

--- a/drop-in/src/main/res/values-ro-rRO/strings.xml
+++ b/drop-in/src/main/res/values-ro-rRO/strings.xml
@@ -9,6 +9,7 @@
 <resources>
     <string name="pay_button">Plătiți</string>
     <string name="pay_button_with_value">Plătiți %s</string>
+    <string name="confirm_preauthorization">Confirmați preautorizarea</string>
     <string name="payment_methods_header">Metode de plată</string>
     <string name="error_dialog_title">Eroare</string>
     <string name="error_dialog_button">Ok</string>
@@ -33,4 +34,6 @@
     <string name="checkout_giftcard_remove_gift_cards_positive_button">Da, șterge</string>
     <string name="checkout_giftcard_remove_gift_cards_negative_button">Anulare</string>
     <string name="checkout_remove_stored_payment_method_body">Ștergeți metoda de plată memorată</string>
+    <string name="checkout_stored_payment_confirmation_message">Confirmați plata %s</string>
+    <string name="checkout_stored_payment_confirmation_cancel_button">Anulare</string>
 </resources>

--- a/drop-in/src/main/res/values-ru-rRU/strings.xml
+++ b/drop-in/src/main/res/values-ru-rRU/strings.xml
@@ -9,6 +9,7 @@
 <resources>
     <string name="pay_button">Заплатить</string>
     <string name="pay_button_with_value">Заплатить %s</string>
+    <string name="confirm_preauthorization">Подтвердить предавторизацию</string>
     <string name="payment_methods_header">Способы оплаты</string>
     <string name="error_dialog_title">Ошибка</string>
     <string name="error_dialog_button">ОК</string>
@@ -33,4 +34,6 @@
     <string name="checkout_giftcard_remove_gift_cards_positive_button">Да, удалить</string>
     <string name="checkout_giftcard_remove_gift_cards_negative_button">Отменить</string>
     <string name="checkout_remove_stored_payment_method_body">Удалить сохраненный способ оплаты</string>
+    <string name="checkout_stored_payment_confirmation_message">Подтвердить оплату %s</string>
+    <string name="checkout_stored_payment_confirmation_cancel_button">Отменить</string>
 </resources>

--- a/drop-in/src/main/res/values-sk-rSK/strings.xml
+++ b/drop-in/src/main/res/values-sk-rSK/strings.xml
@@ -9,6 +9,7 @@
 <resources>
     <string name="pay_button">Zaplatiť</string>
     <string name="pay_button_with_value">Zaplatiť %s</string>
+    <string name="confirm_preauthorization">Potvrďte predbežnú autorizáciu</string>
     <string name="payment_methods_header">Spôsob platby</string>
     <string name="error_dialog_title">Chyba</string>
     <string name="error_dialog_button">OK</string>
@@ -33,4 +34,6 @@
     <string name="checkout_giftcard_remove_gift_cards_positive_button">Áno, odstrániť</string>
     <string name="checkout_giftcard_remove_gift_cards_negative_button">Zrušiť</string>
     <string name="checkout_remove_stored_payment_method_body">Odstrániť uložený spôsob platby</string>
+    <string name="checkout_stored_payment_confirmation_message">Potvrďte platbu pomocou %s</string>
+    <string name="checkout_stored_payment_confirmation_cancel_button">Zrušiť</string>
 </resources>

--- a/drop-in/src/main/res/values-sl-rSI/strings.xml
+++ b/drop-in/src/main/res/values-sl-rSI/strings.xml
@@ -9,6 +9,7 @@
 <resources>
     <string name="pay_button">Plačilo</string>
     <string name="pay_button_with_value">Plačilo %s</string>
+    <string name="confirm_preauthorization">Potrdi predhodno odobritev</string>
     <string name="payment_methods_header">Načini plačila</string>
     <string name="error_dialog_title">Napaka</string>
     <string name="error_dialog_button">OK</string>
@@ -33,4 +34,6 @@
     <string name="checkout_giftcard_remove_gift_cards_positive_button">Da, odstrani</string>
     <string name="checkout_giftcard_remove_gift_cards_negative_button">Prekliči</string>
     <string name="checkout_remove_stored_payment_method_body">Odstrani shranjen način plačila</string>
+    <string name="checkout_stored_payment_confirmation_message">Potrdite plačilo: %s</string>
+    <string name="checkout_stored_payment_confirmation_cancel_button">Prekliči</string>
 </resources>

--- a/drop-in/src/main/res/values-sv-rSE/strings.xml
+++ b/drop-in/src/main/res/values-sv-rSE/strings.xml
@@ -9,6 +9,7 @@
 <resources>
     <string name="pay_button">Betala</string>
     <string name="pay_button_with_value">Betala %s</string>
+    <string name="confirm_preauthorization">Bekräfta förauktorisering</string>
     <string name="payment_methods_header">Betalningsmetoder</string>
     <string name="error_dialog_title">Fel</string>
     <string name="error_dialog_button">OK</string>
@@ -33,4 +34,6 @@
     <string name="checkout_giftcard_remove_gift_cards_positive_button">Ja, ta bort</string>
     <string name="checkout_giftcard_remove_gift_cards_negative_button">Avbryt</string>
     <string name="checkout_remove_stored_payment_method_body">Ta bort sparat betalningssätt</string>
+    <string name="checkout_stored_payment_confirmation_message">Bekräfta %s-betalning</string>
+    <string name="checkout_stored_payment_confirmation_cancel_button">Avbryt</string>
 </resources>

--- a/drop-in/src/main/res/values-zh-rCN/strings.xml
+++ b/drop-in/src/main/res/values-zh-rCN/strings.xml
@@ -9,6 +9,7 @@
 <resources>
     <string name="pay_button">支付</string>
     <string name="pay_button_with_value">支付 %s</string>
+    <string name="confirm_preauthorization">确认预先授权</string>
     <string name="payment_methods_header">支付方式</string>
     <string name="error_dialog_title">错误</string>
     <string name="error_dialog_button">确定</string>
@@ -33,4 +34,6 @@
     <string name="checkout_giftcard_remove_gift_cards_positive_button">是，删除</string>
     <string name="checkout_giftcard_remove_gift_cards_negative_button">取消</string>
     <string name="checkout_remove_stored_payment_method_body">删除存储的支付方式</string>
+    <string name="checkout_stored_payment_confirmation_message">确认 %s 支付</string>
+    <string name="checkout_stored_payment_confirmation_cancel_button">取消</string>
 </resources>

--- a/drop-in/src/main/res/values-zh-rTW/strings.xml
+++ b/drop-in/src/main/res/values-zh-rTW/strings.xml
@@ -9,6 +9,7 @@
 <resources>
     <string name="pay_button">支付</string>
     <string name="pay_button_with_value">支付 %s</string>
+    <string name="confirm_preauthorization">確認預先授權</string>
     <string name="payment_methods_header">付款方式</string>
     <string name="error_dialog_title">錯誤</string>
     <string name="error_dialog_button">確定</string>
@@ -33,4 +34,6 @@
     <string name="checkout_giftcard_remove_gift_cards_positive_button">是，請移除</string>
     <string name="checkout_giftcard_remove_gift_cards_negative_button">取消</string>
     <string name="checkout_remove_stored_payment_method_body">移除已儲存付款方式</string>
+    <string name="checkout_stored_payment_confirmation_message">確認 %s 付款</string>
+    <string name="checkout_stored_payment_confirmation_cancel_button">取消</string>
 </resources>

--- a/drop-in/src/main/res/values/strings.xml
+++ b/drop-in/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
 <resources>
     <string name="pay_button">Pay</string>
     <string name="pay_button_with_value">Pay %s</string>
+    <string name="confirm_preauthorization">Confirm preauthorization</string>
     <string name="payment_methods_header">Payment Methods</string>
     <string name="error_dialog_title">Error</string>
     <string name="error_dialog_button">OK</string>
@@ -33,6 +34,8 @@
     <string name="checkout_giftcard_remove_gift_cards_positive_button">Yes, remove</string>
     <string name="checkout_giftcard_remove_gift_cards_negative_button">Cancel</string>
     <string name="checkout_remove_stored_payment_method_body">Remove stored payment method</string>
+    <string name="checkout_stored_payment_confirmation_message">Confirm %s payment</string>
+    <string name="checkout_stored_payment_confirmation_cancel_button">Cancel</string>
     <!-- Untranslatable strings -->
     <string name="checkout_negative_amount" translatable="false">- %s</string>
 </resources>


### PR DESCRIPTION
## Description
Stored Blik payment methods are now fully supported. Before when trying to open a stored Blik payment method from the payment methods list we threw an exception. Now we show a confirmation dialog and when the user confirms we make the payments call.

https://user-images.githubusercontent.com/17701279/225013423-92bb3262-f4b4-4577-89c7-912eeb57d34d.mp4

## Checklist <!-- Remove any line that's not applicable -->
- [ ] Code is unit tested
- [x] Changes are tested manually
- [x] Link to related issues: #1103 
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-734
