### PR TITLE
Fix AwaitView state restoration

### DIFF
--- a/await/src/main/java/com/adyen/checkout/await/AwaitView.java
+++ b/await/src/main/java/com/adyen/checkout/await/AwaitView.java
@@ -123,6 +123,10 @@ public class AwaitView extends AdyenLinearLayout<AwaitOutputData, AwaitConfigura
 
     @StringRes
     private Integer getMessageTextResource() {
+        if (mPaymentMethodType == null) {
+            return null;
+        }
+
         switch (mPaymentMethodType) {
             case PaymentMethodTypes.BLIK:
                 return R.string.checkout_await_message_blik;


### PR DESCRIPTION
## Description
Passing a String to a switch will call .hashCode(), so if it's null an exception will be thrown. Adding a null check before the switch solves this issue.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
- [x] Link to related issues: fixes #1234 
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-772
