### PR TITLE
Enable querying the WeChat app package

### DIFF
--- a/wechatpay/src/main/AndroidManifest.xml
+++ b/wechatpay/src/main/AndroidManifest.xml
@@ -1,1 +1,7 @@
-<manifest />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <queries>
+        <package android:name="com.tencent.mm" />
+    </queries>
+
+</manifest>


### PR DESCRIPTION
## Description
The WeChat SDK checks if their app is available on the phone. Since Android 11 this is restricted and there should be extra config to make it work again.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-751