### PR TITLE
Persist output data in memory (v4)

### DIFF
--- a/components-core/src/main/java/com/adyen/checkout/components/base/BasePaymentComponent.java
+++ b/components-core/src/main/java/com/adyen/checkout/components/base/BasePaymentComponent.java
@@ -47,6 +47,9 @@ public abstract class BasePaymentComponent<
 
     private final MutableLiveData<OutputDataT> mOutputLiveData = new MutableLiveData<>();
 
+    @Nullable
+    private OutputDataT mOutputData;
+
     private boolean mIsCreatedForDropIn = false;
     private boolean mIsAnalyticsEnabled = true;
 
@@ -154,7 +157,6 @@ public abstract class BasePaymentComponent<
         }
     }
 
-
     @Override
     public void observeOutputData(@NonNull LifecycleOwner lifecycleOwner, @NonNull Observer<OutputDataT> observer) {
         // Parent component needs to overrides this for view to have access to the method in the package
@@ -164,7 +166,7 @@ public abstract class BasePaymentComponent<
     @Nullable
     @Override
     public OutputDataT getOutputData() {
-        return mOutputLiveData.getValue();
+        return mOutputData;
     }
 
     /**
@@ -193,9 +195,10 @@ public abstract class BasePaymentComponent<
      */
     protected void notifyStateChanged(@NonNull OutputDataT outputData) {
         Logger.d(TAG, "notifyStateChanged with OutputData");
+        mOutputData = outputData;
         ThreadManager.MAIN_HANDLER.post(() -> {
-            if (!outputData.equals(mOutputLiveData.getValue())) {
-                mOutputLiveData.setValue(outputData);
+            if (!mOutputData.equals(mOutputLiveData.getValue())) {
+                mOutputLiveData.setValue(mOutputData);
                 notifyStateChanged();
             } else {
                 Logger.d(TAG, "state has not changed");


### PR DESCRIPTION
## Description
Persist output data in memory instead of relying on output data live data.

We update our output data live data on the main thread, which means it could be still null when the component launches. So if any background operation (e.g. fetching country list) finishes quicker than the live data is updated, it will not be able to update the live data itself (since its value is still null).

This was causing issues like the card component loading with an empty country dropdown list and therefore the address form would be broken.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->
