### PR TITLE
Fix restrict annotation for 3DS2 Component Provider

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2ComponentProvider.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2ComponentProvider.kt
@@ -23,8 +23,9 @@ import com.adyen.checkout.components.model.payments.response.Threeds2ChallengeAc
 import com.adyen.checkout.components.model.payments.response.Threeds2FingerprintAction
 import com.adyen.checkout.redirect.RedirectDelegate
 
+class Adyen3DS2ComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class Adyen3DS2ComponentProvider : ActionComponentProvider<Adyen3DS2Component, Adyen3DS2Configuration> {
+constructor() : ActionComponentProvider<Adyen3DS2Component, Adyen3DS2Configuration> {
 
     override fun <T> get(
         owner: T,


### PR DESCRIPTION
## Description
Fix restrict annotation for `Adyen3DS2ComponentProvider`.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-758
