### PR TITLE
Propagate details on error, cancel and timeout from 3ds2 sdk (v4)

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Serializer.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Serializer.kt
@@ -10,7 +10,6 @@ package com.adyen.checkout.adyen3ds2
 
 import com.adyen.checkout.adyen3ds2.model.ChallengeResult
 import com.adyen.checkout.core.exception.ComponentException
-import com.adyen.threeds2.CompletionEvent
 import org.json.JSONException
 import org.json.JSONObject
 
@@ -33,10 +32,13 @@ class Adyen3DS2Serializer {
     }
 
     @Throws(ComponentException::class)
-    fun createChallengeDetails(completionEvent: CompletionEvent): JSONObject {
+    fun createChallengeDetails(
+        transactionStatus: String,
+        errorDetails: String? = null
+    ): JSONObject {
         val challengeDetails = JSONObject()
         try {
-            val challengeResult = ChallengeResult.from(completionEvent)
+            val challengeResult = ChallengeResult.from(transactionStatus, errorDetails)
             challengeDetails.put(CHALLENGE_DETAILS_KEY, challengeResult.payload)
         } catch (e: JSONException) {
             throw ComponentException("Failed to create challenge details", e)
@@ -46,12 +48,14 @@ class Adyen3DS2Serializer {
 
     @Throws(ComponentException::class)
     fun createThreeDsResultDetails(
-        completionEvent: CompletionEvent,
-        authorisationToken: String
+        transactionStatus: String,
+        authorisationToken: String,
+        errorDetails: String? = null,
     ): JSONObject {
         val threeDsDetails = JSONObject()
         try {
-            val challengeResult = ChallengeResult.from(completionEvent, authorisationToken)
+            val challengeResult =
+                ChallengeResult.from(transactionStatus, errorDetails, authorisationToken)
             threeDsDetails.put(THREEDS_RESULT_KEY, challengeResult.payload)
         } catch (e: JSONException) {
             throw ComponentException("Failed to create ThreeDS Result details", e)

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/model/ChallengeResult.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/model/ChallengeResult.kt
@@ -8,7 +8,6 @@
 package com.adyen.checkout.adyen3ds2.model
 
 import com.adyen.checkout.components.encoding.Base64Encoder
-import com.adyen.threeds2.CompletionEvent
 import org.json.JSONException
 import org.json.JSONObject
 
@@ -19,21 +18,27 @@ class ChallengeResult private constructor(val isAuthenticated: Boolean, val payl
         private const val KEY_AUTHORISATION_TOKEN = "authorisationToken"
         private const val VALUE_TRANSACTION_STATUS = "Y"
 
+        private const val KEY_SDK_ERROR = "threeDS2SDKError"
+
         /**
          * Constructs the object base in the result from te 3DS2 SDK.
          *
-         * @param completionEvent The result from the 3DS2 SDK.
+         * @param transactionStatus The transaction status received in the result from the 3DS2 SDK.
+         * @param errorDetails The additional error details received in the result from the 3DS2 SDK.
          * @param authorisationToken The authorisationToken from the API.
          * @return The filled object with the content needed for the details response.
          * @throws JSONException In case parsing fails.
          */
-        @Throws(JSONException::class)
-        fun from(completionEvent: CompletionEvent, authorisationToken: String? = null): ChallengeResult {
-            val transactionStatus = completionEvent.transactionStatus
+        fun from(
+            transactionStatus: String,
+            errorDetails: String? = null,
+            authorisationToken: String? = null
+        ): ChallengeResult {
             val isAuthenticated = VALUE_TRANSACTION_STATUS == transactionStatus
             val jsonObject = JSONObject()
             jsonObject.put(KEY_TRANSACTION_STATUS, transactionStatus)
             jsonObject.putOpt(KEY_AUTHORISATION_TOKEN, authorisationToken)
+            jsonObject.putOpt(KEY_SDK_ERROR, errorDetails)
             val payload = Base64Encoder.encode(jsonObject.toString())
             return ChallengeResult(isAuthenticated, payload)
         }

--- a/build.gradle
+++ b/build.gradle
@@ -11,11 +11,11 @@ ext {
 buildscript {
     // Build Script
     ext.android_gradle_plugin_version = '4.2.2'
-    ext.kotlin_version = '1.6.21'
+    ext.kotlin_version = '1.8.20'
     ext.detekt_gradle_plugin_version = "1.17.1"
     ext.spotbugs_gradle_plugin_version = "4.5.1"
     ext.dokka_version = "1.4.32"
-    ext.hilt_version = "2.40.1"
+    ext.hilt_version = "2.44"
 
     repositories {
         google()
@@ -63,7 +63,7 @@ allprojects {
     ext.browser_version = "1.3.0"
 
     // Adyen Dependencies
-    ext.adyen3ds2_version = "2.2.13"
+    ext.adyen3ds2_version = "2.2.15"
 
     // External Dependencies
     ext.play_services_wallet_version = '18.1.3'

--- a/config/gradle/checksums.gradle
+++ b/config/gradle/checksums.gradle
@@ -9,13 +9,13 @@
 if (!hasProperty("checksums")) {
     final checksums = [
             // Adyen dependencies
-            "com.adyen.threeds:adyen-3ds2:2.2.13:dfa2025daa56db88d9c179cdeb51e143:MD5",
+            "com.adyen.threeds:adyen-3ds2:2.2.15:876c1cda05d330e57c62dc4de35b6c91:MD5",
 
             // Kotlin
-            "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.21:9e7ee18a1a5dd5bf070c7e6f706ccc9c:MD5",
-            "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21:9e7ee18a1a5dd5bf070c7e6f706ccc9c:MD5",
-            "org.jetbrains.kotlin:kotlin-compiler-embeddable:1.6.21:eb3d83e86861d7399e816410e1ceba2c:MD5",
-            "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable:1.6.21:ea6fa29c284656cd40b13825464f5972:MD5",
+            "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.20:2097cb28602f5a6320bcc1bd74914db9:MD5",
+            "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20:2097cb28602f5a6320bcc1bd74914db9:MD5",
+            "org.jetbrains.kotlin:kotlin-compiler-embeddable:1.8.20:13de50e6fde16cef3982f8ef707cde6c:MD5",
+            "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable:1.8.20:d9c35d4c31b7a468cf7c1998922ccad8:MD5",
 
             // Coroutines
             "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1:e427aac656a3159609ea059d38feaf7f:MD5",


### PR DESCRIPTION

## Description
Update 3ds2 sdk to 2.2.15 and start using the new onCompletion callback to get challenge results. Before this change details were emitted only for completion event, however starting from now they will be emitted for all results received from 3ds2 sdk for merchants to be able to get more information about the errors they encounter during the flow.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-748
