### PR TITLE
Pass directory server root certificates to 3DS2 SDK

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/data/model/FingerprintToken.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/data/model/FingerprintToken.kt
@@ -18,13 +18,15 @@ import org.json.JSONObject
 internal data class FingerprintToken(
     val directoryServerId: String? = null,
     val directoryServerPublicKey: String? = null,
+    val directoryServerRootCertificates: String? = null,
     val threeDSServerTransID: String? = null,
-    val threeDSMessageVersion: String? = null
+    val threeDSMessageVersion: String? = null,
 ) : ModelObject() {
 
     companion object {
         private const val DIRECTORY_SERVER_ID = "directoryServerId"
         private const val DIRECTORY_SERVER_PUBLIC_KEY = "directoryServerPublicKey"
+        private const val DIRECTORY_SERVER_ROOT_CERTIFICATES = "directoryServerRootCertificates"
         private const val THREEDS_SERVER_TRANS_ID = "threeDSServerTransID"
         private const val THREEDS_MESSAGE_VERSION = "threeDSMessageVersion"
 
@@ -35,6 +37,7 @@ internal data class FingerprintToken(
                     JSONObject().apply {
                         putOpt(DIRECTORY_SERVER_ID, modelObject.directoryServerId)
                         putOpt(DIRECTORY_SERVER_PUBLIC_KEY, modelObject.directoryServerPublicKey)
+                        putOpt(DIRECTORY_SERVER_ROOT_CERTIFICATES, modelObject.directoryServerRootCertificates)
                         putOpt(THREEDS_SERVER_TRANS_ID, modelObject.threeDSServerTransID)
                         putOpt(THREEDS_MESSAGE_VERSION, modelObject.threeDSMessageVersion)
                     }
@@ -45,12 +48,15 @@ internal data class FingerprintToken(
 
             override fun deserialize(jsonObject: JSONObject): FingerprintToken {
                 return try {
-                    FingerprintToken(
-                        directoryServerId = jsonObject.getStringOrNull(DIRECTORY_SERVER_ID),
-                        directoryServerPublicKey = jsonObject.getStringOrNull(DIRECTORY_SERVER_PUBLIC_KEY),
-                        threeDSServerTransID = jsonObject.getStringOrNull(THREEDS_SERVER_TRANS_ID),
-                        threeDSMessageVersion = jsonObject.getStringOrNull(THREEDS_MESSAGE_VERSION)
-                    )
+                    with(jsonObject) {
+                        FingerprintToken(
+                            directoryServerId = getStringOrNull(DIRECTORY_SERVER_ID),
+                            directoryServerPublicKey = getStringOrNull(DIRECTORY_SERVER_PUBLIC_KEY),
+                            directoryServerRootCertificates = getStringOrNull(DIRECTORY_SERVER_ROOT_CERTIFICATES),
+                            threeDSServerTransID = getStringOrNull(THREEDS_SERVER_TRANS_ID),
+                            threeDSMessageVersion = getStringOrNull(THREEDS_MESSAGE_VERSION)
+                        )
+                    }
                 } catch (e: JSONException) {
                     throw ModelSerializationException(FingerprintToken::class.java, e)
                 }

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2Delegate.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2Delegate.kt
@@ -201,8 +201,9 @@ internal class DefaultAdyen3DS2Delegate(
 
         val fingerprintToken = FingerprintToken.SERIALIZER.deserialize(fingerprintJson)
         val configParameters = AdyenConfigParameters.Builder(
-            fingerprintToken.directoryServerId,
-            fingerprintToken.directoryServerPublicKey
+            /* directoryServerId = */ fingerprintToken.directoryServerId,
+            /* directoryServerPublicKey = */ fingerprintToken.directoryServerPublicKey,
+            /* directoryServerRootCertificates = */ fingerprintToken.directoryServerRootCertificates,
         ).build()
 
         val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegateTest.kt
@@ -771,7 +771,7 @@ internal class DefaultCardDelegateTest(
                     assertNull(fundingSource)
                     assertNull(brand)
                     assertNull(storedPaymentMethodId)
-                    assertEquals("2.2.11", threeDS2SdkVersion)
+                    assertEquals("2.2.12", threeDS2SdkVersion)
                 }
             }
         }
@@ -874,7 +874,7 @@ internal class DefaultCardDelegateTest(
                     assertEquals(PaymentMethodTypes.SCHEME, type)
                     assertEquals(CardType.VISA.txVariant, brand)
                     assertNull(storedPaymentMethodId)
-                    assertEquals("2.2.11", threeDS2SdkVersion)
+                    assertEquals("2.2.12", threeDS2SdkVersion)
                 }
             }
         }

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/StoredCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/StoredCardDelegateTest.kt
@@ -305,7 +305,7 @@ internal class StoredCardDelegateTest(
                     assertNull(encryptedPassword)
                     assertNull(fundingSource)
                     assertNull(brand)
-                    assertEquals("2.2.11", threeDS2SdkVersion)
+                    assertEquals("2.2.12", threeDS2SdkVersion)
                 }
             }
         }

--- a/config/gradle/checksums.gradle
+++ b/config/gradle/checksums.gradle
@@ -9,7 +9,7 @@
 if (!hasProperty("checksums")) {
     final checksums = [
         // Adyen dependencies
-        "com.adyen.threeds:adyen-3ds2:2.2.11:76476cc4231d60c7d453762fc52001e0:MD5",
+        "com.adyen.threeds:adyen-3ds2:2.2.12:8604cda87c67245b3db81889ce14b94a:MD5",
 
         // Kotlin
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10:1cbbdbbfa072d00dc042d6ae62d3154f:MD5",

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -40,7 +40,7 @@ ext {
     recyclerview_version = "1.3.0"
 
     // Adyen Dependencies
-    adyen3ds2_version = "2.2.11"
+    adyen3ds2_version = "2.2.12"
 
     // External Dependencies
     okhttp_version = "4.10.0"


### PR DESCRIPTION
## Description
With version `2.2.12` the 3DS2 SDK now requires the `directoryServerRootCertificates` to be passed through the `AdyenConfigParameters.Builder` class.

We can read this value from the decoded `token` attribute inside the `action` object returned by the checkout API.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
- [x] Link to related issues
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-738
