### PR TITLE
Move public facing classes in econtext to internal package

### DIFF
--- a/convenience-stores-jp/src/main/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPComponent.kt
+++ b/convenience-stores-jp/src/main/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPComponent.kt
@@ -15,7 +15,7 @@ import com.adyen.checkout.components.core.internal.ComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentComponent
 import com.adyen.checkout.components.core.paymentmethod.ConvenienceStoresJPPaymentMethod
 import com.adyen.checkout.conveniencestoresjp.internal.provider.ConvenienceStoresJPComponentProvider
-import com.adyen.checkout.econtext.EContextComponent
+import com.adyen.checkout.econtext.internal.EContextComponent
 import com.adyen.checkout.econtext.internal.ui.EContextDelegate
 
 /**

--- a/convenience-stores-jp/src/main/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPConfiguration.kt
+++ b/convenience-stores-jp/src/main/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPConfiguration.kt
@@ -12,7 +12,7 @@ import android.content.Context
 import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.core.Environment
-import com.adyen.checkout.econtext.EContextConfiguration
+import com.adyen.checkout.econtext.internal.EContextConfiguration
 import kotlinx.parcelize.Parcelize
 import java.util.Locale
 

--- a/econtext/src/main/java/com/adyen/checkout/econtext/internal/EContextComponent.kt
+++ b/econtext/src/main/java/com/adyen/checkout/econtext/internal/EContextComponent.kt
@@ -6,7 +6,7 @@
  * Created by ozgur on 7/6/2022.
  */
 
-package com.adyen.checkout.econtext
+package com.adyen.checkout.econtext.internal
 
 import androidx.annotation.RestrictTo
 import androidx.lifecycle.LifecycleOwner

--- a/econtext/src/main/java/com/adyen/checkout/econtext/internal/EContextConfiguration.kt
+++ b/econtext/src/main/java/com/adyen/checkout/econtext/internal/EContextConfiguration.kt
@@ -6,7 +6,7 @@
  * Created by ozgur on 7/6/2022.
  */
 
-package com.adyen.checkout.econtext
+package com.adyen.checkout.econtext.internal
 
 import android.content.Context
 import androidx.annotation.RestrictTo

--- a/econtext/src/main/java/com/adyen/checkout/econtext/internal/provider/EContextComponentProvider.kt
+++ b/econtext/src/main/java/com/adyen/checkout/econtext/internal/provider/EContextComponentProvider.kt
@@ -38,8 +38,8 @@ import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.components.core.paymentmethod.EContextPaymentMethod
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
-import com.adyen.checkout.econtext.EContextComponent
-import com.adyen.checkout.econtext.EContextConfiguration
+import com.adyen.checkout.econtext.internal.EContextComponent
+import com.adyen.checkout.econtext.internal.EContextConfiguration
 import com.adyen.checkout.econtext.internal.ui.DefaultEContextDelegate
 import com.adyen.checkout.econtext.internal.ui.EContextDelegate
 import com.adyen.checkout.sessions.core.CheckoutSession

--- a/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextComponent.kt
+++ b/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextComponent.kt
@@ -11,6 +11,7 @@ package com.adyen.checkout.econtext
 import com.adyen.checkout.action.internal.DefaultActionHandlingComponent
 import com.adyen.checkout.action.internal.ui.GenericActionDelegate
 import com.adyen.checkout.components.core.internal.ComponentEventHandler
+import com.adyen.checkout.econtext.internal.EContextComponent
 import com.adyen.checkout.econtext.internal.ui.EContextDelegate
 
 internal class TestEContextComponent internal constructor(

--- a/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextConfiguration.kt
+++ b/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextConfiguration.kt
@@ -12,6 +12,7 @@ import android.content.Context
 import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.core.Environment
+import com.adyen.checkout.econtext.internal.EContextConfiguration
 import kotlinx.parcelize.Parcelize
 import java.util.Locale
 

--- a/econtext/src/test/java/com/adyen/checkout/econtext/internal/EContextComponentTest.kt
+++ b/econtext/src/test/java/com/adyen/checkout/econtext/internal/EContextComponentTest.kt
@@ -6,7 +6,7 @@
  * Created by ozgur on 13/2/2023.
  */
 
-package com.adyen.checkout.econtext
+package com.adyen.checkout.econtext.internal
 
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.viewModelScope
@@ -16,6 +16,9 @@ import com.adyen.checkout.action.internal.ui.GenericActionDelegate
 import com.adyen.checkout.components.core.internal.ComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentComponentEvent
 import com.adyen.checkout.core.internal.util.Logger
+import com.adyen.checkout.econtext.TestEContextComponent
+import com.adyen.checkout.econtext.TestEContextComponentState
+import com.adyen.checkout.econtext.TestEContextPaymentMethod
 import com.adyen.checkout.econtext.internal.ui.EContextComponentViewType
 import com.adyen.checkout.econtext.internal.ui.EContextDelegate
 import com.adyen.checkout.test.TestDispatcherExtension

--- a/online-banking-jp/src/main/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPComponent.kt
+++ b/online-banking-jp/src/main/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPComponent.kt
@@ -14,7 +14,7 @@ import com.adyen.checkout.components.core.PaymentMethodTypes
 import com.adyen.checkout.components.core.internal.ComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentComponent
 import com.adyen.checkout.components.core.paymentmethod.OnlineBankingJPPaymentMethod
-import com.adyen.checkout.econtext.EContextComponent
+import com.adyen.checkout.econtext.internal.EContextComponent
 import com.adyen.checkout.econtext.internal.ui.EContextDelegate
 import com.adyen.checkout.onlinebankingjp.internal.provider.OnlineBankingJPComponentProvider
 

--- a/online-banking-jp/src/main/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPConfiguration.kt
+++ b/online-banking-jp/src/main/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPConfiguration.kt
@@ -12,7 +12,7 @@ import android.content.Context
 import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.core.Environment
-import com.adyen.checkout.econtext.EContextConfiguration
+import com.adyen.checkout.econtext.internal.EContextConfiguration
 import kotlinx.parcelize.Parcelize
 import java.util.Locale
 

--- a/payeasy/src/main/java/com/adyen/checkout/payeasy/PayEasyComponent.kt
+++ b/payeasy/src/main/java/com/adyen/checkout/payeasy/PayEasyComponent.kt
@@ -14,7 +14,7 @@ import com.adyen.checkout.components.core.PaymentMethodTypes
 import com.adyen.checkout.components.core.internal.ComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentComponent
 import com.adyen.checkout.components.core.paymentmethod.PayEasyPaymentMethod
-import com.adyen.checkout.econtext.EContextComponent
+import com.adyen.checkout.econtext.internal.EContextComponent
 import com.adyen.checkout.econtext.internal.ui.EContextDelegate
 import com.adyen.checkout.payeasy.internal.provider.PayEasyComponentProvider
 

--- a/payeasy/src/main/java/com/adyen/checkout/payeasy/PayEasyConfiguration.kt
+++ b/payeasy/src/main/java/com/adyen/checkout/payeasy/PayEasyConfiguration.kt
@@ -12,7 +12,7 @@ import android.content.Context
 import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.core.Environment
-import com.adyen.checkout.econtext.EContextConfiguration
+import com.adyen.checkout.econtext.internal.EContextConfiguration
 import kotlinx.parcelize.Parcelize
 import java.util.Locale
 

--- a/seven-eleven/src/main/java/com/adyen/checkout/seveneleven/SevenElevenComponent.kt
+++ b/seven-eleven/src/main/java/com/adyen/checkout/seveneleven/SevenElevenComponent.kt
@@ -14,7 +14,7 @@ import com.adyen.checkout.components.core.PaymentMethodTypes
 import com.adyen.checkout.components.core.internal.ComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentComponent
 import com.adyen.checkout.components.core.paymentmethod.SevenElevenPaymentMethod
-import com.adyen.checkout.econtext.EContextComponent
+import com.adyen.checkout.econtext.internal.EContextComponent
 import com.adyen.checkout.econtext.internal.ui.EContextDelegate
 import com.adyen.checkout.seveneleven.internal.provider.SevenElevenComponentProvider
 

--- a/seven-eleven/src/main/java/com/adyen/checkout/seveneleven/SevenElevenConfiguration.kt
+++ b/seven-eleven/src/main/java/com/adyen/checkout/seveneleven/SevenElevenConfiguration.kt
@@ -12,7 +12,7 @@ import android.content.Context
 import com.adyen.checkout.action.GenericActionConfiguration
 import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.core.Environment
-import com.adyen.checkout.econtext.EContextConfiguration
+import com.adyen.checkout.econtext.internal.EContextConfiguration
 import kotlinx.parcelize.Parcelize
 import java.util.Locale
 


### PR DESCRIPTION
## Description
These classes shouldn't be public facing, since they are abstract.

COAND-724
