### PR TITLE
Telemetry: sending missing API params

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/model/Adyen3DS2ComponentParams.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/model/Adyen3DS2ComponentParams.kt
@@ -13,10 +13,8 @@ import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
 import com.adyen.checkout.core.Environment
 import com.adyen.threeds2.customization.UiCustomization
-import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
-@Parcelize
 internal data class Adyen3DS2ComponentParams(
     override val shopperLocale: Locale,
     override val environment: Environment,

--- a/ach/src/main/java/com/adyen/checkout/ach/internal/provider/ACHDirectDebitComponentProvider.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/internal/provider/ACHDirectDebitComponentProvider.kt
@@ -30,11 +30,11 @@ import com.adyen.checkout.components.core.internal.DefaultComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsMapper
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
+import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepositoryData
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
 import com.adyen.checkout.components.core.internal.data.api.DefaultPublicKeyRepository
 import com.adyen.checkout.components.core.internal.data.api.PublicKeyService
-import com.adyen.checkout.components.core.internal.data.model.AnalyticsSource
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.provider.StoredPaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
@@ -121,15 +121,15 @@ constructor(
             val clientSideEncrypter = ClientSideEncrypter()
             val genericEncrypter = DefaultGenericEncrypter(clientSideEncrypter, dateGenerator)
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val achDelegate = DefaultACHDirectDebitDelegate(
@@ -195,15 +195,15 @@ constructor(
             val clientSideEncrypter = ClientSideEncrypter()
             val genericEncrypter = DefaultGenericEncrypter(clientSideEncrypter, dateGenerator)
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val achDelegate = DefaultACHDirectDebitDelegate(
@@ -276,15 +276,15 @@ constructor(
             val componentParams = componentParamsMapper.mapToParams(configuration, null)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, storedPaymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    storedPaymentMethod = storedPaymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val achDelegate = StoredACHDirectDebitDelegate(
@@ -339,15 +339,15 @@ constructor(
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, storedPaymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    storedPaymentMethod = storedPaymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val achDelegate = StoredACHDirectDebitDelegate(

--- a/ach/src/main/java/com/adyen/checkout/ach/internal/ui/DefaultACHDirectDebitDelegate.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/internal/ui/DefaultACHDirectDebitDelegate.kt
@@ -291,9 +291,10 @@ internal class DefaultACHDirectDebitDelegate(
 
             val achPaymentMethod = ACHDirectDebitPaymentMethod(
                 type = ACHDirectDebitPaymentMethod.PAYMENT_METHOD_TYPE,
+                checkoutAttemptId = analyticsRepository.getCheckoutAttemptId(),
                 encryptedBankAccountNumber = encryptedBankAccountNumber,
                 encryptedBankLocationId = encryptedBankLocationId,
-                ownerName = outputData.ownerName.value
+                ownerName = outputData.ownerName.value,
             )
             val paymentComponentData = PaymentComponentData(
                 order = order,

--- a/ach/src/main/java/com/adyen/checkout/ach/internal/ui/StoredACHDirectDebitDelegate.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/internal/ui/StoredACHDirectDebitDelegate.kt
@@ -115,7 +115,8 @@ internal class StoredACHDirectDebitDelegate(
     private fun createComponentState(): ACHDirectDebitComponentState {
         val paymentMethod = ACHDirectDebitPaymentMethod(
             type = ACHDirectDebitPaymentMethod.PAYMENT_METHOD_TYPE,
-            storedPaymentMethodId = storedPaymentMethod.id
+            checkoutAttemptId = analyticsRepository.getCheckoutAttemptId(),
+            storedPaymentMethodId = storedPaymentMethod.id,
         )
 
         val paymentComponentData = PaymentComponentData(

--- a/ach/src/main/java/com/adyen/checkout/ach/internal/ui/model/ACHDirectDebitComponentParams.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/internal/ui/model/ACHDirectDebitComponentParams.kt
@@ -14,10 +14,8 @@ import com.adyen.checkout.components.core.internal.ui.model.ButtonParams
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.ui.core.internal.ui.model.AddressParams
-import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
-@Parcelize
 internal data class ACHDirectDebitComponentParams(
     override val shopperLocale: Locale,
     override val environment: Environment,

--- a/ach/src/main/java/com/adyen/checkout/ach/internal/ui/model/AddressFieldPolicyParams.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/internal/ui/model/AddressFieldPolicyParams.kt
@@ -9,14 +9,11 @@
 package com.adyen.checkout.ach.internal.ui.model
 
 import com.adyen.checkout.ui.core.internal.ui.model.AddressFieldPolicy
-import kotlinx.parcelize.Parcelize
 
-@Parcelize
 internal sealed class AddressFieldPolicyParams : AddressFieldPolicy {
 
     /**
      * Address form fields will be required.
      */
-    @Parcelize
     object Required : AddressFieldPolicyParams()
 }

--- a/ach/src/test/java/com/adyen/checkout/ach/internal/ui/StoredACHDirectDebitDelegateTest.kt
+++ b/ach/src/test/java/com/adyen/checkout/ach/internal/ui/StoredACHDirectDebitDelegateTest.kt
@@ -35,6 +35,8 @@ import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
 import java.util.Locale
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -86,6 +88,21 @@ internal class StoredACHDirectDebitDelegateTest(
         }
     }
 
+    @Nested
+    inner class AnalyticsTest {
+
+        @Test
+        fun `when component state is valid then PaymentMethodDetails should contain checkoutAttemptId`() = runTest {
+            whenever(analyticsRepository.getCheckoutAttemptId()) doReturn TEST_CHECKOUT_ATTEMPT_ID
+
+            delegate = createAchDelegate()
+
+            delegate.componentStateFlow.test {
+                assertEquals(TEST_CHECKOUT_ATTEMPT_ID, expectMostRecentItem().data.paymentMethod?.checkoutAttemptId)
+            }
+        }
+    }
+
     private fun getAchConfigurationBuilder() = ACHDirectDebitConfiguration.Builder(
         shopperLocale = Locale.US,
         environment = Environment.TEST,
@@ -109,6 +126,7 @@ internal class StoredACHDirectDebitDelegateTest(
         private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
         private val TEST_ORDER = OrderRequest("PSP", "ORDER_DATA")
         private const val STORED_ID = "Stored_id"
+        private const val TEST_CHECKOUT_ATTEMPT_ID = "TEST_CHECKOUT_ATTEMPT_ID"
 
         @JvmStatic
         fun amountSource() = listOf(

--- a/bacs/src/main/java/com/adyen/checkout/bacs/internal/provider/BacsDirectDebitComponentProvider.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/internal/provider/BacsDirectDebitComponentProvider.kt
@@ -27,9 +27,9 @@ import com.adyen.checkout.components.core.internal.DefaultComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsMapper
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
+import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepositoryData
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
-import com.adyen.checkout.components.core.internal.data.model.AnalyticsSource
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
@@ -88,15 +88,15 @@ constructor(
             val componentParams = componentParamsMapper.mapToParams(configuration, null)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val bacsDelegate = DefaultBacsDirectDebitDelegate(
@@ -152,15 +152,15 @@ constructor(
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val bacsDelegate = DefaultBacsDirectDebitDelegate(

--- a/bacs/src/main/java/com/adyen/checkout/bacs/internal/ui/DefaultBacsDirectDebitDelegate.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/internal/ui/DefaultBacsDirectDebitDelegate.kt
@@ -189,6 +189,7 @@ internal class DefaultBacsDirectDebitDelegate(
     ): BacsDirectDebitComponentState {
         val bacsDirectDebitPaymentMethod = BacsDirectDebitPaymentMethod(
             type = BacsDirectDebitPaymentMethod.PAYMENT_METHOD_TYPE,
+            checkoutAttemptId = analyticsRepository.getCheckoutAttemptId(),
             holderName = outputData.holderNameState.value,
             bankAccountNumber = outputData.bankAccountNumberState.value,
             bankLocationId = outputData.sortCodeState.value,

--- a/bacs/src/test/java/com/adyen/checkout/bacs/internal/DefaultBacsDirectDebitDelegateTest.kt
+++ b/bacs/src/test/java/com/adyen/checkout/bacs/internal/DefaultBacsDirectDebitDelegateTest.kt
@@ -45,7 +45,9 @@ import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.util.Locale
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -556,6 +558,30 @@ internal class DefaultBacsDirectDebitDelegateTest(
             }
     }
 
+    @Nested
+    inner class AnalyticsTest {
+
+        @Test
+        fun `when component state is valid then PaymentMethodDetails should contain checkoutAttemptId`() = runTest {
+            whenever(analyticsRepository.getCheckoutAttemptId()) doReturn TEST_CHECKOUT_ATTEMPT_ID
+
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+
+            delegate.componentStateFlow.test {
+                delegate.updateInputData {
+                    holderName = "test"
+                    bankAccountNumber = "12345678"
+                    sortCode = "123456"
+                    shopperEmail = "test@adyen.com"
+                    isAmountConsentChecked = true
+                    isAccountConsentChecked = true
+                }
+
+                assertEquals(TEST_CHECKOUT_ATTEMPT_ID, expectMostRecentItem().data.paymentMethod?.checkoutAttemptId)
+            }
+        }
+    }
+
     private fun createBacsDelegate(
         configuration: BacsDirectDebitConfiguration = getDefaultBacsConfigurationBuilder().build(),
         order: OrderRequest? = TEST_ORDER,
@@ -577,6 +603,7 @@ internal class DefaultBacsDirectDebitDelegateTest(
     companion object {
         private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
         private val TEST_ORDER = OrderRequest("PSP", "ORDER_DATA")
+        private const val TEST_CHECKOUT_ATTEMPT_ID = "TEST_CHECKOUT_ATTEMPT_ID"
 
         @JvmStatic
         fun amountSource() = listOf(

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/internal/provider/BcmcComponentProvider.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/internal/provider/BcmcComponentProvider.kt
@@ -29,11 +29,11 @@ import com.adyen.checkout.components.core.internal.DefaultComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsMapper
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
+import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepositoryData
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
 import com.adyen.checkout.components.core.internal.data.api.DefaultPublicKeyRepository
 import com.adyen.checkout.components.core.internal.data.api.PublicKeyService
-import com.adyen.checkout.components.core.internal.data.model.AnalyticsSource
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
 import com.adyen.checkout.components.core.internal.ui.model.SessionParams
@@ -102,15 +102,15 @@ constructor(
         val cardEncrypter = DefaultCardEncrypter(genericEncrypter)
 
         val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-            analyticsParams = componentParams.analyticsParams,
-            packageName = application.packageName,
-            locale = componentParams.shopperLocale,
-            source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+            analyticsRepositoryData = AnalyticsRepositoryData(
+                application = application,
+                componentParams = componentParams,
+                paymentMethod = paymentMethod,
+            ),
             analyticsService = AnalyticsService(
                 HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
             ),
             analyticsMapper = AnalyticsMapper(),
-            clientKey = componentParams.clientKey,
         )
 
         val bcmcFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
@@ -174,15 +174,15 @@ constructor(
         val cardEncrypter = DefaultCardEncrypter(genericEncrypter)
 
         val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-            analyticsParams = componentParams.analyticsParams,
-            packageName = application.packageName,
-            locale = componentParams.shopperLocale,
-            source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+            analyticsRepositoryData = AnalyticsRepositoryData(
+                application = application,
+                componentParams = componentParams,
+                paymentMethod = paymentMethod,
+            ),
             analyticsService = AnalyticsService(
                 HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
             ),
             analyticsMapper = AnalyticsMapper(),
-            clientKey = componentParams.clientKey,
         )
 
         val bcmcFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/internal/ui/DefaultBcmcDelegate.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/internal/ui/DefaultBcmcDelegate.kt
@@ -221,6 +221,7 @@ internal class DefaultBcmcDelegate(
         // BCMC payment method is scheme type.
         val cardPaymentMethod = CardPaymentMethod(
             type = CardPaymentMethod.PAYMENT_METHOD_TYPE,
+            checkoutAttemptId = analyticsRepository.getCheckoutAttemptId(),
             encryptedCardNumber = encryptedCard.encryptedCardNumber,
             encryptedExpiryMonth = encryptedCard.encryptedExpiryMonth,
             encryptedExpiryYear = encryptedCard.encryptedExpiryYear,

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/internal/ui/model/BcmcComponentParams.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/internal/ui/model/BcmcComponentParams.kt
@@ -13,10 +13,8 @@ import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
 import com.adyen.checkout.components.core.internal.ui.model.ButtonParams
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
 import com.adyen.checkout.core.Environment
-import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
-@Parcelize
 internal data class BcmcComponentParams(
     override val shopperLocale: Locale,
     override val environment: Environment,

--- a/bcmc/src/test/java/com/adyen/checkout/bcmc/internal/ui/DefaultBcmcDelegateTest.kt
+++ b/bcmc/src/test/java/com/adyen/checkout/bcmc/internal/ui/DefaultBcmcDelegateTest.kt
@@ -46,7 +46,9 @@ import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.util.Locale
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -401,6 +403,26 @@ internal class DefaultBcmcDelegateTest(
         }
     }
 
+    @Nested
+    inner class AnalyticsTest {
+
+        @Test
+        fun `when component state is valid then PaymentMethodDetails should contain checkoutAttemptId`() = runTest {
+            whenever(analyticsRepository.getCheckoutAttemptId()) doReturn TEST_CHECKOUT_ATTEMPT_ID
+
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+
+            delegate.componentStateFlow.test {
+                delegate.updateInputData {
+                    cardNumber = TEST_CARD_NUMBER
+                    expiryDate = TEST_EXPIRY_DATE
+                }
+
+                assertEquals(TEST_CHECKOUT_ATTEMPT_ID, expectMostRecentItem().data.paymentMethod?.checkoutAttemptId)
+            }
+        }
+    }
+
     private fun createOutputData(
         cardNumber: FieldState<String>,
         expiryDate: FieldState<ExpiryDate>,
@@ -442,6 +464,7 @@ internal class DefaultBcmcDelegateTest(
         private const val TEST_CARD_NUMBER = "5555444433331111"
         private val TEST_EXPIRY_DATE = ExpiryDate(3, 2030)
         private val TEST_ORDER = OrderRequest("PSP", "ORDER_DATA")
+        private const val TEST_CHECKOUT_ATTEMPT_ID = "TEST_CHECKOUT_ATTEMPT_ID"
 
         @JvmStatic
         fun shouldStorePaymentMethodSource() = listOf(

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/provider/BlikComponentProvider.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/provider/BlikComponentProvider.kt
@@ -29,9 +29,9 @@ import com.adyen.checkout.components.core.internal.DefaultComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsMapper
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
+import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepositoryData
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
-import com.adyen.checkout.components.core.internal.data.model.AnalyticsSource
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.provider.StoredPaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
@@ -104,15 +104,15 @@ constructor(
             val componentParams = componentParamsMapper.mapToParams(configuration, null)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val blikDelegate = DefaultBlikDelegate(
@@ -163,15 +163,15 @@ constructor(
             val componentParams = componentParamsMapper.mapToParams(configuration, null)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, storedPaymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    storedPaymentMethod = storedPaymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val blikDelegate = StoredBlikDelegate(
@@ -227,15 +227,15 @@ constructor(
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val blikDelegate = DefaultBlikDelegate(
@@ -310,15 +310,15 @@ constructor(
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, storedPaymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    storedPaymentMethod = storedPaymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val blikDelegate = StoredBlikDelegate(

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/DefaultBlikDelegate.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/DefaultBlikDelegate.kt
@@ -133,7 +133,8 @@ internal class DefaultBlikDelegate(
     ): BlikComponentState {
         val paymentMethod = BlikPaymentMethod(
             type = BlikPaymentMethod.PAYMENT_METHOD_TYPE,
-            blikCode = outputData.blikCodeField.value
+            checkoutAttemptId = analyticsRepository.getCheckoutAttemptId(),
+            blikCode = outputData.blikCodeField.value,
         )
 
         val paymentComponentData = PaymentComponentData(

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/StoredBlikDelegate.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/StoredBlikDelegate.kt
@@ -111,7 +111,8 @@ internal class StoredBlikDelegate(
     private fun createComponentState(): BlikComponentState {
         val paymentMethod = BlikPaymentMethod(
             type = BlikPaymentMethod.PAYMENT_METHOD_TYPE,
-            storedPaymentMethodId = storedPaymentMethod.id
+            checkoutAttemptId = analyticsRepository.getCheckoutAttemptId(),
+            storedPaymentMethodId = storedPaymentMethod.id,
         )
 
         val paymentComponentData = PaymentComponentData(

--- a/blik/src/test/java/com/adyen/checkout/blik/internal/ui/DefaultBlikDelegateTest.kt
+++ b/blik/src/test/java/com/adyen/checkout/blik/internal/ui/DefaultBlikDelegateTest.kt
@@ -39,7 +39,9 @@ import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.util.Locale
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -249,6 +251,25 @@ internal class DefaultBlikDelegateTest(
         }
     }
 
+    @Nested
+    inner class AnalyticsTest {
+
+        @Test
+        fun `when component state is valid then PaymentMethodDetails should contain checkoutAttemptId`() = runTest {
+            whenever(analyticsRepository.getCheckoutAttemptId()) doReturn TEST_CHECKOUT_ATTEMPT_ID
+
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+
+            delegate.componentStateFlow.test {
+                delegate.updateInputData {
+                    blikCode = "545897"
+                }
+
+                assertEquals(TEST_CHECKOUT_ATTEMPT_ID, expectMostRecentItem().data.paymentMethod?.checkoutAttemptId)
+            }
+        }
+    }
+
     private fun createBlikDelegate(
         configuration: BlikConfiguration = getDefaultBlikConfigurationBuilder().build()
     ) = DefaultBlikDelegate(
@@ -269,6 +290,7 @@ internal class DefaultBlikDelegateTest(
     companion object {
         private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
         private val TEST_ORDER = OrderRequest("PSP", "ORDER_DATA")
+        private const val TEST_CHECKOUT_ATTEMPT_ID = "TEST_CHECKOUT_ATTEMPT_ID"
 
         @JvmStatic
         fun amountSource() = listOf(

--- a/boleto/src/main/java/com/adyen/checkout/boleto/internal/provider/BoletoComponentProvider.kt
+++ b/boleto/src/main/java/com/adyen/checkout/boleto/internal/provider/BoletoComponentProvider.kt
@@ -28,9 +28,9 @@ import com.adyen.checkout.components.core.internal.DefaultComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsMapper
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
+import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepositoryData
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
-import com.adyen.checkout.components.core.internal.data.model.AnalyticsSource
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
 import com.adyen.checkout.components.core.internal.ui.model.SessionParams
@@ -91,15 +91,15 @@ constructor(
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val addressService = AddressService(httpClient)
@@ -159,15 +159,15 @@ constructor(
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
             val addressService = AddressService(httpClient)
             val addressRepository = DefaultAddressRepository(addressService)

--- a/boleto/src/main/java/com/adyen/checkout/boleto/internal/ui/DefaultBoletoDelegate.kt
+++ b/boleto/src/main/java/com/adyen/checkout/boleto/internal/ui/DefaultBoletoDelegate.kt
@@ -233,7 +233,10 @@ internal class DefaultBoletoDelegate(
         outputData: BoletoOutputData = this.outputData
     ): BoletoComponentState {
         val paymentComponentData = PaymentComponentData(
-            paymentMethod = GenericPaymentMethod(paymentMethod.type),
+            paymentMethod = GenericPaymentMethod(
+                type = paymentMethod.type,
+                checkoutAttemptId = analyticsRepository.getCheckoutAttemptId(),
+            ),
             order = order,
             amount = componentParams.amount.takeUnless { it.isEmpty },
             socialSecurityNumber = outputData.socialSecurityNumberState.value,

--- a/boleto/src/main/java/com/adyen/checkout/boleto/internal/ui/model/AddressFieldPolicyParams.kt
+++ b/boleto/src/main/java/com/adyen/checkout/boleto/internal/ui/model/AddressFieldPolicyParams.kt
@@ -9,14 +9,11 @@
 package com.adyen.checkout.boleto.internal.ui.model
 
 import com.adyen.checkout.ui.core.internal.ui.model.AddressFieldPolicy
-import kotlinx.parcelize.Parcelize
 
-@Parcelize
 internal sealed class AddressFieldPolicyParams : AddressFieldPolicy {
 
     /**
      * Address form fields will be required.
      */
-    @Parcelize
     object Required : AddressFieldPolicyParams()
 }

--- a/boleto/src/main/java/com/adyen/checkout/boleto/internal/ui/model/BoletoComponentParams.kt
+++ b/boleto/src/main/java/com/adyen/checkout/boleto/internal/ui/model/BoletoComponentParams.kt
@@ -14,10 +14,8 @@ import com.adyen.checkout.components.core.internal.ui.model.ButtonParams
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.ui.core.internal.ui.model.AddressParams
-import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
-@Parcelize
 internal data class BoletoComponentParams(
     override val isSubmitButtonVisible: Boolean,
     override val shopperLocale: Locale,

--- a/boleto/src/test/java/com/adyen/checkout/boleto/internal/ui/DefaultBoletoDelegateTest.kt
+++ b/boleto/src/test/java/com/adyen/checkout/boleto/internal/ui/DefaultBoletoDelegateTest.kt
@@ -43,7 +43,9 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.util.Locale
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -487,6 +489,25 @@ internal class DefaultBoletoDelegateTest(
         }
     }
 
+    @Nested
+    inner class AnalyticsTest {
+
+        @Test
+        fun `when component state is valid then PaymentMethodDetails should contain checkoutAttemptId`() = runTest {
+            whenever(analyticsRepository.getCheckoutAttemptId()) doReturn TEST_CHECKOUT_ATTEMPT_ID
+
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+
+            delegate.componentStateFlow.test {
+                delegate.updateInputData {
+                    firstName = "Test"
+                }
+
+                assertEquals(TEST_CHECKOUT_ATTEMPT_ID, expectMostRecentItem().data.paymentMethod?.checkoutAttemptId)
+            }
+        }
+    }
+
     @Suppress("LongParameterList")
     private fun createBoletoDelegate(
         submitHandler: SubmitHandler<BoletoComponentState> = this.submitHandler,
@@ -532,6 +553,7 @@ internal class DefaultBoletoDelegateTest(
         private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
         private val TEST_ORDER = OrderRequest("PSP", "ORDER_DATA")
         private const val BRAZIL_COUNTRY_CODE = "BR"
+        private const val TEST_CHECKOUT_ATTEMPT_ID = "TEST_CHECKOUT_ATTEMPT_ID"
 
         @JvmStatic
         fun amountSource() = listOf(

--- a/card/src/main/java/com/adyen/checkout/card/internal/provider/CardComponentProvider.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/provider/CardComponentProvider.kt
@@ -33,11 +33,11 @@ import com.adyen.checkout.components.core.internal.DefaultComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsMapper
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
+import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepositoryData
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
 import com.adyen.checkout.components.core.internal.data.api.DefaultPublicKeyRepository
 import com.adyen.checkout.components.core.internal.data.api.PublicKeyService
-import com.adyen.checkout.components.core.internal.data.model.AnalyticsSource
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.provider.StoredPaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
@@ -136,15 +136,15 @@ constructor(
             val cardValidationMapper = CardValidationMapper()
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val cardDelegate = DefaultCardDelegate(
@@ -217,15 +217,15 @@ constructor(
             val cardValidationMapper = CardValidationMapper()
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val cardDelegate = DefaultCardDelegate(
@@ -306,15 +306,15 @@ constructor(
             val cardEncrypter = DefaultCardEncrypter(genericEncrypter)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, storedPaymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    storedPaymentMethod = storedPaymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val cardDelegate = StoredCardDelegate(
@@ -377,15 +377,15 @@ constructor(
             val cardEncrypter = DefaultCardEncrypter(genericEncrypter)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, storedPaymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    storedPaymentMethod = storedPaymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val cardDelegate = StoredCardDelegate(

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegate.kt
@@ -621,9 +621,10 @@ internal class DefaultCardDelegate(
         firstCardBrand: CardBrand?,
         binValue: String
     ): CardComponentState {
-        val cardPaymentMethod = CardPaymentMethod().apply {
-            type = CardPaymentMethod.PAYMENT_METHOD_TYPE
-
+        val cardPaymentMethod = CardPaymentMethod(
+            type = CardPaymentMethod.PAYMENT_METHOD_TYPE,
+            checkoutAttemptId = analyticsRepository.getCheckoutAttemptId(),
+        ).apply {
             encryptedCardNumber = encryptedCard.encryptedCardNumber
             encryptedExpiryMonth = encryptedCard.encryptedExpiryMonth
             encryptedExpiryYear = encryptedCard.encryptedExpiryYear

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/StoredCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/StoredCardDelegate.kt
@@ -324,9 +324,10 @@ internal class StoredCardDelegate(
         cardNumber: String,
         firstCardBrand: CardBrand?,
     ): CardComponentState {
-        val cardPaymentMethod = CardPaymentMethod().apply {
-            type = CardPaymentMethod.PAYMENT_METHOD_TYPE
-
+        val cardPaymentMethod = CardPaymentMethod(
+            type = CardPaymentMethod.PAYMENT_METHOD_TYPE,
+            checkoutAttemptId = analyticsRepository.getCheckoutAttemptId(),
+        ).apply {
             storedPaymentMethodId = getPaymentMethodId()
 
             if (!isCvcHidden()) {

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/model/AddressFieldPolicyParams.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/model/AddressFieldPolicyParams.kt
@@ -9,25 +9,20 @@
 package com.adyen.checkout.card.internal.ui.model
 
 import com.adyen.checkout.ui.core.internal.ui.model.AddressFieldPolicy
-import kotlinx.parcelize.Parcelize
 
-@Parcelize
 internal sealed class AddressFieldPolicyParams : AddressFieldPolicy {
     /**
      * Address form fields will be required.
      */
-    @Parcelize
     object Required : AddressFieldPolicyParams()
 
     /**
      * Address form fields will be optional.
      */
-    @Parcelize
     object Optional : AddressFieldPolicyParams()
 
     /**
      * Address form fields will be optional for given [brands] and required for the other brands.
      */
-    @Parcelize
     data class OptionalForCardTypes(val brands: List<String>) : AddressFieldPolicyParams()
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/model/CardComponentParams.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/model/CardComponentParams.kt
@@ -17,10 +17,8 @@ import com.adyen.checkout.components.core.internal.ui.model.ButtonParams
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.ui.core.internal.ui.model.AddressParams
-import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
-@Parcelize
 internal data class CardComponentParams(
     override val shopperLocale: Locale,
     override val environment: Environment,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/model/InstallmentOptionParams.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/model/InstallmentOptionParams.kt
@@ -8,16 +8,14 @@
 
 package com.adyen.checkout.card.internal.ui.model
 
-import android.os.Parcelable
 import com.adyen.checkout.card.CardBrand
-import kotlinx.parcelize.Parcelize
 
 /**
  * InstallmentOptionParams is used for defining the details of installment options.
  *
  * Note: All values specified in [values] must be greater than 1.
  */
-internal sealed class InstallmentOptionParams : Parcelable {
+internal sealed class InstallmentOptionParams {
     abstract val values: List<Int>
     abstract val includeRevolving: Boolean
 
@@ -26,7 +24,6 @@ internal sealed class InstallmentOptionParams : Parcelable {
      * @param includeRevolving see [InstallmentOptionParams.includeRevolving]
      * @param cardBrand a [CardBrand] to apply the given options
      */
-    @Parcelize
     data class CardBasedInstallmentOptions(
         override val values: List<Int>,
         override val includeRevolving: Boolean,
@@ -37,7 +34,6 @@ internal sealed class InstallmentOptionParams : Parcelable {
      * @param values see [InstallmentOptionParams.values]
      * @param includeRevolving see [InstallmentOptionParams.includeRevolving]
      */
-    @Parcelize
     data class DefaultInstallmentOptions(
         override val values: List<Int>,
         override val includeRevolving: Boolean

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/model/InstallmentParams.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/model/InstallmentParams.kt
@@ -8,9 +8,7 @@
 
 package com.adyen.checkout.card.internal.ui.model
 
-import android.os.Parcelable
 import com.adyen.checkout.card.CardBrand
-import kotlinx.parcelize.Parcelize
 
 /**
  * Component params class for Installments in Card Component. This class can be used
@@ -24,8 +22,7 @@ import kotlinx.parcelize.Parcelize
  * @param defaultOptions Installment Options to be used for all card types.
  * @param cardBasedOptions Installment Options to be used for specific card types.
  */
-@Parcelize
 internal data class InstallmentParams(
     val defaultOptions: InstallmentOptionParams.DefaultInstallmentOptions? = null,
     val cardBasedOptions: List<InstallmentOptionParams.CardBasedInstallmentOptions> = emptyList()
-) : Parcelable
+)

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegateTest.kt
@@ -82,7 +82,9 @@ import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.util.Locale
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -1016,6 +1018,27 @@ internal class DefaultCardDelegateTest(
         }
     }
 
+    @Nested
+    inner class AnalyticsTest {
+
+        @Test
+        fun `when component state is valid then PaymentMethodDetails should contain checkoutAttemptId`() = runTest {
+            whenever(analyticsRepository.getCheckoutAttemptId()) doReturn TEST_CHECKOUT_ATTEMPT_ID
+
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+
+            delegate.componentStateFlow.test {
+                delegate.updateInputData {
+                    cardNumber = TEST_CARD_NUMBER
+                    securityCode = TEST_SECURITY_CODE
+                    expiryDate = TEST_EXPIRY_DATE
+                }
+
+                assertEquals(TEST_CHECKOUT_ATTEMPT_ID, expectMostRecentItem().data.paymentMethod?.checkoutAttemptId)
+            }
+        }
+    }
+
     @Suppress("LongParameterList")
     private fun createCardDelegate(
         publicKeyRepository: PublicKeyRepository = this.publicKeyRepository,
@@ -1193,6 +1216,7 @@ internal class DefaultCardDelegateTest(
         private val TEST_EXPIRY_DATE = ExpiryDate(3, 2030)
         private const val TEST_SECURITY_CODE = "737"
         private val TEST_ORDER = OrderRequest("PSP", "ORDER_DATA")
+        private const val TEST_CHECKOUT_ATTEMPT_ID = "TEST_CHECKOUT_ATTEMPT_ID"
 
         @JvmStatic
         fun shouldStorePaymentMethodSource() = listOf(

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/provider/CashAppPayComponentProvider.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/provider/CashAppPayComponentProvider.kt
@@ -31,9 +31,9 @@ import com.adyen.checkout.components.core.internal.DefaultComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsMapper
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
+import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepositoryData
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
-import com.adyen.checkout.components.core.internal.data.model.AnalyticsSource
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.provider.StoredPaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
@@ -104,15 +104,15 @@ constructor(
         val viewModelFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
             val componentParams = componentParamsMapper.mapToParams(configuration, null, paymentMethod)
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val cashAppPayDelegate = DefaultCashAppPayDelegate(
@@ -163,15 +163,15 @@ constructor(
         val viewModelFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
             val componentParams = componentParamsMapper.mapToParams(configuration, null, storedPaymentMethod)
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, storedPaymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    storedPaymentMethod = storedPaymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val cashAppPayDelegate = StoredCashAppPayDelegate(
@@ -228,15 +228,15 @@ constructor(
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val cashAppPayDelegate = DefaultCashAppPayDelegate(
@@ -314,15 +314,15 @@ constructor(
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, storedPaymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    storedPaymentMethod = storedPaymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val cashAppPayDelegate = StoredCashAppPayDelegate(

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/DefaultCashAppPayDelegate.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/DefaultCashAppPayDelegate.kt
@@ -169,6 +169,7 @@ constructor(
 
         val cashAppPayPaymentMethod = CashAppPayPaymentMethod(
             type = paymentMethod.type,
+            checkoutAttemptId = analyticsRepository.getCheckoutAttemptId(),
             grantId = oneTimeData?.grantId,
             customerId = onFileData?.customerId,
             onFileGrantId = onFileData?.grantId,

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/StoredCashAppPayDelegate.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/StoredCashAppPayDelegate.kt
@@ -99,6 +99,7 @@ internal class StoredCashAppPayDelegate(
     private fun createComponentState(): CashAppPayComponentState {
         val cashAppPayPaymentMethod = CashAppPayPaymentMethod(
             type = paymentMethod.type,
+            checkoutAttemptId = analyticsRepository.getCheckoutAttemptId(),
             storedPaymentMethodId = paymentMethod.id,
         )
 

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/model/CashAppPayComponentParams.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/model/CashAppPayComponentParams.kt
@@ -14,10 +14,8 @@ import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
 import com.adyen.checkout.components.core.internal.ui.model.ButtonParams
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
 import com.adyen.checkout.core.Environment
-import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
-@Parcelize
 internal data class CashAppPayComponentParams(
     override val isSubmitButtonVisible: Boolean,
     override val shopperLocale: Locale,

--- a/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/DefaultCashAppPayDelegateTest.kt
+++ b/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/DefaultCashAppPayDelegateTest.kt
@@ -452,6 +452,27 @@ internal class DefaultCashAppPayDelegateTest(
         )
     }
 
+    @Nested
+    inner class AnalyticsTest {
+
+        @Test
+        fun `when component state is valid then PaymentMethodDetails should contain checkoutAttemptId`() = runTest {
+            whenever(analyticsRepository.getCheckoutAttemptId()) doReturn TEST_CHECKOUT_ATTEMPT_ID
+
+            val testFlow = delegate.componentStateFlow.test(testScheduler)
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+
+            delegate.updateInputData {
+                authorizationData = CashAppPayAuthorizationData(
+                    oneTimeData = CashAppPayOneTimeData("grantId"),
+                    onFileData = CashAppPayOnFileData("grantId", "cashTag", "customerId")
+                )
+            }
+
+            assertEquals(TEST_CHECKOUT_ATTEMPT_ID, testFlow.latestValue.data.paymentMethod?.checkoutAttemptId)
+        }
+    }
+
     private fun createDefaultCashAppPayDelegate(
         configuration: CashAppPayConfiguration = getConfigurationBuilder().build()
     ) = DefaultCashAppPayDelegate(
@@ -487,6 +508,7 @@ internal class DefaultCashAppPayDelegateTest(
         private val TEST_ORDER = OrderRequest("PSP", "ORDER_DATA")
         private const val TEST_RETURN_URL = "testReturnUrl"
         private const val TEST_SCOPE_ID = "testScopeId"
+        private const val TEST_CHECKOUT_ATTEMPT_ID = "TEST_CHECKOUT_ATTEMPT_ID"
 
         @JvmStatic
         fun amountSource() = listOf(

--- a/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/DefaultCashAppPayDelegateTest.kt
+++ b/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/DefaultCashAppPayDelegateTest.kt
@@ -128,6 +128,7 @@ internal class DefaultCashAppPayDelegateTest(
             data = PaymentComponentData(
                 paymentMethod = CashAppPayPaymentMethod(
                     type = null,
+                    checkoutAttemptId = null,
                     grantId = "grantId",
                     onFileGrantId = "grantId",
                     customerId = "customerId",

--- a/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/StoredCashAppPayDelegateTest.kt
+++ b/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/StoredCashAppPayDelegateTest.kt
@@ -105,6 +105,7 @@ internal class StoredCashAppPayDelegateTest(
             data = PaymentComponentData(
                 paymentMethod = CashAppPayPaymentMethod(
                     type = TEST_PAYMENT_METHOD_TYPE,
+                    checkoutAttemptId = null,
                     storedPaymentMethodId = TEST_PAYMENT_METHOD_ID,
                 ),
                 order = TEST_ORDER,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsMapper.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsMapper.kt
@@ -19,12 +19,14 @@ import java.util.Locale
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class AnalyticsMapper {
+    @Suppress("LongParameterList")
     internal fun getAnalyticsSetupRequest(
         packageName: String,
         locale: Locale,
         source: AnalyticsSource,
         amount: Amount,
         screenWidth: Long,
+        paymentMethods: List<String>,
     ): AnalyticsSetupRequest {
         return AnalyticsSetupRequest(
             version = BuildConfig.CHECKOUT_VERSION,
@@ -38,9 +40,8 @@ class AnalyticsMapper {
             referrer = packageName,
             systemVersion = Build.VERSION.SDK_INT.toString(),
             screenWidth = screenWidth,
-            paymentMethods = null, // TODO implement
+            paymentMethods = paymentMethods,
             amount = amount,
-            level = null, // TODO implement
             containerWidth = null, // unused for Android
         )
     }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsMapper.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsMapper.kt
@@ -11,6 +11,7 @@ package com.adyen.checkout.components.core.internal.data.api
 import android.os.Build
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
+import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.components.core.BuildConfig
 import com.adyen.checkout.components.core.internal.data.model.AnalyticsSetupRequest
 import com.adyen.checkout.components.core.internal.data.model.AnalyticsSource
@@ -21,7 +22,8 @@ class AnalyticsMapper {
     internal fun getAnalyticsSetupRequest(
         packageName: String,
         locale: Locale,
-        source: AnalyticsSource
+        source: AnalyticsSource,
+        amount: Amount,
     ): AnalyticsSetupRequest {
         return AnalyticsSetupRequest(
             version = BuildConfig.CHECKOUT_VERSION,
@@ -36,7 +38,7 @@ class AnalyticsMapper {
             systemVersion = Build.VERSION.SDK_INT.toString(),
             screenWidth = null, // TODO implement
             paymentMethods = null, // TODO implement
-            amount = null, // TODO implement
+            amount = amount,
             level = null, // TODO implement
             containerWidth = null, // unused for Android
         )

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsMapper.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsMapper.kt
@@ -24,6 +24,7 @@ class AnalyticsMapper {
         locale: Locale,
         source: AnalyticsSource,
         amount: Amount,
+        screenWidth: Long,
     ): AnalyticsSetupRequest {
         return AnalyticsSetupRequest(
             version = BuildConfig.CHECKOUT_VERSION,
@@ -36,7 +37,7 @@ class AnalyticsMapper {
             deviceModel = Build.MODEL,
             referrer = packageName,
             systemVersion = Build.VERSION.SDK_INT.toString(),
-            screenWidth = null, // TODO implement
+            screenWidth = screenWidth,
             paymentMethods = null, // TODO implement
             amount = amount,
             level = null, // TODO implement

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsRepository.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsRepository.kt
@@ -13,4 +13,6 @@ import androidx.annotation.RestrictTo
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface AnalyticsRepository {
     suspend fun setupAnalytics()
+
+    fun getCheckoutAttemptId(): String?
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsRepositoryData.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsRepositoryData.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 25/7/2023.
+ */
+
+package com.adyen.checkout.components.core.internal.data.api
+
+import android.app.Application
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.components.core.PaymentMethod
+import com.adyen.checkout.components.core.StoredPaymentMethod
+import com.adyen.checkout.components.core.internal.data.model.AnalyticsSource
+import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParamsLevel
+import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
+import java.util.Locale
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class AnalyticsRepositoryData(
+    val level: AnalyticsParamsLevel,
+    val packageName: String,
+    val locale: Locale,
+    val source: AnalyticsSource,
+    val clientKey: String,
+) {
+    constructor(
+        application: Application,
+        componentParams: ComponentParams,
+        paymentMethod: PaymentMethod,
+    ) : this(
+        level = componentParams.analyticsParams.level,
+        packageName = application.packageName,
+        locale = componentParams.shopperLocale,
+        source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+        clientKey = componentParams.clientKey,
+    )
+
+    constructor(
+        application: Application,
+        componentParams: ComponentParams,
+        storedPaymentMethod: StoredPaymentMethod,
+    ) : this(
+        level = componentParams.analyticsParams.level,
+        packageName = application.packageName,
+        locale = componentParams.shopperLocale,
+        source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, storedPaymentMethod),
+        clientKey = componentParams.clientKey,
+    )
+}

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsRepositoryData.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsRepositoryData.kt
@@ -16,6 +16,7 @@ import com.adyen.checkout.components.core.StoredPaymentMethod
 import com.adyen.checkout.components.core.internal.data.model.AnalyticsSource
 import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParamsLevel
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
+import com.adyen.checkout.components.core.internal.util.screenWidthPixels
 import java.util.Locale
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -26,18 +27,16 @@ data class AnalyticsRepositoryData(
     val source: AnalyticsSource,
     val clientKey: String,
     val amount: Amount,
+    val screenWidth: Int,
 ) {
     constructor(
         application: Application,
         componentParams: ComponentParams,
         paymentMethod: PaymentMethod,
     ) : this(
-        level = componentParams.analyticsParams.level,
-        packageName = application.packageName,
-        locale = componentParams.shopperLocale,
+        application = application,
+        componentParams = componentParams,
         source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
-        clientKey = componentParams.clientKey,
-        amount = componentParams.amount,
     )
 
     constructor(
@@ -45,11 +44,22 @@ data class AnalyticsRepositoryData(
         componentParams: ComponentParams,
         storedPaymentMethod: StoredPaymentMethod,
     ) : this(
+        application = application,
+        componentParams = componentParams,
+        source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, storedPaymentMethod),
+    )
+
+    private constructor(
+        application: Application,
+        componentParams: ComponentParams,
+        source: AnalyticsSource,
+    ) : this(
         level = componentParams.analyticsParams.level,
         packageName = application.packageName,
         locale = componentParams.shopperLocale,
-        source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, storedPaymentMethod),
+        source = source,
         clientKey = componentParams.clientKey,
         amount = componentParams.amount,
+        screenWidth = application.screenWidthPixels,
     )
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsRepositoryData.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsRepositoryData.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.components.core.internal.data.api
 
 import android.app.Application
 import androidx.annotation.RestrictTo
+import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.StoredPaymentMethod
 import com.adyen.checkout.components.core.internal.data.model.AnalyticsSource
@@ -24,6 +25,7 @@ data class AnalyticsRepositoryData(
     val locale: Locale,
     val source: AnalyticsSource,
     val clientKey: String,
+    val amount: Amount,
 ) {
     constructor(
         application: Application,
@@ -35,6 +37,7 @@ data class AnalyticsRepositoryData(
         locale = componentParams.shopperLocale,
         source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
         clientKey = componentParams.clientKey,
+        amount = componentParams.amount,
     )
 
     constructor(
@@ -47,5 +50,6 @@ data class AnalyticsRepositoryData(
         locale = componentParams.shopperLocale,
         source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, storedPaymentMethod),
         clientKey = componentParams.clientKey,
+        amount = componentParams.amount,
     )
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsRepositoryData.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsRepositoryData.kt
@@ -28,6 +28,7 @@ data class AnalyticsRepositoryData(
     val clientKey: String,
     val amount: Amount,
     val screenWidth: Int,
+    val paymentMethods: List<String>,
 ) {
     constructor(
         application: Application,
@@ -37,6 +38,7 @@ data class AnalyticsRepositoryData(
         application = application,
         componentParams = componentParams,
         source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+        paymentMethodType = paymentMethod.type,
     )
 
     constructor(
@@ -47,12 +49,14 @@ data class AnalyticsRepositoryData(
         application = application,
         componentParams = componentParams,
         source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, storedPaymentMethod),
+        paymentMethodType = storedPaymentMethod.type,
     )
 
     private constructor(
         application: Application,
         componentParams: ComponentParams,
         source: AnalyticsSource,
+        paymentMethodType: String?,
     ) : this(
         level = componentParams.analyticsParams.level,
         packageName = application.packageName,
@@ -61,5 +65,6 @@ data class AnalyticsRepositoryData(
         clientKey = componentParams.clientKey,
         amount = componentParams.amount,
         screenWidth = application.screenWidthPixels,
+        paymentMethods = listOfNotNull(paymentMethodType),
     )
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/DefaultAnalyticsRepository.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/DefaultAnalyticsRepository.kt
@@ -28,6 +28,9 @@ class DefaultAnalyticsRepository(
     internal var state: State = State.Uninitialized
         private set
 
+    private var checkoutAttemptId: String? = null
+    override fun getCheckoutAttemptId(): String? = checkoutAttemptId
+
     override suspend fun setupAnalytics() {
         if (!canSendAnalytics(requiredLevel = ALL)) return
         if (state != State.Uninitialized) return
@@ -45,7 +48,8 @@ class DefaultAnalyticsRepository(
                     paymentMethods = paymentMethods,
                 )
             }
-            analyticsService.setupAnalytics(analyticsSetupRequest, analyticsRepositoryData.clientKey)
+            val response = analyticsService.setupAnalytics(analyticsSetupRequest, analyticsRepositoryData.clientKey)
+            checkoutAttemptId = response.checkoutAttemptId
             state = State.Ready
             Logger.v(TAG, "Analytics setup call successful")
         }.onFailure { e ->

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/DefaultAnalyticsRepository.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/DefaultAnalyticsRepository.kt
@@ -41,6 +41,7 @@ class DefaultAnalyticsRepository(
                     locale = locale,
                     source = source,
                     amount = amount,
+                    screenWidth = screenWidth.toLong(),
                 )
             }
             analyticsService.setupAnalytics(analyticsSetupRequest, analyticsRepositoryData.clientKey)

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/DefaultAnalyticsRepository.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/DefaultAnalyticsRepository.kt
@@ -42,6 +42,7 @@ class DefaultAnalyticsRepository(
                     source = source,
                     amount = amount,
                     screenWidth = screenWidth.toLong(),
+                    paymentMethods = paymentMethods,
                 )
             }
             analyticsService.setupAnalytics(analyticsSetupRequest, analyticsRepositoryData.clientKey)

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/DefaultAnalyticsRepository.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/DefaultAnalyticsRepository.kt
@@ -32,7 +32,10 @@ class DefaultAnalyticsRepository(
     override fun getCheckoutAttemptId(): String? = checkoutAttemptId
 
     override suspend fun setupAnalytics() {
-        if (!canSendAnalytics(requiredLevel = ALL)) return
+        if (!canSendAnalytics(requiredLevel = ALL)) {
+            checkoutAttemptId = CHECKOUT_ATTEMPT_ID_FOR_DISABLED_ANALYTICS
+            return
+        }
         if (state != State.Uninitialized) return
         state = State.InProgress
         Logger.v(TAG, "Setting up analytics")
@@ -65,6 +68,9 @@ class DefaultAnalyticsRepository(
 
     companion object {
         private val TAG = LogUtil.getTag()
+
+        @VisibleForTesting
+        internal const val CHECKOUT_ATTEMPT_ID_FOR_DISABLED_ANALYTICS = "do-not-track"
     }
 
     @VisibleForTesting

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/DefaultAnalyticsRepository.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/DefaultAnalyticsRepository.kt
@@ -36,7 +36,12 @@ class DefaultAnalyticsRepository(
 
         runSuspendCatching {
             val analyticsSetupRequest = with(analyticsRepositoryData) {
-                analyticsMapper.getAnalyticsSetupRequest(packageName, locale, source)
+                analyticsMapper.getAnalyticsSetupRequest(
+                    packageName = packageName,
+                    locale = locale,
+                    source = source,
+                    amount = amount,
+                )
             }
             analyticsService.setupAnalytics(analyticsSetupRequest, analyticsRepositoryData.clientKey)
             state = State.Ready

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/model/AnalyticsSetupRequest.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/model/AnalyticsSetupRequest.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.components.core.internal.data.model
 
 import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.core.exception.ModelSerializationException
+import com.adyen.checkout.core.internal.data.model.JsonUtils
 import com.adyen.checkout.core.internal.data.model.ModelObject
 import com.adyen.checkout.core.internal.data.model.ModelUtils
 import com.adyen.checkout.core.internal.data.model.getLongOrNull
@@ -35,7 +36,6 @@ internal data class AnalyticsSetupRequest(
     val screenWidth: Long?,
     val paymentMethods: List<String>?,
     val amount: Amount?,
-    val level: String?,
 ) : ModelObject() {
 
     companion object {
@@ -53,7 +53,6 @@ internal data class AnalyticsSetupRequest(
         private const val SCREEN_WIDTH = "screenWidth"
         private const val PAYMENT_METHODS = "paymentMethods"
         private const val AMOUNT = "amount"
-        private const val LEVEL = "level"
 
         @JvmField
         val SERIALIZER: Serializer<AnalyticsSetupRequest> = object : Serializer<AnalyticsSetupRequest> {
@@ -72,9 +71,8 @@ internal data class AnalyticsSetupRequest(
                         putOpt(SYSTEM_VERSION, modelObject.systemVersion)
                         putOpt(CONTAINER_WIDTH, modelObject.containerWidth)
                         putOpt(SCREEN_WIDTH, modelObject.screenWidth)
-                        putOpt(PAYMENT_METHODS, modelObject.paymentMethods)
+                        putOpt(PAYMENT_METHODS, JsonUtils.serializeOptStringList(modelObject.paymentMethods))
                         putOpt(AMOUNT, ModelUtils.serializeOpt(modelObject.amount, Amount.SERIALIZER))
-                        putOpt(LEVEL, modelObject.level)
                     }
                 } catch (e: JSONException) {
                     throw ModelSerializationException(AnalyticsSetupRequest::class.java, e)
@@ -99,7 +97,6 @@ internal data class AnalyticsSetupRequest(
                             screenWidth = getLongOrNull(SCREEN_WIDTH),
                             paymentMethods = optStringList(PAYMENT_METHODS),
                             amount = ModelUtils.deserializeOpt(optJSONObject(AMOUNT), Amount.SERIALIZER),
-                            level = getStringOrNull(LEVEL),
                         )
                     }
                 } catch (e: JSONException) {

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/AnalyticsParams.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/AnalyticsParams.kt
@@ -8,17 +8,14 @@
 
 package com.adyen.checkout.components.core.internal.ui.model
 
-import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.core.AnalyticsConfiguration
 import com.adyen.checkout.components.core.AnalyticsLevel
-import kotlinx.parcelize.Parcelize
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-@Parcelize
 data class AnalyticsParams(
     val level: AnalyticsParamsLevel,
-) : Parcelable {
+) {
 
     constructor(analyticsConfiguration: AnalyticsConfiguration?) :
         this(level = getLevel(analyticsConfiguration))

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/ButtonComponentParams.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/ButtonComponentParams.kt
@@ -11,11 +11,9 @@ package com.adyen.checkout.components.core.internal.ui.model
 import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.core.Environment
-import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-@Parcelize
 data class ButtonComponentParams(
     override val shopperLocale: Locale,
     override val environment: Environment,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/ComponentParams.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/ComponentParams.kt
@@ -8,14 +8,13 @@
 
 package com.adyen.checkout.components.core.internal.ui.model
 
-import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.core.Environment
 import java.util.Locale
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-interface ComponentParams : Parcelable {
+interface ComponentParams {
     val shopperLocale: Locale
     val environment: Environment
     val clientKey: String

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/GenericComponentParams.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/GenericComponentParams.kt
@@ -11,11 +11,9 @@ package com.adyen.checkout.components.core.internal.ui.model
 import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.core.Environment
-import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-@Parcelize
 data class GenericComponentParams(
     override val shopperLocale: Locale,
     override val environment: Environment,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/util/ContextExtensions.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/util/ContextExtensions.kt
@@ -6,7 +6,7 @@
  * Created by josephj on 14/4/2021.
  */
 
-package com.adyen.checkout.ui.core.internal.util
+package com.adyen.checkout.components.core.internal.util
 
 import android.content.ClipData
 import android.content.ClipboardManager
@@ -47,3 +47,7 @@ fun Context.createLocalizedContext(locale: Locale): Context {
 
     return createConfigurationContext(newConfig) ?: this
 }
+
+val Context.screenWidthPixels: Int
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    get() = resources.displayMetrics.widthPixels

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/ACHDirectDebitPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/ACHDirectDebitPaymentMethod.kt
@@ -17,7 +17,8 @@ import org.json.JSONObject
 
 @Parcelize
 data class ACHDirectDebitPaymentMethod(
-    override var type: String? = null,
+    override var type: String?,
+    override var checkoutAttemptId: String?,
     var encryptedBankAccountNumber: String? = null,
     var encryptedBankLocationId: String? = null,
     var ownerName: String? = null,
@@ -37,6 +38,7 @@ data class ACHDirectDebitPaymentMethod(
                 return try {
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
+                        putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
                         putOpt(ENCRYPTED_BANK_ACCOUNT_NUMBER, modelObject.encryptedBankAccountNumber)
                         putOpt(ENCRYPTED_BANK_LOCATION_ID, modelObject.encryptedBankLocationId)
                         putOpt(OWNER_NAME, modelObject.ownerName)
@@ -50,6 +52,7 @@ data class ACHDirectDebitPaymentMethod(
             override fun deserialize(jsonObject: JSONObject): ACHDirectDebitPaymentMethod {
                 return ACHDirectDebitPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
+                    checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
                     encryptedBankAccountNumber = jsonObject.getStringOrNull(ENCRYPTED_BANK_ACCOUNT_NUMBER),
                     encryptedBankLocationId = jsonObject.getStringOrNull(ENCRYPTED_BANK_LOCATION_ID),
                     ownerName = jsonObject.getStringOrNull(OWNER_NAME),

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/BacsDirectDebitPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/BacsDirectDebitPaymentMethod.kt
@@ -16,10 +16,11 @@ import org.json.JSONObject
 
 @Parcelize
 data class BacsDirectDebitPaymentMethod(
-    override var type: String? = null,
-    var holderName: String? = null,
-    var bankAccountNumber: String? = null,
-    var bankLocationId: String? = null,
+    override var type: String?,
+    override var checkoutAttemptId: String?,
+    var holderName: String?,
+    var bankAccountNumber: String?,
+    var bankLocationId: String?,
 ) : PaymentMethodDetails() {
 
     companion object {
@@ -36,6 +37,7 @@ data class BacsDirectDebitPaymentMethod(
                 return try {
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
+                        putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
                         putOpt(HOLDER_NAME, modelObject.holderName)
                         putOpt(BANK_ACCOUNT_NUMBER, modelObject.bankAccountNumber)
                         putOpt(BANK_LOCATION_ID, modelObject.bankLocationId)
@@ -48,6 +50,7 @@ data class BacsDirectDebitPaymentMethod(
             override fun deserialize(jsonObject: JSONObject): BacsDirectDebitPaymentMethod {
                 return BacsDirectDebitPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
+                    checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
                     holderName = jsonObject.getStringOrNull(HOLDER_NAME),
                     bankAccountNumber = jsonObject.getStringOrNull(BANK_ACCOUNT_NUMBER),
                     bankLocationId = jsonObject.getStringOrNull(BANK_LOCATION_ID)

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/BlikPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/BlikPaymentMethod.kt
@@ -16,7 +16,8 @@ import org.json.JSONObject
 
 @Parcelize
 data class BlikPaymentMethod(
-    override var type: String? = null,
+    override var type: String?,
+    override var checkoutAttemptId: String?,
     var blikCode: String? = null,
     var storedPaymentMethodId: String? = null,
 ) : PaymentMethodDetails() {
@@ -32,6 +33,7 @@ data class BlikPaymentMethod(
                 return try {
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
+                        putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
                         putOpt(BLIK_CODE, modelObject.blikCode)
                         putOpt(STORED_PAYMENT_METHOD_ID, modelObject.storedPaymentMethodId)
                     }
@@ -43,6 +45,7 @@ data class BlikPaymentMethod(
             override fun deserialize(jsonObject: JSONObject): BlikPaymentMethod {
                 return BlikPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
+                    checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
                     blikCode = jsonObject.getStringOrNull(BLIK_CODE),
                     storedPaymentMethodId = jsonObject.getStringOrNull(STORED_PAYMENT_METHOD_ID)
                 )

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/CardPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/CardPaymentMethod.kt
@@ -16,7 +16,8 @@ import org.json.JSONObject
 
 @Parcelize
 data class CardPaymentMethod(
-    override var type: String? = null,
+    override var type: String?,
+    override var checkoutAttemptId: String?,
     var encryptedCardNumber: String? = null,
     var encryptedExpiryMonth: String? = null,
     var encryptedExpiryYear: String? = null,
@@ -50,6 +51,7 @@ data class CardPaymentMethod(
                 return try {
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
+                        putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
                         putOpt(ENCRYPTED_CARD_NUMBER, modelObject.encryptedCardNumber)
                         putOpt(ENCRYPTED_EXPIRY_MONTH, modelObject.encryptedExpiryMonth)
                         putOpt(ENCRYPTED_EXPIRY_YEAR, modelObject.encryptedExpiryYear)
@@ -70,6 +72,7 @@ data class CardPaymentMethod(
             override fun deserialize(jsonObject: JSONObject): CardPaymentMethod {
                 return CardPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
+                    checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
                     encryptedCardNumber = jsonObject.getStringOrNull(ENCRYPTED_CARD_NUMBER),
                     encryptedExpiryMonth = jsonObject.getStringOrNull(ENCRYPTED_EXPIRY_MONTH),
                     encryptedExpiryYear = jsonObject.getStringOrNull(ENCRYPTED_EXPIRY_YEAR),

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/CashAppPayPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/CashAppPayPaymentMethod.kt
@@ -9,7 +9,8 @@ import org.json.JSONObject
 
 @Parcelize
 data class CashAppPayPaymentMethod(
-    override var type: String? = null,
+    override var type: String?,
+    override var checkoutAttemptId: String?,
     var grantId: String? = null,
     var onFileGrantId: String? = null,
     var customerId: String? = null,
@@ -31,6 +32,7 @@ data class CashAppPayPaymentMethod(
             override fun serialize(modelObject: CashAppPayPaymentMethod): JSONObject = JSONObject().apply {
                 try {
                     putOpt(TYPE, modelObject.type)
+                    putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
                     putOpt(GRANT_ID, modelObject.grantId)
                     putOpt(ON_FILE_GRANT_ID, modelObject.onFileGrantId)
                     putOpt(CUSTOMER_ID, modelObject.customerId)
@@ -43,6 +45,7 @@ data class CashAppPayPaymentMethod(
 
             override fun deserialize(jsonObject: JSONObject): CashAppPayPaymentMethod = CashAppPayPaymentMethod(
                 type = jsonObject.getStringOrNull(TYPE),
+                checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
                 grantId = jsonObject.getStringOrNull(GRANT_ID),
                 onFileGrantId = jsonObject.getStringOrNull(ON_FILE_GRANT_ID),
                 customerId = jsonObject.getStringOrNull(CUSTOMER_ID),

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/ConvenienceStoresJPPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/ConvenienceStoresJPPaymentMethod.kt
@@ -18,6 +18,7 @@ import org.json.JSONObject
 @Parcelize
 class ConvenienceStoresJPPaymentMethod(
     override var type: String? = null,
+    override var checkoutAttemptId: String? = null,
     override var firstName: String? = null,
     override var lastName: String? = null,
     override var telephoneNumber: String? = null,
@@ -34,6 +35,7 @@ class ConvenienceStoresJPPaymentMethod(
                     return try {
                         JSONObject().apply {
                             putOpt(TYPE, modelObject.type)
+                            putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
                             putOpt(FIRST_NAME, modelObject.firstName)
                             putOpt(LAST_NAME, modelObject.lastName)
                             putOpt(TELEPHONE_NUMBER, modelObject.telephoneNumber)
@@ -47,6 +49,7 @@ class ConvenienceStoresJPPaymentMethod(
                 override fun deserialize(jsonObject: JSONObject): ConvenienceStoresJPPaymentMethod {
                     return ConvenienceStoresJPPaymentMethod(
                         type = jsonObject.getStringOrNull(TYPE),
+                        checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
                         firstName = jsonObject.getStringOrNull(FIRST_NAME),
                         lastName = jsonObject.getStringOrNull(LAST_NAME),
                         telephoneNumber = jsonObject.getStringOrNull(TELEPHONE_NUMBER),

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/DotpayPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/DotpayPaymentMethod.kt
@@ -17,6 +17,7 @@ import org.json.JSONObject
 @Parcelize
 data class DotpayPaymentMethod(
     override var type: String? = null,
+    override var checkoutAttemptId: String? = null,
     override var issuer: String? = null,
 ) : IssuerListPaymentMethod() {
 
@@ -29,6 +30,7 @@ data class DotpayPaymentMethod(
                 return try {
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
+                        putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
                         putOpt(ISSUER, modelObject.issuer)
                     }
                 } catch (e: JSONException) {
@@ -39,6 +41,7 @@ data class DotpayPaymentMethod(
             override fun deserialize(jsonObject: JSONObject): DotpayPaymentMethod {
                 return DotpayPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
+                    checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
                     issuer = jsonObject.getStringOrNull(ISSUER)
                 )
             }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/EPSPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/EPSPaymentMethod.kt
@@ -17,6 +17,7 @@ import org.json.JSONObject
 @Parcelize
 data class EPSPaymentMethod(
     override var type: String? = null,
+    override var checkoutAttemptId: String? = null,
     override var issuer: String? = null,
 ) : IssuerListPaymentMethod() {
 
@@ -29,6 +30,7 @@ data class EPSPaymentMethod(
                 return try {
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
+                        putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
                         putOpt(ISSUER, modelObject.issuer)
                     }
                 } catch (e: JSONException) {
@@ -39,6 +41,7 @@ data class EPSPaymentMethod(
             override fun deserialize(jsonObject: JSONObject): EPSPaymentMethod {
                 return EPSPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
+                    checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
                     issuer = jsonObject.getStringOrNull(ISSUER)
                 )
             }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/EntercashPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/EntercashPaymentMethod.kt
@@ -17,6 +17,7 @@ import org.json.JSONObject
 @Parcelize
 class EntercashPaymentMethod(
     override var type: String? = null,
+    override var checkoutAttemptId: String? = null,
     override var issuer: String? = null,
 ) : IssuerListPaymentMethod() {
 
@@ -29,6 +30,7 @@ class EntercashPaymentMethod(
                 return try {
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
+                        putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
                         putOpt(ISSUER, modelObject.issuer)
                     }
                 } catch (e: JSONException) {
@@ -39,6 +41,7 @@ class EntercashPaymentMethod(
             override fun deserialize(jsonObject: JSONObject): EntercashPaymentMethod {
                 return EntercashPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
+                    checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
                     issuer = jsonObject.getStringOrNull(ISSUER)
                 )
             }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/GenericPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/GenericPaymentMethod.kt
@@ -15,7 +15,8 @@ import org.json.JSONObject
 
 @Parcelize
 class GenericPaymentMethod(
-    override var type: String? = null,
+    override var type: String?,
+    override var checkoutAttemptId: String?,
 ) : PaymentMethodDetails() {
 
     companion object {
@@ -26,6 +27,7 @@ class GenericPaymentMethod(
                 return try {
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
+                        putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
                     }
                 } catch (e: JSONException) {
                     throw ModelSerializationException(GenericPaymentMethod::class.java, e)
@@ -34,7 +36,8 @@ class GenericPaymentMethod(
 
             override fun deserialize(jsonObject: JSONObject): GenericPaymentMethod {
                 return GenericPaymentMethod(
-                    type = jsonObject.getStringOrNull(TYPE)
+                    type = jsonObject.getStringOrNull(TYPE),
+                    checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
                 )
             }
         }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/GiftCardPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/GiftCardPaymentMethod.kt
@@ -16,10 +16,11 @@ import org.json.JSONObject
 
 @Parcelize
 class GiftCardPaymentMethod(
-    override var type: String? = null,
-    var encryptedCardNumber: String? = null,
-    var encryptedSecurityCode: String? = null,
-    var brand: String? = null,
+    override var type: String?,
+    override var checkoutAttemptId: String?,
+    var encryptedCardNumber: String?,
+    var encryptedSecurityCode: String?,
+    var brand: String?,
 ) : PaymentMethodDetails() {
 
     companion object {
@@ -34,6 +35,7 @@ class GiftCardPaymentMethod(
                 return try {
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
+                        putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
                         putOpt(ENCRYPTED_CARD_NUMBER, modelObject.encryptedCardNumber)
                         putOpt(ENCRYPTED_SECURITY_CODE, modelObject.encryptedSecurityCode)
                         putOpt(BRAND, modelObject.brand)
@@ -46,6 +48,7 @@ class GiftCardPaymentMethod(
             override fun deserialize(jsonObject: JSONObject): GiftCardPaymentMethod {
                 return GiftCardPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
+                    checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
                     encryptedCardNumber = jsonObject.getStringOrNull(ENCRYPTED_CARD_NUMBER),
                     encryptedSecurityCode = jsonObject.getStringOrNull(ENCRYPTED_SECURITY_CODE),
                     brand = jsonObject.getStringOrNull(BRAND)

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/GooglePayPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/GooglePayPaymentMethod.kt
@@ -15,7 +15,8 @@ import org.json.JSONObject
 
 @Parcelize
 class GooglePayPaymentMethod(
-    override var type: String? = null,
+    override var type: String?,
+    override var checkoutAttemptId: String?,
     var googlePayToken: String? = null,
     var googlePayCardNetwork: String? = null,
 ) : PaymentMethodDetails() {
@@ -30,6 +31,7 @@ class GooglePayPaymentMethod(
                 return try {
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
+                        putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
                         putOpt(GOOGLE_PAY_TOKEN, modelObject.googlePayToken)
                         putOpt(GOOGLE_PAY_CARD_NETWORK, modelObject.googlePayCardNetwork)
                     }
@@ -41,6 +43,7 @@ class GooglePayPaymentMethod(
             override fun deserialize(jsonObject: JSONObject): GooglePayPaymentMethod {
                 return GooglePayPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
+                    checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
                     googlePayToken = jsonObject.getStringOrNull(GOOGLE_PAY_TOKEN),
                     googlePayCardNetwork = jsonObject.getStringOrNull(GOOGLE_PAY_CARD_NETWORK)
                 )

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/IdealPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/IdealPaymentMethod.kt
@@ -7,6 +7,7 @@
  */
 package com.adyen.checkout.components.core.paymentmethod
 
+import com.adyen.checkout.components.core.PaymentMethodTypes
 import com.adyen.checkout.core.exception.ModelSerializationException
 import com.adyen.checkout.core.internal.data.model.getStringOrNull
 import kotlinx.parcelize.Parcelize
@@ -16,11 +17,12 @@ import org.json.JSONObject
 @Parcelize
 class IdealPaymentMethod(
     override var type: String? = null,
+    override var checkoutAttemptId: String? = null,
     override var issuer: String? = null,
 ) : IssuerListPaymentMethod() {
 
     companion object {
-        const val PAYMENT_METHOD_TYPE = "ideal"
+        const val PAYMENT_METHOD_TYPE = PaymentMethodTypes.IDEAL
 
         @JvmField
         val SERIALIZER: Serializer<IdealPaymentMethod> = object : Serializer<IdealPaymentMethod> {
@@ -28,6 +30,7 @@ class IdealPaymentMethod(
                 return try {
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
+                        putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
                         putOpt(ISSUER, modelObject.issuer)
                     }
                 } catch (e: JSONException) {
@@ -38,6 +41,7 @@ class IdealPaymentMethod(
             override fun deserialize(jsonObject: JSONObject): IdealPaymentMethod {
                 return IdealPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
+                    checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
                     issuer = jsonObject.getStringOrNull(ISSUER)
                 )
             }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/MBWayPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/MBWayPaymentMethod.kt
@@ -16,8 +16,9 @@ import org.json.JSONObject
 
 @Parcelize
 class MBWayPaymentMethod(
-    override var type: String? = null,
-    var telephoneNumber: String? = null,
+    override var type: String?,
+    override var checkoutAttemptId: String?,
+    var telephoneNumber: String?,
 ) : PaymentMethodDetails() {
 
     companion object {
@@ -30,6 +31,7 @@ class MBWayPaymentMethod(
                 return try {
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
+                        putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
                         putOpt(TELEPHONE_NUMBER, modelObject.telephoneNumber)
                     }
                 } catch (e: JSONException) {
@@ -40,6 +42,7 @@ class MBWayPaymentMethod(
             override fun deserialize(jsonObject: JSONObject): MBWayPaymentMethod {
                 return MBWayPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
+                    checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
                     telephoneNumber = jsonObject.getStringOrNull(TELEPHONE_NUMBER),
                 )
             }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/MolpayPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/MolpayPaymentMethod.kt
@@ -16,6 +16,7 @@ import org.json.JSONObject
 @Parcelize
 class MolpayPaymentMethod(
     override var type: String? = null,
+    override var checkoutAttemptId: String? = null,
     override var issuer: String? = null,
 ) : IssuerListPaymentMethod() {
 
@@ -27,6 +28,7 @@ class MolpayPaymentMethod(
                 return try {
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
+                        putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
                         putOpt(ISSUER, modelObject.issuer)
                     }
                 } catch (e: JSONException) {
@@ -37,6 +39,7 @@ class MolpayPaymentMethod(
             override fun deserialize(jsonObject: JSONObject): MolpayPaymentMethod {
                 return MolpayPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
+                    checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
                     issuer = jsonObject.getStringOrNull(ISSUER),
                 )
             }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OnlineBankingCZPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OnlineBankingCZPaymentMethod.kt
@@ -18,6 +18,7 @@ import org.json.JSONObject
 @Parcelize
 data class OnlineBankingCZPaymentMethod(
     override var type: String? = null,
+    override var checkoutAttemptId: String? = null,
     override var issuer: String? = null,
 ) : IssuerListPaymentMethod() {
 
@@ -30,6 +31,7 @@ data class OnlineBankingCZPaymentMethod(
                 return try {
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
+                        putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
                         putOpt(ISSUER, modelObject.issuer)
                     }
                 } catch (e: JSONException) {
@@ -40,6 +42,7 @@ data class OnlineBankingCZPaymentMethod(
             override fun deserialize(jsonObject: JSONObject): OnlineBankingCZPaymentMethod {
                 return OnlineBankingCZPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
+                    checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
                     issuer = jsonObject.getStringOrNull(ISSUER)
                 )
             }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OnlineBankingJPPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OnlineBankingJPPaymentMethod.kt
@@ -18,6 +18,7 @@ import org.json.JSONObject
 @Parcelize
 class OnlineBankingJPPaymentMethod(
     override var type: String? = null,
+    override var checkoutAttemptId: String? = null,
     override var firstName: String? = null,
     override var lastName: String? = null,
     override var telephoneNumber: String? = null,
@@ -33,6 +34,7 @@ class OnlineBankingJPPaymentMethod(
                 return try {
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
+                        putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
                         putOpt(FIRST_NAME, modelObject.firstName)
                         putOpt(LAST_NAME, modelObject.lastName)
                         putOpt(TELEPHONE_NUMBER, modelObject.telephoneNumber)
@@ -46,6 +48,7 @@ class OnlineBankingJPPaymentMethod(
             override fun deserialize(jsonObject: JSONObject): OnlineBankingJPPaymentMethod {
                 return OnlineBankingJPPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
+                    checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
                     firstName = jsonObject.getStringOrNull(FIRST_NAME),
                     lastName = jsonObject.getStringOrNull(LAST_NAME),
                     telephoneNumber = jsonObject.getStringOrNull(TELEPHONE_NUMBER),

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OnlineBankingPLPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OnlineBankingPLPaymentMethod.kt
@@ -18,6 +18,7 @@ import org.json.JSONObject
 @Parcelize
 class OnlineBankingPLPaymentMethod(
     override var type: String? = null,
+    override var checkoutAttemptId: String? = null,
     override var issuer: String? = null,
 ) : IssuerListPaymentMethod() {
 
@@ -30,6 +31,7 @@ class OnlineBankingPLPaymentMethod(
                 return try {
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
+                        putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
                         putOpt(ISSUER, modelObject.issuer)
                     }
                 } catch (e: JSONException) {
@@ -40,6 +42,7 @@ class OnlineBankingPLPaymentMethod(
             override fun deserialize(jsonObject: JSONObject): OnlineBankingPLPaymentMethod {
                 return OnlineBankingPLPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
+                    checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
                     issuer = jsonObject.getStringOrNull(ISSUER)
                 )
             }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OnlineBankingSKPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OnlineBankingSKPaymentMethod.kt
@@ -18,6 +18,7 @@ import org.json.JSONObject
 @Parcelize
 data class OnlineBankingSKPaymentMethod(
     override var type: String? = null,
+    override var checkoutAttemptId: String? = null,
     override var issuer: String? = null,
 ) : IssuerListPaymentMethod() {
 
@@ -30,6 +31,7 @@ data class OnlineBankingSKPaymentMethod(
                 return try {
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
+                        putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
                         putOpt(ISSUER, modelObject.issuer)
                     }
                 } catch (e: JSONException) {
@@ -40,6 +42,7 @@ data class OnlineBankingSKPaymentMethod(
             override fun deserialize(jsonObject: JSONObject): OnlineBankingSKPaymentMethod {
                 return OnlineBankingSKPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
+                    checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
                     issuer = jsonObject.getStringOrNull(ISSUER)
                 )
             }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OpenBankingPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OpenBankingPaymentMethod.kt
@@ -17,6 +17,7 @@ import org.json.JSONObject
 @Parcelize
 class OpenBankingPaymentMethod(
     override var type: String? = null,
+    override var checkoutAttemptId: String? = null,
     override var issuer: String? = null,
 ) : IssuerListPaymentMethod() {
 
@@ -29,6 +30,7 @@ class OpenBankingPaymentMethod(
                 return try {
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
+                        putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
                         putOpt(ISSUER, modelObject.issuer)
                     }
                 } catch (e: JSONException) {
@@ -39,6 +41,7 @@ class OpenBankingPaymentMethod(
             override fun deserialize(jsonObject: JSONObject): OpenBankingPaymentMethod {
                 return OpenBankingPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
+                    checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
                     issuer = jsonObject.getStringOrNull(ISSUER),
                 )
             }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/PayByBankPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/PayByBankPaymentMethod.kt
@@ -18,7 +18,8 @@ import org.json.JSONObject
 @Parcelize
 class PayByBankPaymentMethod(
     override var type: String? = null,
-    override var issuer: String? = null
+    override var checkoutAttemptId: String? = null,
+    override var issuer: String? = null,
 ) : IssuerListPaymentMethod() {
 
     companion object {
@@ -30,6 +31,7 @@ class PayByBankPaymentMethod(
                 return try {
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
+                        putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
                         putOpt(ISSUER, modelObject.issuer)
                     }
                 } catch (e: JSONException) {
@@ -40,6 +42,7 @@ class PayByBankPaymentMethod(
             override fun deserialize(jsonObject: JSONObject): PayByBankPaymentMethod {
                 return PayByBankPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
+                    checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
                     issuer = jsonObject.getStringOrNull(ISSUER)
                 )
             }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/PayEasyPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/PayEasyPaymentMethod.kt
@@ -18,6 +18,7 @@ import org.json.JSONObject
 @Parcelize
 class PayEasyPaymentMethod(
     override var type: String? = null,
+    override var checkoutAttemptId: String? = null,
     override var firstName: String? = null,
     override var lastName: String? = null,
     override var telephoneNumber: String? = null,
@@ -33,6 +34,7 @@ class PayEasyPaymentMethod(
                 return try {
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
+                        putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
                         putOpt(FIRST_NAME, modelObject.firstName)
                         putOpt(LAST_NAME, modelObject.lastName)
                         putOpt(TELEPHONE_NUMBER, modelObject.telephoneNumber)
@@ -46,6 +48,7 @@ class PayEasyPaymentMethod(
             override fun deserialize(jsonObject: JSONObject): PayEasyPaymentMethod {
                 return PayEasyPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
+                    checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
                     firstName = jsonObject.getStringOrNull(FIRST_NAME),
                     lastName = jsonObject.getStringOrNull(LAST_NAME),
                     telephoneNumber = jsonObject.getStringOrNull(TELEPHONE_NUMBER),

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/PaymentMethodDetails.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/PaymentMethodDetails.kt
@@ -23,9 +23,11 @@ import org.json.JSONObject
 abstract class PaymentMethodDetails : ModelObject() {
 
     abstract var type: String?
+    abstract var checkoutAttemptId: String?
 
     companion object {
         const val TYPE = "type"
+        const val CHECKOUT_ATTEMPT_ID = "checkoutAttemptId"
 
         @JvmField
         val SERIALIZER: Serializer<PaymentMethodDetails> = object : Serializer<PaymentMethodDetails> {

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/SepaPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/SepaPaymentMethod.kt
@@ -16,9 +16,10 @@ import org.json.JSONObject
 
 @Parcelize
 class SepaPaymentMethod(
-    override var type: String? = null,
-    var ownerName: String? = null,
-    var iban: String? = null,
+    override var type: String?,
+    override var checkoutAttemptId: String?,
+    var ownerName: String?,
+    var iban: String?,
 ) : PaymentMethodDetails() {
 
     companion object {
@@ -32,6 +33,7 @@ class SepaPaymentMethod(
                 return try {
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
+                        putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
                         putOpt(OWNER_NAME, modelObject.ownerName)
                         putOpt(IBAN, modelObject.iban)
                     }
@@ -43,6 +45,7 @@ class SepaPaymentMethod(
             override fun deserialize(jsonObject: JSONObject): SepaPaymentMethod {
                 return SepaPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
+                    checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
                     ownerName = jsonObject.getStringOrNull(OWNER_NAME),
                     iban = jsonObject.getStringOrNull(IBAN),
                 )

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/SevenElevenPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/SevenElevenPaymentMethod.kt
@@ -18,6 +18,7 @@ import org.json.JSONObject
 @Parcelize
 class SevenElevenPaymentMethod(
     override var type: String? = null,
+    override var checkoutAttemptId: String? = null,
     override var firstName: String? = null,
     override var lastName: String? = null,
     override var telephoneNumber: String? = null,
@@ -33,6 +34,7 @@ class SevenElevenPaymentMethod(
                 return try {
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
+                        putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
                         putOpt(FIRST_NAME, modelObject.firstName)
                         putOpt(LAST_NAME, modelObject.lastName)
                         putOpt(TELEPHONE_NUMBER, modelObject.telephoneNumber)
@@ -46,6 +48,7 @@ class SevenElevenPaymentMethod(
             override fun deserialize(jsonObject: JSONObject): SevenElevenPaymentMethod {
                 return SevenElevenPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
+                    checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
                     firstName = jsonObject.getStringOrNull(FIRST_NAME),
                     lastName = jsonObject.getStringOrNull(LAST_NAME),
                     telephoneNumber = jsonObject.getStringOrNull(TELEPHONE_NUMBER),

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/UPIPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/UPIPaymentMethod.kt
@@ -16,8 +16,9 @@ import org.json.JSONObject
 
 @Parcelize
 data class UPIPaymentMethod(
-    override var type: String? = null,
-    var virtualPaymentAddress: String? = null,
+    override var type: String?,
+    override var checkoutAttemptId: String?,
+    var virtualPaymentAddress: String?,
 ) : PaymentMethodDetails() {
 
     companion object {
@@ -29,6 +30,7 @@ data class UPIPaymentMethod(
                 return try {
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
+                        putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
                         putOpt(VIRTUAL_PAYMENT_ADDRESS, modelObject.virtualPaymentAddress)
                     }
                 } catch (e: JSONException) {
@@ -39,6 +41,7 @@ data class UPIPaymentMethod(
             override fun deserialize(jsonObject: JSONObject): UPIPaymentMethod {
                 return UPIPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
+                    checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
                     virtualPaymentAddress = jsonObject.getStringOrNull(VIRTUAL_PAYMENT_ADDRESS),
                 )
             }

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsMapperTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsMapperTest.kt
@@ -105,6 +105,7 @@ internal class AnalyticsMapperTest {
                 ),
                 amount = Amount("USD", 1337),
                 screenWidth = 1286,
+                paymentMethods = listOf("scheme", "googlepay"),
             )
 
             val expected = AnalyticsSetupRequest(
@@ -120,9 +121,8 @@ internal class AnalyticsMapperTest {
                 systemVersion = Build.VERSION.SDK_INT.toString(),
                 containerWidth = null,
                 screenWidth = 1286,
-                paymentMethods = null,
+                paymentMethods = listOf("scheme", "googlepay"),
                 amount = Amount("USD", 1337),
-                level = null,
             )
 
             assertEquals(expected.toString(), actual.toString())

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsMapperTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsMapperTest.kt
@@ -9,6 +9,7 @@
 package com.adyen.checkout.components.core.internal.data.api
 
 import android.os.Build
+import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.StoredPaymentMethod
 import com.adyen.checkout.components.core.internal.data.model.AnalyticsSetupRequest
@@ -101,7 +102,8 @@ internal class AnalyticsMapperTest {
                 source = AnalyticsSource.PaymentComponent(
                     isCreatedByDropIn = false,
                     PaymentMethod(type = "PAYMENT_METHOD_TYPE")
-                )
+                ),
+                amount = Amount("USD", 1337)
             )
 
             val expected = AnalyticsSetupRequest(
@@ -118,7 +120,7 @@ internal class AnalyticsMapperTest {
                 containerWidth = null,
                 screenWidth = null,
                 paymentMethods = null,
-                amount = null,
+                amount = Amount("USD", 1337),
                 level = null,
             )
 

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsMapperTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsMapperTest.kt
@@ -103,7 +103,8 @@ internal class AnalyticsMapperTest {
                     isCreatedByDropIn = false,
                     PaymentMethod(type = "PAYMENT_METHOD_TYPE")
                 ),
-                amount = Amount("USD", 1337)
+                amount = Amount("USD", 1337),
+                screenWidth = 1286,
             )
 
             val expected = AnalyticsSetupRequest(
@@ -118,7 +119,7 @@ internal class AnalyticsMapperTest {
                 referrer = "PACKAGE_NAME",
                 systemVersion = Build.VERSION.SDK_INT.toString(),
                 containerWidth = null,
-                screenWidth = null,
+                screenWidth = 1286,
                 paymentMethods = null,
                 amount = Amount("USD", 1337),
                 level = null,

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/api/DefaultAnalyticsRepositoryTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/api/DefaultAnalyticsRepositoryTest.kt
@@ -9,6 +9,7 @@
 package com.adyen.checkout.components.core.internal.data.api
 
 import com.adyen.checkout.components.core.Amount
+import com.adyen.checkout.components.core.internal.data.model.AnalyticsSetupResponse
 import com.adyen.checkout.components.core.internal.data.model.AnalyticsSource
 import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParamsLevel
 import com.adyen.checkout.core.AdyenLogger
@@ -26,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -44,10 +46,12 @@ internal class DefaultAnalyticsRepositoryTest(
     private lateinit var analyticsRepository: DefaultAnalyticsRepository
 
     @BeforeEach
-    fun before() {
+    fun before() = runTest {
         AdyenLogger.setLogLevel(Logger.NONE)
-
         analyticsRepository = getDefaultAnalyticsRepository()
+        whenever(
+            analyticsService.setupAnalytics(any(), any())
+        ) doReturn AnalyticsSetupResponse(checkoutAttemptId = TEST_CHECKOUT_ATTEMPT_ID)
     }
 
     @Test
@@ -77,6 +81,12 @@ internal class DefaultAnalyticsRepositoryTest(
         fun `and AnalyticsService is successful then state is set as initialized`() = runTest {
             analyticsRepository.setupAnalytics()
             assertEquals(DefaultAnalyticsRepository.State.Ready, analyticsRepository.state)
+        }
+
+        @Test
+        fun `and AnalyticsService is successful then checkoutAttemptId is set`() = runTest {
+            analyticsRepository.setupAnalytics()
+            assertEquals(TEST_CHECKOUT_ATTEMPT_ID, analyticsRepository.getCheckoutAttemptId())
         }
 
         @Test
@@ -164,5 +174,6 @@ internal class DefaultAnalyticsRepositoryTest(
         private val TEST_AMOUNT = Amount("USD", 1337)
         private const val SCREEN_WIDTH = 1080
         private val PAYMENT_METHODS = listOf("bcmc", "blik", "boletobancario")
+        private const val TEST_CHECKOUT_ATTEMPT_ID = "TEST_CHECKOUT_ATTEMPT_ID"
     }
 }

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/api/DefaultAnalyticsRepositoryTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/api/DefaultAnalyticsRepositoryTest.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.components.core.internal.data.api
 
 import com.adyen.checkout.components.core.internal.data.model.AnalyticsSource
-import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
 import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParamsLevel
 import com.adyen.checkout.core.AdyenLogger
 import com.adyen.checkout.core.exception.HttpException
@@ -100,7 +99,7 @@ internal class DefaultAnalyticsRepositoryTest(
         @Test
         fun `and level is set to ALL then call is made`() = runTest {
             analyticsRepository = getDefaultAnalyticsRepository(
-                analyticsParams = AnalyticsParams(AnalyticsParamsLevel.ALL)
+                level = AnalyticsParamsLevel.ALL
             )
 
             analyticsRepository.setupAnalytics()
@@ -111,7 +110,7 @@ internal class DefaultAnalyticsRepositoryTest(
         @Test
         fun `and level is set to NONE then call is not made`() = runTest {
             analyticsRepository = getDefaultAnalyticsRepository(
-                analyticsParams = AnalyticsParams(AnalyticsParamsLevel.NONE)
+                level = AnalyticsParamsLevel.NONE
             )
 
             analyticsRepository.setupAnalytics()
@@ -122,7 +121,7 @@ internal class DefaultAnalyticsRepositoryTest(
 
     @Suppress("LongParameterList")
     private fun getDefaultAnalyticsRepository(
-        analyticsParams: AnalyticsParams = AnalyticsParams(AnalyticsParamsLevel.ALL),
+        level: AnalyticsParamsLevel = AnalyticsParamsLevel.ALL,
         packageName: String = PACKAGE_NAME,
         locale: Locale = LOCALE,
         source: AnalyticsSource = ANALYTICS_SOURCE,
@@ -131,13 +130,15 @@ internal class DefaultAnalyticsRepositoryTest(
         clientKey: String = TEST_CLIENT_KEY,
     ): DefaultAnalyticsRepository {
         return DefaultAnalyticsRepository(
-            analyticsParams,
-            packageName,
-            locale,
-            source,
-            analyticsService,
-            analyticsMapper,
-            clientKey,
+            analyticsRepositoryData = AnalyticsRepositoryData(
+                level = level,
+                packageName = packageName,
+                locale = locale,
+                source = source,
+                clientKey = clientKey,
+            ),
+            analyticsService = analyticsService,
+            analyticsMapper = analyticsMapper,
         )
     }
 

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/api/DefaultAnalyticsRepositoryTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/api/DefaultAnalyticsRepositoryTest.kt
@@ -8,6 +8,7 @@
 
 package com.adyen.checkout.components.core.internal.data.api
 
+import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.components.core.internal.data.model.AnalyticsSource
 import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParamsLevel
 import com.adyen.checkout.core.AdyenLogger
@@ -61,7 +62,12 @@ internal class DefaultAnalyticsRepositoryTest(
         @Test
         fun `then AnalyticsService is called`() = runTest {
             analyticsRepository.setupAnalytics()
-            val analyticsSetupRequest = analyticsMapper.getAnalyticsSetupRequest(PACKAGE_NAME, LOCALE, ANALYTICS_SOURCE)
+            val analyticsSetupRequest = analyticsMapper.getAnalyticsSetupRequest(
+                packageName = PACKAGE_NAME,
+                locale = LOCALE,
+                source = ANALYTICS_SOURCE,
+                amount = TEST_AMOUNT
+            )
             verify(analyticsService).setupAnalytics(analyticsSetupRequest, TEST_CLIENT_KEY)
         }
 
@@ -128,6 +134,7 @@ internal class DefaultAnalyticsRepositoryTest(
         analyticsService: AnalyticsService = this.analyticsService,
         analyticsMapper: AnalyticsMapper = this.analyticsMapper,
         clientKey: String = TEST_CLIENT_KEY,
+        amount: Amount = TEST_AMOUNT,
     ): DefaultAnalyticsRepository {
         return DefaultAnalyticsRepository(
             analyticsRepositoryData = AnalyticsRepositoryData(
@@ -136,6 +143,7 @@ internal class DefaultAnalyticsRepositoryTest(
                 locale = locale,
                 source = source,
                 clientKey = clientKey,
+                amount = amount,
             ),
             analyticsService = analyticsService,
             analyticsMapper = analyticsMapper,
@@ -147,5 +155,6 @@ internal class DefaultAnalyticsRepositoryTest(
         private val LOCALE = Locale.US
         private val ANALYTICS_SOURCE = AnalyticsSource.DropIn()
         private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
+        private val TEST_AMOUNT = Amount("USD", 1337)
     }
 }

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/api/DefaultAnalyticsRepositoryTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/api/DefaultAnalyticsRepositoryTest.kt
@@ -68,6 +68,7 @@ internal class DefaultAnalyticsRepositoryTest(
                 source = ANALYTICS_SOURCE,
                 amount = TEST_AMOUNT,
                 screenWidth = SCREEN_WIDTH.toLong(),
+                paymentMethods = PAYMENT_METHODS,
             )
             verify(analyticsService).setupAnalytics(analyticsSetupRequest, TEST_CLIENT_KEY)
         }
@@ -137,6 +138,7 @@ internal class DefaultAnalyticsRepositoryTest(
         clientKey: String = TEST_CLIENT_KEY,
         amount: Amount = TEST_AMOUNT,
         screenWidth: Int = SCREEN_WIDTH,
+        paymentMethods: List<String> = PAYMENT_METHODS,
     ): DefaultAnalyticsRepository {
         return DefaultAnalyticsRepository(
             analyticsRepositoryData = AnalyticsRepositoryData(
@@ -147,6 +149,7 @@ internal class DefaultAnalyticsRepositoryTest(
                 clientKey = clientKey,
                 amount = amount,
                 screenWidth = screenWidth,
+                paymentMethods = paymentMethods,
             ),
             analyticsService = analyticsService,
             analyticsMapper = analyticsMapper,
@@ -160,5 +163,6 @@ internal class DefaultAnalyticsRepositoryTest(
         private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
         private val TEST_AMOUNT = Amount("USD", 1337)
         private const val SCREEN_WIDTH = 1080
+        private val PAYMENT_METHODS = listOf("bcmc", "blik", "boletobancario")
     }
 }

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/api/DefaultAnalyticsRepositoryTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/api/DefaultAnalyticsRepositoryTest.kt
@@ -19,6 +19,7 @@ import com.adyen.checkout.test.TestDispatcherExtension
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -97,6 +98,13 @@ internal class DefaultAnalyticsRepositoryTest(
         }
 
         @Test
+        fun `and AnalyticsService returns an error then checkoutAttemptId is not set`() = runTest {
+            whenever(analyticsService.setupAnalytics(any(), any())) doThrow HttpException(1, "error_message", null)
+            analyticsRepository.setupAnalytics()
+            assertNull(analyticsRepository.getCheckoutAttemptId())
+        }
+
+        @Test
         fun `multiple times then AnalyticsService is only called once`() = runTest {
             analyticsRepository.setupAnalytics()
             analyticsRepository.setupAnalytics()
@@ -134,6 +142,20 @@ internal class DefaultAnalyticsRepositoryTest(
             analyticsRepository.setupAnalytics()
 
             verify(analyticsService, never()).setupAnalytics(any(), any())
+        }
+
+        @Test
+        fun `and level is set to NONE then checkoutAttemptId is not set`() = runTest {
+            analyticsRepository = getDefaultAnalyticsRepository(
+                level = AnalyticsParamsLevel.NONE
+            )
+
+            analyticsRepository.setupAnalytics()
+
+            assertEquals(
+                DefaultAnalyticsRepository.CHECKOUT_ATTEMPT_ID_FOR_DISABLED_ANALYTICS,
+                analyticsRepository.getCheckoutAttemptId()
+            )
         }
     }
 

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/api/DefaultAnalyticsRepositoryTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/api/DefaultAnalyticsRepositoryTest.kt
@@ -66,7 +66,8 @@ internal class DefaultAnalyticsRepositoryTest(
                 packageName = PACKAGE_NAME,
                 locale = LOCALE,
                 source = ANALYTICS_SOURCE,
-                amount = TEST_AMOUNT
+                amount = TEST_AMOUNT,
+                screenWidth = SCREEN_WIDTH.toLong(),
             )
             verify(analyticsService).setupAnalytics(analyticsSetupRequest, TEST_CLIENT_KEY)
         }
@@ -135,6 +136,7 @@ internal class DefaultAnalyticsRepositoryTest(
         analyticsMapper: AnalyticsMapper = this.analyticsMapper,
         clientKey: String = TEST_CLIENT_KEY,
         amount: Amount = TEST_AMOUNT,
+        screenWidth: Int = SCREEN_WIDTH,
     ): DefaultAnalyticsRepository {
         return DefaultAnalyticsRepository(
             analyticsRepositoryData = AnalyticsRepositoryData(
@@ -144,6 +146,7 @@ internal class DefaultAnalyticsRepositoryTest(
                 source = source,
                 clientKey = clientKey,
                 amount = amount,
+                screenWidth = screenWidth,
             ),
             analyticsService = analyticsService,
             analyticsMapper = analyticsMapper,
@@ -156,5 +159,6 @@ internal class DefaultAnalyticsRepositoryTest(
         private val ANALYTICS_SOURCE = AnalyticsSource.DropIn()
         private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
         private val TEST_AMOUNT = Amount("USD", 1337)
+        private const val SCREEN_WIDTH = 1080
     }
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/ActionComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/ActionComponentDialogFragment.kt
@@ -27,6 +27,7 @@ import com.adyen.checkout.components.core.ActionComponentCallback
 import com.adyen.checkout.components.core.ActionComponentData
 import com.adyen.checkout.components.core.ComponentError
 import com.adyen.checkout.components.core.action.Action
+import com.adyen.checkout.components.core.internal.util.toast
 import com.adyen.checkout.core.exception.CancellationException
 import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.core.exception.PermissionException
@@ -36,7 +37,6 @@ import com.adyen.checkout.dropin.R
 import com.adyen.checkout.dropin.databinding.FragmentGenericActionComponentBinding
 import com.adyen.checkout.dropin.internal.provider.mapToParams
 import com.adyen.checkout.dropin.internal.util.arguments
-import com.adyen.checkout.ui.core.internal.util.toast
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInActivity.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInActivity.kt
@@ -31,6 +31,7 @@ import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.PaymentMethodsApiResponse
 import com.adyen.checkout.components.core.StoredPaymentMethod
 import com.adyen.checkout.components.core.action.Action
+import com.adyen.checkout.components.core.internal.util.createLocalizedContext
 import com.adyen.checkout.core.internal.util.LogUtil
 import com.adyen.checkout.core.internal.util.Logger
 import com.adyen.checkout.dropin.BalanceDropInServiceResult
@@ -58,7 +59,6 @@ import com.adyen.checkout.giftcard.GiftCardComponentState
 import com.adyen.checkout.redirect.RedirectComponent
 import com.adyen.checkout.sessions.core.CheckoutSession
 import com.adyen.checkout.sessions.core.SessionPaymentResult
-import com.adyen.checkout.ui.core.internal.util.createLocalizedContext
 import com.adyen.checkout.wechatpay.WeChatPayUtils
 import kotlinx.coroutines.launch
 
@@ -683,7 +683,6 @@ internal class DropInActivity :
                 dropInConfiguration = dropInConfiguration,
                 paymentMethodsApiResponse = paymentMethodsApiResponse,
                 service = service,
-                packageName = context.packageName
             )
             return intent
         }
@@ -700,7 +699,6 @@ internal class DropInActivity :
                 dropInConfiguration = dropInConfiguration,
                 checkoutSession = checkoutSession,
                 service = service,
-                packageName = context.packageName
             )
             return intent
         }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInSavedStateHandleContainer.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInSavedStateHandleContainer.kt
@@ -39,7 +39,6 @@ internal class DropInSavedStateHandleContainer(
     var cachedGiftCardComponentState: GiftCardComponentState? by SavedStateHandleProperty(CACHED_GIFT_CARD)
     var cachedPartialPaymentAmount: Amount? by SavedStateHandleProperty(PARTIAL_PAYMENT_AMOUNT)
     var currentOrder: OrderModel? by SavedStateHandleProperty(CURRENT_ORDER)
-    var packageName: String? by SavedStateHandleProperty(PACKAGE_NAME_KEY)
 }
 
 internal object DropInBundleHandler {
@@ -50,13 +49,11 @@ internal object DropInBundleHandler {
         dropInConfiguration: DropInConfiguration,
         paymentMethodsApiResponse: PaymentMethodsApiResponse,
         service: ComponentName,
-        packageName: String,
     ) {
         intent.apply {
             putExtra(PAYMENT_METHODS_RESPONSE_KEY, paymentMethodsApiResponse)
             putExtra(DROP_IN_CONFIGURATION_KEY, dropInConfiguration)
             putExtra(DROP_IN_SERVICE_KEY, service)
-            putExtra(PACKAGE_NAME_KEY, packageName)
             putExtra(AMOUNT, dropInConfiguration.amount)
         }
     }
@@ -66,14 +63,12 @@ internal object DropInBundleHandler {
         dropInConfiguration: DropInConfiguration,
         checkoutSession: CheckoutSession,
         service: ComponentName,
-        packageName: String,
     ) {
         putIntentExtras(
             intent,
             dropInConfiguration,
             checkoutSession.sessionSetupResponse.paymentMethodsApiResponse ?: PaymentMethodsApiResponse(),
             service,
-            packageName,
         )
         intent.apply {
             putExtra(SESSION_KEY, checkoutSession.sessionSetupResponse.mapToDetails())
@@ -102,7 +97,6 @@ private const val IS_SESSIONS_FLOW_TAKEN_OVER_KEY = "IS_SESSIONS_FLOW_TAKEN_OVER
 private const val DROP_IN_CONFIGURATION_KEY = "DROP_IN_CONFIGURATION_KEY"
 private const val DROP_IN_SERVICE_KEY = "DROP_IN_SERVICE_KEY"
 private const val IS_WAITING_FOR_RESULT_KEY = "IS_WAITING_FOR_RESULT_KEY"
-private const val PACKAGE_NAME_KEY = "PACKAGE_NAME_KEY"
 private const val CACHED_GIFT_CARD = "CACHED_GIFT_CARD"
 private const val CURRENT_ORDER = "CURRENT_ORDER"
 private const val PARTIAL_PAYMENT_AMOUNT = "PARTIAL_PAYMENT_AMOUNT"

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInSavedStateHandleContainer.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInSavedStateHandleContainer.kt
@@ -57,6 +57,7 @@ internal object DropInBundleHandler {
             putExtra(DROP_IN_CONFIGURATION_KEY, dropInConfiguration)
             putExtra(DROP_IN_SERVICE_KEY, service)
             putExtra(PACKAGE_NAME_KEY, packageName)
+            putExtra(AMOUNT, dropInConfiguration.amount)
         }
     }
 
@@ -76,6 +77,7 @@ internal object DropInBundleHandler {
         )
         intent.apply {
             putExtra(SESSION_KEY, checkoutSession.sessionSetupResponse.mapToDetails())
+            putExtra(AMOUNT, checkoutSession.sessionSetupResponse.amount)
         }
     }
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModel.kt
@@ -63,7 +63,7 @@ internal class DropInViewModel(
     val serviceComponentName: ComponentName = requireNotNull(bundleHandler.serviceComponentName)
 
     var amount: Amount
-        get() = bundleHandler.amount ?: getInitialAmount()
+        get() = requireNotNull(bundleHandler.amount)
         private set(value) {
             bundleHandler.amount = value
         }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModelFactory.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModelFactory.kt
@@ -21,17 +21,21 @@ import com.adyen.checkout.components.core.internal.data.api.OrderStatusRepositor
 import com.adyen.checkout.components.core.internal.data.api.OrderStatusService
 import com.adyen.checkout.components.core.internal.data.model.AnalyticsSource
 import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
+import com.adyen.checkout.components.core.internal.util.screenWidthPixels
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
 import com.adyen.checkout.dropin.DropInConfiguration
 
 internal class DropInViewModelFactory(
     activity: ComponentActivity
 ) : AbstractSavedStateViewModelFactory(activity, activity.intent.extras) {
+
+    private val packageName: String = activity.packageName
+    private val screenWidth: Int = activity.screenWidthPixels
+
     override fun <T : ViewModel> create(key: String, modelClass: Class<T>, handle: SavedStateHandle): T {
         val bundleHandler = DropInSavedStateHandleContainer(handle)
 
         val dropInConfiguration: DropInConfiguration = requireNotNull(bundleHandler.dropInConfiguration)
-        val packageName: String = requireNotNull(bundleHandler.packageName)
         val amount: Amount = requireNotNull(bundleHandler.amount)
 
         val httpClient = HttpClientFactory.getHttpClient(dropInConfiguration.environment)
@@ -44,6 +48,7 @@ internal class DropInViewModelFactory(
                 source = AnalyticsSource.DropIn(),
                 clientKey = dropInConfiguration.clientKey,
                 amount = amount,
+                screenWidth = screenWidth,
             ),
             analyticsService = AnalyticsService(
                 HttpClientFactory.getAnalyticsHttpClient(dropInConfiguration.environment)

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModelFactory.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModelFactory.kt
@@ -37,6 +37,7 @@ internal class DropInViewModelFactory(
 
         val dropInConfiguration: DropInConfiguration = requireNotNull(bundleHandler.dropInConfiguration)
         val amount: Amount = requireNotNull(bundleHandler.amount)
+        val paymentMethods = bundleHandler.paymentMethodsApiResponse?.paymentMethods?.mapNotNull { it.type }.orEmpty()
 
         val httpClient = HttpClientFactory.getHttpClient(dropInConfiguration.environment)
         val orderStatusRepository = OrderStatusRepository(OrderStatusService(httpClient))
@@ -49,6 +50,7 @@ internal class DropInViewModelFactory(
                 clientKey = dropInConfiguration.clientKey,
                 amount = amount,
                 screenWidth = screenWidth,
+                paymentMethods = paymentMethods,
             ),
             analyticsService = AnalyticsService(
                 HttpClientFactory.getAnalyticsHttpClient(dropInConfiguration.environment)

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModelFactory.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModelFactory.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.AbstractSavedStateViewModelFactory
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsMapper
+import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepositoryData
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
 import com.adyen.checkout.components.core.internal.data.api.OrderStatusRepository
@@ -34,15 +35,17 @@ internal class DropInViewModelFactory(
         val httpClient = HttpClientFactory.getHttpClient(dropInConfiguration.environment)
         val orderStatusRepository = OrderStatusRepository(OrderStatusService(httpClient))
         val analyticsRepository = DefaultAnalyticsRepository(
-            analyticsParams = AnalyticsParams(dropInConfiguration.analyticsConfiguration),
-            packageName = packageName,
-            locale = dropInConfiguration.shopperLocale,
-            source = AnalyticsSource.DropIn(),
+            analyticsRepositoryData = AnalyticsRepositoryData(
+                level = AnalyticsParams(dropInConfiguration.analyticsConfiguration).level,
+                packageName = packageName,
+                locale = dropInConfiguration.shopperLocale,
+                source = AnalyticsSource.DropIn(),
+                clientKey = dropInConfiguration.clientKey,
+            ),
             analyticsService = AnalyticsService(
                 HttpClientFactory.getAnalyticsHttpClient(dropInConfiguration.environment)
             ),
             analyticsMapper = AnalyticsMapper(),
-            clientKey = dropInConfiguration.clientKey,
         )
 
         @Suppress("UNCHECKED_CAST")

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModelFactory.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModelFactory.kt
@@ -12,6 +12,7 @@ import androidx.activity.ComponentActivity
 import androidx.lifecycle.AbstractSavedStateViewModelFactory
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsMapper
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepositoryData
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
@@ -31,6 +32,7 @@ internal class DropInViewModelFactory(
 
         val dropInConfiguration: DropInConfiguration = requireNotNull(bundleHandler.dropInConfiguration)
         val packageName: String = requireNotNull(bundleHandler.packageName)
+        val amount: Amount = requireNotNull(bundleHandler.amount)
 
         val httpClient = HttpClientFactory.getHttpClient(dropInConfiguration.environment)
         val orderStatusRepository = OrderStatusRepository(OrderStatusService(httpClient))
@@ -41,6 +43,7 @@ internal class DropInViewModelFactory(
                 locale = dropInConfiguration.shopperLocale,
                 source = AnalyticsSource.DropIn(),
                 clientKey = dropInConfiguration.clientKey,
+                amount = amount,
             ),
             analyticsService = AnalyticsService(
                 HttpClientFactory.getAnalyticsHttpClient(dropInConfiguration.environment)

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/model/DropInComponentParams.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/model/DropInComponentParams.kt
@@ -13,10 +13,8 @@ import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
 import com.adyen.checkout.core.Environment
-import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
-@Parcelize
 internal data class DropInComponentParams(
     override val shopperLocale: Locale,
     override val environment: Environment,

--- a/econtext/src/main/java/com/adyen/checkout/econtext/internal/provider/EContextComponentProvider.kt
+++ b/econtext/src/main/java/com/adyen/checkout/econtext/internal/provider/EContextComponentProvider.kt
@@ -27,9 +27,9 @@ import com.adyen.checkout.components.core.internal.DefaultComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsMapper
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
+import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepositoryData
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
-import com.adyen.checkout.components.core.internal.data.model.AnalyticsSource
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
@@ -94,15 +94,15 @@ constructor(
                 val componentParams = componentParamsMapper.mapToParams(configuration, null)
 
                 val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                    analyticsParams = componentParams.analyticsParams,
-                    packageName = application.packageName,
-                    locale = componentParams.shopperLocale,
-                    source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                    analyticsRepositoryData = AnalyticsRepositoryData(
+                        application = application,
+                        componentParams = componentParams,
+                        paymentMethod = paymentMethod,
+                    ),
                     analyticsService = AnalyticsService(
                         HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                     ),
                     analyticsMapper = AnalyticsMapper(),
-                    clientKey = componentParams.clientKey,
                 )
                 val eContextDelegate = DefaultEContextDelegate(
                     observerRepository = PaymentObserverRepository(),
@@ -158,15 +158,15 @@ constructor(
                 val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
                 val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                    analyticsParams = componentParams.analyticsParams,
-                    packageName = application.packageName,
-                    locale = componentParams.shopperLocale,
-                    source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                    analyticsRepositoryData = AnalyticsRepositoryData(
+                        application = application,
+                        componentParams = componentParams,
+                        paymentMethod = paymentMethod,
+                    ),
                     analyticsService = AnalyticsService(
                         HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                     ),
                     analyticsMapper = AnalyticsMapper(),
-                    clientKey = componentParams.clientKey,
                 )
                 val eContextDelegate = DefaultEContextDelegate(
                     observerRepository = PaymentObserverRepository(),

--- a/econtext/src/main/java/com/adyen/checkout/econtext/internal/ui/DefaultEContextDelegate.kt
+++ b/econtext/src/main/java/com/adyen/checkout/econtext/internal/ui/DefaultEContextDelegate.kt
@@ -118,6 +118,7 @@ internal class DefaultEContextDelegate<
     ): EContextComponentStateT {
         val eContextPaymentMethod = typedPaymentMethodFactory().apply {
             type = getPaymentMethodType()
+            checkoutAttemptId = analyticsRepository.getCheckoutAttemptId()
             firstName = outputData.firstNameState.value
             lastName = outputData.lastNameState.value
             telephoneNumber = outputData.phoneNumberState.value

--- a/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextPaymentMethod.kt
+++ b/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextPaymentMethod.kt
@@ -13,6 +13,7 @@ import com.adyen.checkout.components.core.paymentmethod.EContextPaymentMethod
 
 internal class TestEContextPaymentMethod(
     override var firstName: String? = "firstName",
+    override var checkoutAttemptId: String? = "checkoutAttemptId",
     override var lastName: String? = "lastName",
     override var telephoneNumber: String? = "telephoneNumber",
     override var shopperEmail: String? = "shopperEmail",

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/provider/GiftCardComponentProvider.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/provider/GiftCardComponentProvider.kt
@@ -20,11 +20,11 @@ import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsMapper
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
+import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepositoryData
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
 import com.adyen.checkout.components.core.internal.data.api.DefaultPublicKeyRepository
 import com.adyen.checkout.components.core.internal.data.api.PublicKeyService
-import com.adyen.checkout.components.core.internal.data.model.AnalyticsSource
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
@@ -100,15 +100,15 @@ constructor(
             val publicKeyService = PublicKeyService(httpClient)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val giftCardDelegate = DefaultGiftCardDelegate(
@@ -171,15 +171,15 @@ constructor(
             val publicKeyService = PublicKeyService(httpClient)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val giftCardDelegate = DefaultGiftCardDelegate(

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/ui/DefaultGiftCardDelegate.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/ui/DefaultGiftCardDelegate.kt
@@ -195,6 +195,7 @@ internal class DefaultGiftCardDelegate(
 
         val giftCardPaymentMethod = GiftCardPaymentMethod(
             type = GiftCardPaymentMethod.PAYMENT_METHOD_TYPE,
+            checkoutAttemptId = analyticsRepository.getCheckoutAttemptId(),
             encryptedCardNumber = encryptedCard.encryptedCardNumber,
             encryptedSecurityCode = encryptedCard.encryptedSecurityCode,
             brand = paymentMethod.brand,

--- a/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/ui/DefaultGiftCardDelegateTest.kt
+++ b/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/ui/DefaultGiftCardDelegateTest.kt
@@ -45,7 +45,9 @@ import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.util.Locale
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -351,6 +353,26 @@ internal class DefaultGiftCardDelegateTest(
         }
     }
 
+    @Nested
+    inner class AnalyticsTest {
+
+        @Test
+        fun `when component state is valid then PaymentMethodDetails should contain checkoutAttemptId`() = runTest {
+            whenever(analyticsRepository.getCheckoutAttemptId()) doReturn TEST_CHECKOUT_ATTEMPT_ID
+
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+
+            delegate.componentStateFlow.test {
+                delegate.updateInputData {
+                    cardNumber = "5555444433330000"
+                    pin = "737"
+                }
+
+                assertEquals(TEST_CHECKOUT_ATTEMPT_ID, expectMostRecentItem().data.paymentMethod?.checkoutAttemptId)
+            }
+        }
+    }
+
     private fun createGiftCardDelegate(
         configuration: GiftCardConfiguration = getDefaultGiftCardConfigurationBuilder().build(),
         order: OrderRequest? = TEST_ORDER
@@ -374,6 +396,7 @@ internal class DefaultGiftCardDelegateTest(
     companion object {
         private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
         private val TEST_ORDER = OrderRequest("PSP", "ORDER_DATA")
+        private const val TEST_CHECKOUT_ATTEMPT_ID = "TEST_CHECKOUT_ATTEMPT_ID"
 
         @JvmStatic
         fun amountSource() = listOf(

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/provider/GooglePayComponentProvider.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/provider/GooglePayComponentProvider.kt
@@ -24,9 +24,9 @@ import com.adyen.checkout.components.core.internal.PaymentMethodAvailabilityChec
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsMapper
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
+import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepositoryData
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
-import com.adyen.checkout.components.core.internal.data.model.AnalyticsSource
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
 import com.adyen.checkout.components.core.internal.ui.model.SessionParams
@@ -98,15 +98,15 @@ constructor(
         val googlePayFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val googlePayDelegate = DefaultGooglePayDelegate(
@@ -162,15 +162,15 @@ constructor(
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val googlePayDelegate = DefaultGooglePayDelegate(

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/DefaultGooglePayDelegate.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/DefaultGooglePayDelegate.kt
@@ -110,7 +110,11 @@ internal class DefaultGooglePayDelegate(
             GooglePayUtils.findToken(it).isNotEmpty()
         } ?: false
 
-        val paymentMethod = GooglePayUtils.createGooglePayPaymentMethod(paymentData, paymentMethod.type)
+        val paymentMethod = GooglePayUtils.createGooglePayPaymentMethod(
+            paymentData = paymentData,
+            paymentMethodType = paymentMethod.type,
+            checkoutAttemptId = analyticsRepository.getCheckoutAttemptId(),
+        )
         val paymentComponentData = PaymentComponentData(
             paymentMethod = paymentMethod,
             order = order,
@@ -145,14 +149,17 @@ internal class DefaultGooglePayDelegate(
                 val paymentData = PaymentData.getFromIntent(data)
                 updateComponentState(paymentData)
             }
+
             Activity.RESULT_CANCELED -> {
                 exceptionChannel.trySend(ComponentException("Payment canceled."))
             }
+
             AutoResolveHelper.RESULT_ERROR -> {
                 val status = AutoResolveHelper.getStatusFromIntent(data)
                 val statusMessage: String = status?.let { ": ${it.statusMessage}" }.orEmpty()
                 exceptionChannel.trySend(ComponentException("GooglePay returned an error$statusMessage"))
             }
+
             else -> Unit
         }
     }

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParams.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParams.kt
@@ -15,10 +15,8 @@ import com.adyen.checkout.core.Environment
 import com.adyen.checkout.googlepay.BillingAddressParameters
 import com.adyen.checkout.googlepay.MerchantInfo
 import com.adyen.checkout.googlepay.ShippingAddressParameters
-import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
-@Parcelize
 internal data class GooglePayComponentParams(
     override val shopperLocale: Locale,
     override val environment: Environment,

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/util/GooglePayUtils.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/util/GooglePayUtils.kt
@@ -124,25 +124,30 @@ internal object GooglePayUtils {
      * @param paymentMethodType the type of the payment method.
      * @return The object matching the data for the API call to Adyen.
      */
-    fun createGooglePayPaymentMethod(paymentData: PaymentData?, paymentMethodType: String?): GooglePayPaymentMethod? {
+    fun createGooglePayPaymentMethod(
+        paymentData: PaymentData?,
+        paymentMethodType: String?,
+        checkoutAttemptId: String?
+    ): GooglePayPaymentMethod? {
         if (paymentData == null) {
             return null
         }
-        val paymentMethod = GooglePayPaymentMethod()
-        paymentMethod.type = paymentMethodType
-        return try {
-            val paymentDataJson = JSONObject(paymentData.toJson())
-            val paymentMethodDataJson = paymentDataJson.getJSONObject(PAYMENT_METHOD_DATA)
-            val tokenizationDataJson = paymentMethodDataJson.getJSONObject(TOKENIZATION_DATA)
-            paymentMethod.googlePayToken = tokenizationDataJson.getString(TOKEN)
-            val infoJson = paymentMethodDataJson.optJSONObject(INFO)
-            if (infoJson != null && infoJson.has(CARD_NETWORK)) {
-                paymentMethod.googlePayCardNetwork = infoJson.getString(CARD_NETWORK)
+        return GooglePayPaymentMethod(
+            type = paymentMethodType,
+            checkoutAttemptId = checkoutAttemptId,
+        ).apply {
+            try {
+                val paymentDataJson = JSONObject(paymentData.toJson())
+                val paymentMethodDataJson = paymentDataJson.getJSONObject(PAYMENT_METHOD_DATA)
+                val tokenizationDataJson = paymentMethodDataJson.getJSONObject(TOKENIZATION_DATA)
+                googlePayToken = tokenizationDataJson.getString(TOKEN)
+                val infoJson = paymentMethodDataJson.optJSONObject(INFO)
+                if (infoJson != null && infoJson.has(CARD_NETWORK)) {
+                    googlePayCardNetwork = infoJson.getString(CARD_NETWORK)
+                }
+            } catch (e: JSONException) {
+                Logger.e(TAG, "Failed to find Google Pay token.", e)
             }
-            paymentMethod
-        } catch (e: JSONException) {
-            Logger.e(TAG, "Failed to find Google Pay token.", e)
-            null
         }
     }
 

--- a/instant/src/main/java/com/adyen/checkout/instant/internal/provider/InstantPaymentComponentProvider.kt
+++ b/instant/src/main/java/com/adyen/checkout/instant/internal/provider/InstantPaymentComponentProvider.kt
@@ -24,9 +24,9 @@ import com.adyen.checkout.components.core.internal.DefaultComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsMapper
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
+import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepositoryData
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
-import com.adyen.checkout.components.core.internal.data.model.AnalyticsSource
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
@@ -88,15 +88,15 @@ constructor(
             val componentParams = componentParamsMapper.mapToParams(configuration, null)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val instantPaymentDelegate = DefaultInstantPaymentDelegate(
@@ -151,15 +151,15 @@ constructor(
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val instantPaymentDelegate = DefaultInstantPaymentDelegate(

--- a/instant/src/main/java/com/adyen/checkout/instant/internal/ui/DefaultInstantPaymentDelegate.kt
+++ b/instant/src/main/java/com/adyen/checkout/instant/internal/ui/DefaultInstantPaymentDelegate.kt
@@ -53,7 +53,10 @@ internal class DefaultInstantPaymentDelegate(
 
     private fun createComponentState(): InstantComponentState {
         val paymentComponentData = PaymentComponentData<PaymentMethodDetails>(
-            paymentMethod = GenericPaymentMethod(paymentMethod.type),
+            paymentMethod = GenericPaymentMethod(
+                type = paymentMethod.type,
+                checkoutAttemptId = analyticsRepository.getCheckoutAttemptId(),
+            ),
             order = order,
             amount = componentParams.amount.takeUnless { it.isEmpty },
         )

--- a/instant/src/test/java/com/adyen/checkout/instant/internal/ui/DefaultInstantPaymentDelegateTest.kt
+++ b/instant/src/test/java/com/adyen/checkout/instant/internal/ui/DefaultInstantPaymentDelegateTest.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
@@ -33,7 +34,9 @@ import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.util.Locale
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -88,6 +91,21 @@ class DefaultInstantPaymentDelegateTest(
         verify(analyticsRepository).setupAnalytics()
     }
 
+    @Nested
+    inner class AnalyticsTest {
+
+        @Test
+        fun `when component state is valid then PaymentMethodDetails should contain checkoutAttemptId`() = runTest {
+            whenever(analyticsRepository.getCheckoutAttemptId()) doReturn TEST_CHECKOUT_ATTEMPT_ID
+
+            delegate = createInstantPaymentDelegate()
+
+            delegate.componentStateFlow.test {
+                assertEquals(TEST_CHECKOUT_ATTEMPT_ID, expectMostRecentItem().data.paymentMethod?.checkoutAttemptId)
+            }
+        }
+    }
+
     private fun getInstantPaymentConfigurationBuilder(): InstantPaymentConfiguration.Builder {
         return InstantPaymentConfiguration.Builder(
             Locale.US,
@@ -112,6 +130,7 @@ class DefaultInstantPaymentDelegateTest(
         private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
         private const val TYPE = "txVariant"
         private val TEST_ORDER = OrderRequest("PSP", "ORDER_DATA")
+        private const val TEST_CHECKOUT_ATTEMPT_ID = "TEST_CHECKOUT_ATTEMPT_ID"
 
         @JvmStatic
         fun amountSource() = listOf(

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/provider/IssuerListComponentProvider.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/provider/IssuerListComponentProvider.kt
@@ -27,9 +27,9 @@ import com.adyen.checkout.components.core.internal.DefaultComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsMapper
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
+import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepositoryData
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
-import com.adyen.checkout.components.core.internal.data.model.AnalyticsSource
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
 import com.adyen.checkout.components.core.internal.ui.model.SessionParams
@@ -99,15 +99,15 @@ constructor(
             val componentParams = componentParamsMapper.mapToParams(configuration, null)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
             val issuerListDelegate = DefaultIssuerListDelegate(
                 observerRepository = PaymentObserverRepository(),
@@ -164,15 +164,15 @@ constructor(
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
             val issuerListDelegate = DefaultIssuerListDelegate(
                 observerRepository = PaymentObserverRepository(),

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/ui/DefaultIssuerListDelegate.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/ui/DefaultIssuerListDelegate.kt
@@ -147,6 +147,7 @@ internal class DefaultIssuerListDelegate<
     ): ComponentStateT {
         val issuerListPaymentMethod = typedPaymentMethodFactory().apply {
             type = getPaymentMethodType()
+            checkoutAttemptId = analyticsRepository.getCheckoutAttemptId()
             issuer = outputData.selectedIssuer?.id.orEmpty()
         }
 

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/ui/model/IssuerListComponentParams.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/ui/model/IssuerListComponentParams.kt
@@ -15,11 +15,9 @@ import com.adyen.checkout.components.core.internal.ui.model.ButtonParams
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.issuerlist.IssuerListViewType
-import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-@Parcelize
 data class IssuerListComponentParams(
     override val shopperLocale: Locale,
     override val environment: Environment,

--- a/issuer-list/src/test/java/com/adyen/checkout/issuerlist/internal/ui/DefaultIssuerListDelegateTest.kt
+++ b/issuer-list/src/test/java/com/adyen/checkout/issuerlist/internal/ui/DefaultIssuerListDelegateTest.kt
@@ -44,7 +44,9 @@ import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.util.Locale
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -287,6 +289,25 @@ internal class DefaultIssuerListDelegateTest(
         }
     }
 
+    @Nested
+    inner class AnalyticsTest {
+
+        @Test
+        fun `when component state is valid then PaymentMethodDetails should contain checkoutAttemptId`() = runTest {
+            whenever(analyticsRepository.getCheckoutAttemptId()) doReturn TEST_CHECKOUT_ATTEMPT_ID
+
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+
+            delegate.componentStateFlow.test {
+                delegate.updateInputData {
+                    selectedIssuer = IssuerModel(id = "id", name = "test", environment = Environment.TEST)
+                }
+
+                assertEquals(TEST_CHECKOUT_ATTEMPT_ID, expectMostRecentItem().data.paymentMethod?.checkoutAttemptId)
+            }
+        }
+    }
+
     private fun createIssuerListDelegate(
         configuration: TestIssuerListConfiguration = getDefaultTestIssuerListConfigurationBuilder().build()
     ) = DefaultIssuerListDelegate(
@@ -309,6 +330,7 @@ internal class DefaultIssuerListDelegateTest(
     companion object {
         private const val TEST_CLIENT_KEY_1 = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
         private val TEST_ORDER = OrderRequest("PSP", "ORDER_DATA")
+        private const val TEST_CHECKOUT_ATTEMPT_ID = "TEST_CHECKOUT_ATTEMPT_ID"
 
         @JvmStatic
         fun amountSource() = listOf(

--- a/issuer-list/src/test/java/com/adyen/checkout/issuerlist/utils/TestIssuerPaymentMethod.kt
+++ b/issuer-list/src/test/java/com/adyen/checkout/issuerlist/utils/TestIssuerPaymentMethod.kt
@@ -13,6 +13,7 @@ import com.adyen.checkout.components.core.paymentmethod.IssuerListPaymentMethod
 
 internal class TestIssuerPaymentMethod(
     override var issuer: String? = "issuer",
+    override var checkoutAttemptId: String? = "checkoutAttemptId",
     override var type: String? = "type"
 ) : IssuerListPaymentMethod() {
 

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/provider/MBWayComponentProvider.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/provider/MBWayComponentProvider.kt
@@ -23,9 +23,9 @@ import com.adyen.checkout.components.core.internal.DefaultComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsMapper
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
+import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepositoryData
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
-import com.adyen.checkout.components.core.internal.data.model.AnalyticsSource
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
@@ -88,15 +88,15 @@ constructor(
             val componentParams = componentParamsMapper.mapToParams(configuration, null)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val mbWayDelegate = DefaultMBWayDelegate(
@@ -152,15 +152,15 @@ constructor(
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val mbWayDelegate = DefaultMBWayDelegate(

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/DefaultMBWayDelegate.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/DefaultMBWayDelegate.kt
@@ -137,6 +137,7 @@ internal class DefaultMBWayDelegate(
     ): MBWayComponentState {
         val paymentMethod = MBWayPaymentMethod(
             type = MBWayPaymentMethod.PAYMENT_METHOD_TYPE,
+            checkoutAttemptId = analyticsRepository.getCheckoutAttemptId(),
             telephoneNumber = outputData.mobilePhoneNumberFieldState.value
         )
 

--- a/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/DefaultMBWayDelegateTest.kt
+++ b/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/DefaultMBWayDelegateTest.kt
@@ -37,7 +37,9 @@ import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.util.Locale
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -252,6 +254,26 @@ internal class DefaultMBWayDelegateTest(
         }
     }
 
+    @Nested
+    inner class AnalyticsTest {
+
+        @Test
+        fun `when component state is valid then PaymentMethodDetails should contain checkoutAttemptId`() = runTest {
+            whenever(analyticsRepository.getCheckoutAttemptId()) doReturn TEST_CHECKOUT_ATTEMPT_ID
+
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+
+            delegate.componentStateFlow.test {
+                delegate.updateInputData {
+                    countryCode = "+1"
+                    localPhoneNumber = "9257348920"
+                }
+
+                assertEquals(TEST_CHECKOUT_ATTEMPT_ID, expectMostRecentItem().data.paymentMethod?.checkoutAttemptId)
+            }
+        }
+    }
+
     private fun createMBWayDelegate(
         configuration: MBWayConfiguration = getDefaultMBWayConfigurationBuilder().build()
     ) = DefaultMBWayDelegate(
@@ -272,6 +294,7 @@ internal class DefaultMBWayDelegateTest(
     companion object {
         private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
         private val TEST_ORDER = OrderRequest("PSP", "ORDER_DATA")
+        private const val TEST_CHECKOUT_ATTEMPT_ID = "TEST_CHECKOUT_ATTEMPT_ID"
 
         @JvmStatic
         fun amountSource() = listOf(

--- a/online-banking-core/src/main/java/com/adyen/checkout/onlinebankingcore/internal/provider/OnlineBankingComponentProvider.kt
+++ b/online-banking-core/src/main/java/com/adyen/checkout/onlinebankingcore/internal/provider/OnlineBankingComponentProvider.kt
@@ -27,9 +27,9 @@ import com.adyen.checkout.components.core.internal.DefaultComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsMapper
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
+import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepositoryData
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
-import com.adyen.checkout.components.core.internal.data.model.AnalyticsSource
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
@@ -95,15 +95,15 @@ constructor(
             val componentParams = componentParamsMapper.mapToParams(configuration, null)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val onlineBankingDelegate = DefaultOnlineBankingDelegate(
@@ -165,15 +165,15 @@ constructor(
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val onlineBankingDelegate = DefaultOnlineBankingDelegate(

--- a/online-banking-core/src/main/java/com/adyen/checkout/onlinebankingcore/internal/ui/DefaultOnlineBankingDelegate.kt
+++ b/online-banking-core/src/main/java/com/adyen/checkout/onlinebankingcore/internal/ui/DefaultOnlineBankingDelegate.kt
@@ -153,9 +153,11 @@ internal class DefaultOnlineBankingDelegate<
     private fun createComponentState(
         outputData: OnlineBankingOutputData = this.outputData
     ): ComponentStateT {
-        val issuerListPaymentMethod = paymentMethodFactory()
-        issuerListPaymentMethod.type = getPaymentMethodType()
-        issuerListPaymentMethod.issuer = outputData.selectedIssuer?.id
+        val issuerListPaymentMethod = paymentMethodFactory().apply {
+            type = getPaymentMethodType()
+            checkoutAttemptId = analyticsRepository.getCheckoutAttemptId()
+            issuer = outputData.selectedIssuer?.id
+        }
 
         val paymentComponentData = PaymentComponentData(
             paymentMethod = issuerListPaymentMethod,

--- a/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/internal/ui/DefaultOnlineBankingDelegateTest.kt
+++ b/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/internal/ui/DefaultOnlineBankingDelegateTest.kt
@@ -43,6 +43,7 @@ import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -235,6 +236,25 @@ internal class DefaultOnlineBankingDelegateTest(
         }
     }
 
+    @Nested
+    inner class AnalyticsTest {
+
+        @Test
+        fun `when component state is valid then PaymentMethodDetails should contain checkoutAttemptId`() = runTest {
+            whenever(analyticsRepository.getCheckoutAttemptId()) doReturn TEST_CHECKOUT_ATTEMPT_ID
+
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+
+            delegate.componentStateFlow.test {
+                delegate.updateInputData {
+                    selectedIssuer = OnlineBankingModel(id = "id", name = "test")
+                }
+
+                assertEquals(TEST_CHECKOUT_ATTEMPT_ID, expectMostRecentItem().data.paymentMethod?.checkoutAttemptId)
+            }
+        }
+    }
+
     private fun createOnlineBankingDelegate(
         configuration: TestOnlineBankingConfiguration = getDefaultTestOnlineBankingConfigurationBuilder().build(),
         order: OrderRequest? = TEST_ORDER,
@@ -267,6 +287,7 @@ internal class DefaultOnlineBankingDelegateTest(
         private const val TEST_URL = "any-url"
         private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
         private val TEST_ORDER = OrderRequest("PSP", "ORDER_DATA")
+        private const val TEST_CHECKOUT_ATTEMPT_ID = "TEST_CHECKOUT_ATTEMPT_ID"
 
         @JvmStatic
         fun amountSource() = listOf(

--- a/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/utils/TestOnlineBankingPaymentMethod.kt
+++ b/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/utils/TestOnlineBankingPaymentMethod.kt
@@ -13,6 +13,7 @@ import com.adyen.checkout.components.core.paymentmethod.IssuerListPaymentMethod
 
 internal class TestOnlineBankingPaymentMethod(
     override var issuer: String? = "issuer",
+    override var checkoutAttemptId: String? = "checkoutAttemptId",
     override var type: String? = "type"
 ) : IssuerListPaymentMethod() {
 

--- a/paybybank/src/main/java/com/adyen/checkout/paybybank/internal/provider/PayByBankComponentProvider.kt
+++ b/paybybank/src/main/java/com/adyen/checkout/paybybank/internal/provider/PayByBankComponentProvider.kt
@@ -23,9 +23,9 @@ import com.adyen.checkout.components.core.internal.DefaultComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsMapper
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
+import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepositoryData
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
-import com.adyen.checkout.components.core.internal.data.model.AnalyticsSource
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
@@ -88,15 +88,15 @@ constructor(
             val componentParams = componentParamsMapper.mapToParams(configuration, null)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val payByBankDelegate = DefaultPayByBankDelegate(
@@ -152,15 +152,15 @@ constructor(
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val payByBankDelegate = DefaultPayByBankDelegate(

--- a/paybybank/src/main/java/com/adyen/checkout/paybybank/internal/ui/DefaultPayByBankDelegate.kt
+++ b/paybybank/src/main/java/com/adyen/checkout/paybybank/internal/ui/DefaultPayByBankDelegate.kt
@@ -145,6 +145,7 @@ internal class DefaultPayByBankDelegate(
     ): PayByBankComponentState {
         val payByBankPaymentMethod = PayByBankPaymentMethod(
             type = getPaymentMethodType(),
+            checkoutAttemptId = analyticsRepository.getCheckoutAttemptId(),
             issuer = outputData?.selectedIssuer?.id,
         )
 

--- a/paybybank/src/test/java/com/adyen/checkout/paybybank/internal/ui/DefaultPayByBankDelegateTest.kt
+++ b/paybybank/src/test/java/com/adyen/checkout/paybybank/internal/ui/DefaultPayByBankDelegateTest.kt
@@ -43,7 +43,9 @@ import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.util.*
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -255,6 +257,25 @@ internal class DefaultPayByBankDelegateTest(
             }
     }
 
+    @Nested
+    inner class AnalyticsTest {
+
+        @Test
+        fun `when component state is valid then PaymentMethodDetails should contain checkoutAttemptId`() = runTest {
+            whenever(analyticsRepository.getCheckoutAttemptId()) doReturn TEST_CHECKOUT_ATTEMPT_ID
+
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+
+            delegate.componentStateFlow.test {
+                delegate.updateInputData {
+                    selectedIssuer = IssuerModel(id = "id", name = "test", environment = Environment.TEST)
+                }
+
+                assertEquals(TEST_CHECKOUT_ATTEMPT_ID, expectMostRecentItem().data.paymentMethod?.checkoutAttemptId)
+            }
+        }
+    }
+
     private fun getPayByBankConfigurationBuilder(): PayByBankConfiguration.Builder {
         return PayByBankConfiguration.Builder(
             Locale.US,
@@ -283,6 +304,7 @@ internal class DefaultPayByBankDelegateTest(
     companion object {
         private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
         private val TEST_ORDER = OrderRequest("PSP", "ORDER_DATA")
+        private const val TEST_CHECKOUT_ATTEMPT_ID = "TEST_CHECKOUT_ATTEMPT_ID"
 
         @JvmStatic
         fun amountSource() = listOf(

--- a/qr-code/src/main/java/com/adyen/checkout/qrcode/internal/ui/view/FullQRCodeView.kt
+++ b/qr-code/src/main/java/com/adyen/checkout/qrcode/internal/ui/view/FullQRCodeView.kt
@@ -24,6 +24,7 @@ import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
 import com.adyen.checkout.components.core.internal.ui.model.TimerData
 import com.adyen.checkout.components.core.internal.util.CurrencyUtils
 import com.adyen.checkout.components.core.internal.util.isEmpty
+import com.adyen.checkout.components.core.internal.util.toast
 import com.adyen.checkout.core.exception.PermissionException
 import com.adyen.checkout.core.internal.util.LogUtil
 import com.adyen.checkout.core.internal.util.Logger
@@ -37,7 +38,6 @@ import com.adyen.checkout.ui.core.internal.ui.LogoSize
 import com.adyen.checkout.ui.core.internal.ui.load
 import com.adyen.checkout.ui.core.internal.ui.loadLogo
 import com.adyen.checkout.ui.core.internal.util.setLocalizedTextFromStyle
-import com.adyen.checkout.ui.core.internal.util.toast
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach

--- a/qr-code/src/main/java/com/adyen/checkout/qrcode/internal/ui/view/SimpleQRCodeView.kt
+++ b/qr-code/src/main/java/com/adyen/checkout/qrcode/internal/ui/view/SimpleQRCodeView.kt
@@ -17,6 +17,7 @@ import androidx.annotation.StringRes
 import com.adyen.checkout.components.core.PaymentMethodTypes
 import com.adyen.checkout.components.core.internal.ui.ComponentDelegate
 import com.adyen.checkout.components.core.internal.ui.model.TimerData
+import com.adyen.checkout.components.core.internal.util.copyTextToClipboard
 import com.adyen.checkout.core.internal.util.LogUtil
 import com.adyen.checkout.core.internal.util.Logger
 import com.adyen.checkout.qrcode.R
@@ -25,7 +26,6 @@ import com.adyen.checkout.qrcode.internal.ui.QRCodeDelegate
 import com.adyen.checkout.qrcode.internal.ui.model.QRCodeOutputData
 import com.adyen.checkout.ui.core.internal.ui.ComponentView
 import com.adyen.checkout.ui.core.internal.ui.loadLogo
-import com.adyen.checkout.ui.core.internal.util.copyTextToClipboard
 import com.adyen.checkout.ui.core.internal.util.setLocalizedTextFromStyle
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.launchIn

--- a/sepa/src/main/java/com/adyen/checkout/sepa/internal/provider/SepaComponentProvider.kt
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/internal/provider/SepaComponentProvider.kt
@@ -23,9 +23,9 @@ import com.adyen.checkout.components.core.internal.DefaultComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsMapper
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
+import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepositoryData
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
-import com.adyen.checkout.components.core.internal.data.model.AnalyticsSource
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
@@ -89,15 +89,15 @@ constructor(
             val componentParams = componentParamsMapper.mapToParams(configuration, null)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val sepaDelegate = DefaultSepaDelegate(
@@ -153,15 +153,15 @@ constructor(
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val sepaDelegate = DefaultSepaDelegate(

--- a/sepa/src/main/java/com/adyen/checkout/sepa/internal/ui/DefaultSepaDelegate.kt
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/internal/ui/DefaultSepaDelegate.kt
@@ -124,6 +124,7 @@ internal class DefaultSepaDelegate(
     ): SepaComponentState {
         val paymentMethod = SepaPaymentMethod(
             type = SepaPaymentMethod.PAYMENT_METHOD_TYPE,
+            checkoutAttemptId = analyticsRepository.getCheckoutAttemptId(),
             ownerName = outputData.ownerNameField.value,
             iban = outputData.ibanNumberField.value
         )

--- a/sepa/src/test/java/com/adyen/checkout/sepa/internal/ui/DefaultSepaDelegateTest.kt
+++ b/sepa/src/test/java/com/adyen/checkout/sepa/internal/ui/DefaultSepaDelegateTest.kt
@@ -39,7 +39,9 @@ import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.util.Locale
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -179,6 +181,26 @@ internal class DefaultSepaDelegateTest(
         }
     }
 
+    @Nested
+    inner class AnalyticsTest {
+
+        @Test
+        fun `when component state is valid then PaymentMethodDetails should contain checkoutAttemptId`() = runTest {
+            whenever(analyticsRepository.getCheckoutAttemptId()) doReturn TEST_CHECKOUT_ATTEMPT_ID
+
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+
+            delegate.componentStateFlow.test {
+                delegate.updateInputData {
+                    name = "name"
+                    iban = "NL02ABNA0123456789"
+                }
+
+                assertEquals(TEST_CHECKOUT_ATTEMPT_ID, expectMostRecentItem().data.paymentMethod?.checkoutAttemptId)
+            }
+        }
+    }
+
     private fun createSepaDelegate(
         configuration: SepaConfiguration = getDefaultSepaConfigurationBuilder().build(),
         order: Order? = TEST_ORDER,
@@ -200,6 +222,7 @@ internal class DefaultSepaDelegateTest(
     companion object {
         private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
         private val TEST_ORDER = OrderRequest("PSP", "ORDER_DATA")
+        private const val TEST_CHECKOUT_ATTEMPT_ID = "TEST_CHECKOUT_ATTEMPT_ID"
 
         @JvmStatic
         fun amountSource() = listOf(

--- a/sessions-core/src/test/java/com/adyen/checkout/sessions/core/internal/TestPaymentMethod.kt
+++ b/sessions-core/src/test/java/com/adyen/checkout/sessions/core/internal/TestPaymentMethod.kt
@@ -13,6 +13,7 @@ import com.adyen.checkout.components.core.paymentmethod.PaymentMethodDetails
 
 internal class TestPaymentMethod(
     override var type: String? = null,
+    override var checkoutAttemptId: String? = null,
 ) : PaymentMethodDetails() {
     override fun writeToParcel(dest: Parcel, flags: Int) {
         // noop

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/AdyenComponentView.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/AdyenComponentView.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.lifecycleScope
 import com.adyen.checkout.components.core.internal.Component
 import com.adyen.checkout.components.core.internal.ui.ComponentDelegate
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
+import com.adyen.checkout.components.core.internal.util.createLocalizedContext
 import com.adyen.checkout.core.internal.util.LogUtil
 import com.adyen.checkout.core.internal.util.Logger
 import com.adyen.checkout.ui.core.databinding.AdyenComponentViewBinding
@@ -34,7 +35,6 @@ import com.adyen.checkout.ui.core.internal.ui.ViewProvidingDelegate
 import com.adyen.checkout.ui.core.internal.ui.ViewableComponent
 import com.adyen.checkout.ui.core.internal.ui.view.PayButton
 import com.adyen.checkout.ui.core.internal.util.PayButtonFormatter
-import com.adyen.checkout.ui.core.internal.util.createLocalizedContext
 import com.adyen.checkout.ui.core.internal.util.hideKeyboard
 import com.adyen.checkout.ui.core.internal.util.resetFocus
 import kotlinx.coroutines.CoroutineScope

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/model/AddressParams.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/model/AddressParams.kt
@@ -8,28 +8,23 @@
 
 package com.adyen.checkout.ui.core.internal.ui.model
 
-import android.os.Parcelable
 import androidx.annotation.RestrictTo
-import kotlinx.parcelize.Parcelize
 
 /**
  * Configuration class for Address Form in Address View. This class can be used define the
  * visibility of the address form.
  */
-@Parcelize
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-sealed class AddressParams : Parcelable {
+sealed class AddressParams {
 
     /**
      * Address Form will be hidden.
      */
-    @Parcelize
     object None : AddressParams()
 
     /**
      * Only postal code will be shown as part of the card component.
      */
-    @Parcelize
     data class PostalCode(
         val addressFieldPolicy: AddressFieldPolicy
     ) : AddressParams()
@@ -41,7 +36,6 @@ sealed class AddressParams : Parcelable {
      * @param supportedCountryCodes Supported country codes to be filtered from the available country
      * options.
      */
-    @Parcelize
     data class FullAddress(
         val defaultCountryCode: String? = null,
         val supportedCountryCodes: List<String> = emptyList(),
@@ -53,4 +47,4 @@ sealed class AddressParams : Parcelable {
  * Configuration for requirement of the address fields.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-interface AddressFieldPolicy : Parcelable
+interface AddressFieldPolicy

--- a/ui-core/src/test/java/com/adyen/checkout/ui/core/internal/ui/model/Required.kt
+++ b/ui-core/src/test/java/com/adyen/checkout/ui/core/internal/ui/model/Required.kt
@@ -9,8 +9,6 @@
 package com.adyen.checkout.ui.core.internal.ui.model
 
 import androidx.annotation.RestrictTo
-import kotlinx.parcelize.Parcelize
 
 @RestrictTo(RestrictTo.Scope.TESTS)
-@Parcelize
 internal class Required : AddressFieldPolicy

--- a/upi/src/main/java/com/adyen/checkout/upi/internal/provider/UPIComponentProvider.kt
+++ b/upi/src/main/java/com/adyen/checkout/upi/internal/provider/UPIComponentProvider.kt
@@ -23,9 +23,9 @@ import com.adyen.checkout.components.core.internal.DefaultComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsMapper
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
+import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepositoryData
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
-import com.adyen.checkout.components.core.internal.data.model.AnalyticsSource
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
@@ -83,15 +83,15 @@ constructor(
             val componentParams = componentParamsMapper.mapToParams(configuration, null)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val upiDelegate = DefaultUPIDelegate(
@@ -147,15 +147,15 @@ constructor(
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
-                analyticsParams = componentParams.analyticsParams,
-                packageName = application.packageName,
-                locale = componentParams.shopperLocale,
-                source = AnalyticsSource.PaymentComponent(componentParams.isCreatedByDropIn, paymentMethod),
+                analyticsRepositoryData = AnalyticsRepositoryData(
+                    application = application,
+                    componentParams = componentParams,
+                    paymentMethod = paymentMethod,
+                ),
                 analyticsService = AnalyticsService(
                     HttpClientFactory.getAnalyticsHttpClient(componentParams.environment)
                 ),
                 analyticsMapper = AnalyticsMapper(),
-                clientKey = componentParams.clientKey,
             )
 
             val upiDelegate = DefaultUPIDelegate(

--- a/upi/src/main/java/com/adyen/checkout/upi/internal/ui/DefaultUPIDelegate.kt
+++ b/upi/src/main/java/com/adyen/checkout/upi/internal/ui/DefaultUPIDelegate.kt
@@ -130,6 +130,7 @@ internal class DefaultUPIDelegate(
     ): UPIComponentState {
         val paymentMethod = UPIPaymentMethod(
             type = if (outputData.mode == UPIMode.VPA) PaymentMethodTypes.UPI_COLLECT else PaymentMethodTypes.UPI_QR,
+            checkoutAttemptId = analyticsRepository.getCheckoutAttemptId(),
             virtualPaymentAddress = if (outputData.mode == UPIMode.VPA) {
                 outputData.virtualPaymentAddressFieldState.value
             } else {

--- a/upi/src/test/java/com/adyen/checkout/upi/internal/ui/DefaultUPIDelegateTest.kt
+++ b/upi/src/test/java/com/adyen/checkout/upi/internal/ui/DefaultUPIDelegateTest.kt
@@ -45,7 +45,9 @@ import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.util.Locale
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -213,6 +215,25 @@ internal class DefaultUPIDelegateTest(
         }
     }
 
+    @Nested
+    inner class AnalyticsTest {
+
+        @Test
+        fun `when component state is valid then PaymentMethodDetails should contain checkoutAttemptId`() = runTest {
+            whenever(analyticsRepository.getCheckoutAttemptId()) doReturn TEST_CHECKOUT_ATTEMPT_ID
+
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+
+            delegate.componentStateFlow.test {
+                delegate.updateInputData {
+                    mode = UPIMode.QR
+                }
+
+                assertEquals(TEST_CHECKOUT_ATTEMPT_ID, expectMostRecentItem().data.paymentMethod?.checkoutAttemptId)
+            }
+        }
+    }
+
     private fun getDefaultUPIConfigurationBuilder(): UPIConfiguration.Builder {
         return UPIConfiguration.Builder(
             Locale.US,
@@ -236,6 +257,7 @@ internal class DefaultUPIDelegateTest(
     companion object {
         private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
         private val TEST_ORDER = OrderRequest("PSP", "ORDER_DATA")
+        private const val TEST_CHECKOUT_ATTEMPT_ID = "TEST_CHECKOUT_ATTEMPT_ID"
 
         @JvmStatic
         fun amountSource() = listOf(

--- a/voucher/src/main/java/com/adyen/checkout/voucher/internal/ui/view/FullVoucherView.kt
+++ b/voucher/src/main/java/com/adyen/checkout/voucher/internal/ui/view/FullVoucherView.kt
@@ -18,13 +18,13 @@ import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.components.core.internal.ui.ComponentDelegate
 import com.adyen.checkout.components.core.internal.util.CurrencyUtils
 import com.adyen.checkout.components.core.internal.util.DateUtils
+import com.adyen.checkout.components.core.internal.util.copyTextToClipboard
 import com.adyen.checkout.components.core.internal.util.isEmpty
 import com.adyen.checkout.core.internal.util.LogUtil
 import com.adyen.checkout.core.internal.util.Logger
 import com.adyen.checkout.ui.core.internal.ui.ComponentView
 import com.adyen.checkout.ui.core.internal.ui.LogoSize
 import com.adyen.checkout.ui.core.internal.ui.loadLogo
-import com.adyen.checkout.ui.core.internal.util.copyTextToClipboard
 import com.adyen.checkout.ui.core.internal.util.setLocalizedTextFromStyle
 import com.adyen.checkout.voucher.R
 import com.adyen.checkout.voucher.databinding.FullVoucherViewBinding


### PR DESCRIPTION
## Description
- Sending amount, screen width and payment methods to the Analytics API.
- Adding checkout attempt ID to the `/payments` call request body.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-481
