### PR TITLE
Allow CVC to be empty when bin lookup returns "hidden" (v4)

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponent.kt
@@ -302,15 +302,14 @@ class CardComponent private constructor(
         Logger.d(TAG, "makeCvcUIState: $cvcPolicy")
         return when {
             cardDelegate.isCvcHidden() -> InputFieldUIState.HIDDEN
-            // we treat CvcPolicy.HIDDEN as OPTIONAL for now to avoid hiding and showing the cvc field while the user is typing the card number
-            cvcPolicy == Brand.FieldPolicy.OPTIONAL || cvcPolicy == Brand.FieldPolicy.HIDDEN -> InputFieldUIState.OPTIONAL
+            cvcPolicy?.isRequired() == false -> InputFieldUIState.OPTIONAL
             else -> InputFieldUIState.REQUIRED
         }
     }
 
     private fun makeExpiryDateUIState(expiryDatePolicy: Brand.FieldPolicy?): InputFieldUIState {
-        return when (expiryDatePolicy) {
-            Brand.FieldPolicy.OPTIONAL, Brand.FieldPolicy.HIDDEN -> InputFieldUIState.OPTIONAL
+        return when {
+            expiryDatePolicy?.isRequired() == false -> InputFieldUIState.OPTIONAL
             else -> InputFieldUIState.REQUIRED
         }
     }

--- a/card/src/main/java/com/adyen/checkout/card/api/model/Brand.kt
+++ b/card/src/main/java/com/adyen/checkout/card/api/model/Brand.kt
@@ -83,6 +83,12 @@ data class Brand(
         OPTIONAL("optional"),
         HIDDEN("hidden");
 
+        // We treat both HIDDEN and OPTIONAL the same way now, as optional, to avoid hiding and showing the cvc field
+        // while the user is typing the card number
+        fun isRequired(): Boolean {
+            return this == REQUIRED
+        }
+
         companion object {
             @JvmStatic
             fun parse(value: String): FieldPolicy {

--- a/card/src/main/java/com/adyen/checkout/card/util/CardValidationUtils.kt
+++ b/card/src/main/java/com/adyen/checkout/card/util/CardValidationUtils.kt
@@ -91,7 +91,7 @@ object CardValidationUtils {
                     invalidState
                 }
             }
-            fieldPolicy == Brand.FieldPolicy.OPTIONAL && expiryDate != ExpiryDate.INVALID_DATE -> {
+            fieldPolicy?.isRequired() == false && expiryDate != ExpiryDate.INVALID_DATE -> {
                 FieldState(expiryDate, Validation.Valid)
             }
             else -> invalidState
@@ -107,7 +107,7 @@ object CardValidationUtils {
         val invalidState = Validation.Invalid(R.string.checkout_security_code_not_valid)
         val validation = when {
             !StringUtil.isDigitsAndSeparatorsOnly(normalizedSecurityCode) -> invalidState
-            cardType?.cvcPolicy == Brand.FieldPolicy.OPTIONAL && length == 0 -> Validation.Valid
+            cardType?.cvcPolicy?.isRequired() == false && length == 0 -> Validation.Valid
             cardType?.cardBrand?.cardType == CardType.AMERICAN_EXPRESS && length == AMEX_SECURITY_CODE_SIZE -> Validation.Valid
             cardType?.cardBrand?.cardType != CardType.AMERICAN_EXPRESS && length == GENERAL_CARD_SECURITY_CODE_SIZE -> Validation.Valid
             else -> invalidState


### PR DESCRIPTION
## Description
CVC field is still being validated as required when bin lookup returns that the CVC should be "hidden". 
We should treat hidden as optional and allow this field to be empty when bin lookup returns "hidden".

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-783