### PR TITLE
Fix error highlighting in BcmcView (v4)

### DIFF
--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcView.java
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcView.java
@@ -230,7 +230,7 @@ public final class BcmcView
                     ? outputData.getCardHolderNameField().getValidation()
                     : null;
             if (hasFocus) {
-                setCardNumberError(null);
+                mCardHolderNameInput.setError(null);
             } else if (cardHolderValidation != null && !cardHolderValidation.isValid()) {
                 final int errorReasonResId = ((Validation.Invalid) cardHolderValidation).getReason();
                 mCardHolderNameInput.setError(mLocalizedContext.getString(errorReasonResId));


### PR DESCRIPTION
## Description
Changing focus on the card holder input did not correctly highlight validation errors. This was caused by the card holder input removing the highlight from the card number input when focussed.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
- [x] Link to related issues: #1119 
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-737