### PR TITLE
Group Compose and Kotlin for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,18 @@
   "labels": ["Dependencies"],
   "packageRules" : [
     {
+      "matchPackagePatterns": [
+        "androidx.compose.compiler:compiler"
+      ],
+      "groupName": "kotlin"
+    },
+    {
+      "matchPackagePatterns": [
+        "org.jetbrains.kotlin.*"
+      ],
+      "groupName": "kotlin"
+    },
+    {
       "matchPackagePatterns" : ["*"],
       "minimumReleaseAge" : "30 days",
       "schedule" : ["on the first day of the month"]


### PR DESCRIPTION
## Description
This will make sure Compose and Kotlin will get updated in the same PR, so we will no longer run into compatibility conflicts.

