### PR TITLE
Prevent crash when rotating the phone while being in the redirection screen

### DIFF
--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInActivity.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInActivity.kt
@@ -606,7 +606,7 @@ internal class DropInActivity :
     private fun setLoading(showLoading: Boolean) {
         val loadingDialog = getFragmentByTag(LOADING_FRAGMENT_TAG)
         if (showLoading) {
-            if (loadingDialog == null) {
+            if (loadingDialog == null && !supportFragmentManager.isDestroyed) {
                 LoadingDialogFragment.newInstance().show(supportFragmentManager, LOADING_FRAGMENT_TAG)
             }
         } else {


### PR DESCRIPTION
## Description
Fixed an exception that appears when rotating the phone while being in the redirection screen. 
Reproduction path with example app (video is attached): 
- Open DropIn by clicking start
- Select iDEAL and select a test issuer
- Wait for browser to open the redirect url showing the issuer simulation 
- Rotate phone 
- Press continue
Video for reproduction: https://github.com/Adyen/adyen-android/assets/13377878/b3243776-b956-421e-9856-995d45d427fd
Video with fix applied: https://github.com/Adyen/adyen-android/assets/13377878/23c656cb-5789-4f6a-a438-f1b210f45501


## Checklist
- [ ] Code is unit tested
- [X] Changes are tested manually
- [ ] Link to related issues
- [ ] Add relevant labels to PR  

COAND-XXX
