### PR TITLE
Fix selected card index not being reset when a new card is detected

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegate.kt
@@ -244,6 +244,9 @@ class DefaultCardDelegate(
                 }
                 updateOutputData(detectedCardTypes = detectedCardTypes)
             }
+            .map { detectedCardTypes -> detectedCardTypes.map { it.cardBrand } }
+            .distinctUntilChanged()
+            .onEach { inputData.selectedCardIndex = -1 }
             .launchIn(coroutineScope)
     }
 

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegateTest.kt
@@ -426,6 +426,10 @@ internal class DefaultCardDelegateTest(
 
                 delegate.updateInputData {
                     cardNumber = invalidLuhnCardNumber
+                }
+
+                // we need to update selectedCardIndex separate from cardNumber to simulate the actual use case
+                delegate.updateInputData {
                     selectedCardIndex = 1
                 }
 


### PR DESCRIPTION
## Description
[//]: # (Include a short summary of your changes)
[//]: # (If this is a new feature: attach screenshots or a video if applicable)
[//]: # (If this is a bug fix: include a reproduction path)
The issue is when a new card is inputted we keep selected card index which results in incorrectly selecting a brand if the new card being inputted is dual branded. 

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-795
