### PR TITLE
Add workflow to validate release notes

### DIFF
--- a/.github/workflows/check_release_notes.yml
+++ b/.github/workflows/check_release_notes.yml
@@ -1,0 +1,35 @@
+name: Check Release Notes
+
+# Every PR with a label should include an update to the release notes
+on:
+  pull_request:
+    branches-ignore:
+      - 'main'
+    types: [ opened, synchronize, reopened, labeled, unlabeled ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  release-notes-check:
+    # https://github.com/actions/virtual-environments/
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check release notes
+        if: |
+          contains(github.event.pull_request.labels.*.name, 'Breaking change') ||
+          contains(github.event.pull_request.labels.*.name, 'Feature') ||
+          contains(github.event.pull_request.labels.*.name, 'Fix')
+        run: |
+          git fetch origin develop --depth 1
+          if [ -n "$(git diff origin/develop RELEASE_NOTES.md)" ]
+          then
+            echo "RELEASE_NOTES.md was updated"
+            exit 0
+          else
+            echo "::error::Add release notes for your PR by updating RELEASE_NOTES.md"
+            exit 1
+          fi


### PR DESCRIPTION
## Description
Add a workflow to make sure we update the release notes file when a PR has a 'Feature', 'Fix' or 'Breaking change' label.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-762
