### PR TITLE
Fix jumping bottom sheet

### DIFF
--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/AdyenComponentView.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/AdyenComponentView.kt
@@ -13,6 +13,7 @@ import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.widget.LinearLayout
 import androidx.core.view.children
+import androidx.core.view.doOnNextLayout
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.lifecycle.LifecycleOwner
@@ -124,9 +125,11 @@ class AdyenComponentView @JvmOverloads constructor(
 
         val localizedContext = context.createLocalizedContext(componentParams.shopperLocale)
 
-        val view = componentView.getView()
-        binding.frameLayoutComponentContainer.addView(view)
-        view.updateLayoutParams { width = LayoutParams.MATCH_PARENT }
+        binding.frameLayoutComponentContainer.doOnNextLayout {
+            val view = componentView.getView()
+            binding.frameLayoutComponentContainer.addView(view)
+            view.updateLayoutParams { width = LayoutParams.MATCH_PARENT }
+        }
 
         componentView.initView(delegate, coroutineScope, localizedContext)
 


### PR DESCRIPTION
## Description
The drop-in bottom sheet was jumping position when a new view was loaded into it and navigating to another activity at the same time. Having a slight delay prevents the jumping from happening.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-792
