### PR TITLE
Apply shopper locale if provided to the sessions API call

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/model/Adyen3DS2ComponentParamsMapper.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/model/Adyen3DS2ComponentParamsMapper.kt
@@ -62,6 +62,7 @@ internal class Adyen3DS2ComponentParamsMapper(
         if (sessionParams == null) return this
         return copy(
             amount = sessionParams.amount ?: amount,
+            shopperLocale = sessionParams.shopperLocale ?: shopperLocale,
         )
     }
 

--- a/ach/src/main/java/com/adyen/checkout/ach/internal/ui/model/ACHDirectDebitComponentParamsMapper.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/internal/ui/model/ACHDirectDebitComponentParamsMapper.kt
@@ -82,6 +82,7 @@ internal class ACHDirectDebitComponentParamsMapper(
         return copy(
             isStorePaymentFieldVisible = sessionParams.enableStoreDetails ?: isStorePaymentFieldVisible,
             amount = sessionParams.amount ?: amount,
+            shopperLocale = sessionParams.shopperLocale ?: shopperLocale,
         )
     }
 

--- a/ach/src/test/java/com/adyen/checkout/ach/internal/ui/model/ACHDirectDebitComponentParamsMapperTest.kt
+++ b/ach/src/test/java/com/adyen/checkout/ach/internal/ui/model/ACHDirectDebitComponentParamsMapperTest.kt
@@ -173,6 +173,7 @@ internal class ACHDirectDebitComponentParamsMapperTest {
             installmentConfiguration = null,
             amount = null,
             returnUrl = "",
+            shopperLocale = null,
         )
 
         val params = ACHDirectDebitComponentParamsMapper(null, null).mapToParams(
@@ -218,6 +219,7 @@ internal class ACHDirectDebitComponentParamsMapperTest {
                 installmentConfiguration = null,
                 amount = sessionsValue,
                 returnUrl = "",
+                shopperLocale = null,
             ),
         )
 
@@ -227,6 +229,28 @@ internal class ACHDirectDebitComponentParamsMapperTest {
         )
 
         assertEquals(expected, params)
+    }
+
+    @Test
+    fun `when shopper locale is set in sessions then the mapped params should match it`() {
+        val configuration = CheckoutConfiguration(
+            environment = Environment.TEST,
+            shopperLocale = Locale.US,
+            clientKey = TEST_CLIENT_KEY_1,
+        )
+
+        val params = ACHDirectDebitComponentParamsMapper(null, null).mapToParams(
+            checkoutConfiguration = configuration,
+            sessionParams = SessionParams(
+                enableStoreDetails = false,
+                installmentConfiguration = null,
+                amount = null,
+                returnUrl = null,
+                shopperLocale = Locale.GERMAN,
+            ),
+        )
+
+        assertEquals(Locale.GERMAN, params.shopperLocale)
     }
 
     private fun createCheckoutConfiguration(

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/internal/ui/model/BcmcComponentParamsMapper.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/internal/ui/model/BcmcComponentParamsMapper.kt
@@ -81,6 +81,7 @@ internal class BcmcComponentParamsMapper(
         return copy(
             isStorePaymentFieldVisible = sessionParams.enableStoreDetails ?: isStorePaymentFieldVisible,
             amount = sessionParams.amount ?: amount,
+            shopperLocale = sessionParams.shopperLocale ?: shopperLocale,
         )
     }
 

--- a/bcmc/src/test/java/com/adyen/checkout/bcmc/internal/ui/model/BcmcComponentParamsMapperTest.kt
+++ b/bcmc/src/test/java/com/adyen/checkout/bcmc/internal/ui/model/BcmcComponentParamsMapperTest.kt
@@ -130,6 +130,7 @@ internal class BcmcComponentParamsMapperTest {
                 installmentConfiguration = null,
                 amount = null,
                 returnUrl = "",
+                shopperLocale = null,
             ),
             PaymentMethod(),
         )
@@ -158,6 +159,7 @@ internal class BcmcComponentParamsMapperTest {
                 installmentConfiguration = null,
                 amount = sessionsValue,
                 returnUrl = "",
+                shopperLocale = null,
             ),
             PaymentMethod(),
         )
@@ -168,6 +170,29 @@ internal class BcmcComponentParamsMapperTest {
         )
 
         assertEquals(expected, params)
+    }
+
+    @Test
+    fun `when shopper locale is set in sessions then the mapped params should match it`() {
+        val configuration = CheckoutConfiguration(
+            environment = Environment.TEST,
+            shopperLocale = Locale.US,
+            clientKey = TEST_CLIENT_KEY_1,
+        )
+
+        val params = BcmcComponentParamsMapper(null, null).mapToParams(
+            checkoutConfiguration = configuration,
+            sessionParams = SessionParams(
+                enableStoreDetails = false,
+                installmentConfiguration = null,
+                amount = null,
+                returnUrl = null,
+                shopperLocale = Locale.GERMAN,
+            ),
+            paymentMethod = PaymentMethod(),
+        )
+
+        assertEquals(Locale.GERMAN, params.shopperLocale)
     }
 
     private fun createCheckoutConfiguration(

--- a/boleto/src/main/java/com/adyen/checkout/boleto/internal/ui/model/BoletoComponentParamsMapper.kt
+++ b/boleto/src/main/java/com/adyen/checkout/boleto/internal/ui/model/BoletoComponentParamsMapper.kt
@@ -65,6 +65,7 @@ internal class BoletoComponentParamsMapper(
         if (sessionParams == null) return this
         return copy(
             amount = sessionParams.amount ?: amount,
+            shopperLocale = sessionParams.shopperLocale ?: shopperLocale,
         )
     }
 

--- a/boleto/src/test/java/com/adyen/checkout/boleto/internal/ui/model/BoletoComponentParamsMapperTest.kt
+++ b/boleto/src/test/java/com/adyen/checkout/boleto/internal/ui/model/BoletoComponentParamsMapperTest.kt
@@ -131,6 +131,7 @@ internal class BoletoComponentParamsMapperTest {
                 installmentConfiguration = null,
                 amount = sessionsValue,
                 returnUrl = "",
+                shopperLocale = null,
             ),
         )
 
@@ -140,6 +141,28 @@ internal class BoletoComponentParamsMapperTest {
         )
 
         assertEquals(expected, params)
+    }
+
+    @Test
+    fun `when shopper locale is set in sessions then the mapped params should match it`() {
+        val configuration = CheckoutConfiguration(
+            environment = Environment.TEST,
+            shopperLocale = Locale.US,
+            clientKey = TEST_CLIENT_KEY_1,
+        )
+
+        val params = BoletoComponentParamsMapper(null, null).mapToParams(
+            configuration = configuration,
+            sessionParams = SessionParams(
+                enableStoreDetails = false,
+                installmentConfiguration = null,
+                amount = null,
+                returnUrl = null,
+                shopperLocale = Locale.GERMAN,
+            ),
+        )
+
+        assertEquals(Locale.GERMAN, params.shopperLocale)
     }
 
     private fun createCheckoutConfiguration(

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapper.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapper.kt
@@ -186,6 +186,7 @@ internal class CardComponentParamsMapper(
         sessionParams: SessionParams?
     ): CardComponentParams {
         if (sessionParams == null) return this
+        val shopperLocale = sessionParams.shopperLocale ?: shopperLocale
         return copy(
             isStorePaymentFieldVisible = sessionParams.enableStoreDetails ?: isStorePaymentFieldVisible,
             // we don't fall back to the original value of installmentParams value on purpose
@@ -197,6 +198,7 @@ internal class CardComponentParamsMapper(
                 shopperLocale = shopperLocale,
             ),
             amount = sessionParams.amount ?: amount,
+            shopperLocale = shopperLocale,
         )
     }
 

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapperTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapperTest.kt
@@ -280,6 +280,7 @@ internal class CardComponentParamsMapperTest {
                 installmentConfiguration = null,
                 amount = null,
                 returnUrl = "",
+                shopperLocale = null,
             ),
         )
 
@@ -311,6 +312,7 @@ internal class CardComponentParamsMapperTest {
                 installmentConfiguration = null,
                 amount = null,
                 returnUrl = "",
+                shopperLocale = null,
             ),
         )
 
@@ -355,6 +357,7 @@ internal class CardComponentParamsMapperTest {
                 installmentConfiguration = installmentConfiguration,
                 amount = null,
                 returnUrl = "",
+                shopperLocale = null,
             ),
         )
 
@@ -438,6 +441,7 @@ internal class CardComponentParamsMapperTest {
                     installmentConfiguration = null,
                     amount = sessionsValue,
                     returnUrl = "",
+                    shopperLocale = null,
                 ),
             )
 
@@ -447,6 +451,29 @@ internal class CardComponentParamsMapperTest {
         )
 
         assertEquals(expected, params)
+    }
+
+    @Test
+    fun `when shopper locale is set in sessions then the mapped params should match it`() {
+        val configuration = CheckoutConfiguration(
+            environment = Environment.TEST,
+            shopperLocale = Locale.US,
+            clientKey = TEST_CLIENT_KEY_1,
+        )
+
+        val params = CardComponentParamsMapper(InstallmentsParamsMapper(), null, null).mapToParamsDefault(
+            checkoutConfiguration = configuration,
+            sessionParams = SessionParams(
+                enableStoreDetails = false,
+                installmentConfiguration = null,
+                amount = null,
+                returnUrl = null,
+                shopperLocale = Locale.GERMAN,
+            ),
+            paymentMethod = PaymentMethod(),
+        )
+
+        assertEquals(Locale.GERMAN, params.shopperLocale)
     }
 
     private fun createCheckoutConfiguration(

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/model/CashAppPayComponentParamsMapper.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/model/CashAppPayComponentParamsMapper.kt
@@ -119,6 +119,7 @@ internal class CashAppPayComponentParamsMapper(
             amount = sessionParams.amount ?: amount,
             showStorePaymentField = sessionParams.enableStoreDetails ?: showStorePaymentField,
             returnUrl = sessionParams.returnUrl ?: returnUrl,
+            shopperLocale = sessionParams.shopperLocale ?: shopperLocale,
         )
     }
 }

--- a/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/model/CashAppPayComponentParamsMapperTest.kt
+++ b/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/model/CashAppPayComponentParamsMapperTest.kt
@@ -152,6 +152,7 @@ internal class CashAppPayComponentParamsMapperTest {
                 installmentConfiguration = null,
                 amount = null,
                 returnUrl = TEST_RETURN_URL,
+                shopperLocale = null,
             ),
             paymentMethod = getDefaultPaymentMethod(),
             context = Application(),
@@ -183,6 +184,7 @@ internal class CashAppPayComponentParamsMapperTest {
                 installmentConfiguration = null,
                 amount = sessionsValue,
                 returnUrl = TEST_RETURN_URL,
+                shopperLocale = null,
             ),
             paymentMethod = getDefaultPaymentMethod(),
             context = Application(),
@@ -228,7 +230,7 @@ internal class CashAppPayComponentParamsMapperTest {
 
         val params = CashAppPayComponentParamsMapper(null, null).mapToParams(
             configuration = configuration,
-            sessionParams = SessionParams(false, null, null, "sessionReturnUrl"),
+            sessionParams = SessionParams(false, null, null, "sessionReturnUrl", null),
             paymentMethod = getDefaultPaymentMethod(),
             context = Application(),
         )
@@ -319,6 +321,26 @@ internal class CashAppPayComponentParamsMapperTest {
         )
 
         assertEquals(expected, params.returnUrl)
+    }
+
+    @Test
+    fun `when shopper locale is set in sessions then the mapped params should match it`() {
+        val configuration = createCheckoutConfiguration()
+
+        val params = CashAppPayComponentParamsMapper(null, null).mapToParams(
+            configuration = configuration,
+            sessionParams = SessionParams(
+                enableStoreDetails = false,
+                installmentConfiguration = null,
+                amount = null,
+                returnUrl = TEST_RETURN_URL,
+                shopperLocale = Locale.GERMAN,
+            ),
+            paymentMethod = getDefaultPaymentMethod(),
+            context = Application(),
+        )
+
+        assertEquals(Locale.GERMAN, params.shopperLocale)
     }
 
     @Suppress("LongParameterList")

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/ButtonComponentParamsMapper.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/ButtonComponentParamsMapper.kt
@@ -50,6 +50,7 @@ class ButtonComponentParamsMapper(
         if (sessionParams == null) return this
         return copy(
             amount = sessionParams.amount ?: amount,
+            shopperLocale = sessionParams.shopperLocale ?: shopperLocale,
         )
     }
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/GenericComponentParamsMapper.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/GenericComponentParamsMapper.kt
@@ -55,6 +55,7 @@ class GenericComponentParamsMapper(
         if (sessionParams == null) return this
         return copy(
             amount = sessionParams.amount ?: amount,
+            shopperLocale = sessionParams.shopperLocale ?: shopperLocale,
         )
     }
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/SessionParams.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/SessionParams.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.components.core.internal.ui.model
 
 import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.core.Amount
+import java.util.Locale
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class SessionParams(
@@ -17,4 +18,5 @@ data class SessionParams(
     val installmentConfiguration: SessionInstallmentConfiguration?,
     val amount: Amount?,
     val returnUrl: String?,
+    val shopperLocale: Locale?,
 )

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/ui/model/ButtonComponentParamsMapperTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/ui/model/ButtonComponentParamsMapperTest.kt
@@ -92,6 +92,7 @@ internal class ButtonComponentParamsMapperTest {
                 installmentConfiguration = null,
                 amount = sessionsValue,
                 returnUrl = "",
+                shopperLocale = null,
             ),
         )
 
@@ -99,6 +100,29 @@ internal class ButtonComponentParamsMapperTest {
             getButtonComponentParams().copy(amount = expectedValue, isCreatedByDropIn = dropInOverrideParams != null)
 
         assertEquals(expected, params)
+    }
+
+    @Test
+    fun `when shopper locale is set in sessions then the mapped params should match it`() {
+        val configuration = CheckoutConfiguration(
+            environment = Environment.TEST,
+            shopperLocale = Locale.US,
+            clientKey = TEST_CLIENT_KEY_1,
+        )
+
+        val params = ButtonComponentParamsMapper(null, null).mapToParams(
+            checkoutConfiguration = configuration,
+            configuration = configuration.getConfiguration(TEST_CONFIGURATION_KEY),
+            sessionParams = SessionParams(
+                enableStoreDetails = false,
+                installmentConfiguration = null,
+                amount = null,
+                returnUrl = null,
+                shopperLocale = Locale.GERMAN,
+            ),
+        )
+
+        assertEquals(Locale.GERMAN, params.shopperLocale)
     }
 
     private fun createCheckoutConfiguration(

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/ui/model/GenericComponentParamsMapperTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/ui/model/GenericComponentParamsMapperTest.kt
@@ -97,6 +97,7 @@ internal class GenericComponentParamsMapperTest {
                 installmentConfiguration = null,
                 amount = sessionsValue,
                 returnUrl = "",
+                shopperLocale = null,
             ),
         )
 
@@ -104,6 +105,28 @@ internal class GenericComponentParamsMapperTest {
             getGenericComponentParams().copy(amount = expectedValue, isCreatedByDropIn = dropInOverrideParams != null)
 
         assertEquals(expected, params)
+    }
+
+    @Test
+    fun `when shopper locale is set in sessions then the mapped params should match it`() {
+        val configuration = CheckoutConfiguration(
+            environment = Environment.TEST,
+            shopperLocale = Locale.US,
+            clientKey = TEST_CLIENT_KEY_1,
+        )
+
+        val params = GenericComponentParamsMapper(null, null).mapToParams(
+            configuration = configuration,
+            sessionParams = SessionParams(
+                enableStoreDetails = false,
+                installmentConfiguration = null,
+                amount = null,
+                returnUrl = null,
+                shopperLocale = Locale.GERMAN,
+            ),
+        )
+
+        assertEquals(Locale.GERMAN, params.shopperLocale)
     }
 
     private fun createCheckoutConfiguration(

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropIn.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropIn.kt
@@ -23,6 +23,8 @@ import com.adyen.checkout.dropin.internal.ui.model.SessionDropInResultContractPa
 import com.adyen.checkout.dropin.internal.util.DropInPrefs
 import com.adyen.checkout.sessions.core.CheckoutSession
 import com.adyen.checkout.sessions.core.CheckoutSessionProvider
+import com.adyen.checkout.sessions.core.internal.ui.model.SessionParamsFactory
+import java.util.Locale
 
 /**
  * Drop-in is our pre-built checkout UI for accepting payments. You only need to integrate through your backend with the
@@ -135,7 +137,11 @@ object DropIn {
             checkoutSession,
             serviceClass,
         )
-        startPayment(context, dropInLauncher, checkoutConfiguration, sessionDropInResultContractParams)
+
+        val sessionParams = SessionParamsFactory.create(checkoutSession)
+        val shopperLocale = sessionParams.shopperLocale ?: checkoutConfiguration.shopperLocale
+
+        startPayment(context, dropInLauncher, shopperLocale, sessionDropInResultContractParams)
     }
 
     /**
@@ -228,17 +234,17 @@ object DropIn {
             paymentMethodsApiResponse,
             serviceClass,
         )
-        startPayment(context, dropInLauncher, checkoutConfiguration, dropInResultContractParams)
+        startPayment(context, dropInLauncher, checkoutConfiguration.shopperLocale, dropInResultContractParams)
     }
 
     private fun <T> startPayment(
         context: Context,
         dropInLauncher: ActivityResultLauncher<T>,
-        checkoutConfiguration: CheckoutConfiguration,
+        shopperLocale: Locale,
         params: T,
     ) {
         updateDefaultLogLevel(context)
-        DropInPrefs.setShopperLocale(context, checkoutConfiguration.shopperLocale)
+        DropInPrefs.setShopperLocale(context, shopperLocale)
         dropInLauncher.launch(params)
     }
 

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/ui/model/GiftCardComponentParamsMapper.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/ui/model/GiftCardComponentParamsMapper.kt
@@ -59,6 +59,7 @@ internal class GiftCardComponentParamsMapper(
         if (sessionParams == null) return this
         return copy(
             amount = sessionParams.amount ?: amount,
+            shopperLocale = sessionParams.shopperLocale ?: shopperLocale,
         )
     }
 }

--- a/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/ui/model/GiftCardComponentParamsMapperTest.kt
+++ b/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/ui/model/GiftCardComponentParamsMapperTest.kt
@@ -97,12 +97,35 @@ internal class GiftCardComponentParamsMapperTest {
                 installmentConfiguration = null,
                 amount = sessionsValue,
                 returnUrl = "",
+                shopperLocale = null,
             ),
         )
 
         val expected = getComponentParams(amount = expectedValue, isCreatedByDropIn = dropInOverrideParams != null)
 
         assertEquals(expected, params)
+    }
+
+    @Test
+    fun `when shopper locale is set in sessions then the mapped params should match it`() {
+        val configuration = CheckoutConfiguration(
+            environment = Environment.TEST,
+            shopperLocale = Locale.US,
+            clientKey = TEST_CLIENT_KEY_1,
+        )
+
+        val params = GiftCardComponentParamsMapper(null, null).mapToParams(
+            configuration = configuration,
+            sessionParams = SessionParams(
+                enableStoreDetails = false,
+                installmentConfiguration = null,
+                amount = null,
+                returnUrl = null,
+                shopperLocale = Locale.GERMAN,
+            ),
+        )
+
+        assertEquals(Locale.GERMAN, params.shopperLocale)
     }
 
     private fun createCheckoutConfiguration(

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParamsMapper.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParamsMapper.kt
@@ -140,6 +140,7 @@ internal class GooglePayComponentParamsMapper(
         if (sessionParams == null) return this
         return copy(
             amount = sessionParams.amount ?: amount,
+            shopperLocale = sessionParams.shopperLocale ?: shopperLocale,
         )
     }
 

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParamsMapperTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParamsMapperTest.kt
@@ -358,6 +358,7 @@ internal class GooglePayComponentParamsMapperTest {
                 installmentConfiguration = null,
                 amount = sessionsValue,
                 returnUrl = "",
+                shopperLocale = null,
             ),
         )
 
@@ -367,6 +368,25 @@ internal class GooglePayComponentParamsMapperTest {
         )
 
         assertEquals(expected, params)
+    }
+
+    @Test
+    fun `when shopper locale is set in sessions then the mapped params should match it`() {
+        val configuration = createCheckoutConfiguration()
+
+        val params = GooglePayComponentParamsMapper(null, null).mapToParams(
+            configuration = configuration,
+            sessionParams = SessionParams(
+                enableStoreDetails = false,
+                installmentConfiguration = null,
+                amount = null,
+                returnUrl = null,
+                shopperLocale = Locale.GERMAN,
+            ),
+            paymentMethod = PaymentMethod(),
+        )
+
+        assertEquals(Locale.GERMAN, params.shopperLocale)
     }
 
     private fun createCheckoutConfiguration(

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/ui/model/IssuerListComponentParamsMapper.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/ui/model/IssuerListComponentParamsMapper.kt
@@ -66,6 +66,7 @@ class IssuerListComponentParamsMapper(
         if (sessionParams == null) return this
         return copy(
             amount = sessionParams.amount ?: amount,
+            shopperLocale = sessionParams.shopperLocale ?: shopperLocale,
         )
     }
 }

--- a/issuer-list/src/test/java/com/adyen/checkout/issuerlist/internal/ui/model/IssuerListComponentParamsMapperTest.kt
+++ b/issuer-list/src/test/java/com/adyen/checkout/issuerlist/internal/ui/model/IssuerListComponentParamsMapperTest.kt
@@ -138,6 +138,7 @@ internal class IssuerListComponentParamsMapperTest {
                 installmentConfiguration = null,
                 amount = sessionsValue,
                 returnUrl = "",
+                shopperLocale = null,
             ),
         )
 
@@ -147,6 +148,29 @@ internal class IssuerListComponentParamsMapperTest {
         )
 
         assertEquals(expected, params)
+    }
+
+    @Test
+    fun `when shopper locale is set in sessions then the mapped params should match it`() {
+        val configuration = CheckoutConfiguration(
+            environment = Environment.TEST,
+            shopperLocale = Locale.US,
+            clientKey = TEST_CLIENT_KEY_1,
+        )
+
+        val params = IssuerListComponentParamsMapper(null, null).mapToParams(
+            checkoutConfiguration = configuration,
+            configuration = configuration.getConfiguration(TEST_CONFIGURATION_KEY),
+            sessionParams = SessionParams(
+                enableStoreDetails = false,
+                installmentConfiguration = null,
+                amount = null,
+                returnUrl = null,
+                shopperLocale = Locale.GERMAN,
+            ),
+        )
+
+        assertEquals(Locale.GERMAN, params.shopperLocale)
     }
 
     private fun createCheckoutConfiguration(

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/SessionSetupResponse.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/SessionSetupResponse.kt
@@ -25,7 +25,8 @@ data class SessionSetupResponse(
     val expiresAt: String,
     val paymentMethodsApiResponse: PaymentMethodsApiResponse?,
     val returnUrl: String?,
-    val configuration: SessionSetupConfiguration?
+    val configuration: SessionSetupConfiguration?,
+    val shopperLocale: String?,
 ) : ModelObject() {
 
     companion object {
@@ -36,6 +37,7 @@ data class SessionSetupResponse(
         private const val PAYMENT_METHODS = "paymentMethods"
         private const val RETURN_URL = "returnUrl"
         private const val CONFIGURATION = "configuration"
+        private const val SHOPPER_LOCALE = "shopperLocale"
 
         @JvmField
         val SERIALIZER: Serializer<SessionSetupResponse> = object : Serializer<SessionSetupResponse> {
@@ -58,6 +60,7 @@ data class SessionSetupResponse(
                         CONFIGURATION,
                         ModelUtils.serializeOpt(modelObject.configuration, SessionSetupConfiguration.SERIALIZER)
                     )
+                    jsonObject.putOpt(SHOPPER_LOCALE, modelObject.shopperLocale)
                 } catch (e: JSONException) {
                     throw ModelSerializationException(SessionSetupResponse::class.java, e)
                 }
@@ -79,7 +82,8 @@ data class SessionSetupResponse(
                         configuration = ModelUtils.deserializeOpt(
                             jsonObject.optJSONObject(CONFIGURATION),
                             SessionSetupConfiguration.SERIALIZER
-                        )
+                        ),
+                        shopperLocale = jsonObject.optString(SHOPPER_LOCALE),
                     )
                 } catch (e: JSONException) {
                     throw ModelSerializationException(SessionSetupResponse::class.java, e)

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/data/model/SessionDetails.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/data/model/SessionDetails.kt
@@ -26,7 +26,8 @@ data class SessionDetails(
     val amount: Amount?,
     val expiresAt: String,
     val returnUrl: String?,
-    val sessionSetupConfiguration: SessionSetupConfiguration?
+    val sessionSetupConfiguration: SessionSetupConfiguration?,
+    val shopperLocale: String?,
 ) : Parcelable
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -37,7 +38,8 @@ fun SessionSetupResponse.mapToDetails(): SessionDetails {
         amount = amount,
         expiresAt = expiresAt,
         returnUrl = returnUrl,
-        sessionSetupConfiguration = configuration
+        sessionSetupConfiguration = configuration,
+        shopperLocale = shopperLocale,
     )
 }
 

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/ui/model/SessionParamsFactory.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/ui/model/SessionParamsFactory.kt
@@ -9,35 +9,28 @@
 package com.adyen.checkout.sessions.core.internal.ui.model
 
 import androidx.annotation.RestrictTo
-import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.components.core.internal.ui.model.SessionInstallmentConfiguration
 import com.adyen.checkout.components.core.internal.ui.model.SessionInstallmentOptionsParams
 import com.adyen.checkout.components.core.internal.ui.model.SessionParams
+import com.adyen.checkout.core.internal.util.LocaleUtil
 import com.adyen.checkout.sessions.core.CheckoutSession
-import com.adyen.checkout.sessions.core.SessionSetupConfiguration
 import com.adyen.checkout.sessions.core.internal.data.model.SessionDetails
+import com.adyen.checkout.sessions.core.internal.data.model.mapToDetails
+import java.util.Locale
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 object SessionParamsFactory {
     // Used for components
     fun create(checkoutSession: CheckoutSession): SessionParams {
-        return create(
-            checkoutSession.sessionSetupResponse.configuration,
-            checkoutSession.sessionSetupResponse.amount,
-            checkoutSession.sessionSetupResponse.returnUrl
-        )
+        return checkoutSession.sessionSetupResponse.mapToDetails().mapToParams()
     }
 
     // Used for Drop-in
     fun create(sessionDetails: SessionDetails): SessionParams {
-        return create(sessionDetails.sessionSetupConfiguration, sessionDetails.amount, sessionDetails.returnUrl)
+        return sessionDetails.mapToParams()
     }
 
-    private fun create(
-        sessionSetupConfiguration: SessionSetupConfiguration?,
-        amount: Amount?,
-        returnUrl: String?,
-    ): SessionParams {
+    private fun SessionDetails.mapToParams(): SessionParams {
         return SessionParams(
             enableStoreDetails = sessionSetupConfiguration?.enableStoreDetails,
             installmentConfiguration = SessionInstallmentConfiguration(
@@ -48,10 +41,19 @@ object SessionParamsFactory {
                         values = it.value?.values,
                     )
                 }?.toMap(),
-                showInstallmentAmount = sessionSetupConfiguration?.showInstallmentAmount
+                showInstallmentAmount = sessionSetupConfiguration?.showInstallmentAmount,
             ),
             amount = amount,
             returnUrl = returnUrl,
+            shopperLocale = getShopperLocale(shopperLocale),
         )
+    }
+
+    private fun getShopperLocale(shopperLocaleString: String?): Locale? {
+        return shopperLocaleString?.let {
+            LocaleUtil.fromLanguageTag(it)
+        }?.takeIf {
+            LocaleUtil.isValidLocale(it)
+        }
     }
 }

--- a/sessions-core/src/test/java/com/adyen/checkout/sessions/core/internal/SessionInteractorTest.kt
+++ b/sessions-core/src/test/java/com/adyen/checkout/sessions/core/internal/SessionInteractorTest.kt
@@ -756,7 +756,8 @@ internal class SessionInteractorTest(
         expiresAt: String = "",
         returnUrl: String = "",
         paymentMethods: PaymentMethodsApiResponse? = PaymentMethodsApiResponse(),
-        configuration: SessionSetupConfiguration? = null
+        configuration: SessionSetupConfiguration? = null,
+        shopperLocale: String? = null,
     ): SessionSetupResponse {
         return SessionSetupResponse(
             id = id,
@@ -765,7 +766,8 @@ internal class SessionInteractorTest(
             expiresAt = expiresAt,
             paymentMethodsApiResponse = paymentMethods,
             returnUrl = returnUrl,
-            configuration = configuration
+            configuration = configuration,
+            shopperLocale = shopperLocale,
         )
     }
 


### PR DESCRIPTION
## Description
The sessions setup call returns a shopper locale if the merchant set this value in the `/sessions` call. We will now read this value and apply it on our end.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-847
