### PR TITLE
Fix cancel button not working during WeChat flow

### DIFF
--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/internal/ui/DefaultWeChatDelegate.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/internal/ui/DefaultWeChatDelegate.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import org.json.JSONException
 import org.json.JSONObject
 
+@Suppress("TooManyFunctions")
 internal class DefaultWeChatDelegate(
     private val observerRepository: ActionObserverRepository,
     override val componentParams: GenericComponentParams,
@@ -153,6 +154,10 @@ internal class DefaultWeChatDelegate(
             details = details,
             paymentData = paymentDataRepository.paymentData,
         )
+    }
+
+    override fun onError(e: CheckoutException) {
+        exceptionChannel.trySend(e)
     }
 
     override fun onCleared() {


### PR DESCRIPTION
## Description
By propagating the view errors correctly to the component the cancel flow is now correctly working.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-798
