### PR TITLE
Configure renovate to reduce noise and improve stability

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,12 @@
   "extends": [
     "config:base"
   ],
-  "labels": ["Dependencies"]
+  "labels": ["Dependencies"],
+  "packageRules" : [
+    {
+      "matchPackagePatterns" : ["*"],
+      "minimumReleaseAge" : "30 days",
+      "schedule" : ["on the first day of the month"]
+    }
+  ]
 }


### PR DESCRIPTION
## Description
Configure renovate to reduce noise and improve stability by only updating releases more than 30 days old and grouping all updates at the start of the month.