### PR TITLE
Make threedsRequestorAppURL overridable (v4)

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
@@ -325,7 +325,8 @@ class Adyen3DS2Component(
             acsSignedContent = challenge.acsSignedContent
             // This field was introduced in version 2.2.0 so older protocols don't expect it to be present and might throw an error.
             if (challenge.messageVersion != PROTOCOL_VERSION_2_1_0) {
-                threeDSRequestorAppURL = ChallengeParameters.getEmbeddedRequestorAppURL(getApplication())
+                threeDSRequestorAppURL = configuration.threeDSRequestorAppURL
+                    ?: ChallengeParameters.getEmbeddedRequestorAppURL(getApplication())
             }
         }
     }

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2ComponentProvider.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2ComponentProvider.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.adyen3ds2
 
 import android.app.Application
 import android.os.Bundle
+import androidx.annotation.RestrictTo
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
@@ -22,6 +23,7 @@ import com.adyen.checkout.components.model.payments.response.Threeds2ChallengeAc
 import com.adyen.checkout.components.model.payments.response.Threeds2FingerprintAction
 import com.adyen.checkout.redirect.RedirectDelegate
 
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class Adyen3DS2ComponentProvider : ActionComponentProvider<Adyen3DS2Component, Adyen3DS2Configuration> {
 
     override fun <T> get(

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Configuration.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Configuration.kt
@@ -8,18 +8,35 @@
 package com.adyen.checkout.adyen3ds2
 
 import android.content.Context
+import android.content.IntentFilter
 import android.os.Parcel
 import android.os.Parcelable
 import com.adyen.checkout.components.base.BaseConfigurationBuilder
 import com.adyen.checkout.components.base.Configuration
 import com.adyen.checkout.core.api.Environment
+import com.adyen.threeds2.internal.ui.activity.ChallengeActivity
 import java.util.Locale
 
 class Adyen3DS2Configuration : Configuration {
 
-    private constructor(builder: Builder) : super(builder.builderShopperLocale, builder.builderEnvironment, builder.builderClientKey)
+    val threeDSRequestorAppURL: String?
 
-    private constructor(inputParcel: Parcel) : super(inputParcel)
+    private constructor(builder: Builder) : super(
+        builder.builderShopperLocale,
+        builder.builderEnvironment,
+        builder.builderClientKey
+    ) {
+        threeDSRequestorAppURL = builder.threeDSRequestorAppURL
+    }
+
+    private constructor(inputParcel: Parcel) : super(inputParcel) {
+        threeDSRequestorAppURL = inputParcel.readString()
+    }
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        super.writeToParcel(parcel, flags)
+        parcel.writeString(threeDSRequestorAppURL)
+    }
 
     /**
      * Builder to create a [Adyen3DS2Configuration].
@@ -41,7 +58,14 @@ class Adyen3DS2Configuration : Configuration {
          * @param environment   The [Environment] to be used for network calls to Adyen.
          * @param clientKey Your Client Key used for network calls from the SDK to Adyen.
          */
-        constructor(shopperLocale: Locale, environment: Environment, clientKey: String) : super(shopperLocale, environment, clientKey)
+        constructor(shopperLocale: Locale, environment: Environment, clientKey: String) : super(
+            shopperLocale,
+            environment,
+            clientKey
+        )
+
+        internal var threeDSRequestorAppURL: String? = null
+            private set
 
         /**
          * Constructor that copies an existing configuration.
@@ -58,6 +82,20 @@ class Adyen3DS2Configuration : Configuration {
             return super.setEnvironment(builderEnvironment) as Builder
         }
 
+        /**
+         * Sets the 3DS Requestor App URL. This is used to call your app after an out-of-band (OOB)
+         * authentication occurs.
+         *
+         * Make sure to also override [ChallengeActivity]'s [IntentFilter] with your own URL like
+         * [this](https://docs.adyen.com/online-payments/classic-integrations/api-integration-ecommerce/3d-secure/native-3ds2/android-sdk-integration#handling-android-app-links)
+         * when using this method.
+         */
+        @Suppress("MaxLineLength")
+        fun setThreeDSRequestorAppURL(threeDSRequestorAppURL: String): Builder {
+            this.threeDSRequestorAppURL = threeDSRequestorAppURL
+            return this
+        }
+
         override fun buildInternal(): Adyen3DS2Configuration {
             return Adyen3DS2Configuration(this)
         }
@@ -65,14 +103,15 @@ class Adyen3DS2Configuration : Configuration {
 
     companion object {
         @JvmField
-        val CREATOR: Parcelable.Creator<Adyen3DS2Configuration> = object : Parcelable.Creator<Adyen3DS2Configuration> {
-            override fun createFromParcel(`in`: Parcel): Adyen3DS2Configuration {
-                return Adyen3DS2Configuration(`in`)
-            }
+        val CREATOR: Parcelable.Creator<Adyen3DS2Configuration> =
+            object : Parcelable.Creator<Adyen3DS2Configuration> {
+                override fun createFromParcel(`in`: Parcel): Adyen3DS2Configuration {
+                    return Adyen3DS2Configuration(`in`)
+                }
 
-            override fun newArray(size: Int): Array<Adyen3DS2Configuration?> {
-                return arrayOfNulls(size)
+                override fun newArray(size: Int): Array<Adyen3DS2Configuration?> {
+                    return arrayOfNulls(size)
+                }
             }
-        }
     }
 }


### PR DESCRIPTION
## Description
With this method in the configuration it is possible to override the return URL used by the 3DS2 SDK. If not set, the default value from the 3DS2 SDK will be used.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-725
