### PR TITLE
Improve consistency in preselected stored payment methods

### DIFF
--- a/ach/src/main/java/com/adyen/checkout/ach/ACHDirectDebitComponent.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/ACHDirectDebitComponent.kt
@@ -13,16 +13,17 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.adyen.checkout.ach.internal.provider.ACHDirectDebitComponentProvider
 import com.adyen.checkout.ach.internal.ui.ACHDirectDebitDelegate
+import com.adyen.checkout.ach.internal.ui.DefaultACHDirectDebitDelegate
 import com.adyen.checkout.action.internal.ActionHandlingComponent
 import com.adyen.checkout.action.internal.DefaultActionHandlingComponent
 import com.adyen.checkout.action.internal.ui.GenericActionDelegate
+import com.adyen.checkout.components.core.PaymentMethodTypes
 import com.adyen.checkout.components.core.internal.ButtonComponent
 import com.adyen.checkout.components.core.internal.ComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentComponent
 import com.adyen.checkout.components.core.internal.PaymentComponentEvent
 import com.adyen.checkout.components.core.internal.toActionCallback
 import com.adyen.checkout.components.core.internal.ui.ComponentDelegate
-import com.adyen.checkout.components.core.PaymentMethodTypes
 import com.adyen.checkout.core.internal.util.LogUtil
 import com.adyen.checkout.core.internal.util.Logger
 import com.adyen.checkout.ui.core.internal.ui.ButtonDelegate
@@ -72,14 +73,15 @@ class ACHDirectDebitComponent internal constructor(
         genericActionDelegate.removeObserver()
     }
 
-    override fun isConfirmationRequired(): Boolean = achDirectDebitDelegate.isConfirmationRequired()
+    override fun isConfirmationRequired(): Boolean =
+        (achDirectDebitDelegate as? ButtonDelegate)?.isConfirmationRequired() ?: false
 
     override fun submit() {
         (delegate as? ButtonDelegate)?.onSubmit() ?: Logger.e(TAG, "Component is currently not submittable, ignoring.")
     }
 
     override fun setInteractionBlocked(isInteractionBlocked: Boolean) {
-        (delegate as? ACHDirectDebitDelegate)?.setInteractionBlocked(isInteractionBlocked)
+        (delegate as? DefaultACHDirectDebitDelegate)?.setInteractionBlocked(isInteractionBlocked)
             ?: Logger.e(TAG, "Payment component is not interactable, ignoring.")
     }
 

--- a/ach/src/main/java/com/adyen/checkout/ach/internal/provider/ACHDirectDebitComponentProvider.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/internal/provider/ACHDirectDebitComponentProvider.kt
@@ -22,10 +22,10 @@ import com.adyen.checkout.ach.internal.ui.StoredACHDirectDebitDelegate
 import com.adyen.checkout.ach.internal.ui.model.ACHDirectDebitComponentParamsMapper
 import com.adyen.checkout.action.internal.DefaultActionHandlingComponent
 import com.adyen.checkout.action.internal.provider.GenericActionComponentProvider
+import com.adyen.checkout.components.core.ComponentCallback
 import com.adyen.checkout.components.core.Order
 import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.StoredPaymentMethod
-import com.adyen.checkout.components.core.ComponentCallback
 import com.adyen.checkout.components.core.internal.DefaultComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsMapper
@@ -273,7 +273,6 @@ class ACHDirectDebitComponentProvider(
                 observerRepository = PaymentObserverRepository(),
                 storedPaymentMethod = storedPaymentMethod,
                 analyticsRepository = analyticsRepository,
-                submitHandler = SubmitHandler(savedStateHandle),
                 componentParams = componentParams,
                 order = order
             )
@@ -333,7 +332,6 @@ class ACHDirectDebitComponentProvider(
                 observerRepository = PaymentObserverRepository(),
                 storedPaymentMethod = storedPaymentMethod,
                 analyticsRepository = analyticsRepository,
-                submitHandler = SubmitHandler(savedStateHandle),
                 componentParams = componentParams,
                 order = checkoutSession.order
             )

--- a/ach/src/main/java/com/adyen/checkout/ach/internal/ui/ACHDirectDebitDelegate.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/internal/ui/ACHDirectDebitDelegate.kt
@@ -14,16 +14,12 @@ import com.adyen.checkout.ach.internal.ui.model.ACHDirectDebitOutputData
 import com.adyen.checkout.components.core.internal.ui.PaymentComponentDelegate
 import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.ui.core.internal.ui.AddressDelegate
-import com.adyen.checkout.ui.core.internal.ui.ButtonDelegate
-import com.adyen.checkout.ui.core.internal.ui.UIStateDelegate
 import com.adyen.checkout.ui.core.internal.ui.ViewProvidingDelegate
 import kotlinx.coroutines.flow.Flow
 
 internal interface ACHDirectDebitDelegate :
     PaymentComponentDelegate<ACHDirectDebitComponentState>,
     ViewProvidingDelegate,
-    ButtonDelegate,
-    UIStateDelegate,
     AddressDelegate {
     val outputData: ACHDirectDebitOutputData
 
@@ -34,6 +30,4 @@ internal interface ACHDirectDebitDelegate :
     val exceptionFlow: Flow<CheckoutException>
 
     fun updateInputData(update: ACHDirectDebitInputData.() -> Unit)
-
-    fun setInteractionBlocked(isInteractionBlocked: Boolean)
 }

--- a/ach/src/main/java/com/adyen/checkout/ach/internal/ui/DefaultACHDirectDebitDelegate.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/internal/ui/DefaultACHDirectDebitDelegate.kt
@@ -33,10 +33,12 @@ import com.adyen.checkout.cse.internal.BaseGenericEncrypter
 import com.adyen.checkout.ui.core.internal.data.api.AddressRepository
 import com.adyen.checkout.ui.core.internal.ui.AddressFormUIState
 import com.adyen.checkout.ui.core.internal.ui.ButtonComponentViewType
+import com.adyen.checkout.ui.core.internal.ui.ButtonDelegate
 import com.adyen.checkout.ui.core.internal.ui.ComponentViewType
 import com.adyen.checkout.ui.core.internal.ui.PaymentComponentUIEvent
 import com.adyen.checkout.ui.core.internal.ui.PaymentComponentUIState
 import com.adyen.checkout.ui.core.internal.ui.SubmitHandler
+import com.adyen.checkout.ui.core.internal.ui.UIStateDelegate
 import com.adyen.checkout.ui.core.internal.ui.model.AddressInputModel
 import com.adyen.checkout.ui.core.internal.ui.model.AddressListItem
 import com.adyen.checkout.ui.core.internal.ui.model.AddressOutputData
@@ -67,7 +69,7 @@ internal class DefaultACHDirectDebitDelegate(
     private val genericEncrypter: BaseGenericEncrypter,
     override val componentParams: ACHDirectDebitComponentParams,
     private val order: Order?
-) : ACHDirectDebitDelegate {
+) : ACHDirectDebitDelegate, ButtonDelegate, UIStateDelegate {
 
     private val inputData: ACHDirectDebitInputData = ACHDirectDebitInputData()
 
@@ -343,7 +345,7 @@ internal class DefaultACHDirectDebitDelegate(
         observerRepository.removeObservers()
     }
 
-    override fun setInteractionBlocked(isInteractionBlocked: Boolean) {
+    internal fun setInteractionBlocked(isInteractionBlocked: Boolean) {
         submitHandler.setInteractionBlocked(isInteractionBlocked)
     }
 

--- a/ach/src/test/java/com/adyen/checkout/ach/internal/ui/DefaultACHDirectDebitDelegateTest.kt
+++ b/ach/src/test/java/com/adyen/checkout/ach/internal/ui/DefaultACHDirectDebitDelegateTest.kt
@@ -65,7 +65,7 @@ internal class DefaultACHDirectDebitDelegateTest(
     private lateinit var publicKeyRepository: TestPublicKeyRepository
     private lateinit var addressRepository: TestAddressRepository
     private lateinit var genericEncrypter: TestGenericEncrypter
-    private lateinit var delegate: ACHDirectDebitDelegate
+    private lateinit var delegate: DefaultACHDirectDebitDelegate
 
     @BeforeEach
     fun setUp() {

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/StoredCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/StoredCardDelegateTest.kt
@@ -29,6 +29,7 @@ import com.adyen.checkout.card.internal.ui.model.InputFieldUIState
 import com.adyen.checkout.card.internal.ui.model.InstallmentsParamsMapper
 import com.adyen.checkout.card.internal.ui.view.InstallmentModel
 import com.adyen.checkout.components.core.OrderRequest
+import com.adyen.checkout.components.core.PaymentMethodTypes
 import com.adyen.checkout.components.core.StoredPaymentMethod
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
@@ -37,7 +38,6 @@ import com.adyen.checkout.components.core.internal.test.TestPublicKeyRepository
 import com.adyen.checkout.components.core.internal.ui.model.ComponentMode
 import com.adyen.checkout.components.core.internal.ui.model.FieldState
 import com.adyen.checkout.components.core.internal.ui.model.Validation
-import com.adyen.checkout.components.core.PaymentMethodTypes
 import com.adyen.checkout.components.core.paymentmethod.CardPaymentMethod
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.cse.internal.BaseCardEncrypter
@@ -96,6 +96,32 @@ internal class StoredCardDelegateTest(
             assertEquals(publicKeyRepository.errorResult.exceptionOrNull(), exception.cause)
 
             cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when component is initialized with cvc shown, then view flow emits CardComponentViewType`() = runTest {
+        delegate = createCardDelegate(
+            configuration = getDefaultCardConfigurationBuilder()
+                .setHideCvcStoredCard(false)
+                .build()
+        )
+        delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+        delegate.viewFlow.test {
+            assertEquals(CardComponentViewType, expectMostRecentItem())
+        }
+    }
+
+    @Test
+    fun `when component is initialized with cvc hidden, then view flow emits null`() = runTest {
+        delegate = createCardDelegate(
+            configuration = getDefaultCardConfigurationBuilder()
+                .setHideCvcStoredCard(true)
+                .build()
+        )
+        delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+        delegate.viewFlow.test {
+            assertEquals(null, expectMostRecentItem())
         }
     }
 
@@ -327,6 +353,7 @@ internal class StoredCardDelegateTest(
                     .setSubmitButtonVisible(false)
                     .build()
             )
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
 
             assertFalse(delegate.shouldShowSubmitButton())
         }
@@ -338,6 +365,7 @@ internal class StoredCardDelegateTest(
                     .setSubmitButtonVisible(true)
                     .build()
             )
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
 
             assertTrue(delegate.shouldShowSubmitButton())
         }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodListDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodListDialogFragment.kt
@@ -20,7 +20,6 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
 import com.adyen.checkout.components.core.StoredPaymentMethod
-import com.adyen.checkout.components.core.internal.ButtonComponent
 import com.adyen.checkout.components.core.internal.PaymentComponent
 import com.adyen.checkout.core.internal.util.LogUtil
 import com.adyen.checkout.core.internal.util.Logger
@@ -112,9 +111,6 @@ internal class PaymentMethodListDialogFragment :
                     }
                     is PaymentMethodListStoredEvent.ShowStoredComponentDialog -> {
                         protocol.showStoredComponentDialog(event.storedPaymentMethod, false)
-                    }
-                    PaymentMethodListStoredEvent.SubmitComponent -> {
-                        (component as? ButtonComponent)?.submit()
                     }
                     is PaymentMethodListStoredEvent.RequestPaymentsCall -> {
                         protocol.requestPaymentsCall(event.state)

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodsListViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodsListViewModel.kt
@@ -17,10 +17,10 @@ import com.adyen.checkout.components.core.ComponentCallback
 import com.adyen.checkout.components.core.ComponentError
 import com.adyen.checkout.components.core.PaymentComponentState
 import com.adyen.checkout.components.core.PaymentMethod
+import com.adyen.checkout.components.core.PaymentMethodTypes
 import com.adyen.checkout.components.core.StoredPaymentMethod
 import com.adyen.checkout.components.core.internal.data.model.OrderPaymentMethod
 import com.adyen.checkout.components.core.internal.util.CurrencyUtils
-import com.adyen.checkout.components.core.PaymentMethodTypes
 import com.adyen.checkout.components.core.internal.util.bufferedChannel
 import com.adyen.checkout.core.internal.util.LogUtil
 import com.adyen.checkout.core.internal.util.Logger
@@ -161,7 +161,7 @@ internal class PaymentMethodsListViewModel(
     }
 
     override fun onSubmit(state: PaymentComponentState<*>) {
-        eventsChannel.trySend(PaymentMethodListStoredEvent.RequestPaymentsCall(state))
+        // no ops
     }
 
     override fun onAdditionalDetails(actionComponentData: ActionComponentData) {
@@ -193,8 +193,9 @@ internal class PaymentMethodsListViewModel(
     }
 
     fun onClickConfirmationButton() {
+        val state = componentState ?: return
         if (componentState?.isValid == true) {
-            eventsChannel.trySend(PaymentMethodListStoredEvent.SubmitComponent)
+            eventsChannel.trySend(PaymentMethodListStoredEvent.RequestPaymentsCall(state))
         }
     }
 
@@ -260,8 +261,6 @@ internal sealed class PaymentMethodListStoredEvent {
 
     class ShowConfirmationPopup(val paymentMethodName: String, val storedPaymentMethodModel: StoredPaymentMethodModel) :
         PaymentMethodListStoredEvent()
-
-    object SubmitComponent : PaymentMethodListStoredEvent()
 
     data class RequestPaymentsCall(val state: PaymentComponentState<*>) : PaymentMethodListStoredEvent()
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PreselectedStoredPaymentMethodFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PreselectedStoredPaymentMethodFragment.kt
@@ -18,7 +18,6 @@ import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import com.adyen.checkout.components.core.ComponentError
 import com.adyen.checkout.components.core.StoredPaymentMethod
-import com.adyen.checkout.components.core.internal.ButtonComponent
 import com.adyen.checkout.components.core.internal.PaymentComponent
 import com.adyen.checkout.components.core.internal.util.DateUtils
 import com.adyen.checkout.core.exception.CheckoutException
@@ -183,10 +182,6 @@ internal class PreselectedStoredPaymentMethodFragment : DropInBottomSheetDialogF
             when (event) {
                 is PreselectedStoredEvent.ShowStoredPaymentScreen -> {
                     protocol.showStoredComponentDialog(storedPaymentMethod, true)
-                }
-                is PreselectedStoredEvent.SubmitComponent -> {
-                    (component as? ButtonComponent)?.submit()
-                        ?: throw CheckoutException("Component must be of type ButtonComponent.")
                 }
                 is PreselectedStoredEvent.RequestPaymentsCall -> {
                     protocol.requestPaymentsCall(event.state)

--- a/drop-in/src/test/java/com/adyen/checkout/internal/ui/PreselectedStoredPaymentViewModelTest.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/internal/ui/PreselectedStoredPaymentViewModelTest.kt
@@ -116,17 +116,6 @@ internal class PreselectedStoredPaymentViewModelTest {
     }
 
     @Test
-    fun `when component emits a submit event then view model should emit to request a payments call`() = runTest {
-        viewModel.eventsFlow.test {
-            val componentState =
-                TestComponentState(PaymentComponentData(), isInputValid = true, isReady = true)
-            viewModel.onSubmit(componentState)
-
-            assertEquals(PreselectedStoredEvent.RequestPaymentsCall(componentState), awaitItem())
-        }
-    }
-
-    @Test
     fun `when component emits an action event then view model should throw an exception`() = runTest {
         viewModel.eventsFlow.test {
             assertThrows<IllegalStateException> {
@@ -149,7 +138,7 @@ internal class PreselectedStoredPaymentViewModelTest {
         }
 
     @Test
-    fun `when button is clicked with a valid input then view model should request submitting the component`() =
+    fun `when button is clicked with a valid input then view model should request payments call`() =
         runTest {
             viewModel.eventsFlow.test {
                 val componentState =
@@ -157,7 +146,7 @@ internal class PreselectedStoredPaymentViewModelTest {
                 viewModel.onStateChanged(componentState)
                 viewModel.onButtonClicked()
 
-                assertEquals(PreselectedStoredEvent.SubmitComponent, awaitItem())
+                assertEquals(PreselectedStoredEvent.RequestPaymentsCall(componentState), awaitItem())
             }
         }
 


### PR DESCRIPTION
## Description
[//]: # (Include a short summary of your changes)
[//]: # (If this is a new feature: attach screenshots or a video if applicable)
[//]: # (If this is a bug fix: include a reproduction path)
Stored card triggers a payment on instantiation if cvc is hidden. Stored ach triggers a payment on instantiation always. These are propogated through onStateChanged callback. PreselectedStoredPaymentViewModel receives the new state and stores and uses it to trigger a payments call on pay button click. In the flows where a payments call is triggered on instantiation no view type is emitted anymore. Since stored ach doesn't support any UI anymore related delegates have been removed from common ACHDirectDebitDelegate and have been put into DefaultACHDirectDebitDelegate.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-733
