### PR TITLE
Rename telemetry to analytics

### DIFF
--- a/example-app/src/main/java/com/adyen/checkout/example/data/storage/KeyValueStorage.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/data/storage/KeyValueStorage.kt
@@ -34,7 +34,7 @@ interface KeyValueStorage {
     fun getInstallmentOptionsMode(): CardInstallmentOptionsMode
     fun useSessions(): Boolean
     fun setUseSessions(useSessions: Boolean)
-    fun getTelemetryLevel(): AnalyticsLevel
+    fun getAnalyticsLevel(): AnalyticsLevel
 }
 
 @Suppress("TooManyFunctions")
@@ -164,12 +164,12 @@ internal class DefaultKeyValueStorage(
         }
     }
 
-    override fun getTelemetryLevel(): AnalyticsLevel {
+    override fun getAnalyticsLevel(): AnalyticsLevel {
         return AnalyticsLevel.valueOf(
             sharedPreferences.getString(
                 appContext = appContext,
-                stringRes = R.string.telemetry_level_key,
-                defaultStringRes = R.string.preferences_default_telemetry_level,
+                stringRes = R.string.analytics_level_key,
+                defaultStringRes = R.string.preferences_default_analytics_level,
             )
         )
     }

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/configuration/CheckoutConfigurationProvider.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/configuration/CheckoutConfigurationProvider.kt
@@ -147,7 +147,7 @@ internal class CheckoutConfigurationProvider @Inject constructor(
             .build()
 
     private fun getAnalyticsConfiguration(): AnalyticsConfiguration {
-        val analyticsLevel = keyValueStorage.getTelemetryLevel()
+        val analyticsLevel = keyValueStorage.getAnalyticsLevel()
         return AnalyticsConfiguration(level = analyticsLevel)
     }
 

--- a/example-app/src/main/res/values/arrays.xml
+++ b/example-app/src/main/res/values/arrays.xml
@@ -46,12 +46,12 @@
         <item>@string/night_theme_night</item>
     </array>
 
-    <array name="telemetry_level_entries">
+    <array name="analytics_level_entries">
         <item>"All"</item>
         <item>"None"</item>
     </array>
 
-    <array name="telemetry_level_values">
+    <array name="analytics_level_values">
         <item>"ALL"</item>
         <item>"NONE"</item>
     </array>

--- a/example-app/src/main/res/values/strings.xml
+++ b/example-app/src/main/res/values/strings.xml
@@ -33,7 +33,7 @@
     <string name="merchant_account_title">Merchant Account</string>
     <string name="card_settings_title">Card</string>
     <string name="other_payment_methods_settings_title">Other payment methods</string>
-    <string name="telemetry_title">Telemetry</string>
+    <string name="analytics_title">Analytics</string>
     <string name="app_title">App</string>
 
     <string name="shopper_information">Shopper Information</string>
@@ -58,8 +58,8 @@
     <string name="instant_payment_method_type_key">instant_payment_method_type</string>
     <string name="instant_payment_method_type_title">Instant Payment Method Type</string>
     <string name="use_sessions_key">use_sessions</string>
-    <string name="telemetry_level_key">telemetry_level</string>
-    <string name="telemetry_level_title">Level</string>
+    <string name="analytics_level_key">analytics_level</string>
+    <string name="analytics_level_title">Level</string>
 
     <string name="night_theme_title">Theme</string>
     <!-- Should be same as DefaultNightThemeRepository.PREF_KEY_NIGHT_THEME -->
@@ -85,6 +85,6 @@
     <string name="preferences_default_installment_options_mode">NONE</string>
     <string name="preferences_default_instant_payment_method">wechatpaySDK</string>
     <string name="preferences_default_use_sessions">true</string>
-    <string name="preferences_default_telemetry_level">ALL</string>
+    <string name="preferences_default_analytics_level">ALL</string>
 
 </resources>

--- a/example-app/src/main/res/xml/preferences.xml
+++ b/example-app/src/main/res/xml/preferences.xml
@@ -105,14 +105,14 @@
 
     </PreferenceCategory>
 
-    <PreferenceCategory android:title="@string/telemetry_title">
+    <PreferenceCategory android:title="@string/analytics_title">
 
         <DropDownPreference
-            android:defaultValue="@string/preferences_default_telemetry_level"
-            android:entries="@array/telemetry_level_entries"
-            android:entryValues="@array/telemetry_level_values"
-            android:key="@string/telemetry_level_key"
-            android:title="@string/telemetry_level_title"
+            android:defaultValue="@string/preferences_default_analytics_level"
+            android:entries="@array/analytics_level_entries"
+            android:entryValues="@array/analytics_level_values"
+            android:key="@string/analytics_level_key"
+            android:title="@string/analytics_level_title"
             app:useSimpleSummaryProvider="true" />
 
     </PreferenceCategory>


### PR DESCRIPTION
## Description
Rename telemetry (only used in the example app) to analytics to preserve consistency with the SDK and because analytics is a broader term that fits our use case more than telemetry.

## Checklist <!-- Remove any line that's not applicable -->
- [ ] Code is unit tested
- [x] Changes are tested manually