### PR TITLE
Give action-core another namespace

### DIFF
--- a/action-core/build.gradle
+++ b/action-core/build.gradle
@@ -19,7 +19,7 @@ ext.mavenArtifactDescription = "Adyen Checkout Action Core module."
 apply from: "${rootDir}/config/gradle/sharedTasks.gradle"
 
 android {
-    namespace 'com.adyen.checkout.action'
+    namespace 'com.adyen.checkout.action.core'
     compileSdkVersion compile_sdk_version
 
     defaultConfig {


### PR DESCRIPTION
## Description
It used the same namespace as action, so it would generate a duplicate BuildConfig class. Ultimately failing the build when implementing the action module.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
- [x] Link to related issues
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-820
