### PR TITLE
Do not rebase renovate PRs automatically

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,6 @@
       "minimumReleaseAge" : "30 days",
       "schedule" : ["on the first day of the month"]
     }
-  ]
+  ],
+  "rebaseWhen" : "never"
 }


### PR DESCRIPTION
## Description
Stop renovate from automatically rebasing PRs to reduce notification noise.
You can manually rebase or click on the rebase checkbox in the PR description.

## Checklist <!-- Remove any line that's not applicable -->
- [ ] Code is unit tested
- [ ] Changes are tested manually