### PR TITLE
Use Cash App Pay's button

### DIFF
--- a/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/CashAppPayComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/ui/component/CashAppPayComponentDialogFragment.kt
@@ -17,7 +17,6 @@ import androidx.core.view.isVisible
 import com.adyen.checkout.cashapppay.CashAppPayComponent
 import com.adyen.checkout.components.ComponentError
 import com.adyen.checkout.components.model.paymentmethods.PaymentMethod
-import com.adyen.checkout.components.util.CurrencyUtils
 import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.core.log.LogUtil
 import com.adyen.checkout.core.log.Logger
@@ -60,11 +59,6 @@ class CashAppPayComponentDialogFragment : DropInBottomSheetDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         Logger.d(TAG, "onViewCreated")
-
-        if (!dropInViewModel.amount.isEmpty) {
-            val value = CurrencyUtils.formatAmount(dropInViewModel.amount, dropInViewModel.dropInConfiguration.shopperLocale)
-            binding.payButton.text = String.format(resources.getString(R.string.pay_button_with_value), value)
-        }
 
         cashAppPayComponent.observe(viewLifecycleOwner) { state ->
             if (state.isValid) {

--- a/drop-in/src/main/res/layout/fragment_cash_app_pay_component.xml
+++ b/drop-in/src/main/res/layout/fragment_cash_app_pay_component.xml
@@ -44,10 +44,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent" />
 
-            <androidx.appcompat.widget.AppCompatButton
+            <app.cash.paykit.core.ui.CashAppPayLightButton
                 android:id="@+id/payButton"
-                style="@style/AdyenCheckout.Button.Colored"
-                android:text="@string/pay_button" />
+                style="@style/AdyenCheckout.DropIn.CashAppPay.Button" />
 
             <androidx.core.widget.ContentLoadingProgressBar
                 android:id="@+id/progressBar"

--- a/drop-in/src/main/res/values/styles.xml
+++ b/drop-in/src/main/res/values/styles.xml
@@ -102,4 +102,11 @@
         <item name="android:layout_marginEnd">8dp</item>
     </style>
 
+    <style name="AdyenCheckout.DropIn.CashAppPay.Button" parent="AdyenCheckout">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">@dimen/primary_button_height</item>
+        <item name="android:layout_marginStart">@dimen/standard_margin</item>
+        <item name="android:layout_marginEnd">@dimen/standard_margin</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
## Description
Instead of using our default button we should use [the one provided by the Cash App SDK](https://developers.cash.app/docs/api/technical-documentation/sdks/pay-kit/android-getting-started#cashapppaybutton). In our drop-in. This doesn't apply to the component as we have no button there.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-634
