### PR TITLE
Support checkout API v70 on example app (v4)

### DIFF
--- a/example-app/src/main/java/com/adyen/checkout/example/data/api/model/paymentsRequest/RecurringProcessingModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/data/api/model/paymentsRequest/RecurringProcessingModel.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 3/5/2023.
+ */
+
+package com.adyen.checkout.example.data.api.model.paymentsRequest
+
+import androidx.annotation.Keep
+
+@Keep
+enum class RecurringProcessingModel(val recurringModel: String) {
+    SUBSCRIPTION("Subscription"),
+    CARD_ON_FILE("CardOnFile"),
+    UNSCHEDULED_CARD_ON_FILE("UnscheduledCardOnFile")
+}

--- a/example-app/src/main/java/com/adyen/checkout/example/service/RequestUtils.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/service/RequestUtils.kt
@@ -13,6 +13,7 @@ import com.adyen.checkout.components.model.payments.request.OrderRequest
 import com.adyen.checkout.example.data.api.model.paymentsRequest.AdditionalData
 import com.adyen.checkout.example.data.api.model.paymentsRequest.Item
 import com.adyen.checkout.example.data.api.model.paymentsRequest.PaymentMethodsRequest
+import com.adyen.checkout.example.data.api.model.paymentsRequest.RecurringProcessingModel
 import com.adyen.checkout.example.data.storage.KeyValueStorage
 import com.google.gson.Gson
 import org.json.JSONArray
@@ -41,7 +42,8 @@ fun createPaymentRequest(
     additionalData: AdditionalData,
     force3DS2Challenge: Boolean = true,
     threeDSAuthenticationOnly: Boolean = false,
-    shopperEmail: String? = null
+    shopperEmail: String? = null,
+    recurringProcessingModel: String? = RecurringProcessingModel.SUBSCRIPTION.recurringModel,
 ): JSONObject {
 
     return JSONObject(paymentComponentData.toString()).apply {
@@ -64,6 +66,7 @@ fun createPaymentRequest(
             put("threeDS2RequestData", threeDS2RequestData)
         }
         put("shopperEmail", shopperEmail)
+        put("recurringProcessingModel", recurringProcessingModel)
     }
 }
 


### PR DESCRIPTION
## Description
Add `recurringProcessingModel` to the `/payments` request in the example app, as it's a required field for API v70.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-755
