### PR TITLE
Temporarily group all Renovate dependency updates in one PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,10 @@
   "extends": [
     "config:base"
   ],
-  "labels": ["Dependencies"]
+  "labels": ["Dependencies"],
+  "packageRules": [
+    {
+      "groupName": "all-dependencies"
+    }
+  ]
 }


### PR DESCRIPTION
To resolve the huge amount of open PRs we currently have.