### PR TITLE
Fix QRCodeCountDownTimer initialization error

### DIFF
--- a/qr-code/src/main/java/com/adyen/checkout/qrcode/internal/QRCodeCountDownTimer.kt
+++ b/qr-code/src/main/java/com/adyen/checkout/qrcode/internal/QRCodeCountDownTimer.kt
@@ -12,7 +12,7 @@ import android.os.CountDownTimer
 
 internal class QRCodeCountDownTimer {
 
-    private lateinit var countDownTimer: CountDownTimer
+    private var countDownTimer: CountDownTimer? = null
 
     fun attach(
         millisInFuture: Long,
@@ -29,10 +29,10 @@ internal class QRCodeCountDownTimer {
     }
 
     fun start() {
-        countDownTimer.start()
+        countDownTimer?.start()
     }
 
     fun cancel() {
-        countDownTimer.cancel()
+        countDownTimer?.cancel()
     }
 }


### PR DESCRIPTION
## Description
If the timer was not properly initialized and `cancel()` was called, then it would crash. Making the timer nullable instead of `lateinit` fixes it.