### PR TITLE
Fix QR code actions for InstantPaymentComponent

### DIFF
--- a/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentComponent.kt
+++ b/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentComponent.kt
@@ -32,7 +32,10 @@ class InstantPaymentComponent internal constructor(
     ViewableComponent,
     ActionHandlingComponent by actionHandlingComponent {
 
-    override val delegate: ComponentDelegate get() = actionHandlingComponent.activeDelegate
+    @Suppress("ForbiddenComment")
+    // FIXME: Using actionHandlingComponent.activeDelegate will crash for QR code actions. This is a workaround for the
+    //  actual issue.
+    override val delegate: ComponentDelegate get() = genericActionDelegate.delegate
 
     override val viewFlow: Flow<ComponentViewType?> = genericActionDelegate.viewFlow
 


### PR DESCRIPTION
## Description
Using a payment method like Duitnow would crash. This was because the delegate received by the QR code view was not the correct delegate type yet. 

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-786
