### PR TITLE
Update WeChat SDK to 6.8.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ allprojects {
 
     // External Dependencies
     ext.play_services_wallet_version = '18.1.3'
-    ext.wechat_pay_version = "6.6.4"
+    ext.wechat_pay_version = "6.8.0"
     ext.cash_app_pay_version = '2.1.0'
 
     // Drop-in

--- a/config/gradle/checksums.gradle
+++ b/config/gradle/checksums.gradle
@@ -36,7 +36,7 @@ if (!hasProperty("checksums")) {
             "com.google.android.gms:play-services-wallet:18.1.3:2314339d19e7fe101ae793085ed08863:MD5",
 
             // WeChatPay
-            "com.tencent.mm.opensdk:wechat-sdk-android-without-mta:6.6.4:8ae40b8665f98587e716b4593401aef2:MD5",
+            "com.tencent.mm.opensdk:wechat-sdk-android-without-mta:6.8.0:5c90b3c5711c8a53cb619edefe8f0aa0:MD5",
 
             // Cash App Pay
             "app.cash.paykit:core:2.1.0:2026387e6572b0e28e448877199e6802:MD5",


### PR DESCRIPTION
## Description
This should make WeChat work on Android 11+ again.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually