### PR TITLE
Fix polling interval values in polling action components

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,7 @@
 ## Fixed
 - For drop-in with sessions, error dialogs will no longer display user unfriendly messages.
 - Overriding some of the XML styles without specifying a parent style no longer causes a build error.
+- The Await and QR Code action components will no longer be stuck in a loading state for a long time after the payment is finalized. 
 
 ## Changed
 

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/StatusRepository.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/StatusRepository.kt
@@ -105,8 +105,8 @@ class DefaultStatusRepository constructor(
     companion object {
         private val TAG = LogUtil.getTag()
 
-        private val POLLING_DELAY_FAST = TimeUnit.SECONDS.toMillis(60)
-        private val POLLING_DELAY_SLOW = TimeUnit.SECONDS.toMillis(60)
-        private val POLLING_THRESHOLD = TimeUnit.SECONDS.toMillis(120)
+        private val POLLING_DELAY_FAST = TimeUnit.SECONDS.toMillis(2)
+        private val POLLING_DELAY_SLOW = TimeUnit.SECONDS.toMillis(10)
+        private val POLLING_THRESHOLD = TimeUnit.SECONDS.toMillis(60)
     }
 }


### PR DESCRIPTION
## Description
For polling action components (Await and QR code) the polling intervals were set to very big values which can leave shoppers stuck on the loading screen for a long time after the payment was processed.

This PR fixes these values and aligns them again with v4.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
- [x] Link to related issues
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->
