### PR TITLE
Fix dual branded flow check

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegate.kt
@@ -675,7 +675,7 @@ internal class DefaultCardDelegate(
 
     private fun isDualBrandedFlow(detectedCardTypes: List<DetectedCardType>): Boolean {
         val reliableDetectedCards = detectedCardTypes.filter { it.isReliable }
-        return reliableDetectedCards.size > 1 && reliableDetectedCards.any { it.isSelected }
+        return reliableDetectedCards.size > 1
     }
 
     private fun showStorePaymentField(): Boolean {


### PR DESCRIPTION
## Description
Brand parameter was being set incorrectly in a dual branded card payment where no brand is selected.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-676
