### PR TITLE
Fix 3DS2 frictionless flow (v4)

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Component.kt
@@ -210,6 +210,8 @@ class Adyen3DS2Component(
             notifyException(CheckoutException("Unexpected 3DS2 exception.", throwable))
         }
         viewModelScope.launch(Dispatchers.Default + coroutineExceptionHandler) {
+            // This makes sure the 3DS2 SDK doesn't re-use any state from previous transactions
+            closeTransaction(getApplication())
             try {
                 Logger.d(TAG, "initialize 3DS2 SDK")
                 ThreeDS2Service.INSTANCE.initialize(activity, configParameters, null, mUiCustomization)


### PR DESCRIPTION
## Description
This solves an issue in the frictionless flow where if the first
challenge fails and the second is retried with a different card, it
would fail as well. Because the second challenge would be performed
with data from the first challenge.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-771
