### PR TITLE
Remove RequiredSize from XML

### DIFF
--- a/await/src/main/res/layout/await_view.xml
+++ b/await/src/main/res/layout/await_view.xml
@@ -19,8 +19,7 @@
         android:id="@+id/imageView_logo"
         style="@style/AdyenCheckout.Image.Logo.Large"
         android:layout_gravity="center_horizontal"
-        android:contentDescription="@null"
-        tools:ignore="RequiredSize" />
+        android:contentDescription="@null" />
 
     <TextView
         android:id="@+id/textView_open_app"

--- a/bacs/src/main/res/layout/bacs_direct_debit_confirmation_view.xml
+++ b/bacs/src/main/res/layout/bacs_direct_debit_confirmation_view.xml
@@ -25,7 +25,6 @@
             android:enabled="false"
             android:nextFocusDown="@id/editText_bankAccountNumber"
             android:nextFocusForward="@id/editText_bankAccountNumber"
-            tools:ignore="RequiredSize"
             tools:text="O. Tasoluk" />
     </com.google.android.material.textfield.TextInputLayout>
 
@@ -41,7 +40,6 @@
             android:enabled="false"
             android:nextFocusDown="@id/editText_sortCode"
             android:nextFocusForward="@id/editText_sortCode"
-            tools:ignore="RequiredSize"
             tools:text="12345678" />
     </com.google.android.material.textfield.TextInputLayout>
 
@@ -57,7 +55,6 @@
             android:enabled="false"
             android:nextFocusDown="@id/editText_shopperEmail"
             android:nextFocusForward="@id/editText_shopperEmail"
-            tools:ignore="RequiredSize"
             tools:text="123456" />
     </com.google.android.material.textfield.TextInputLayout>
 
@@ -71,7 +68,6 @@
             android:id="@+id/editText_shopperEmail"
             style="@style/AdyenCheckout.Bacs.ShopperEmailInput"
             android:enabled="false"
-            tools:ignore="RequiredSize"
             tools:text="example@mail.com" />
     </com.google.android.material.textfield.TextInputLayout>
 

--- a/bacs/src/main/res/layout/bacs_direct_debit_input_view.xml
+++ b/bacs/src/main/res/layout/bacs_direct_debit_input_view.xml
@@ -23,8 +23,7 @@
             android:id="@+id/editText_holderName"
             style="@style/AdyenCheckout.Bacs.HolderNameInput"
             android:nextFocusDown="@id/editText_bankAccountNumber"
-            android:nextFocusForward="@id/editText_bankAccountNumber"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@id/editText_bankAccountNumber" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -37,8 +36,7 @@
             android:id="@+id/editText_bankAccountNumber"
             style="@style/AdyenCheckout.Bacs.AccountNumberInput"
             android:nextFocusDown="@id/editText_sortCode"
-            android:nextFocusForward="@id/editText_sortCode"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@id/editText_sortCode" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -51,8 +49,7 @@
             android:id="@+id/editText_sortCode"
             style="@style/AdyenCheckout.Bacs.SortCodeInput"
             android:nextFocusDown="@id/editText_shopperEmail"
-            android:nextFocusForward="@id/editText_shopperEmail"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@id/editText_shopperEmail" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -64,8 +61,7 @@
         <com.adyen.checkout.ui.core.internal.ui.view.AdyenTextInputEditText
             android:id="@+id/editText_shopperEmail"
             style="@style/AdyenCheckout.Bacs.ShopperEmailInput"
-            android:autofillHints="emailAddress"
-            tools:ignore="RequiredSize" />
+            android:autofillHints="emailAddress" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <androidx.appcompat.widget.SwitchCompat

--- a/bcmc/src/main/res/layout/bcmc_view.xml
+++ b/bcmc/src/main/res/layout/bcmc_view.xml
@@ -28,8 +28,7 @@
                 android:id="@+id/editText_cardNumber"
                 style="@style/AdyenCheckout.Card.CardNumberInput"
                 android:nextFocusDown="@+id/editText_expiryDate"
-                android:nextFocusForward="@+id/editText_expiryDate"
-                tools:ignore="RequiredSize" />
+                android:nextFocusForward="@+id/editText_expiryDate" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <LinearLayout
@@ -67,8 +66,7 @@
             android:id="@+id/editText_expiryDate"
             style="@style/AdyenCheckout.Card.ExpiryDateInput"
             android:nextFocusRight="@+id/editText_securityCode"
-            android:nextFocusForward="@+id/editText_securityCode"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@+id/editText_securityCode" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -81,8 +79,7 @@
             android:id="@+id/editText_cardHolder"
             style="@style/AdyenCheckout.Card.HolderNameInput"
             android:nextFocusDown="@id/editText_postalCode"
-            android:nextFocusForward="@id/editText_postalCode"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@id/editText_postalCode" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <androidx.appcompat.widget.SwitchCompat

--- a/blik/src/main/res/layout/blik_view.xml
+++ b/blik/src/main/res/layout/blik_view.xml
@@ -28,8 +28,7 @@
 
         <com.adyen.checkout.ui.core.internal.ui.view.AdyenTextInputEditText
             android:id="@+id/editText_blikCode"
-            style="@style/AdyenCheckout.Blik.BlikCodeInput"
-            tools:ignore="RequiredSize" />
+            style="@style/AdyenCheckout.Blik.BlikCodeInput" />
     </com.google.android.material.textfield.TextInputLayout>
 
 </merge>

--- a/card/src/main/res/layout/card_view.xml
+++ b/card/src/main/res/layout/card_view.xml
@@ -29,8 +29,7 @@
                 android:id="@+id/editText_cardNumber"
                 style="@style/AdyenCheckout.Card.CardNumberInput"
                 android:nextFocusDown="@id/editText_expiryDate"
-                android:nextFocusForward="@id/editText_expiryDate"
-                tools:ignore="RequiredSize" />
+                android:nextFocusForward="@id/editText_expiryDate" />
         </com.google.android.material.textfield.TextInputLayout>
 
 
@@ -105,8 +104,7 @@
                 android:id="@+id/editText_expiryDate"
                 style="@style/AdyenCheckout.Card.ExpiryDateInput"
                 android:nextFocusDown="@id/editText_securityCode"
-                android:nextFocusForward="@id/editText_securityCode"
-                tools:ignore="RequiredSize" />
+                android:nextFocusForward="@id/editText_securityCode" />
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
@@ -121,8 +119,7 @@
                 android:id="@+id/editText_securityCode"
                 style="@style/AdyenCheckout.Card.SecurityCodeInput"
                 android:nextFocusDown="@id/editText_cardHolder"
-                android:nextFocusForward="@id/editText_cardHolder"
-                tools:ignore="RequiredSize" />
+                android:nextFocusForward="@id/editText_cardHolder" />
         </com.google.android.material.textfield.TextInputLayout>
     </LinearLayout>
 
@@ -136,8 +133,7 @@
             android:id="@+id/editText_cardHolder"
             style="@style/AdyenCheckout.Card.HolderNameInput"
             android:nextFocusDown="@id/editText_postalCode"
-            android:nextFocusForward="@id/editText_postalCode"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@id/editText_postalCode" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -151,8 +147,7 @@
             style="@style/AdyenCheckout.PostalCodeInput"
             android:autofillHints="postalCode"
             android:nextFocusDown="@id/editText_socialSecurityNumber"
-            android:nextFocusForward="@id/editText_socialSecurityNumber"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@id/editText_socialSecurityNumber" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -165,8 +160,7 @@
             android:id="@+id/editText_socialSecurityNumber"
             style="@style/AdyenCheckout.Card.SocialSecurityNumberInput"
             android:nextFocusDown="@id/editText_kcpBirthDateOrTaxNumber"
-            android:nextFocusForward="@id/editText_kcpBirthDateOrTaxNumber"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@id/editText_kcpBirthDateOrTaxNumber" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -179,8 +173,7 @@
             android:id="@+id/editText_kcpBirthDateOrTaxNumber"
             style="@style/AdyenCheckout.Card.KcpBirthDateOrTaxNumber"
             android:nextFocusDown="@id/editText_kcpCardPassword"
-            android:nextFocusForward="@id/editText_kcpCardPassword"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@id/editText_kcpCardPassword" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -193,8 +186,7 @@
             android:id="@+id/editText_kcpCardPassword"
             style="@style/AdyenCheckout.Card.KcpCardPassword"
             android:nextFocusDown="@id/addressFormInput"
-            android:nextFocusForward="@id/addressFormInput"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@id/addressFormInput" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout

--- a/econtext/src/main/res/layout/econtext_view.xml
+++ b/econtext/src/main/res/layout/econtext_view.xml
@@ -21,8 +21,7 @@
 
         <com.adyen.checkout.ui.core.internal.ui.view.AdyenTextInputEditText
             android:id="@+id/editText_firstName"
-            style="@style/AdyenCheckout.EContext.FirstNameInput"
-            tools:ignore="RequiredSize" />
+            style="@style/AdyenCheckout.EContext.FirstNameInput" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -33,8 +32,7 @@
 
         <com.adyen.checkout.ui.core.internal.ui.view.AdyenTextInputEditText
             android:id="@+id/editText_lastName"
-            style="@style/AdyenCheckout.EContext.LastNameInput"
-            tools:ignore="RequiredSize" />
+            style="@style/AdyenCheckout.EContext.LastNameInput" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -45,8 +43,7 @@
 
         <com.adyen.checkout.ui.core.internal.ui.view.AdyenTextInputEditText
             android:id="@+id/editText_emailAddress"
-            style="@style/AdyenCheckout.EContext.ShopperEmailInput"
-            tools:ignore="RequiredSize" />
+            style="@style/AdyenCheckout.EContext.ShopperEmailInput" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <LinearLayout
@@ -82,8 +79,7 @@
             <com.adyen.checkout.ui.core.internal.ui.view.AdyenTextInputEditText
                 android:id="@+id/editText_mobileNumber"
                 style="@style/AdyenCheckout.EContext.PhoneNumberInput"
-                android:autofillHints="phoneNational"
-                tools:ignore="RequiredSize" />
+                android:autofillHints="phoneNational" />
         </com.google.android.material.textfield.TextInputLayout>
     </LinearLayout>
 </merge>

--- a/giftcard/src/main/res/layout/giftcard_view.xml
+++ b/giftcard/src/main/res/layout/giftcard_view.xml
@@ -21,8 +21,7 @@
 
         <com.adyen.checkout.giftcard.internal.ui.view.GiftCardNumberInput
             android:id="@+id/editText_giftcardNumber"
-            style="@style/AdyenCheckout.GiftCard.GiftCardNumberInput"
-            tools:ignore="RequiredSize" />
+            style="@style/AdyenCheckout.GiftCard.GiftCardNumberInput" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -33,8 +32,7 @@
 
         <com.adyen.checkout.ui.core.internal.ui.view.AdyenTextInputEditText
             android:id="@+id/editText_giftcardPin"
-            style="@style/AdyenCheckout.GiftCard.GiftCardPinInput"
-            tools:ignore="RequiredSize" />
+            style="@style/AdyenCheckout.GiftCard.GiftCardPinInput" />
     </com.google.android.material.textfield.TextInputLayout>
 
 </merge>

--- a/mbway/src/main/res/layout/mbway_view.xml
+++ b/mbway/src/main/res/layout/mbway_view.xml
@@ -48,8 +48,7 @@
             <com.adyen.checkout.ui.core.internal.ui.view.AdyenTextInputEditText
                 android:id="@+id/editText_mobileNumber"
                 style="@style/AdyenCheckout.MBWay.MobileNumberInput"
-                android:autofillHints="phoneNational"
-                tools:ignore="RequiredSize" />
+                android:autofillHints="phoneNational" />
         </com.google.android.material.textfield.TextInputLayout>
     </LinearLayout>
 

--- a/paybybank/src/main/res/layout/pay_by_bank_view.xml
+++ b/paybybank/src/main/res/layout/pay_by_bank_view.xml
@@ -24,8 +24,7 @@
 
         <com.adyen.checkout.ui.core.internal.ui.view.AdyenTextInputEditText
             android:id="@+id/editText_searchQuery"
-            style="@style/AdyenCheckout.PayByBank.SearchQueryInput"
-            tools:ignore="RequiredSize" />
+            style="@style/AdyenCheckout.PayByBank.SearchQueryInput" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <androidx.recyclerview.widget.RecyclerView

--- a/qr-code/src/main/res/layout/full_qrcode_view.xml
+++ b/qr-code/src/main/res/layout/full_qrcode_view.xml
@@ -35,8 +35,7 @@
         android:id="@+id/imageView_qrcode"
         style="@style/AdyenCheckout.QrCode.Image"
         android:layout_gravity="center_horizontal"
-        android:contentDescription="@null"
-        tools:ignore="RequiredSize" />
+        android:contentDescription="@null" />
 
     <TextView
         android:id="@+id/textview_amount"

--- a/qr-code/src/main/res/layout/simple_qrcode_view.xml
+++ b/qr-code/src/main/res/layout/simple_qrcode_view.xml
@@ -17,8 +17,7 @@
         android:id="@+id/imageView_logo"
         style="@style/AdyenCheckout.Image.Logo.Large"
         android:layout_gravity="center_horizontal"
-        android:contentDescription="@null"
-        tools:ignore="RequiredSize" />
+        android:contentDescription="@null" />
 
     <TextView
         android:id="@+id/textView_top_label"

--- a/sepa/src/main/res/layout/sepa_view.xml
+++ b/sepa/src/main/res/layout/sepa_view.xml
@@ -21,8 +21,7 @@
 
         <com.adyen.checkout.ui.core.internal.ui.view.AdyenTextInputEditText
             android:id="@+id/editText_holderName"
-            style="@style/AdyenCheckout.Sepa.HolderNameInput"
-            tools:ignore="RequiredSize" />
+            style="@style/AdyenCheckout.Sepa.HolderNameInput" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -33,8 +32,7 @@
 
         <com.adyen.checkout.sepa.internal.ui.view.IbanInput
             android:id="@+id/editText_ibanNumber"
-            style="@style/AdyenCheckout.Sepa.AccountNumberInput"
-            tools:ignore="RequiredSize" />
+            style="@style/AdyenCheckout.Sepa.AccountNumberInput" />
     </com.google.android.material.textfield.TextInputLayout>
 
 </merge>

--- a/ui-core/src/main/res/layout/address_form_br.xml
+++ b/ui-core/src/main/res/layout/address_form_br.xml
@@ -24,8 +24,7 @@
             style="@style/AdyenCheckout.StreetInput"
             android:autofillHints="postalAddress"
             android:nextFocusDown="@id/editText_houseNumber"
-            android:nextFocusForward="@id/editText_houseNumber"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@id/editText_houseNumber" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -39,8 +38,7 @@
             style="@style/AdyenCheckout.HouseNumberInput"
             android:autofillHints="postalAddress"
             android:nextFocusDown="@id/editText_apartmentSuite"
-            android:nextFocusForward="@id/editText_apartmentSuite"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@id/editText_apartmentSuite" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -54,8 +52,7 @@
             style="@style/AdyenCheckout.ApartmentSuiteInput"
             android:autofillHints="postalAddress"
             android:nextFocusDown="@id/editText_postalCode"
-            android:nextFocusForward="@id/editText_postalCode"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@id/editText_postalCode" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -69,8 +66,7 @@
             style="@style/AdyenCheckout.PostalCodeInput"
             android:autofillHints="postalCode"
             android:nextFocusDown="@id/editText_city"
-            android:nextFocusForward="@id/editText_city"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@id/editText_city" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -82,8 +78,7 @@
         <com.adyen.checkout.ui.core.internal.ui.view.AdyenTextInputEditText
             android:id="@+id/editText_city"
             style="@style/AdyenCheckout.CityInput"
-            android:autofillHints="postalAddress"
-            tools:ignore="RequiredSize" />
+            android:autofillHints="postalAddress" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout

--- a/ui-core/src/main/res/layout/address_form_ca.xml
+++ b/ui-core/src/main/res/layout/address_form_ca.xml
@@ -24,8 +24,7 @@
             style="@style/AdyenCheckout.AddressInput"
             android:autofillHints="postalAddress"
             android:nextFocusDown="@id/editText_apartmentSuite"
-            android:nextFocusForward="@id/editText_apartmentSuite"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@id/editText_apartmentSuite" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -39,8 +38,7 @@
             style="@style/AdyenCheckout.ApartmentSuiteInput"
             android:autofillHints="postalAddress"
             android:nextFocusDown="@id/editText_city"
-            android:nextFocusForward="@id/editText_city"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@id/editText_city" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -54,8 +52,7 @@
             style="@style/AdyenCheckout.CityInput"
             android:autofillHints="postalAddress"
             android:nextFocusDown="@id/editText_postalCode"
-            android:nextFocusForward="@id/editText_postalCode"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@id/editText_postalCode" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -67,8 +64,7 @@
         <com.adyen.checkout.ui.core.internal.ui.view.AdyenTextInputEditText
             android:id="@+id/editText_postalCode"
             style="@style/AdyenCheckout.PostalCodeInput"
-            android:autofillHints="postalCode"
-            tools:ignore="RequiredSize" />
+            android:autofillHints="postalCode" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -82,7 +78,6 @@
             style="@style/AdyenCheckout.DropdownTextInputEditText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:autofillHints="postalAddress"
-            tools:ignore="RequiredSize" />
+            android:autofillHints="postalAddress" />
     </com.google.android.material.textfield.TextInputLayout>
 </merge>

--- a/ui-core/src/main/res/layout/address_form_default.xml
+++ b/ui-core/src/main/res/layout/address_form_default.xml
@@ -24,8 +24,7 @@
             style="@style/AdyenCheckout.StreetInput"
             android:autofillHints="postalAddress"
             android:nextFocusDown="@id/editText_houseNumber"
-            android:nextFocusForward="@id/editText_houseNumber"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@id/editText_houseNumber" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -39,8 +38,7 @@
             style="@style/AdyenCheckout.HouseNumberInput"
             android:autofillHints="postalAddress"
             android:nextFocusDown="@id/editText_apartmentSuite"
-            android:nextFocusForward="@id/editText_apartmentSuite"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@id/editText_apartmentSuite" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -54,8 +52,7 @@
             style="@style/AdyenCheckout.ApartmentSuiteInput"
             android:autofillHints="postalAddress"
             android:nextFocusDown="@id/editText_postalCode"
-            android:nextFocusForward="@id/editText_postalCode"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@id/editText_postalCode" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -69,8 +66,7 @@
             style="@style/AdyenCheckout.PostalCodeInput"
             android:autofillHints="postalCode"
             android:nextFocusDown="@id/editText_city"
-            android:nextFocusForward="@id/editText_city"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@id/editText_city" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -84,8 +80,7 @@
             style="@style/AdyenCheckout.CityInput"
             android:autofillHints="postalAddress"
             android:nextFocusDown="@id/editText_provinceTerritory"
-            android:nextFocusForward="@id/editText_provinceTerritory"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@id/editText_provinceTerritory" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -97,7 +92,6 @@
         <com.adyen.checkout.ui.core.internal.ui.view.AdyenTextInputEditText
             android:id="@+id/editText_provinceTerritory"
             style="@style/AdyenCheckout.ProvinceTerritoryInput"
-            android:autofillHints="postalAddress"
-            tools:ignore="RequiredSize" />
+            android:autofillHints="postalAddress" />
     </com.google.android.material.textfield.TextInputLayout>
 </merge>

--- a/ui-core/src/main/res/layout/address_form_gb.xml
+++ b/ui-core/src/main/res/layout/address_form_gb.xml
@@ -24,8 +24,7 @@
             style="@style/AdyenCheckout.HouseNumberInput"
             android:autofillHints="postalAddress"
             android:nextFocusDown="@id/editText_street"
-            android:nextFocusForward="@id/editText_street"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@id/editText_street" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -39,8 +38,7 @@
             style="@style/AdyenCheckout.StreetInput"
             android:autofillHints="postalAddress"
             android:nextFocusDown="@id/editText_city"
-            android:nextFocusForward="@id/editText_city"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@id/editText_city" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -54,8 +52,7 @@
             style="@style/AdyenCheckout.CityTownInput"
             android:autofillHints="postalAddress"
             android:nextFocusDown="@id/editText_postalCode"
-            android:nextFocusForward="@id/editText_postalCode"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@id/editText_postalCode" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -67,7 +64,6 @@
         <com.adyen.checkout.ui.core.internal.ui.view.AdyenTextInputEditText
             android:id="@+id/editText_postalCode"
             style="@style/AdyenCheckout.PostalCodeInput"
-            android:autofillHints="postalCode"
-            tools:ignore="RequiredSize" />
+            android:autofillHints="postalCode" />
     </com.google.android.material.textfield.TextInputLayout>
 </merge>

--- a/ui-core/src/main/res/layout/address_form_us.xml
+++ b/ui-core/src/main/res/layout/address_form_us.xml
@@ -24,8 +24,7 @@
             style="@style/AdyenCheckout.AddressInput"
             android:autofillHints="postalAddress"
             android:nextFocusDown="@id/editText_apartmentSuite"
-            android:nextFocusForward="@id/editText_apartmentSuite"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@id/editText_apartmentSuite" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -39,8 +38,7 @@
             style="@style/AdyenCheckout.ApartmentSuiteInput"
             android:autofillHints="postalAddress"
             android:nextFocusDown="@id/editText_city"
-            android:nextFocusForward="@id/editText_city"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@id/editText_city" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -54,8 +52,7 @@
             style="@style/AdyenCheckout.CityInput"
             android:autofillHints="postalAddress"
             android:nextFocusDown="@id/editText_postalCode"
-            android:nextFocusForward="@id/editText_postalCode"
-            tools:ignore="RequiredSize" />
+            android:nextFocusForward="@id/editText_postalCode" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <LinearLayout
@@ -91,8 +88,7 @@
             <com.adyen.checkout.ui.core.internal.ui.view.AdyenTextInputEditText
                 android:id="@+id/editText_postalCode"
                 style="@style/AdyenCheckout.ZipCodeInput"
-                android:autofillHints="postalCode"
-                tools:ignore="RequiredSize" />
+                android:autofillHints="postalCode" />
         </com.google.android.material.textfield.TextInputLayout>
 
     </LinearLayout>

--- a/ui-core/src/main/res/layout/view_payment_in_progress.xml
+++ b/ui-core/src/main/res/layout/view_payment_in_progress.xml
@@ -30,8 +30,7 @@
         app:layout_constraintEnd_toStartOf="@id/textView_paymentInProgress_description"
         app:layout_constraintHorizontal_chainStyle="packed"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/textView_paymentInProgress_title"
-        tools:ignore="RequiredSize" />
+        app:layout_constraintTop_toBottomOf="@id/textView_paymentInProgress_title" />
 
     <TextView
         android:id="@+id/textView_paymentInProgress_description"


### PR DESCRIPTION
There was a lint [bug](https://issuetracker.google.com/issues/155088391) called " Error: The required layout_width and layout_height attributes are missing [RequiredSize]" when we give layout_width and layout_height from style. To prevent this error "tools:ignore ="RequiredSize" was used. The bug was fixed  so we don't need to use it anymore


## Description
[//]: # (Include a short summary of your changes)
[//]: # (If this is a new feature: attach screenshots or a video if applicable)
[//]: # (If this is a bug fix: include a reproduction path)

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-645
