### PR TITLE
Fix infinite loading spinner

### DIFF
--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInActivity.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInActivity.kt
@@ -380,8 +380,8 @@ internal class DropInActivity :
     }
 
     override fun removeStoredPaymentMethod(storedPaymentMethod: StoredPaymentMethod) {
-        dropInService?.requestRemoveStoredPaymentMethod(storedPaymentMethod)
         setLoading(true)
+        dropInService?.requestRemoveStoredPaymentMethod(storedPaymentMethod)
     }
 
     private fun handleDropInServiceResult(dropInServiceResult: BaseDropInServiceResult) {


### PR DESCRIPTION
## Description
This fixes an issue where a loading spinner would show infinitely when an error is returned in the remove stored payment method callback.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-801
