### PR TITLE
Fix frozen screen when dismissing gift card fragment

### DIFF
--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/ActionComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/ActionComponentDialogFragment.kt
@@ -143,7 +143,6 @@ internal class ActionComponentDialogFragment :
     }
 
     override fun onCancel(dialog: DialogInterface) {
-        super.onCancel(dialog)
         Logger.d(TAG, "onCancel")
         if (shouldFinishWithAction()) {
             protocol.finishWithAction()

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/BaseComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/BaseComponentDialogFragment.kt
@@ -8,7 +8,6 @@
 
 package com.adyen.checkout.dropin.internal.ui
 
-import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -133,12 +132,6 @@ internal abstract class BaseComponentDialogFragment :
         } catch (e: CheckoutException) {
             handleError(ComponentError(e))
         }
-    }
-
-    override fun onCancel(dialog: DialogInterface) {
-        super.onCancel(dialog)
-        Logger.d(TAG, "onCancel")
-        protocol.terminateDropIn()
     }
 
     override fun onSubmit(state: PaymentComponentState<*>) {

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInBottomSheetDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInBottomSheetDialogFragment.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.dropin.internal.ui
 
 import android.app.Dialog
 import android.content.Context
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.KeyEvent
 import android.widget.FrameLayout
@@ -79,6 +80,11 @@ internal abstract class DropInBottomSheetDialogFragment : BottomSheetDialogFragm
 
     open fun onBackPressed(): Boolean {
         return false
+    }
+
+    override fun onCancel(dialog: DialogInterface) {
+        Logger.d(TAG, "onCancel")
+        protocol.terminateDropIn()
     }
 
     companion object {

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/GiftCardComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/GiftCardComponentDialogFragment.kt
@@ -8,6 +8,7 @@
 
 package com.adyen.checkout.dropin.internal.ui
 
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -127,6 +128,12 @@ internal class GiftCardComponentDialogFragment : DropInBottomSheetDialogFragment
     private fun handleError(componentError: ComponentError) {
         Logger.e(TAG, componentError.errorMessage)
         protocol.showError(null, getString(R.string.component_error), componentError.errorMessage, true)
+    }
+
+    override fun onCancel(dialog: DialogInterface) {
+        super.onCancel(dialog)
+        Logger.d(TAG, "onCancel")
+        protocol.terminateDropIn()
     }
 
     override fun onBackPressed(): Boolean {

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/GiftCardComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/GiftCardComponentDialogFragment.kt
@@ -8,7 +8,6 @@
 
 package com.adyen.checkout.dropin.internal.ui
 
-import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -128,12 +127,6 @@ internal class GiftCardComponentDialogFragment : DropInBottomSheetDialogFragment
     private fun handleError(componentError: ComponentError) {
         Logger.e(TAG, componentError.errorMessage)
         protocol.showError(null, getString(R.string.component_error), componentError.errorMessage, true)
-    }
-
-    override fun onCancel(dialog: DialogInterface) {
-        super.onCancel(dialog)
-        Logger.d(TAG, "onCancel")
-        protocol.terminateDropIn()
     }
 
     override fun onBackPressed(): Boolean {

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/GiftCardPaymentConfirmationDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/GiftCardPaymentConfirmationDialogFragment.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.dropin.internal.ui
 
 import android.content.Context
-import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -98,12 +97,6 @@ internal class GiftCardPaymentConfirmationDialogFragment : DropInBottomSheetDial
         binding.recyclerViewGiftCards.adapter = PaymentMethodAdapter().apply {
             submitList(paymentMethods)
         }
-    }
-
-    override fun onCancel(dialog: DialogInterface) {
-        super.onCancel(dialog)
-        Logger.d(TAG, "onCancel")
-        protocol.terminateDropIn()
     }
 
     override fun onBackPressed(): Boolean {

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/GooglePayComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/GooglePayComponentDialogFragment.kt
@@ -8,7 +8,6 @@
 
 package com.adyen.checkout.dropin.internal.ui
 
-import android.content.DialogInterface
 import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -112,12 +111,6 @@ internal class GooglePayComponentDialogFragment :
     override fun onBackPressed(): Boolean {
         Logger.d(TAG, "onBackPressed")
         return performBackAction()
-    }
-
-    override fun onCancel(dialog: DialogInterface) {
-        super.onCancel(dialog)
-        Logger.d(TAG, "onCancel")
-        protocol.terminateDropIn()
     }
 
     private fun handleError(componentError: ComponentError) {

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodListDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodListDialogFragment.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.dropin.internal.ui
 
 import android.content.Context
-import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -141,12 +140,6 @@ internal class PaymentMethodListDialogFragment :
         paymentMethodAdapter = null
         binding.recyclerViewPaymentMethods.adapter = null
         _binding = null
-    }
-
-    override fun onCancel(dialog: DialogInterface) {
-        super.onCancel(dialog)
-        Logger.d(TAG, "onCancel")
-        protocol.terminateDropIn()
     }
 
     override fun onBackPressed(): Boolean {

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PreselectedStoredPaymentMethodFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PreselectedStoredPaymentMethodFragment.kt
@@ -8,7 +8,6 @@
 
 package com.adyen.checkout.dropin.internal.ui
 
-import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -224,12 +223,6 @@ internal class PreselectedStoredPaymentMethodFragment : DropInBottomSheetDialogF
                 dialog.dismiss()
             }
             .show()
-    }
-
-    override fun onCancel(dialog: DialogInterface) {
-        super.onCancel(dialog)
-        Logger.d(TAG, "onCancel")
-        protocol.terminateDropIn()
     }
 
     override fun onDestroyView() {


### PR DESCRIPTION
## Description
When a user dismisses the gift card fragment drop-in would not be terminated. This blocks the user with an invisible activity and makes the merchant app seem unresponsive. By simply overriding onCancel this was fixed.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-817
