### PR TITLE
Fix crash triggered by layout inspector

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/Adyen3DS2ViewProvider.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/Adyen3DS2ViewProvider.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.adyen3ds2.internal.ui
 
 import android.content.Context
-import android.util.AttributeSet
 import com.adyen.checkout.ui.core.internal.ui.ComponentView
 import com.adyen.checkout.ui.core.internal.ui.ComponentViewType
 import com.adyen.checkout.ui.core.internal.ui.ViewProvider
@@ -20,10 +19,8 @@ internal object Adyen3DS2ViewProvider : ViewProvider {
     override fun getView(
         viewType: ComponentViewType,
         context: Context,
-        attrs: AttributeSet?,
-        defStyleAttr: Int
     ): ComponentView = when (viewType) {
-        Adyen3DS2ComponentViewType -> PaymentInProgressView(context, attrs, defStyleAttr)
+        Adyen3DS2ComponentViewType -> PaymentInProgressView(context)
         else -> error("Unsupported view type")
     }
 }

--- a/ach/src/main/java/com/adyen/checkout/ach/internal/ui/ACHDirectDebitViewProvider.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/internal/ui/ACHDirectDebitViewProvider.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.ach.internal.ui
 
 import android.content.Context
-import android.util.AttributeSet
 import com.adyen.checkout.ach.internal.ui.view.ACHDirectDebitView
 import com.adyen.checkout.ui.core.internal.ui.AmountButtonComponentViewType
 import com.adyen.checkout.ui.core.internal.ui.ButtonComponentViewType
@@ -21,11 +20,9 @@ internal object ACHDirectDebitViewProvider : ViewProvider {
     override fun getView(
         viewType: ComponentViewType,
         context: Context,
-        attrs: AttributeSet?,
-        defStyleAttr: Int
     ): ComponentView {
         return when (viewType) {
-            ACHDirectDebitComponentViewType -> ACHDirectDebitView(context, attrs, defStyleAttr)
+            ACHDirectDebitComponentViewType -> ACHDirectDebitView(context)
             else -> throw IllegalArgumentException("Unsupported view type")
         }
     }

--- a/await/src/main/java/com/adyen/checkout/await/internal/ui/AwaitViewProvider.kt
+++ b/await/src/main/java/com/adyen/checkout/await/internal/ui/AwaitViewProvider.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.await.internal.ui
 
 import android.content.Context
-import android.util.AttributeSet
 import com.adyen.checkout.await.internal.ui.view.AwaitView
 import com.adyen.checkout.ui.core.internal.ui.ComponentView
 import com.adyen.checkout.ui.core.internal.ui.ComponentViewType
@@ -20,11 +19,9 @@ internal object AwaitViewProvider : ViewProvider {
     override fun getView(
         viewType: ComponentViewType,
         context: Context,
-        attrs: AttributeSet?,
-        defStyleAttr: Int
     ): ComponentView {
         return when (viewType) {
-            AwaitComponentViewType -> AwaitView(context, attrs, defStyleAttr)
+            AwaitComponentViewType -> AwaitView(context)
             else -> throw IllegalArgumentException("Unsupported view type")
         }
     }

--- a/bacs/src/main/java/com/adyen/checkout/bacs/internal/ui/BacsDirectDebitViewProvider.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/internal/ui/BacsDirectDebitViewProvider.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.bacs.internal.ui
 
 import android.content.Context
-import android.util.AttributeSet
 import com.adyen.checkout.bacs.R
 import com.adyen.checkout.bacs.internal.ui.view.BacsDirectDebitConfirmationView
 import com.adyen.checkout.bacs.internal.ui.view.BacsDirectDebitInputView
@@ -22,12 +21,10 @@ internal object BacsDirectDebitViewProvider : ViewProvider {
     override fun getView(
         viewType: ComponentViewType,
         context: Context,
-        attrs: AttributeSet?,
-        defStyleAttr: Int
     ): ComponentView {
         return when (viewType) {
-            BacsComponentViewType.INPUT -> BacsDirectDebitInputView(context, attrs, defStyleAttr)
-            BacsComponentViewType.CONFIRMATION -> BacsDirectDebitConfirmationView(context, attrs, defStyleAttr)
+            BacsComponentViewType.INPUT -> BacsDirectDebitInputView(context)
+            BacsComponentViewType.CONFIRMATION -> BacsDirectDebitConfirmationView(context)
             else -> throw IllegalArgumentException("Unsupported view type")
         }
     }

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/internal/ui/BcmcViewProvider.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/internal/ui/BcmcViewProvider.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.bcmc.internal.ui
 
 import android.content.Context
-import android.util.AttributeSet
 import com.adyen.checkout.bcmc.internal.ui.view.BcmcView
 import com.adyen.checkout.ui.core.internal.ui.AmountButtonComponentViewType
 import com.adyen.checkout.ui.core.internal.ui.ButtonComponentViewType
@@ -22,10 +21,8 @@ internal object BcmcViewProvider : ViewProvider {
     override fun getView(
         viewType: ComponentViewType,
         context: Context,
-        attrs: AttributeSet?,
-        defStyleAttr: Int
     ): ComponentView = when (viewType) {
-        BcmcComponentViewType -> BcmcView(context, attrs, defStyleAttr)
+        BcmcComponentViewType -> BcmcView(context)
         else -> throw IllegalArgumentException("Unsupported view type")
     }
 }

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/BlikViewProvider.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/BlikViewProvider.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.blik.internal.ui
 
 import android.content.Context
-import android.util.AttributeSet
 import com.adyen.checkout.blik.internal.ui.view.BlikView
 import com.adyen.checkout.ui.core.internal.ui.AmountButtonComponentViewType
 import com.adyen.checkout.ui.core.internal.ui.ButtonComponentViewType
@@ -21,11 +20,9 @@ internal object BlikViewProvider : ViewProvider {
     override fun getView(
         viewType: ComponentViewType,
         context: Context,
-        attrs: AttributeSet?,
-        defStyleAttr: Int
     ): ComponentView {
         return when (viewType) {
-            BlikComponentViewType -> BlikView(context, attrs, defStyleAttr)
+            BlikComponentViewType -> BlikView(context)
             else -> throw IllegalArgumentException("Unsupported view type")
         }
     }

--- a/boleto/src/main/java/com/adyen/checkout/boleto/internal/ui/BoletoViewProvider.kt
+++ b/boleto/src/main/java/com/adyen/checkout/boleto/internal/ui/BoletoViewProvider.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.boleto.internal.ui
 
 import android.content.Context
-import android.util.AttributeSet
 import com.adyen.checkout.boleto.R
 import com.adyen.checkout.boleto.internal.ui.view.BoletoView
 import com.adyen.checkout.ui.core.internal.ui.ButtonComponentViewType
@@ -21,10 +20,8 @@ internal object BoletoViewProvider : ViewProvider {
     override fun getView(
         viewType: ComponentViewType,
         context: Context,
-        attrs: AttributeSet?,
-        defStyleAttr: Int
     ): ComponentView = when (viewType) {
-        BoletoComponentViewType -> BoletoView(context, attrs, defStyleAttr)
+        BoletoComponentViewType -> BoletoView(context)
         else -> throw IllegalArgumentException("Unsupported view type")
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardViewProvider.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardViewProvider.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.card.internal.ui
 
 import android.content.Context
-import android.util.AttributeSet
 import com.adyen.checkout.card.internal.ui.view.CardView
 import com.adyen.checkout.card.internal.ui.view.StoredCardView
 import com.adyen.checkout.ui.core.internal.ui.AmountButtonComponentViewType
@@ -23,12 +22,10 @@ internal object CardViewProvider : ViewProvider {
     override fun getView(
         viewType: ComponentViewType,
         context: Context,
-        attrs: AttributeSet?,
-        defStyleAttr: Int
     ): ComponentView {
         return when (viewType) {
-            CardComponentViewType.DefaultCardView -> CardView(context, attrs, defStyleAttr)
-            CardComponentViewType.StoredCardView -> StoredCardView(context, attrs, defStyleAttr)
+            CardComponentViewType.DefaultCardView -> CardView(context)
+            CardComponentViewType.StoredCardView -> StoredCardView(context)
             else -> throw IllegalArgumentException("Unsupported view type")
         }
     }

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/CashAppPayViewProvider.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/CashAppPayViewProvider.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.cashapppay.internal.ui
 
 import android.content.Context
-import android.util.AttributeSet
 import com.adyen.checkout.cashapppay.internal.ui.view.CashAppPayButtonView
 import com.adyen.checkout.cashapppay.internal.ui.view.CashAppPayView
 import com.adyen.checkout.cashapppay.internal.ui.view.CashAppPayWaitingView
@@ -25,18 +24,16 @@ internal object CashAppPayViewProvider : ViewProvider {
     override fun getView(
         viewType: ComponentViewType,
         context: Context,
-        attrs: AttributeSet?,
-        defStyleAttr: Int
     ): ComponentView = when (viewType) {
-        CashAppPayComponentViewType -> CashAppPayView(context, attrs, defStyleAttr)
-        PaymentInProgressViewType -> CashAppPayWaitingView(context, attrs, defStyleAttr)
+        CashAppPayComponentViewType -> CashAppPayView(context)
+        PaymentInProgressViewType -> CashAppPayWaitingView(context)
         else -> throw IllegalArgumentException("Unsupported view type")
     }
 }
 
 internal class CashAppPayButtonViewProvider : ButtonViewProvider {
-    override fun getButton(context: Context, attrs: AttributeSet?, defStyleAttr: Int): PayButton =
-        CashAppPayButtonView(context, attrs, defStyleAttr)
+    override fun getButton(context: Context): PayButton =
+        CashAppPayButtonView(context)
 }
 
 internal object CashAppPayComponentViewType : ButtonComponentViewType {

--- a/econtext/src/main/java/com/adyen/checkout/econtext/internal/ui/EContextViewProvider.kt
+++ b/econtext/src/main/java/com/adyen/checkout/econtext/internal/ui/EContextViewProvider.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.econtext.internal.ui
 
 import android.content.Context
-import android.util.AttributeSet
 import com.adyen.checkout.econtext.internal.ui.view.EContextView
 import com.adyen.checkout.ui.core.internal.ui.ButtonComponentViewType
 import com.adyen.checkout.ui.core.internal.ui.ComponentView
@@ -21,11 +20,9 @@ internal object EContextViewProvider : ViewProvider {
     override fun getView(
         viewType: ComponentViewType,
         context: Context,
-        attrs: AttributeSet?,
-        defStyleAttr: Int
     ): ComponentView {
         return when (viewType) {
-            EContextComponentViewType -> EContextView(context, attrs, defStyleAttr)
+            EContextComponentViewType -> EContextView(context)
             else -> throw IllegalArgumentException("Unsupported view type")
         }
     }

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/ui/GiftCardViewProvider.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/ui/GiftCardViewProvider.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.giftcard.internal.ui
 
 import android.content.Context
-import android.util.AttributeSet
 import com.adyen.checkout.giftcard.R
 import com.adyen.checkout.giftcard.internal.ui.view.GiftCardView
 import com.adyen.checkout.ui.core.internal.ui.ButtonComponentViewType
@@ -22,11 +21,9 @@ internal object GiftCardViewProvider : ViewProvider {
     override fun getView(
         viewType: ComponentViewType,
         context: Context,
-        attrs: AttributeSet?,
-        defStyleAttr: Int
     ): ComponentView {
         return when (viewType) {
-            GiftCardComponentViewType -> GiftCardView(context, attrs, defStyleAttr)
+            GiftCardComponentViewType -> GiftCardView(context)
             else -> throw IllegalArgumentException("Unsupported view type")
         }
     }

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/ui/IssuerListViewProvider.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/ui/IssuerListViewProvider.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.issuerlist.internal.ui
 
 import android.content.Context
-import android.util.AttributeSet
 import com.adyen.checkout.issuerlist.internal.ui.view.IssuerListRecyclerView
 import com.adyen.checkout.issuerlist.internal.ui.view.IssuerListSpinnerView
 import com.adyen.checkout.ui.core.internal.ui.AmountButtonComponentViewType
@@ -23,12 +22,10 @@ internal object IssuerListViewProvider : ViewProvider {
     override fun getView(
         viewType: ComponentViewType,
         context: Context,
-        attrs: AttributeSet?,
-        defStyleAttr: Int
     ): ComponentView {
         return when (viewType) {
-            IssuerListComponentViewType.RecyclerView -> IssuerListRecyclerView(context, attrs, defStyleAttr)
-            IssuerListComponentViewType.SpinnerView -> IssuerListSpinnerView(context, attrs, defStyleAttr)
+            IssuerListComponentViewType.RecyclerView -> IssuerListRecyclerView(context)
+            IssuerListComponentViewType.SpinnerView -> IssuerListSpinnerView(context)
             else -> throw IllegalArgumentException("Unsupported view type")
         }
     }

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/MbWayViewProvider.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/MbWayViewProvider.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.mbway.internal.ui
 
 import android.content.Context
-import android.util.AttributeSet
 import com.adyen.checkout.mbway.internal.ui.view.MbWayView
 import com.adyen.checkout.ui.core.internal.ui.AmountButtonComponentViewType
 import com.adyen.checkout.ui.core.internal.ui.ButtonComponentViewType
@@ -22,10 +21,8 @@ internal object MbWayViewProvider : ViewProvider {
     override fun getView(
         viewType: ComponentViewType,
         context: Context,
-        attrs: AttributeSet?,
-        defStyleAttr: Int
     ): ComponentView = when (viewType) {
-        MbWayComponentViewType -> MbWayView(context, attrs, defStyleAttr)
+        MbWayComponentViewType -> MbWayView(context)
         else -> throw IllegalArgumentException("Unsupported view type")
     }
 }

--- a/online-banking-core/src/main/java/com/adyen/checkout/onlinebankingcore/internal/ui/OnlineBankingViewProvider.kt
+++ b/online-banking-core/src/main/java/com/adyen/checkout/onlinebankingcore/internal/ui/OnlineBankingViewProvider.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.onlinebankingcore.internal.ui
 
 import android.content.Context
-import android.util.AttributeSet
 import com.adyen.checkout.ui.core.internal.ui.AmountButtonComponentViewType
 import com.adyen.checkout.ui.core.internal.ui.ButtonComponentViewType
 import com.adyen.checkout.ui.core.internal.ui.ComponentView
@@ -21,11 +20,9 @@ internal object OnlineBankingViewProvider : ViewProvider {
     override fun getView(
         viewType: ComponentViewType,
         context: Context,
-        attrs: AttributeSet?,
-        defStyleAttr: Int
     ): ComponentView {
         return when (viewType) {
-            OnlineBankingComponentViewType -> OnlineBankingView(context, attrs, defStyleAttr)
+            OnlineBankingComponentViewType -> OnlineBankingView(context)
             else -> throw IllegalArgumentException("Unsupported view type")
         }
     }

--- a/paybybank/src/main/java/com/adyen/checkout/paybybank/internal/ui/PayByBankViewProvider.kt
+++ b/paybybank/src/main/java/com/adyen/checkout/paybybank/internal/ui/PayByBankViewProvider.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.paybybank.internal.ui
 
 import android.content.Context
-import android.util.AttributeSet
 import com.adyen.checkout.paybybank.internal.ui.view.PayByBankView
 import com.adyen.checkout.ui.core.internal.ui.ComponentView
 import com.adyen.checkout.ui.core.internal.ui.ComponentViewType
@@ -20,11 +19,9 @@ internal object PayByBankViewProvider : ViewProvider {
     override fun getView(
         viewType: ComponentViewType,
         context: Context,
-        attrs: AttributeSet?,
-        defStyleAttr: Int
     ): ComponentView {
         return when (viewType) {
-            PayByBankComponentViewType -> PayByBankView(context, attrs, defStyleAttr)
+            PayByBankComponentViewType -> PayByBankView(context)
             else -> throw IllegalArgumentException("Unsupported view type")
         }
     }

--- a/qr-code/src/main/java/com/adyen/checkout/qrcode/internal/ui/QrCodeViewProvider.kt
+++ b/qr-code/src/main/java/com/adyen/checkout/qrcode/internal/ui/QrCodeViewProvider.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.qrcode.internal.ui
 
 import android.content.Context
-import android.util.AttributeSet
 import com.adyen.checkout.qrcode.internal.ui.view.FullQRCodeView
 import com.adyen.checkout.qrcode.internal.ui.view.SimpleQRCodeView
 import com.adyen.checkout.ui.core.internal.ui.ComponentView
@@ -22,12 +21,10 @@ internal object QrCodeViewProvider : ViewProvider {
     override fun getView(
         viewType: ComponentViewType,
         context: Context,
-        attrs: AttributeSet?,
-        defStyleAttr: Int
     ): ComponentView = when (viewType) {
-        QrCodeComponentViewType.SIMPLE_QR_CODE -> SimpleQRCodeView(context, attrs, defStyleAttr)
-        QrCodeComponentViewType.FULL_QR_CODE -> FullQRCodeView(context, attrs, defStyleAttr)
-        QrCodeComponentViewType.REDIRECT -> PaymentInProgressView(context, attrs, defStyleAttr)
+        QrCodeComponentViewType.SIMPLE_QR_CODE -> SimpleQRCodeView(context)
+        QrCodeComponentViewType.FULL_QR_CODE -> FullQRCodeView(context)
+        QrCodeComponentViewType.REDIRECT -> PaymentInProgressView(context)
         else -> throw IllegalArgumentException("Unsupported view type")
     }
 }

--- a/redirect/src/main/java/com/adyen/checkout/redirect/internal/ui/RedirectViewProvider.kt
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/internal/ui/RedirectViewProvider.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.redirect.internal.ui
 
 import android.content.Context
-import android.util.AttributeSet
 import com.adyen.checkout.ui.core.internal.ui.ComponentView
 import com.adyen.checkout.ui.core.internal.ui.ComponentViewType
 import com.adyen.checkout.ui.core.internal.ui.ViewProvider
@@ -20,10 +19,8 @@ internal object RedirectViewProvider : ViewProvider {
     override fun getView(
         viewType: ComponentViewType,
         context: Context,
-        attrs: AttributeSet?,
-        defStyleAttr: Int
     ): ComponentView = when (viewType) {
-        RedirectComponentViewType -> PaymentInProgressView(context, attrs, defStyleAttr)
+        RedirectComponentViewType -> PaymentInProgressView(context)
         else -> throw IllegalArgumentException("Unsupported view type")
     }
 }

--- a/sepa/src/main/java/com/adyen/checkout/sepa/internal/ui/SepaViewProvider.kt
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/internal/ui/SepaViewProvider.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.sepa.internal.ui
 
 import android.content.Context
-import android.util.AttributeSet
 import com.adyen.checkout.sepa.internal.ui.view.SepaView
 import com.adyen.checkout.ui.core.internal.ui.AmountButtonComponentViewType
 import com.adyen.checkout.ui.core.internal.ui.ButtonComponentViewType
@@ -22,11 +21,9 @@ internal object SepaViewProvider : ViewProvider {
     override fun getView(
         viewType: ComponentViewType,
         context: Context,
-        attrs: AttributeSet?,
-        defStyleAttr: Int
     ): ComponentView {
         return when (viewType) {
-            SepaComponentViewType -> SepaView(context, attrs, defStyleAttr)
+            SepaComponentViewType -> SepaView(context)
             else -> throw IllegalArgumentException("Unsupported view type")
         }
     }

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/AdyenComponentView.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/AdyenComponentView.kt
@@ -49,8 +49,8 @@ import java.lang.ref.WeakReference
  */
 class AdyenComponentView @JvmOverloads constructor(
     context: Context,
-    private val attrs: AttributeSet? = null,
-    private val defStyleAttr: Int = 0
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
 ) :
     LinearLayout(context, attrs, defStyleAttr) {
 
@@ -120,7 +120,7 @@ class AdyenComponentView @JvmOverloads constructor(
         componentParams: ComponentParams,
         coroutineScope: CoroutineScope,
     ) {
-        val componentView = viewType.viewProvider.getView(viewType, context, attrs, defStyleAttr)
+        val componentView = viewType.viewProvider.getView(viewType, context)
         this.componentView = componentView
 
         val localizedContext = context.createLocalizedContext(componentParams.shopperLocale)
@@ -148,7 +148,7 @@ class AdyenComponentView @JvmOverloads constructor(
 
             binding.frameLayoutButtonContainer.isVisible = buttonDelegate.shouldShowSubmitButton()
             val buttonView = (viewType as ButtonComponentViewType)
-                .buttonViewProvider.getButton(context, attrs, defStyleAttr)
+                .buttonViewProvider.getButton(context)
             buttonView.setText(viewType, componentParams, localizedContext)
             buttonView.setOnClickListener {
                 buttonDelegate.onSubmit()

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/ButtonViewProvider.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/ButtonViewProvider.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.ui.core.internal.ui
 
 import android.content.Context
-import android.util.AttributeSet
 import androidx.annotation.RestrictTo
 import com.adyen.checkout.ui.core.internal.ui.view.DefaultPayButton
 import com.adyen.checkout.ui.core.internal.ui.view.PayButton
@@ -18,13 +17,10 @@ import com.adyen.checkout.ui.core.internal.ui.view.PayButton
 interface ButtonViewProvider {
     fun getButton(
         context: Context,
-        attrs: AttributeSet?,
-        defStyleAttr: Int,
     ): PayButton
 }
 
 internal class DefaultButtonViewProvider : ButtonViewProvider {
 
-    override fun getButton(context: Context, attrs: AttributeSet?, defStyleAttr: Int): PayButton =
-        DefaultPayButton(context, attrs, defStyleAttr)
+    override fun getButton(context: Context): PayButton = DefaultPayButton(context)
 }

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/ViewProvider.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/ViewProvider.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.ui.core.internal.ui
 
 import android.content.Context
-import android.util.AttributeSet
 import androidx.annotation.RestrictTo
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -17,7 +16,5 @@ interface ViewProvider {
     fun getView(
         viewType: ComponentViewType,
         context: Context,
-        attrs: AttributeSet?,
-        defStyleAttr: Int
     ): ComponentView
 }

--- a/upi/src/main/java/com/adyen/checkout/upi/internal/ui/UPIViewProvider.kt
+++ b/upi/src/main/java/com/adyen/checkout/upi/internal/ui/UPIViewProvider.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.upi.internal.ui
 
 import android.content.Context
-import android.util.AttributeSet
 import com.adyen.checkout.ui.core.internal.ui.ButtonComponentViewType
 import com.adyen.checkout.ui.core.internal.ui.ComponentView
 import com.adyen.checkout.ui.core.internal.ui.ComponentViewType
@@ -22,10 +21,8 @@ internal object UPIViewProvider : ViewProvider {
     override fun getView(
         viewType: ComponentViewType,
         context: Context,
-        attrs: AttributeSet?,
-        defStyleAttr: Int
     ): ComponentView = when (viewType) {
-        UPIComponentViewType -> UPIView(context, attrs, defStyleAttr)
+        UPIComponentViewType -> UPIView(context)
         else -> throw IllegalArgumentException("Unsupported view type")
     }
 }

--- a/voucher/src/main/java/com/adyen/checkout/voucher/internal/ui/VoucherViewProvider.kt
+++ b/voucher/src/main/java/com/adyen/checkout/voucher/internal/ui/VoucherViewProvider.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.voucher.internal.ui
 
 import android.content.Context
-import android.util.AttributeSet
 import com.adyen.checkout.ui.core.internal.ui.ComponentView
 import com.adyen.checkout.ui.core.internal.ui.ComponentViewType
 import com.adyen.checkout.ui.core.internal.ui.ViewProvider
@@ -21,12 +20,10 @@ internal object VoucherViewProvider : ViewProvider {
     override fun getView(
         viewType: ComponentViewType,
         context: Context,
-        attrs: AttributeSet?,
-        defStyleAttr: Int
     ): ComponentView {
         return when (viewType) {
-            VoucherComponentViewType.SIMPLE_VOUCHER -> VoucherView(context, attrs, defStyleAttr)
-            VoucherComponentViewType.FULL_VOUCHER -> FullVoucherView(context, attrs, defStyleAttr)
+            VoucherComponentViewType.SIMPLE_VOUCHER -> VoucherView(context)
+            VoucherComponentViewType.FULL_VOUCHER -> FullVoucherView(context)
             else -> throw IllegalArgumentException("Unsupported view type")
         }
     }

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/internal/ui/WeChatViewProvider.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/internal/ui/WeChatViewProvider.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.wechatpay.internal.ui
 
 import android.content.Context
-import android.util.AttributeSet
 import com.adyen.checkout.ui.core.internal.ui.ComponentView
 import com.adyen.checkout.ui.core.internal.ui.ComponentViewType
 import com.adyen.checkout.ui.core.internal.ui.ViewProvider
@@ -20,10 +19,8 @@ internal object WeChatViewProvider : ViewProvider {
     override fun getView(
         viewType: ComponentViewType,
         context: Context,
-        attrs: AttributeSet?,
-        defStyleAttr: Int
     ): ComponentView = when (viewType) {
-        WeChatComponentViewType -> PaymentInProgressView(context, attrs, defStyleAttr)
+        WeChatComponentViewType -> PaymentInProgressView(context)
         else -> throw IllegalArgumentException("Unsupported view type")
     }
 }


### PR DESCRIPTION
## Description
The layout inspector enables a developer option that would trigger some sort of XML parsing to happen. This XML was not available (because we create the views programatically), so it resulted in a crash.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-809
