### PR TITLE
Always clean up ThreeDS2Service before starting 3DS transaction

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2Delegate.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2Delegate.kt
@@ -211,6 +211,9 @@ internal class DefaultAdyen3DS2Delegate(
         }
 
         coroutineScope.launch(defaultDispatcher + coroutineExceptionHandler) {
+            // This makes sure the 3DS2 SDK doesn't re-use any state from previous transactions
+            closeTransaction()
+
             @Suppress("SwallowedException")
             try {
                 Logger.d(TAG, "initialize 3DS2 SDK")


### PR DESCRIPTION
## Description
This solves an issue in the frictionless flow where if the first challenge fails and the second is retried with a different card, it would fail as well. Because the second challenge would be performed with data from the first challenge.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-771
