### PR TITLE
Make threedsRequestorAppURL overridable

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Configuration.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Configuration.kt
@@ -8,17 +8,20 @@
 package com.adyen.checkout.adyen3ds2
 
 import android.content.Context
+import android.content.IntentFilter
 import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.components.core.internal.BaseConfigurationBuilder
 import com.adyen.checkout.components.core.internal.Configuration
 import com.adyen.checkout.core.Environment
 import com.adyen.threeds2.customization.UiCustomization
+import com.adyen.threeds2.internal.ui.activity.ChallengeActivity
 import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
 /**
  * Configuration class for the [Adyen3DS2Component].
  */
+@Suppress("LongParameterList")
 @Parcelize
 class Adyen3DS2Configuration private constructor(
     override val shopperLocale: Locale,
@@ -27,6 +30,7 @@ class Adyen3DS2Configuration private constructor(
     override val isAnalyticsEnabled: Boolean?,
     override val amount: Amount,
     val uiCustomization: UiCustomization?,
+    val threeDSRequestorAppURL: String?,
 ) : Configuration {
 
     /**
@@ -35,6 +39,8 @@ class Adyen3DS2Configuration private constructor(
     class Builder : BaseConfigurationBuilder<Adyen3DS2Configuration, Builder> {
 
         private var uiCustomization: UiCustomization? = null
+
+        private var threeDSRequestorAppURL: String? = null
 
         /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
@@ -72,6 +78,20 @@ class Adyen3DS2Configuration private constructor(
             return this
         }
 
+        /**
+         * Sets the 3DS Requestor App URL. This is used to call your app after an out-of-band (OOB)
+         * authentication occurs.
+         *
+         * Make sure to also override [ChallengeActivity]'s [IntentFilter] with your own URL like
+         * [this](https://docs.adyen.com/online-payments/classic-integrations/api-integration-ecommerce/3d-secure/native-3ds2/android-sdk-integration#handling-android-app-links)
+         * when using this method.
+         */
+        @Suppress("MaxLineLength")
+        fun setThreeDSRequestorAppURL(threeDSRequestorAppURL: String): Builder {
+            this.threeDSRequestorAppURL = threeDSRequestorAppURL
+            return this
+        }
+
         override fun buildInternal(): Adyen3DS2Configuration {
             return Adyen3DS2Configuration(
                 shopperLocale = shopperLocale,
@@ -80,6 +100,7 @@ class Adyen3DS2Configuration private constructor(
                 isAnalyticsEnabled = isAnalyticsEnabled,
                 amount = amount,
                 uiCustomization = uiCustomization,
+                threeDSRequestorAppURL = threeDSRequestorAppURL,
             )
         }
     }

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/provider/Adyen3DS2ComponentProvider.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/provider/Adyen3DS2ComponentProvider.kt
@@ -23,11 +23,11 @@ import com.adyen.checkout.adyen3ds2.internal.data.model.Adyen3DS2Serializer
 import com.adyen.checkout.adyen3ds2.internal.ui.Adyen3DS2Delegate
 import com.adyen.checkout.adyen3ds2.internal.ui.DefaultAdyen3DS2Delegate
 import com.adyen.checkout.adyen3ds2.internal.ui.model.Adyen3DS2ComponentParamsMapper
+import com.adyen.checkout.components.core.ActionComponentCallback
 import com.adyen.checkout.components.core.action.Action
 import com.adyen.checkout.components.core.action.Threeds2Action
 import com.adyen.checkout.components.core.action.Threeds2ChallengeAction
 import com.adyen.checkout.components.core.action.Threeds2FingerprintAction
-import com.adyen.checkout.components.core.ActionComponentCallback
 import com.adyen.checkout.components.core.internal.ActionObserverRepository
 import com.adyen.checkout.components.core.internal.DefaultActionComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentDataRepository
@@ -79,9 +79,11 @@ class Adyen3DS2ComponentProvider(
         savedStateHandle: SavedStateHandle,
         application: Application,
     ): Adyen3DS2Delegate {
+        val defaultThreeDSRequestorAppURL = ChallengeParameters.getEmbeddedRequestorAppURL(application)
         val componentParams = componentParamsMapper.mapToParams(
-            configuration,
-            null
+            adyen3DS2Configuration = configuration,
+            sessionParams = null,
+            defaultThreeDSRequestorAppURL = defaultThreeDSRequestorAppURL,
         )
         val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
         val submitFingerprintService = SubmitFingerprintService(httpClient)
@@ -89,7 +91,6 @@ class Adyen3DS2ComponentProvider(
         val paymentDataRepository = PaymentDataRepository(savedStateHandle)
         val adyen3DS2DetailsParser = Adyen3DS2Serializer()
         val redirectHandler = DefaultRedirectHandler()
-        val embeddedRequestorAppUrl = ChallengeParameters.getEmbeddedRequestorAppURL(application)
         return DefaultAdyen3DS2Delegate(
             observerRepository = ActionObserverRepository(),
             savedStateHandle = savedStateHandle,
@@ -100,7 +101,6 @@ class Adyen3DS2ComponentProvider(
             redirectHandler = redirectHandler,
             threeDS2Service = ThreeDS2Service.INSTANCE,
             defaultDispatcher = Dispatchers.Default,
-            embeddedRequestorAppUrl = embeddedRequestorAppUrl,
             base64Encoder = AndroidBase64Encoder(),
             application = application,
         )

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2Delegate.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2Delegate.kt
@@ -77,7 +77,6 @@ internal class DefaultAdyen3DS2Delegate(
     private val redirectHandler: RedirectHandler,
     private val threeDS2Service: ThreeDS2Service,
     private val defaultDispatcher: CoroutineDispatcher,
-    private val embeddedRequestorAppUrl: String,
     private val base64Encoder: Base64Encoder,
     private val application: Application,
 ) : Adyen3DS2Delegate, ChallengeStatusReceiver, SavedStateHandleContainer {
@@ -365,7 +364,7 @@ internal class DefaultAdyen3DS2Delegate(
             // This field was introduced in version 2.2.0 so older protocols don't expect it to be present and might
             // throw an error.
             if (challenge.messageVersion != PROTOCOL_VERSION_2_1_0) {
-                threeDSRequestorAppURL = embeddedRequestorAppUrl
+                threeDSRequestorAppURL = componentParams.threeDSRequestorAppURL
             }
         }
     }

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/model/Adyen3DS2ComponentParams.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/model/Adyen3DS2ComponentParams.kt
@@ -24,4 +24,5 @@ internal data class Adyen3DS2ComponentParams(
     override val isCreatedByDropIn: Boolean,
     override val amount: Amount,
     val uiCustomization: UiCustomization?,
+    val threeDSRequestorAppURL: String,
 ) : ComponentParams

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/model/Adyen3DS2ComponentParamsMapper.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/model/Adyen3DS2ComponentParamsMapper.kt
@@ -20,14 +20,17 @@ internal class Adyen3DS2ComponentParamsMapper(
     fun mapToParams(
         adyen3DS2Configuration: Adyen3DS2Configuration,
         sessionParams: SessionParams?,
+        defaultThreeDSRequestorAppURL: String,
     ): Adyen3DS2ComponentParams {
         return adyen3DS2Configuration
-            .mapToParamsInternal()
+            .mapToParamsInternal(defaultThreeDSRequestorAppURL)
             .override(overrideComponentParams)
             .override(sessionParams ?: overrideSessionParams)
     }
 
-    private fun Adyen3DS2Configuration.mapToParamsInternal(): Adyen3DS2ComponentParams {
+    private fun Adyen3DS2Configuration.mapToParamsInternal(
+        defaultThreeDSRequestorAppURL: String,
+    ): Adyen3DS2ComponentParams {
         return Adyen3DS2ComponentParams(
             shopperLocale = shopperLocale,
             environment = environment,
@@ -36,6 +39,7 @@ internal class Adyen3DS2ComponentParamsMapper(
             isCreatedByDropIn = false,
             amount = amount,
             uiCustomization = uiCustomization,
+            threeDSRequestorAppURL = threeDSRequestorAppURL ?: defaultThreeDSRequestorAppURL,
         )
     }
 

--- a/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2DelegateTest.kt
+++ b/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2DelegateTest.kt
@@ -90,14 +90,14 @@ internal class DefaultAdyen3DS2DelegateTest(
         delegate = DefaultAdyen3DS2Delegate(
             observerRepository = ActionObserverRepository(),
             savedStateHandle = SavedStateHandle(),
-            componentParams = Adyen3DS2ComponentParamsMapper(null, null).mapToParams(configuration, null),
+            componentParams = Adyen3DS2ComponentParamsMapper(null, null)
+                .mapToParams(configuration, null, "embeddedRequestorAppUrl"),
             submitFingerprintRepository = submitFingerprintRepository,
             paymentDataRepository = paymentDataRepository,
             adyen3DS2Serializer = adyen3DS2Serializer,
             redirectHandler = redirectHandler,
             threeDS2Service = threeDS2Service,
             defaultDispatcher = dispatcher,
-            embeddedRequestorAppUrl = "embeddedRequestorAppUrl",
             base64Encoder = base64Encoder,
             application = Application(),
         )

--- a/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/internal/ui/model/Adyen3DS2ComponentParamsMapperTest.kt
+++ b/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/internal/ui/model/Adyen3DS2ComponentParamsMapperTest.kt
@@ -24,7 +24,8 @@ internal class Adyen3DS2ComponentParamsMapperTest {
         val adyen3DS2Configuration = getAdyen3DS2ConfigurationBuilder()
             .build()
 
-        val params = Adyen3DS2ComponentParamsMapper(null, null).mapToParams(adyen3DS2Configuration, null)
+        val params = Adyen3DS2ComponentParamsMapper(null, null)
+            .mapToParams(adyen3DS2Configuration, null, TEST_REQUESTOR_APP_URL)
 
         val expected = getAdyen3DS2ComponentParams()
 
@@ -35,14 +36,18 @@ internal class Adyen3DS2ComponentParamsMapperTest {
     fun `when parent configuration is null and custom 3ds2 configuration fields are set then all fields should match`() {
         val uiCustomization = UiCustomization()
 
+        val testUrl = "https://adyen.com"
         val adyen3DS2Configuration = getAdyen3DS2ConfigurationBuilder()
             .setUiCustomization(uiCustomization)
+            .setThreeDSRequestorAppURL(testUrl)
             .build()
 
-        val params = Adyen3DS2ComponentParamsMapper(null, null).mapToParams(adyen3DS2Configuration, null)
+        val params = Adyen3DS2ComponentParamsMapper(null, null)
+            .mapToParams(adyen3DS2Configuration, null, TEST_REQUESTOR_APP_URL)
 
         val expected = getAdyen3DS2ComponentParams(
-            uiCustomization = uiCustomization
+            uiCustomization = uiCustomization,
+            threeDSRequestorAppURL = testUrl,
         )
 
         Assertions.assertEquals(expected, params)
@@ -67,7 +72,8 @@ internal class Adyen3DS2ComponentParamsMapperTest {
             )
         )
 
-        val params = Adyen3DS2ComponentParamsMapper(overrideParams, null).mapToParams(adyen3DS2Configuration, null)
+        val params = Adyen3DS2ComponentParamsMapper(overrideParams, null)
+            .mapToParams(adyen3DS2Configuration, null, TEST_REQUESTOR_APP_URL)
 
         val expected = getAdyen3DS2ComponentParams(
             shopperLocale = Locale.GERMAN,
@@ -98,6 +104,7 @@ internal class Adyen3DS2ComponentParamsMapperTest {
         isCreatedByDropIn: Boolean = false,
         amount: Amount = Amount.EMPTY,
         uiCustomization: UiCustomization? = null,
+        threeDSRequestorAppURL: String = TEST_REQUESTOR_APP_URL,
     ) = Adyen3DS2ComponentParams(
         shopperLocale = shopperLocale,
         environment = environment,
@@ -106,10 +113,12 @@ internal class Adyen3DS2ComponentParamsMapperTest {
         isCreatedByDropIn = isCreatedByDropIn,
         amount = amount,
         uiCustomization = uiCustomization,
+        threeDSRequestorAppURL = threeDSRequestorAppURL,
     )
 
     companion object {
         private const val TEST_CLIENT_KEY_1 = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
         private const val TEST_CLIENT_KEY_2 = "live_qwertyui34566776787zxcvbnmqwerty"
+        private const val TEST_REQUESTOR_APP_URL = "TEST_REQUESTOR_APP_URL"
     }
 }


### PR DESCRIPTION
## Description
With this method in the configuration it is possible to override the return URL used by the 3DS2 SDK. If not set, the default value from the 3DS2 SDK will be used.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-725
