### PR TITLE
Suppress ProGuard issues coming from Cash App SDK

### DIFF
--- a/example-app/proguard-rules.pro
+++ b/example-app/proguard-rules.pro
@@ -19,3 +19,7 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Temporary rules to fix an issue with the Cash App SDK
+-dontwarn kotlinx.serialization.KSerializer
+-dontwarn kotlinx.serialization.Serializable


### PR DESCRIPTION
## Description
Suppress the errors that ProGuard gives. The issue stems from the Cash App SDK.
