### PR TITLE
Pass directory server root certificates to 3DS2 SDK (v4)

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
@@ -200,8 +200,9 @@ class Adyen3DS2Component(
 
         val fingerprintToken = FingerprintToken.SERIALIZER.deserialize(fingerprintJson)
         val configParameters = AdyenConfigParameters.Builder(
-            fingerprintToken.directoryServerId,
-            fingerprintToken.directoryServerPublicKey
+            /* directoryServerId = */ fingerprintToken.directoryServerId,
+            /* directoryServerPublicKey = */ fingerprintToken.directoryServerPublicKey,
+            /* directoryServerRootCertificates = */ fingerprintToken.directoryServerRootCertificates,
         ).build()
 
         val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/model/FingerprintToken.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/model/FingerprintToken.kt
@@ -19,8 +19,9 @@ import org.json.JSONObject
 data class FingerprintToken(
     val directoryServerId: String? = null,
     val directoryServerPublicKey: String? = null,
+    val directoryServerRootCertificates: String? = null,
     val threeDSServerTransID: String? = null,
-    val threeDSMessageVersion: String? = null
+    val threeDSMessageVersion: String? = null,
 ) : ModelObject() {
 
     override fun writeToParcel(dest: Parcel, flags: Int) {
@@ -30,6 +31,7 @@ data class FingerprintToken(
     companion object {
         private const val DIRECTORY_SERVER_ID = "directoryServerId"
         private const val DIRECTORY_SERVER_PUBLIC_KEY = "directoryServerPublicKey"
+        private const val DIRECTORY_SERVER_ROOT_CERTIFICATES = "directoryServerRootCertificates"
         private const val THREEDS_SERVER_TRANS_ID = "threeDSServerTransID"
         private const val THREEDS_MESSAGE_VERSION = "threeDSMessageVersion"
 
@@ -43,6 +45,7 @@ data class FingerprintToken(
                     JSONObject().apply {
                         putOpt(DIRECTORY_SERVER_ID, modelObject.directoryServerId)
                         putOpt(DIRECTORY_SERVER_PUBLIC_KEY, modelObject.directoryServerPublicKey)
+                        putOpt(DIRECTORY_SERVER_ROOT_CERTIFICATES, modelObject.directoryServerRootCertificates)
                         putOpt(THREEDS_SERVER_TRANS_ID, modelObject.threeDSServerTransID)
                         putOpt(THREEDS_MESSAGE_VERSION, modelObject.threeDSMessageVersion)
                     }
@@ -56,6 +59,7 @@ data class FingerprintToken(
                     FingerprintToken(
                         directoryServerId = jsonObject.getStringOrNull(DIRECTORY_SERVER_ID),
                         directoryServerPublicKey = jsonObject.getStringOrNull(DIRECTORY_SERVER_PUBLIC_KEY),
+                        directoryServerRootCertificates = jsonObject.getStringOrNull(DIRECTORY_SERVER_ROOT_CERTIFICATES),
                         threeDSServerTransID = jsonObject.getStringOrNull(THREEDS_SERVER_TRANS_ID),
                         threeDSMessageVersion = jsonObject.getStringOrNull(THREEDS_MESSAGE_VERSION)
                     )

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ allprojects {
     ext.browser_version = "1.3.0"
 
     // Adyen Dependencies
-    ext.adyen3ds2_version = "2.2.11"
+    ext.adyen3ds2_version = "2.2.12"
 
     // External Dependencies
     ext.play_services_wallet_version = '18.1.3'

--- a/config/gradle/checksums.gradle
+++ b/config/gradle/checksums.gradle
@@ -9,7 +9,7 @@
 if (!hasProperty("checksums")) {
     final checksums = [
             // Adyen dependencies
-            "com.adyen.threeds:adyen-3ds2:2.2.11:76476cc4231d60c7d453762fc52001e0:MD5",
+            "com.adyen.threeds:adyen-3ds2:2.2.12:8604cda87c67245b3db81889ce14b94a:MD5",
 
             // Kotlin
             "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.21:9e7ee18a1a5dd5bf070c7e6f706ccc9c:MD5",


### PR DESCRIPTION
## Description
With version `2.2.12` the 3DS2 SDK now requires the `directoryServerRootCertificates` to be passed through the `AdyenConfigParameters.Builder` class.

We can read this value from the decoded `token` attribute inside the `action` object returned by the checkout API.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
- [x] Link to related issues
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-738