### PR TITLE
Add UPI collect and QR to Drop-in configuration

### DIFF
--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
@@ -346,6 +346,8 @@ class DropInConfiguration private constructor(
          */
         fun addUPIConfiguration(upiConfiguration: UPIConfiguration): Builder {
             availablePaymentConfigs[PaymentMethodTypes.UPI] = upiConfiguration
+            availablePaymentConfigs[PaymentMethodTypes.UPI_COLLECT] = upiConfiguration
+            availablePaymentConfigs[PaymentMethodTypes.UPI_QR] = upiConfiguration
             return this
         }
 


### PR DESCRIPTION
## Description
We get the configuration by payment method type and in some edge cases UPI collect and/or QR could be used. Adding these keys to the Drop-in configuration makes sure the given `UpiConfiguration` will be used for all the UPI payment method types.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
