### PR TITLE
Add workflow that updates verification metadata

### DIFF
--- a/.github/workflows/update_verification_metadata.yml
+++ b/.github/workflows/update_verification_metadata.yml
@@ -1,0 +1,45 @@
+name: Update verification metadata
+
+on:
+  push:
+    branches:
+      - 'renovate/**'
+    paths:
+      - 'dependencies.gradle'
+
+jobs:
+  gradle-update-verification-metadata:
+    # https://github.com/actions/virtual-environments/
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      # https://github.com/marketplace/actions/checkout
+      - uses: actions/checkout@v3
+
+      # Setup Java 17
+      # https://github.com/marketplace/actions/setup-java-jdk
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 17
+          cache: 'gradle'
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      # Run gradlew check
+      - name: Gradle update verification metadata
+        run: ./gradlew --write-verification-metadata sha256 build --no-daemon
+
+      - name: Commit
+        run: |
+          git config --local user.email 'action@github.com'
+          git config --local user.name 'GitHub Action'
+          git add .
+          git commit -am 'Update verification metadata'
+
+      - name: Push
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}


### PR DESCRIPTION
## Description
This workflow should automatically update the verification metadata if the `dependencies.gradle` file is updated by Renovate. Not sure how to test this except for merging it and rebasing current Renovate PRs.

## Checklist <!-- Remove any line that's not applicable -->
- [ ] Changes are tested manually

COAND-770
