### PR TITLE
Enable querying the WeChat app package (v4)

### DIFF
--- a/wechatpay/src/main/AndroidManifest.xml
+++ b/wechatpay/src/main/AndroidManifest.xml
@@ -1,2 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.adyen.checkout.wechatpay" />
+    package="com.adyen.checkout.wechatpay">
+
+    <queries>
+        <package android:name="com.tencent.mm" />
+    </queries>
+
+</manifest>


### PR DESCRIPTION
## Description
The WeChat SDK checks if their app is available on the phone. Since Android 11 this is restricted and there should be extra config to make it work again.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-751
