### PR TITLE
Add missing parent styles in XML

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,7 @@
 
 ## Fixed
 - For drop-in with sessions, error dialogs will no longer display user unfriendly messages.
+- Overriding some of the XML styles without specifying a parent style no longer causes a build error.
 
 ## Changed
 

--- a/bacs/src/main/res/values/styles.xml
+++ b/bacs/src/main/res/values/styles.xml
@@ -31,6 +31,8 @@
         <item name="android:inputType">textEmailAddress</item>
     </style>
 
+    <style name="AdyenCheckout.Bacs.Switch" />
+
     <style name="AdyenCheckout.Bacs.Switch.Amount" parent="AdyenCheckout.Switch">
         <item name="android:text">@string/bacs_consent_amount</item>
         <item name="android:layout_marginBottom">@dimen/standard_quarter_margin</item>

--- a/paybybank/src/main/res/values/styles.xml
+++ b/paybybank/src/main/res/values/styles.xml
@@ -7,6 +7,8 @@
   -->
 
 <resources>
+    <style name="AdyenCheckout.PayByBank" />
+
     <style name="AdyenCheckout.PayByBank.SearchQueryInput" parent="AdyenCheckout.TextInputEditText">
         <item name="android:hint">@string/checkout_pay_by_bank_search</item>
         <item name="android:inputType">text</item>

--- a/ui-core/src/main/res/values/styles.xml
+++ b/ui-core/src/main/res/values/styles.xml
@@ -150,6 +150,8 @@
         <item name="colorAccent">?attr/colorPrimary</item>
     </style>
 
+    <style name="AdyenCheckout.Button" />
+
     <style name="AdyenCheckout.Button.Colored" parent="AdyenCheckout.Button.Primary">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">@dimen/primary_button_height</item>
@@ -173,6 +175,8 @@
         <item name="android:textSize">16sp</item>
         <item name="android:layout_gravity">center_vertical</item>
     </style>
+
+    <style name="AdyenCheckout.PaymentInProgressView" />
 
     <style name="AdyenCheckout.PaymentInProgressView.TitleTextView" parent="AdyenCheckout">
         <item name="android:text">@string/paymentInProgressView_title</item>
@@ -300,6 +304,8 @@
     <style name="AdyenCheckout.DropdownTextInputLayout.ProvinceTerritoryInput" parent="AdyenCheckout.DropdownTextInputLayout">
         <item name="android:hint">@string/checkout_address_form_province_territory_hint</item>
     </style>
+
+    <style name="AdyenCheckout.AddressForm" />
 
     <style name="AdyenCheckout.AddressForm.HeaderTextAppearance" parent="AdyenCheckout.TextAppearance">
         <item name="android:textSize">12sp</item>

--- a/upi/src/main/res/values/styles.xml
+++ b/upi/src/main/res/values/styles.xml
@@ -7,6 +7,8 @@
   -->
 <resources>
 
+    <style name="AdyenCheckout.UPI" />
+
     <style name="AdyenCheckout.UPI.ModeSelectionTextView" parent="AdyenCheckout.TextAppearance.Primary">
         <item name="android:text">@string/checkout_upi_mode_selection</item>
     </style>

--- a/voucher/src/main/res/values/styles.xml
+++ b/voucher/src/main/res/values/styles.xml
@@ -10,6 +10,8 @@
 
     <style name="AdyenCheckout.Voucher" />
 
+    <style name="AdyenCheckout.Voucher.Description" />
+
     <style name="AdyenCheckout.Voucher.Description.Bacs" parent="AdyenCheckout.TextAppearance.Primary">
         <item name="android:layout_marginStart">@dimen/standard_double_margin</item>
         <item name="android:layout_marginEnd">@dimen/standard_double_margin</item>


### PR DESCRIPTION
## Description
Some styles are not overridable and will cause a build error, because their parent style is not declared in `styles.xml`.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-841