### PR TITLE
Improve logging of API errors

### DIFF
--- a/checkout-core/src/main/java/com/adyen/checkout/core/exception/HttpException.kt
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/exception/HttpException.kt
@@ -14,7 +14,7 @@ import com.adyen.checkout.core.internal.data.model.ErrorResponseBody
  * Indicates that an internal API call has failed.
  */
 class HttpException(
-    code: Int,
+    val code: Int,
     message: String,
     val errorBody: ErrorResponseBody?,
-) : CheckoutException("$code $message")
+) : CheckoutException(message)

--- a/checkout-core/src/main/java/com/adyen/checkout/core/internal/data/model/ErrorResponseBody.kt
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/internal/data/model/ErrorResponseBody.kt
@@ -21,6 +21,7 @@ data class ErrorResponseBody(
     val errorCode: String?,
     val message: String?,
     val errorType: String?,
+    val pspReference: String?,
 ) : ModelObject() {
 
     companion object {
@@ -29,6 +30,7 @@ data class ErrorResponseBody(
         private const val ERROR_CODE = "errorCode"
         private const val MESSAGE = "message"
         private const val ERROR_TYPE = "errorType"
+        private const val PSP_REFERENCE = "pspReference"
 
         @JvmField
         val SERIALIZER: Serializer<ErrorResponseBody> = object : Serializer<ErrorResponseBody> {
@@ -39,6 +41,7 @@ data class ErrorResponseBody(
                     jsonObject.putOpt(ERROR_CODE, modelObject.errorCode)
                     jsonObject.putOpt(MESSAGE, modelObject.message)
                     jsonObject.putOpt(ERROR_TYPE, modelObject.errorType)
+                    jsonObject.putOpt(PSP_REFERENCE, modelObject.pspReference)
                 } catch (e: JSONException) {
                     throw ModelSerializationException(ErrorResponseBody::class.java, e)
                 }
@@ -52,6 +55,7 @@ data class ErrorResponseBody(
                         errorCode = jsonObject.optString(ERROR_CODE),
                         message = jsonObject.optString(MESSAGE),
                         errorType = jsonObject.optString(ERROR_TYPE),
+                        pspReference = jsonObject.optString(PSP_REFERENCE),
                     )
                 } catch (e: JSONException) {
                     throw ModelSerializationException(ErrorResponseBody::class.java, e)

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/DefaultAnalyticsRepository.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/DefaultAnalyticsRepository.kt
@@ -58,8 +58,7 @@ class DefaultAnalyticsRepository(
             Logger.v(TAG, "Analytics setup call successful")
         }.onFailure { e ->
             state = State.Failed
-            // TODO change back to error when all analytic endpoints are live
-            Logger.w(TAG, "Failed to send analytics setup call - ${e::class.simpleName}: ${e.message}")
+            Logger.e(TAG, "Failed to send analytics setup call - ${e::class.simpleName}: ${e.message}")
         }
     }
 


### PR DESCRIPTION
## Description
- Added detailed error logging to internal API calls:
  - Logging is added on the HTTP client level, to make sure it covers every call.
  - If the error body is a json string with the expected format, we log it as it is to make debugging easier.
  - Otherwise, the error code and body or message are logged.
- Added `pspReference` attribute to the error response body.
- Changed analytics API error logging level back to `e` now that the endpoints are live.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually