### PR TITLE
Move 3DS2 UI customization to configuration

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
@@ -24,7 +24,6 @@ import com.adyen.checkout.core.internal.util.LogUtil
 import com.adyen.checkout.core.internal.util.Logger
 import com.adyen.checkout.ui.core.internal.ui.ComponentViewType
 import com.adyen.checkout.ui.core.internal.ui.ViewableComponent
-import com.adyen.threeds2.customization.UiCustomization
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -50,16 +49,6 @@ class Adyen3DS2Component internal constructor(
 
     internal fun removeObserver() {
         delegate.removeObserver()
-    }
-
-    /**
-     * Set a [UiCustomization] object to be passed to the 3DS2 SDK for customizing the challenge screen.
-     * Needs to be set before handling any action.
-     *
-     * @param uiCustomization The customization object.
-     */
-    fun setUiCustomization(uiCustomization: UiCustomization?) {
-        delegate.set3DS2UICustomization(uiCustomization)
     }
 
     override fun handleAction(action: Action, activity: Activity) {

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Configuration.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Configuration.kt
@@ -12,6 +12,7 @@ import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.components.core.internal.BaseConfigurationBuilder
 import com.adyen.checkout.components.core.internal.Configuration
 import com.adyen.checkout.core.Environment
+import com.adyen.threeds2.customization.UiCustomization
 import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
@@ -24,13 +25,16 @@ class Adyen3DS2Configuration private constructor(
     override val environment: Environment,
     override val clientKey: String,
     override val isAnalyticsEnabled: Boolean?,
-    override val amount: Amount
+    override val amount: Amount,
+    val uiCustomization: UiCustomization?,
 ) : Configuration {
 
     /**
      * Builder to create an [Adyen3DS2Configuration].
      */
     class Builder : BaseConfigurationBuilder<Adyen3DS2Configuration, Builder> {
+
+        private var uiCustomization: UiCustomization? = null
 
         /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
@@ -58,6 +62,16 @@ class Adyen3DS2Configuration private constructor(
             clientKey
         )
 
+        /**
+         * Set a [UiCustomization] object to be passed to the 3DS2 SDK for customizing the challenge screen.
+         *
+         * @param uiCustomization The customization object.
+         */
+        fun setUiCustomization(uiCustomization: UiCustomization?): Builder {
+            this.uiCustomization = uiCustomization
+            return this
+        }
+
         override fun buildInternal(): Adyen3DS2Configuration {
             return Adyen3DS2Configuration(
                 shopperLocale = shopperLocale,
@@ -65,6 +79,7 @@ class Adyen3DS2Configuration private constructor(
                 clientKey = clientKey,
                 isAnalyticsEnabled = isAnalyticsEnabled,
                 amount = amount,
+                uiCustomization = uiCustomization,
             )
         }
     }

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/provider/Adyen3DS2ComponentProvider.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/provider/Adyen3DS2ComponentProvider.kt
@@ -22,6 +22,7 @@ import com.adyen.checkout.adyen3ds2.internal.data.api.SubmitFingerprintService
 import com.adyen.checkout.adyen3ds2.internal.data.model.Adyen3DS2Serializer
 import com.adyen.checkout.adyen3ds2.internal.ui.Adyen3DS2Delegate
 import com.adyen.checkout.adyen3ds2.internal.ui.DefaultAdyen3DS2Delegate
+import com.adyen.checkout.adyen3ds2.internal.ui.model.Adyen3DS2ComponentParamsMapper
 import com.adyen.checkout.components.core.action.Action
 import com.adyen.checkout.components.core.action.Threeds2Action
 import com.adyen.checkout.components.core.action.Threeds2ChallengeAction
@@ -32,7 +33,6 @@ import com.adyen.checkout.components.core.internal.DefaultActionComponentEventHa
 import com.adyen.checkout.components.core.internal.PaymentDataRepository
 import com.adyen.checkout.components.core.internal.provider.ActionComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
-import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.internal.util.AndroidBase64Encoder
 import com.adyen.checkout.components.core.internal.util.get
@@ -49,7 +49,7 @@ class Adyen3DS2ComponentProvider(
     overrideSessionParams: SessionParams? = null,
 ) : ActionComponentProvider<Adyen3DS2Component, Adyen3DS2Configuration, Adyen3DS2Delegate> {
 
-    private val componentParamsMapper = GenericComponentParamsMapper(overrideComponentParams, overrideSessionParams)
+    private val componentParamsMapper = Adyen3DS2ComponentParamsMapper(overrideComponentParams, overrideSessionParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/Adyen3DS2Delegate.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/Adyen3DS2Delegate.kt
@@ -13,14 +13,10 @@ import com.adyen.checkout.components.core.internal.ui.ActionDelegate
 import com.adyen.checkout.components.core.internal.ui.DetailsEmittingDelegate
 import com.adyen.checkout.components.core.internal.ui.IntentHandlingDelegate
 import com.adyen.checkout.ui.core.internal.ui.ViewProvidingDelegate
-import com.adyen.threeds2.customization.UiCustomization
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface Adyen3DS2Delegate :
     ActionDelegate,
     DetailsEmittingDelegate,
     IntentHandlingDelegate,
-    ViewProvidingDelegate {
-
-    fun set3DS2UICustomization(uiCustomization: UiCustomization?)
-}
+    ViewProvidingDelegate

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2Delegate.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2Delegate.kt
@@ -49,7 +49,6 @@ import com.adyen.threeds2.ProtocolErrorEvent
 import com.adyen.threeds2.RuntimeErrorEvent
 import com.adyen.threeds2.ThreeDS2Service
 import com.adyen.threeds2.Transaction
-import com.adyen.threeds2.customization.UiCustomization
 import com.adyen.threeds2.exception.InvalidInputException
 import com.adyen.threeds2.exception.SDKAlreadyInitializedException
 import com.adyen.threeds2.exception.SDKNotInitializedException
@@ -93,8 +92,6 @@ internal class DefaultAdyen3DS2Delegate(
 
     private var _coroutineScope: CoroutineScope? = null
     private val coroutineScope: CoroutineScope get() = requireNotNull(_coroutineScope)
-
-    private var uiCustomization: UiCustomization? = null
 
     private var currentTransaction: Transaction? = null
 
@@ -380,10 +377,6 @@ internal class DefaultAdyen3DS2Delegate(
         } catch (e: CheckoutException) {
             exceptionChannel.trySend(e)
         }
-    }
-
-    override fun set3DS2UICustomization(uiCustomization: UiCustomization?) {
-        this.uiCustomization = uiCustomization
     }
 
     override fun completed(completionEvent: CompletionEvent) {

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2Delegate.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2Delegate.kt
@@ -21,6 +21,7 @@ import com.adyen.checkout.adyen3ds2.internal.data.model.Adyen3DS2Serializer
 import com.adyen.checkout.adyen3ds2.internal.data.model.ChallengeToken
 import com.adyen.checkout.adyen3ds2.internal.data.model.FingerprintToken
 import com.adyen.checkout.adyen3ds2.internal.data.model.SubmitFingerprintResult
+import com.adyen.checkout.adyen3ds2.internal.ui.model.Adyen3DS2ComponentParams
 import com.adyen.checkout.components.core.ActionComponentData
 import com.adyen.checkout.components.core.action.Action
 import com.adyen.checkout.components.core.action.BaseThreeds2Action
@@ -33,7 +34,6 @@ import com.adyen.checkout.components.core.internal.ActionObserverRepository
 import com.adyen.checkout.components.core.internal.PaymentDataRepository
 import com.adyen.checkout.components.core.internal.SavedStateHandleContainer
 import com.adyen.checkout.components.core.internal.SavedStateHandleProperty
-import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParams
 import com.adyen.checkout.components.core.internal.util.Base64Encoder
 import com.adyen.checkout.components.core.internal.util.bufferedChannel
 import com.adyen.checkout.core.exception.CheckoutException
@@ -71,7 +71,7 @@ import org.json.JSONObject
 internal class DefaultAdyen3DS2Delegate(
     private val observerRepository: ActionObserverRepository,
     override val savedStateHandle: SavedStateHandle,
-    override val componentParams: GenericComponentParams,
+    override val componentParams: Adyen3DS2ComponentParams,
     private val submitFingerprintRepository: SubmitFingerprintRepository,
     private val paymentDataRepository: PaymentDataRepository,
     private val adyen3DS2Serializer: Adyen3DS2Serializer,
@@ -214,7 +214,7 @@ internal class DefaultAdyen3DS2Delegate(
         coroutineScope.launch(defaultDispatcher + coroutineExceptionHandler) {
             try {
                 Logger.d(TAG, "initialize 3DS2 SDK")
-                threeDS2Service.initialize(activity, configParameters, null, uiCustomization)
+                threeDS2Service.initialize(activity, configParameters, null, componentParams.uiCustomization)
             } catch (e: SDKRuntimeException) {
                 exceptionChannel.trySend(ComponentException("Failed to initialize 3DS2 SDK", e))
                 return@launch

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/model/Adyen3DS2ComponentParams.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/model/Adyen3DS2ComponentParams.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2023 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 24/3/2023.
+ */
+
+package com.adyen.checkout.adyen3ds2.internal.ui.model
+
+import com.adyen.checkout.components.core.Amount
+import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
+import com.adyen.checkout.core.Environment
+import com.adyen.threeds2.customization.UiCustomization
+import kotlinx.parcelize.Parcelize
+import java.util.Locale
+
+@Parcelize
+internal data class Adyen3DS2ComponentParams(
+    override val shopperLocale: Locale,
+    override val environment: Environment,
+    override val clientKey: String,
+    override val isAnalyticsEnabled: Boolean,
+    override val isCreatedByDropIn: Boolean,
+    override val amount: Amount,
+    val uiCustomization: UiCustomization?,
+) : ComponentParams

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/model/Adyen3DS2ComponentParamsMapper.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/model/Adyen3DS2ComponentParamsMapper.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 24/3/2023.
+ */
+
+package com.adyen.checkout.adyen3ds2.internal.ui.model
+
+import com.adyen.checkout.adyen3ds2.Adyen3DS2Configuration
+import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
+import com.adyen.checkout.components.core.internal.ui.model.SessionParams
+
+internal class Adyen3DS2ComponentParamsMapper(
+    private val overrideComponentParams: ComponentParams?,
+    private val overrideSessionParams: SessionParams?,
+) {
+
+    fun mapToParams(
+        adyen3DS2Configuration: Adyen3DS2Configuration,
+        sessionParams: SessionParams?,
+    ): Adyen3DS2ComponentParams {
+        return adyen3DS2Configuration
+            .mapToParamsInternal()
+            .override(overrideComponentParams)
+            .override(sessionParams ?: overrideSessionParams)
+    }
+
+    private fun Adyen3DS2Configuration.mapToParamsInternal(): Adyen3DS2ComponentParams {
+        return Adyen3DS2ComponentParams(
+            shopperLocale = shopperLocale,
+            environment = environment,
+            clientKey = clientKey,
+            isAnalyticsEnabled = isAnalyticsEnabled ?: true,
+            isCreatedByDropIn = false,
+            amount = amount,
+            uiCustomization = uiCustomization,
+        )
+    }
+
+    private fun Adyen3DS2ComponentParams.override(
+        overrideComponentParams: ComponentParams?
+    ): Adyen3DS2ComponentParams {
+        if (overrideComponentParams == null) return this
+        return copy(
+            shopperLocale = overrideComponentParams.shopperLocale,
+            environment = overrideComponentParams.environment,
+            clientKey = overrideComponentParams.clientKey,
+            isAnalyticsEnabled = overrideComponentParams.isAnalyticsEnabled,
+            isCreatedByDropIn = overrideComponentParams.isCreatedByDropIn,
+            amount = overrideComponentParams.amount,
+        )
+    }
+
+    private fun Adyen3DS2ComponentParams.override(
+        sessionParams: SessionParams? = null
+    ): Adyen3DS2ComponentParams {
+        if (sessionParams == null) return this
+        return copy(
+            amount = sessionParams.amount ?: amount,
+        )
+    }
+}

--- a/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/Adyen3DS2ComponentTest.kt
+++ b/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/Adyen3DS2ComponentTest.kt
@@ -22,7 +22,6 @@ import com.adyen.checkout.core.internal.util.Logger
 import com.adyen.checkout.test.TestDispatcherExtension
 import com.adyen.checkout.test.extensions.invokeOnCleared
 import com.adyen.checkout.ui.core.internal.test.TestComponentViewType
-import com.adyen.threeds2.customization.UiCustomization
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
@@ -122,13 +121,5 @@ internal class Adyen3DS2ComponentTest(
         component.handleIntent(intent)
 
         verify(adyen3DS2Delegate).handleIntent(intent)
-    }
-
-    @Test
-    fun `when setUiCustomization is called then setUiCustomization in delegate is called`() {
-        val uiCustomization = UiCustomization()
-        component.setUiCustomization(uiCustomization)
-
-        verify(adyen3DS2Delegate).set3DS2UICustomization(uiCustomization)
     }
 }

--- a/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2DelegateTest.kt
+++ b/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2DelegateTest.kt
@@ -19,6 +19,7 @@ import com.adyen.checkout.adyen3ds2.Cancelled3DS2Exception
 import com.adyen.checkout.adyen3ds2.internal.data.api.SubmitFingerprintRepository
 import com.adyen.checkout.adyen3ds2.internal.data.model.Adyen3DS2Serializer
 import com.adyen.checkout.adyen3ds2.internal.data.model.SubmitFingerprintResult
+import com.adyen.checkout.adyen3ds2.internal.ui.model.Adyen3DS2ComponentParamsMapper
 import com.adyen.checkout.components.core.ActionComponentData
 import com.adyen.checkout.components.core.action.RedirectAction
 import com.adyen.checkout.components.core.action.Threeds2Action
@@ -26,7 +27,6 @@ import com.adyen.checkout.components.core.action.Threeds2ChallengeAction
 import com.adyen.checkout.components.core.action.Threeds2FingerprintAction
 import com.adyen.checkout.components.core.internal.ActionObserverRepository
 import com.adyen.checkout.components.core.internal.PaymentDataRepository
-import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
 import com.adyen.checkout.components.core.internal.util.JavaBase64Encoder
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.core.exception.ComponentException
@@ -90,7 +90,7 @@ internal class DefaultAdyen3DS2DelegateTest(
         delegate = DefaultAdyen3DS2Delegate(
             observerRepository = ActionObserverRepository(),
             savedStateHandle = SavedStateHandle(),
-            componentParams = GenericComponentParamsMapper(null, null).mapToParams(configuration, null),
+            componentParams = Adyen3DS2ComponentParamsMapper(null, null).mapToParams(configuration, null),
             submitFingerprintRepository = submitFingerprintRepository,
             paymentDataRepository = paymentDataRepository,
             adyen3DS2Serializer = adyen3DS2Serializer,

--- a/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/internal/ui/model/Adyen3DS2ComponentParamsMapperTest.kt
+++ b/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/internal/ui/model/Adyen3DS2ComponentParamsMapperTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2023 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 27/3/2023.
+ */
+
+package com.adyen.checkout.adyen3ds2.internal.ui.model
+
+import com.adyen.checkout.adyen3ds2.Adyen3DS2Configuration
+import com.adyen.checkout.components.core.Amount
+import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParams
+import com.adyen.checkout.core.Environment
+import com.adyen.threeds2.customization.UiCustomization
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.util.Locale
+
+internal class Adyen3DS2ComponentParamsMapperTest {
+
+    @Test
+    fun `when parent configuration is null and custom 3ds2 configuration fields are null then all fields should match`() {
+        val adyen3DS2Configuration = getAdyen3DS2ConfigurationBuilder()
+            .build()
+
+        val params = Adyen3DS2ComponentParamsMapper(null, null).mapToParams(adyen3DS2Configuration, null)
+
+        val expected = getAdyen3DS2ComponentParams()
+
+        Assertions.assertEquals(expected, params)
+    }
+
+    @Test
+    fun `when parent configuration is null and custom 3ds2 configuration fields are set then all fields should match`() {
+        val uiCustomization = UiCustomization()
+
+        val adyen3DS2Configuration = getAdyen3DS2ConfigurationBuilder()
+            .setUiCustomization(uiCustomization)
+            .build()
+
+        val params = Adyen3DS2ComponentParamsMapper(null, null).mapToParams(adyen3DS2Configuration, null)
+
+        val expected = getAdyen3DS2ComponentParams(
+            uiCustomization = uiCustomization
+        )
+
+        Assertions.assertEquals(expected, params)
+    }
+
+    @Test
+    fun `when parent configuration is set then parent configuration fields should override 3ds2 configuration fields`() {
+        val adyen3DS2Configuration = getAdyen3DS2ConfigurationBuilder()
+            .build()
+
+        // this is in practice DropInComponentParams, but we don't have access to it in this module and any
+        // ComponentParams class can work
+        val overrideParams = GenericComponentParams(
+            shopperLocale = Locale.GERMAN,
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+            isAnalyticsEnabled = false,
+            isCreatedByDropIn = true,
+            amount = Amount(
+                currency = "USD",
+                value = 25_00L
+            )
+        )
+
+        val params = Adyen3DS2ComponentParamsMapper(overrideParams, null).mapToParams(adyen3DS2Configuration, null)
+
+        val expected = getAdyen3DS2ComponentParams(
+            shopperLocale = Locale.GERMAN,
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+            isAnalyticsEnabled = false,
+            isCreatedByDropIn = true,
+            amount = Amount(
+                currency = "USD",
+                value = 25_00L
+            ),
+        )
+
+        Assertions.assertEquals(expected, params)
+    }
+
+    private fun getAdyen3DS2ConfigurationBuilder() = Adyen3DS2Configuration.Builder(
+        shopperLocale = Locale.US,
+        environment = Environment.TEST,
+        clientKey = TEST_CLIENT_KEY_1
+    )
+
+    private fun getAdyen3DS2ComponentParams(
+        shopperLocale: Locale = Locale.US,
+        environment: Environment = Environment.TEST,
+        clientKey: String = TEST_CLIENT_KEY_1,
+        isAnalyticsEnabled: Boolean = true,
+        isCreatedByDropIn: Boolean = false,
+        amount: Amount = Amount.EMPTY,
+        uiCustomization: UiCustomization? = null,
+    ) = Adyen3DS2ComponentParams(
+        shopperLocale = shopperLocale,
+        environment = environment,
+        clientKey = clientKey,
+        isAnalyticsEnabled = isAnalyticsEnabled,
+        isCreatedByDropIn = isCreatedByDropIn,
+        amount = amount,
+        uiCustomization = uiCustomization,
+    )
+
+    companion object {
+        private const val TEST_CLIENT_KEY_1 = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
+        private const val TEST_CLIENT_KEY_2 = "live_qwertyui34566776787zxcvbnmqwerty"
+    }
+}

--- a/action/src/main/java/com/adyen/checkout/action/internal/ActionHandlingComponent.kt
+++ b/action/src/main/java/com/adyen/checkout/action/internal/ActionHandlingComponent.kt
@@ -12,7 +12,6 @@ import android.app.Activity
 import android.content.Intent
 import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.core.action.Action
-import com.adyen.threeds2.customization.UiCustomization
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface ActionHandlingComponent {
@@ -40,12 +39,4 @@ interface ActionHandlingComponent {
      * @param intent The received [Intent].
      */
     fun handleIntent(intent: Intent)
-
-    /**
-     * Set a [UiCustomization] object to be passed to the 3DS2 SDK for customizing the challenge screen.
-     * Needs to be set before handling any action.
-     *
-     * @param uiCustomization The customization object.
-     */
-    fun set3DS2UICustomization(uiCustomization: UiCustomization?)
 }

--- a/action/src/main/java/com/adyen/checkout/action/internal/DefaultActionHandlingComponent.kt
+++ b/action/src/main/java/com/adyen/checkout/action/internal/DefaultActionHandlingComponent.kt
@@ -16,7 +16,6 @@ import com.adyen.checkout.action.internal.ui.GenericActionDelegate
 import com.adyen.checkout.components.core.internal.ui.ComponentDelegate
 import com.adyen.checkout.components.core.internal.ui.PaymentComponentDelegate
 import com.adyen.checkout.components.core.action.Action
-import com.adyen.threeds2.customization.UiCustomization
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class DefaultActionHandlingComponent(
@@ -41,9 +40,5 @@ class DefaultActionHandlingComponent(
 
     override fun handleIntent(intent: Intent) {
         genericActionDelegate.handleIntent(intent)
-    }
-
-    override fun set3DS2UICustomization(uiCustomization: UiCustomization?) {
-        genericActionDelegate.set3DS2UICustomization(uiCustomization)
     }
 }

--- a/action/src/main/java/com/adyen/checkout/action/internal/ui/DefaultGenericActionDelegate.kt
+++ b/action/src/main/java/com/adyen/checkout/action/internal/ui/DefaultGenericActionDelegate.kt
@@ -32,7 +32,6 @@ import com.adyen.checkout.core.internal.util.LogUtil
 import com.adyen.checkout.core.internal.util.Logger
 import com.adyen.checkout.ui.core.internal.ui.ComponentViewType
 import com.adyen.checkout.ui.core.internal.ui.ViewProvidingDelegate
-import com.adyen.threeds2.customization.UiCustomization
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -64,8 +63,6 @@ internal class DefaultGenericActionDelegate(
 
     private val detailsChannel: Channel<ActionComponentData> = bufferedChannel()
     override val detailsFlow: Flow<ActionComponentData> = detailsChannel.receiveAsFlow()
-
-    private var uiCustomization: UiCustomization? = null
 
     override fun initialize(coroutineScope: CoroutineScope) {
         Logger.d(TAG, "initialize")
@@ -112,8 +109,6 @@ internal class DefaultGenericActionDelegate(
 
             delegate.initialize(coroutineScope)
 
-            set3DS2UICustomizationInDelegate(delegate)
-
             observeDetails(delegate)
             observeExceptions(delegate)
             observeViewFlow(delegate)
@@ -143,19 +138,6 @@ internal class DefaultGenericActionDelegate(
         delegate.viewFlow
             .onEach { _viewFlow.tryEmit(it) }
             .launchIn(coroutineScope)
-    }
-
-    override fun set3DS2UICustomization(uiCustomization: UiCustomization?) {
-        this.uiCustomization = uiCustomization
-        set3DS2UICustomizationInDelegate(_delegate)
-    }
-
-    private fun set3DS2UICustomizationInDelegate(delegate: ActionDelegate?) {
-        if (delegate !is Adyen3DS2Delegate) return
-        if (uiCustomization != null) {
-            Logger.d(TAG, "Setting UICustomization on 3DS2 delegate")
-        }
-        delegate.set3DS2UICustomization(uiCustomization)
     }
 
     override fun handleIntent(intent: Intent) {
@@ -190,7 +172,6 @@ internal class DefaultGenericActionDelegate(
         _delegate?.onCleared()
         _delegate = null
         _coroutineScope = null
-        uiCustomization = null
     }
 
     companion object {

--- a/action/src/main/java/com/adyen/checkout/action/internal/ui/GenericActionDelegate.kt
+++ b/action/src/main/java/com/adyen/checkout/action/internal/ui/GenericActionDelegate.kt
@@ -13,7 +13,6 @@ import com.adyen.checkout.components.core.internal.ui.ActionDelegate
 import com.adyen.checkout.components.core.internal.ui.DetailsEmittingDelegate
 import com.adyen.checkout.components.core.internal.ui.IntentHandlingDelegate
 import com.adyen.checkout.ui.core.internal.ui.ViewProvidingDelegate
-import com.adyen.threeds2.customization.UiCustomization
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface GenericActionDelegate :
@@ -23,8 +22,6 @@ interface GenericActionDelegate :
     ViewProvidingDelegate {
 
     val delegate: ActionDelegate
-
-    fun set3DS2UICustomization(uiCustomization: UiCustomization?)
 
     fun refreshStatus()
 }

--- a/action/src/test/java/com/adyen/checkout/action/internal/ui/DefaultGenericActionDelegateTest.kt
+++ b/action/src/test/java/com/adyen/checkout/action/internal/ui/DefaultGenericActionDelegateTest.kt
@@ -16,7 +16,6 @@ import app.cash.turbine.test
 import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.components.core.ActionComponentData
 import com.adyen.checkout.components.core.action.RedirectAction
-import com.adyen.checkout.components.core.action.Threeds2Action
 import com.adyen.checkout.components.core.action.Threeds2ChallengeAction
 import com.adyen.checkout.components.core.action.Threeds2FingerprintAction
 import com.adyen.checkout.components.core.internal.ActionObserverRepository
@@ -26,7 +25,6 @@ import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.core.internal.util.Logger
 import com.adyen.checkout.ui.core.internal.test.TestComponentViewType
-import com.adyen.threeds2.customization.UiCustomization
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -206,46 +204,6 @@ internal class DefaultGenericActionDelegateTest(
 
         assertTrue(testDelegate.refreshStatusCalled)
     }
-
-    @Test
-    fun `when set3DS2UICustomization is called on the generic delegate after handleAction then it's also called on the 3DS2 delegate`() =
-        runTest {
-            val adyen3DS2Delegate = Test3DS2Delegate()
-            whenever(
-                actionDelegateProvider.getDelegate(any(), any(), any(), any())
-            ) doReturn adyen3DS2Delegate
-
-            genericActionDelegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
-
-            genericActionDelegate.handleAction(Threeds2Action(), activity)
-
-            assertEquals(adyen3DS2Delegate, genericActionDelegate.delegate)
-
-            val uiCustomization = UiCustomization()
-            genericActionDelegate.set3DS2UICustomization(uiCustomization)
-
-            assertEquals(uiCustomization, adyen3DS2Delegate.uiCustomization)
-        }
-
-    @Test
-    fun `when set3DS2UICustomization is called on the generic delegate before handleAction then it's also called on the 3DS2 delegate`() =
-        runTest {
-            val adyen3DS2Delegate = Test3DS2Delegate()
-            whenever(
-                actionDelegateProvider.getDelegate(any(), any(), any(), any())
-            ) doReturn adyen3DS2Delegate
-
-            genericActionDelegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
-
-            val uiCustomization = UiCustomization()
-            genericActionDelegate.set3DS2UICustomization(uiCustomization)
-
-            genericActionDelegate.handleAction(Threeds2Action(), activity)
-
-            assertEquals(adyen3DS2Delegate, genericActionDelegate.delegate)
-
-            assertEquals(uiCustomization, adyen3DS2Delegate.uiCustomization)
-        }
 
     @Test
     fun `when handleAction is called with a Threeds2ChallengeAction the inner delegate is not re-created`() = runTest {

--- a/action/src/test/java/com/adyen/checkout/action/internal/ui/TestActionDelegate.kt
+++ b/action/src/test/java/com/adyen/checkout/action/internal/ui/TestActionDelegate.kt
@@ -33,7 +33,6 @@ import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.qrcode.internal.ui.model.QRCodeOutputData
 import com.adyen.checkout.ui.core.internal.ui.ComponentViewType
 import com.adyen.checkout.ui.core.internal.ui.ViewProvidingDelegate
-import com.adyen.threeds2.customization.UiCustomization
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -132,15 +131,9 @@ internal class Test3DS2Delegate : Adyen3DS2Delegate {
 
     override val viewFlow: Flow<ComponentViewType?> = MutableSharedFlow(extraBufferCapacity = 1)
 
-    var uiCustomization: UiCustomization? = null
-
     var handleActionCalled = false
 
     override fun initialize(coroutineScope: CoroutineScope) = Unit
-
-    override fun set3DS2UICustomization(uiCustomization: UiCustomization?) {
-        this.uiCustomization = uiCustomization
-    }
 
     override fun handleAction(action: Action, activity: Activity) {
         handleActionCalled = true


### PR DESCRIPTION
## Description
With version `2.2.12` the `UiCustomization` class in the 3DS2 SDK is now `Parcelable`.

Which means that we can move this class to the 3DS2 configuration and remove the `setUiCustomization` and `set3DS2UICustomization` methods from delegates and components.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-739