### PR TITLE
Fix address fetch crash (v4)

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/AddressDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/AddressDelegate.kt
@@ -14,6 +14,7 @@ import com.adyen.checkout.card.api.model.AddressItem
 import com.adyen.checkout.card.repository.AddressRepository
 import com.adyen.checkout.card.ui.AddressSpecification
 import com.adyen.checkout.components.base.Configuration
+import com.adyen.checkout.core.exception.CheckoutException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -39,12 +40,16 @@ class AddressDelegate(
             cache[countryCode]?.let {
                 _statesFlow.tryEmit(it)
             } ?: coroutineScope.launch {
-                val states = addressRepository.getAddressData(
-                    environment = configuration.environment,
-                    dataType = AddressDataType.STATE,
-                    localeString = configuration.shopperLocale.toLanguageTag(),
-                    countryCode = countryCode
-                )
+                val states = try {
+                    addressRepository.getAddressData(
+                        environment = configuration.environment,
+                        dataType = AddressDataType.STATE,
+                        localeString = configuration.shopperLocale.toLanguageTag(),
+                        countryCode = countryCode
+                    )
+                } catch (e: CheckoutException) {
+                    emptyList()
+                }
                 if (states.isNotEmpty()) {
                     cache.put(countryCode, states)
                 }

--- a/card/src/main/java/com/adyen/checkout/card/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponent.kt
@@ -269,7 +269,12 @@ class CardComponent private constructor(
 
     private fun requestCountryList(cardDelegate: NewCardDelegate) {
         viewModelScope.launch {
-            val countries = cardDelegate.getCountryList()
+            val countries = try {
+                cardDelegate.getCountryList()
+            } catch (e: CheckoutException) {
+                notifyException(e)
+                emptyList()
+            }
             val countryOptions = AddressFormUtils.initializeCountryOptions(cardConfiguration.addressConfiguration, countries)
             countryOptions.firstOrNull { it.selected }?.let {
                 inputData.address.country = it.code

--- a/card/src/main/java/com/adyen/checkout/card/ui/AddressSpecification.kt
+++ b/card/src/main/java/com/adyen/checkout/card/ui/AddressSpecification.kt
@@ -9,6 +9,7 @@
 
 package com.adyen.checkout.card.ui
 
+import androidx.annotation.Keep
 import androidx.annotation.StyleRes
 import com.adyen.checkout.card.R
 
@@ -16,7 +17,8 @@ import com.adyen.checkout.card.R
  * Specification for address form alternatives depending on the country.
  */
 @Suppress("LongParameterList")
-enum class AddressSpecification(
+@Keep
+internal enum class AddressSpecification(
     internal val street: AddressFieldSpec,
     internal val houseNumber: AddressFieldSpec,
     internal val apartmentSuite: AddressFieldSpec,


### PR DESCRIPTION
## Description
- Return empty list when fetching country or states fails. Before it would crash. Now when fetching countries fails we notify the merchant and display a dialog to the shopper. This should prevent the shopper from proceeding to the empty states list.

- Keep AddressSpecification from being obfuscated. We are mapping country codes the this enum's entries. This will not work if the enum is obfuscated.


## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
- [x] Link to related issues: fixes #1261 
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-777
