### PR TITLE
Inject coroutine dispatchers

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/data/api/SubmitFingerprintService.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/data/api/SubmitFingerprintService.kt
@@ -12,23 +12,25 @@ import com.adyen.checkout.adyen3ds2.internal.data.model.SubmitFingerprintRequest
 import com.adyen.checkout.adyen3ds2.internal.data.model.SubmitFingerprintResponse
 import com.adyen.checkout.core.internal.data.api.HttpClient
 import com.adyen.checkout.core.internal.data.api.post
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 internal class SubmitFingerprintService(
     private val httpClient: HttpClient,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
 
     suspend fun submitFingerprint(
         request: SubmitFingerprintRequest,
         clientKey: String
-    ): SubmitFingerprintResponse = withContext(Dispatchers.IO) {
+    ): SubmitFingerprintResponse = withContext(ioDispatcher) {
         httpClient.post(
             path = "v1/submitThreeDS2Fingerprint",
             queryParameters = mapOf("token" to clientKey),
             body = request,
             requestSerializer = SubmitFingerprintRequest.SERIALIZER,
-            responseSerializer = SubmitFingerprintResponse.SERIALIZER
+            responseSerializer = SubmitFingerprintResponse.SERIALIZER,
         )
     }
 }

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/data/api/SubmitFingerprintService.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/data/api/SubmitFingerprintService.kt
@@ -18,13 +18,13 @@ import kotlinx.coroutines.withContext
 
 internal class SubmitFingerprintService(
     private val httpClient: HttpClient,
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
 
     suspend fun submitFingerprint(
         request: SubmitFingerprintRequest,
         clientKey: String
-    ): SubmitFingerprintResponse = withContext(ioDispatcher) {
+    ): SubmitFingerprintResponse = withContext(coroutineDispatcher) {
         httpClient.post(
             path = "v1/submitThreeDS2Fingerprint",
             queryParameters = mapOf("token" to clientKey),

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/provider/Adyen3DS2ComponentProvider.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/provider/Adyen3DS2ComponentProvider.kt
@@ -100,7 +100,7 @@ constructor(
             adyen3DS2Serializer = adyen3DS2DetailsParser,
             redirectHandler = redirectHandler,
             threeDS2Service = ThreeDS2Service.INSTANCE,
-            defaultDispatcher = Dispatchers.Default,
+            coroutineDispatcher = Dispatchers.Default,
             base64Encoder = AndroidBase64Encoder(),
             application = application,
         )

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2Delegate.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2Delegate.kt
@@ -75,7 +75,7 @@ internal class DefaultAdyen3DS2Delegate(
     private val adyen3DS2Serializer: Adyen3DS2Serializer,
     private val redirectHandler: RedirectHandler,
     private val threeDS2Service: ThreeDS2Service,
-    private val defaultDispatcher: CoroutineDispatcher,
+    private val coroutineDispatcher: CoroutineDispatcher,
     private val base64Encoder: Base64Encoder,
     private val application: Application,
 ) : Adyen3DS2Delegate, ChallengeStatusHandler, SavedStateHandleContainer {
@@ -215,7 +215,7 @@ internal class DefaultAdyen3DS2Delegate(
             exceptionChannel.trySend(CheckoutException("Unexpected 3DS2 exception.", throwable))
         }
 
-        coroutineScope.launch(defaultDispatcher + coroutineExceptionHandler) {
+        coroutineScope.launch(coroutineDispatcher + coroutineExceptionHandler) {
             // This makes sure the 3DS2 SDK doesn't re-use any state from previous transactions
             closeTransaction()
 

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2Delegate.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2Delegate.kt
@@ -38,6 +38,7 @@ import com.adyen.checkout.components.core.internal.util.Base64Encoder
 import com.adyen.checkout.components.core.internal.util.bufferedChannel
 import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.core.exception.ComponentException
+import com.adyen.checkout.core.exception.ModelSerializationException
 import com.adyen.checkout.core.internal.util.LogUtil
 import com.adyen.checkout.core.internal.util.Logger
 import com.adyen.checkout.ui.core.internal.RedirectHandler
@@ -48,10 +49,10 @@ import com.adyen.threeds2.ChallengeStatusHandler
 import com.adyen.threeds2.ThreeDS2Service
 import com.adyen.threeds2.Transaction
 import com.adyen.threeds2.exception.InvalidInputException
-import com.adyen.threeds2.exception.SDKAlreadyInitializedException
 import com.adyen.threeds2.exception.SDKNotInitializedException
 import com.adyen.threeds2.exception.SDKRuntimeException
 import com.adyen.threeds2.parameters.ChallengeParameters
+import com.adyen.threeds2.parameters.ConfigParameters
 import com.adyen.threeds2.util.AdyenConfigParameters
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineExceptionHandler
@@ -109,7 +110,7 @@ internal class DefaultAdyen3DS2Delegate(
             permissionFlow = null,
             lifecycleOwner = lifecycleOwner,
             coroutineScope = coroutineScope,
-            callback = callback
+            callback = callback,
         )
     }
 
@@ -117,7 +118,6 @@ internal class DefaultAdyen3DS2Delegate(
         observerRepository.removeObservers()
     }
 
-    @Suppress("ReturnCount")
     override fun handleAction(action: Action, activity: Activity) {
         if (action !is BaseThreeds2Action) {
             exceptionChannel.trySend(ComponentException("Unsupported action"))
@@ -127,41 +127,54 @@ internal class DefaultAdyen3DS2Delegate(
         val paymentData = action.paymentData
         paymentDataRepository.paymentData = paymentData
         when (action) {
-            is Threeds2FingerprintAction -> {
-                if (action.token.isNullOrEmpty()) {
-                    exceptionChannel.trySend(ComponentException("Fingerprint token not found."))
-                    return
-                }
-                identifyShopper(
-                    activity = activity,
-                    encodedFingerprintToken = action.token.orEmpty(),
-                    submitFingerprintAutomatically = false,
-                )
-            }
-
-            is Threeds2ChallengeAction -> {
-                if (action.token.isNullOrEmpty()) {
-                    exceptionChannel.trySend(ComponentException("Challenge token not found."))
-                    return
-                }
-                challengeShopper(activity, action.token.orEmpty())
-            }
-
-            is Threeds2Action -> {
-                if (action.token.isNullOrEmpty()) {
-                    exceptionChannel.trySend(ComponentException("3DS2 token not found."))
-                    return
-                }
-                if (action.subtype == null) {
-                    exceptionChannel.trySend(ComponentException("3DS2 Action subtype not found."))
-                    return
-                }
-                val subtype = Threeds2Action.SubType.parse(action.subtype.orEmpty())
-                // We need to keep authorizationToken in memory to access it later when the 3DS2 challenge is done
-                authorizationToken = action.authorisationToken
-                handleActionSubtype(activity, subtype, action.token.orEmpty())
-            }
+            is Threeds2FingerprintAction -> handleThreeds2FingerprintAction(action, activity)
+            is Threeds2ChallengeAction -> handleThreeds2ChallengeAction(action, activity)
+            is Threeds2Action -> handleThreeds2Action(action, activity)
         }
+    }
+
+    private fun handleThreeds2FingerprintAction(
+        action: Threeds2FingerprintAction,
+        activity: Activity,
+    ) {
+        if (action.token.isNullOrEmpty()) {
+            exceptionChannel.trySend(ComponentException("Fingerprint token not found."))
+            return
+        }
+        identifyShopper(
+            activity = activity,
+            encodedFingerprintToken = action.token.orEmpty(),
+            submitFingerprintAutomatically = false,
+        )
+    }
+
+    private fun handleThreeds2ChallengeAction(
+        action: Threeds2ChallengeAction,
+        activity: Activity,
+    ) {
+        if (action.token.isNullOrEmpty()) {
+            exceptionChannel.trySend(ComponentException("Challenge token not found."))
+            return
+        }
+        challengeShopper(activity, action.token.orEmpty())
+    }
+
+    private fun handleThreeds2Action(
+        action: Threeds2Action,
+        activity: Activity,
+    ) {
+        if (action.token.isNullOrEmpty()) {
+            exceptionChannel.trySend(ComponentException("3DS2 token not found."))
+            return
+        }
+        if (action.subtype == null) {
+            exceptionChannel.trySend(ComponentException("3DS2 Action subtype not found."))
+            return
+        }
+        val subtype = Threeds2Action.SubType.parse(action.subtype.orEmpty())
+        // We need to keep authorizationToken in memory to access it later when the 3DS2 challenge is done
+        authorizationToken = action.authorisationToken
+        handleActionSubtype(activity, subtype, action.token.orEmpty())
     }
 
     private fun handleActionSubtype(
@@ -180,34 +193,22 @@ internal class DefaultAdyen3DS2Delegate(
         }
     }
 
-    @Suppress("LongMethod")
     @VisibleForTesting
-    @Throws(ComponentException::class)
     internal fun identifyShopper(
         activity: Activity,
         encodedFingerprintToken: String,
         submitFingerprintAutomatically: Boolean,
     ) {
         Logger.d(TAG, "identifyShopper - submitFingerprintAutomatically: $submitFingerprintAutomatically")
-        val decodedFingerprintToken = base64Encoder.decode(encodedFingerprintToken)
 
-        val fingerprintJson: JSONObject = try {
-            JSONObject(decodedFingerprintToken)
-        } catch (e: JSONException) {
-            throw ComponentException("JSON parsing of FingerprintToken failed", e)
+        val fingerprintToken = try {
+            decodeFingerprintToken(encodedFingerprintToken)
+        } catch (e: CheckoutException) {
+            exceptionChannel.trySend(ComponentException("Failed to decode fingerprint token", e))
+            return
         }
 
-        val fingerprintToken = FingerprintToken.SERIALIZER.deserialize(fingerprintJson)
-        val configParameters = AdyenConfigParameters.Builder(
-            // directoryServerId
-            fingerprintToken.directoryServerId,
-            // directoryServerPublicKey
-            fingerprintToken.directoryServerPublicKey,
-            // directoryServerRootCertificates
-            fingerprintToken.directoryServerRootCertificates,
-        )
-            .deviceParameterBlockList(componentParams.deviceParameterBlockList)
-            .build()
+        val configParameters = createAdyenConfigParameters(fingerprintToken)
 
         val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
             Logger.e(TAG, "Unexpected uncaught 3DS2 Exception", throwable)
@@ -218,38 +219,15 @@ internal class DefaultAdyen3DS2Delegate(
             // This makes sure the 3DS2 SDK doesn't re-use any state from previous transactions
             closeTransaction()
 
-            @Suppress("SwallowedException")
             try {
                 Logger.d(TAG, "initialize 3DS2 SDK")
                 threeDS2Service.initialize(activity, configParameters, null, componentParams.uiCustomization)
             } catch (e: SDKRuntimeException) {
                 exceptionChannel.trySend(ComponentException("Failed to initialize 3DS2 SDK", e))
                 return@launch
-            } catch (e: SDKAlreadyInitializedException) {
-                // This shouldn't cause any side effect.
-                Logger.w(TAG, "3DS2 Service already initialized.")
             }
 
-            currentTransaction = try {
-                Logger.d(TAG, "create transaction")
-                if (fingerprintToken.threeDSMessageVersion != null) {
-                    threeDS2Service.createTransaction(null, fingerprintToken.threeDSMessageVersion)
-                } else {
-                    exceptionChannel.trySend(
-                        ComponentException(
-                            "Failed to create 3DS2 Transaction. Missing " +
-                                "threeDSMessageVersion inside fingerprintToken."
-                        )
-                    )
-                    return@launch
-                }
-            } catch (e: SDKNotInitializedException) {
-                exceptionChannel.trySend(ComponentException("Failed to create 3DS2 Transaction", e))
-                return@launch
-            } catch (e: SDKRuntimeException) {
-                exceptionChannel.trySend(ComponentException("Failed to create 3DS2 Transaction", e))
-                return@launch
-            }
+            currentTransaction = createTransaction(fingerprintToken) ?: return@launch
 
             val authenticationRequestParameters = currentTransaction?.authenticationRequestParameters
             if (authenticationRequestParameters == null) {
@@ -257,11 +235,60 @@ internal class DefaultAdyen3DS2Delegate(
                 return@launch
             }
             val encodedFingerprint = createEncodedFingerprint(authenticationRequestParameters)
+
             if (submitFingerprintAutomatically) {
                 submitFingerprintAutomatically(activity, encodedFingerprint)
             } else {
                 emitDetails(adyen3DS2Serializer.createFingerprintDetails(encodedFingerprint))
             }
+        }
+    }
+
+    @Throws(ComponentException::class, ModelSerializationException::class)
+    private fun decodeFingerprintToken(encoded: String): FingerprintToken {
+        val decodedFingerprintToken = base64Encoder.decode(encoded)
+
+        val fingerprintJson: JSONObject = try {
+            JSONObject(decodedFingerprintToken)
+        } catch (e: JSONException) {
+            throw ComponentException("JSON parsing of FingerprintToken failed", e)
+        }
+
+        return FingerprintToken.SERIALIZER.deserialize(fingerprintJson)
+    }
+
+    private fun createAdyenConfigParameters(
+        fingerprintToken: FingerprintToken
+    ): ConfigParameters = AdyenConfigParameters.Builder(
+        // directoryServerId
+        fingerprintToken.directoryServerId,
+        // directoryServerPublicKey
+        fingerprintToken.directoryServerPublicKey,
+        // directoryServerRootCertificates
+        fingerprintToken.directoryServerRootCertificates,
+    )
+        .deviceParameterBlockList(componentParams.deviceParameterBlockList)
+        .build()
+
+    private fun createTransaction(fingerprintToken: FingerprintToken): Transaction? {
+        if (fingerprintToken.threeDSMessageVersion == null) {
+            exceptionChannel.trySend(
+                ComponentException(
+                    "Failed to create 3DS2 Transaction. Missing threeDSMessageVersion inside fingerprintToken.",
+                ),
+            )
+            return null
+        }
+
+        return try {
+            Logger.d(TAG, "create transaction")
+            threeDS2Service.createTransaction(null, fingerprintToken.threeDSMessageVersion)
+        } catch (e: SDKNotInitializedException) {
+            exceptionChannel.trySend(ComponentException("Failed to create 3DS2 Transaction", e))
+            null
+        } catch (e: SDKRuntimeException) {
+            exceptionChannel.trySend(ComponentException("Failed to create 3DS2 Transaction", e))
+            null
         }
     }
 
@@ -292,11 +319,11 @@ internal class DefaultAdyen3DS2Delegate(
         submitFingerprintRepository.submitFingerprint(
             encodedFingerprint,
             componentParams.clientKey,
-            paymentDataRepository.paymentData
+            paymentDataRepository.paymentData,
         )
             .fold(
                 onSuccess = { result -> onSubmitFingerprintResult(result, activity) },
-                onFailure = { e -> exceptionChannel.trySend(ComponentException("Unable to submit fingerprint", e)) }
+                onFailure = { e -> exceptionChannel.trySend(ComponentException("Unable to submit fingerprint", e)) },
             )
     }
 
@@ -340,13 +367,12 @@ internal class DefaultAdyen3DS2Delegate(
     }
 
     @VisibleForTesting
-    @Throws(ComponentException::class)
     internal fun challengeShopper(activity: Activity, encodedChallengeToken: String) {
         Logger.d(TAG, "challengeShopper")
 
         if (currentTransaction == null) {
             exceptionChannel.trySend(
-                Authentication3DS2Exception("Failed to make challenge, missing reference to initial transaction.")
+                Authentication3DS2Exception("Failed to make challenge, missing reference to initial transaction."),
             )
             return
         }
@@ -477,13 +503,13 @@ internal class DefaultAdyen3DS2Delegate(
         return if (token == null) {
             adyen3DS2Serializer.createChallengeDetails(
                 transactionStatus = transactionStatus,
-                errorDetails = errorDetails
+                errorDetails = errorDetails,
             )
         } else {
             adyen3DS2Serializer.createThreeDsResultDetails(
                 transactionStatus = transactionStatus,
                 errorDetails = errorDetails,
-                authorisationToken = token
+                authorisationToken = token,
             )
         }
     }

--- a/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2DelegateTest.kt
+++ b/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2DelegateTest.kt
@@ -53,7 +53,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
@@ -166,9 +165,11 @@ internal class DefaultAdyen3DS2DelegateTest(
         fun `fingerprint is malformed, then an exception is thrown`(dispatcher: TestDispatcher) = runTest {
             delegate.initialize(CoroutineScope(dispatcher))
 
-            assertThrows<ComponentException> {
+            delegate.exceptionFlow.test {
                 val encodedJson = base64Encoder.encode("{incorrectJson}")
                 delegate.identifyShopper(Activity(), encodedJson, false)
+
+                assertTrue(awaitItem() is ComponentException)
             }
         }
 

--- a/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2DelegateTest.kt
+++ b/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2DelegateTest.kt
@@ -43,7 +43,8 @@ import com.adyen.threeds2.exception.InvalidInputException
 import com.adyen.threeds2.exception.SDKRuntimeException
 import com.adyen.threeds2.parameters.ChallengeParameters
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.json.JSONException
 import org.json.JSONObject
@@ -64,6 +65,7 @@ import org.mockito.kotlin.whenever
 import java.io.IOException
 import java.util.Locale
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(MockitoExtension::class, TestDispatcherExtension::class)
 internal class DefaultAdyen3DS2DelegateTest(
     @Mock private val submitFingerprintRepository: SubmitFingerprintRepository,
@@ -78,7 +80,7 @@ internal class DefaultAdyen3DS2DelegateTest(
     private val base64Encoder = JavaBase64Encoder()
 
     @BeforeEach
-    fun beforeEach(dispatcher: TestDispatcher) {
+    fun setup() {
         redirectHandler = TestRedirectHandler()
         paymentDataRepository = PaymentDataRepository(SavedStateHandle())
         val configuration = CheckoutConfiguration(Locale.US, Environment.TEST, TEST_CLIENT_KEY)
@@ -94,7 +96,7 @@ internal class DefaultAdyen3DS2DelegateTest(
             adyen3DS2Serializer = adyen3DS2Serializer,
             redirectHandler = redirectHandler,
             threeDS2Service = threeDS2Service,
-            defaultDispatcher = dispatcher,
+            defaultDispatcher = UnconfinedTestDispatcher(),
             base64Encoder = base64Encoder,
             application = Application(),
         )
@@ -105,10 +107,8 @@ internal class DefaultAdyen3DS2DelegateTest(
     inner class HandleActionTest {
 
         @Test
-        fun `Threeds2FingerprintAction and token is null, then an exception is thrown`(
-            dispatcher: TestDispatcher
-        ) = runTest {
-            delegate.initialize(CoroutineScope(dispatcher))
+        fun `Threeds2FingerprintAction and token is null, then an exception is thrown`() = runTest {
+            delegate.initialize(this)
 
             delegate.exceptionFlow.test {
                 delegate.handleAction(Threeds2FingerprintAction(token = null), Activity())
@@ -118,10 +118,8 @@ internal class DefaultAdyen3DS2DelegateTest(
         }
 
         @Test
-        fun `Threeds2ChallengeAction and token is null, then an exception is thrown`(
-            dispatcher: TestDispatcher
-        ) = runTest {
-            delegate.initialize(CoroutineScope(dispatcher))
+        fun `Threeds2ChallengeAction and token is null, then an exception is thrown`() = runTest {
+            delegate.initialize(this)
 
             delegate.exceptionFlow.test {
                 delegate.handleAction(Threeds2ChallengeAction(token = null), Activity())
@@ -131,10 +129,8 @@ internal class DefaultAdyen3DS2DelegateTest(
         }
 
         @Test
-        fun `Threeds2Action and token is null, then an exception is thrown`(
-            dispatcher: TestDispatcher
-        ) = runTest {
-            delegate.initialize(CoroutineScope(dispatcher))
+        fun `Threeds2Action and token is null, then an exception is thrown`() = runTest {
+            delegate.initialize(this)
 
             delegate.exceptionFlow.test {
                 delegate.handleAction(Threeds2Action(token = null), Activity())
@@ -144,10 +140,8 @@ internal class DefaultAdyen3DS2DelegateTest(
         }
 
         @Test
-        fun `Threeds2Action and sub type is null, then an exception is thrown`(
-            dispatcher: TestDispatcher
-        ) = runTest {
-            delegate.initialize(CoroutineScope(dispatcher))
+        fun `Threeds2Action and sub type is null, then an exception is thrown`() = runTest {
+            delegate.initialize(this)
 
             delegate.exceptionFlow.test {
                 delegate.handleAction(Threeds2Action(token = "sometoken", subtype = null), Activity())
@@ -162,8 +156,8 @@ internal class DefaultAdyen3DS2DelegateTest(
     inner class IdentifyShopperTest {
 
         @Test
-        fun `fingerprint is malformed, then an exception is thrown`(dispatcher: TestDispatcher) = runTest {
-            delegate.initialize(CoroutineScope(dispatcher))
+        fun `fingerprint is malformed, then an exception is thrown`() = runTest {
+            delegate.initialize(this)
 
             delegate.exceptionFlow.test {
                 val encodedJson = base64Encoder.encode("{incorrectJson}")
@@ -174,36 +168,35 @@ internal class DefaultAdyen3DS2DelegateTest(
         }
 
         @Test
-        fun `3ds2 sdk throws an exception while initializing, then an exception emitted`(dispatcher: TestDispatcher) =
-            runTest {
-                val error = SDKRuntimeException("test", "test", null)
-                whenever(threeDS2Service.initialize(any(), any(), anyOrNull(), anyOrNull())) doAnswer {
-                    throw error
-                }
-                delegate.initialize(CoroutineScope(dispatcher))
-
-                delegate.exceptionFlow.test {
-                    val encodedJson = base64Encoder.encode(
-                        """
-                            {
-                            "directoryServerId":"id",
-                            "directoryServerPublicKey":"key"
-                            }
-                        """.trimIndent(),
-                    )
-                    delegate.identifyShopper(Activity(), encodedJson, false)
-
-                    assertEquals(error, awaitItem().cause)
-                }
+        fun `3ds2 sdk throws an exception while initializing, then an exception emitted`() = runTest {
+            val error = SDKRuntimeException("test", "test", null)
+            whenever(threeDS2Service.initialize(any(), any(), anyOrNull(), anyOrNull())) doAnswer {
+                throw error
             }
+            delegate.initialize(this)
+
+            delegate.exceptionFlow.test {
+                val encodedJson = base64Encoder.encode(
+                    """
+                        {
+                        "directoryServerId":"id",
+                        "directoryServerPublicKey":"key"
+                        }
+                    """.trimIndent(),
+                )
+                delegate.identifyShopper(Activity(), encodedJson, false)
+
+                assertEquals(error, awaitItem().cause)
+            }
+        }
 
         @Test
-        fun `creating 3ds2 transaction fails, then an exception emitted`(dispatcher: TestDispatcher) = runTest {
+        fun `creating 3ds2 transaction fails, then an exception emitted`() = runTest {
             val error = SDKRuntimeException("test", "test", null)
             whenever(threeDS2Service.createTransaction(anyOrNull(), any())) doAnswer {
                 throw error
             }
-            delegate.initialize(CoroutineScope(dispatcher))
+            delegate.initialize(this)
 
             delegate.exceptionFlow.test {
                 val encodedJson = base64Encoder.encode(TEST_FINGERPRINT_TOKEN)
@@ -214,9 +207,9 @@ internal class DefaultAdyen3DS2DelegateTest(
         }
 
         @Test
-        fun `transaction parameters are null, then an exception emitted`(dispatcher: TestDispatcher) = runTest {
+        fun `transaction parameters are null, then an exception emitted`() = runTest {
             whenever(threeDS2Service.createTransaction(anyOrNull(), any())) doReturn TestTransaction()
-            delegate.initialize(CoroutineScope(dispatcher))
+            delegate.initialize(this)
 
             delegate.exceptionFlow.test {
                 val encodedJson = base64Encoder.encode(TEST_FINGERPRINT_TOKEN)
@@ -227,41 +220,36 @@ internal class DefaultAdyen3DS2DelegateTest(
         }
 
         @Test
-        fun `fingerprint is submitted automatically and result is completed, then details are emitted`(
-            dispatcher: TestDispatcher
-        ) =
-            runTest {
-                val authReqParams = TestAuthenticationRequestParameters(
-                    deviceData = "deviceData",
-                    sdkTransactionID = "sdkTransactionID",
-                    sdkAppID = "sdkAppID",
-                    sdkReferenceNumber = "sdkReferenceNumber",
-                    sdkEphemeralPublicKey = "{}",
-                    messageVersion = "messageVersion",
+        fun `fingerprint is submitted automatically and result is completed, then details are emitted`() = runTest {
+            val authReqParams = TestAuthenticationRequestParameters(
+                deviceData = "deviceData",
+                sdkTransactionID = "sdkTransactionID",
+                sdkAppID = "sdkAppID",
+                sdkReferenceNumber = "sdkReferenceNumber",
+                sdkEphemeralPublicKey = "{}",
+                messageVersion = "messageVersion",
+            )
+            whenever(threeDS2Service.createTransaction(anyOrNull(), any())) doReturn TestTransaction(authReqParams)
+            val submitFingerprintResult = SubmitFingerprintResult.Completed(JSONObject())
+            whenever(submitFingerprintRepository.submitFingerprint(any(), any(), anyOrNull())) doReturn
+                Result.success(submitFingerprintResult)
+
+            delegate.initialize(this)
+
+            delegate.detailsFlow.test {
+                val encodedJson = base64Encoder.encode(TEST_FINGERPRINT_TOKEN)
+                delegate.identifyShopper(Activity(), encodedJson, true)
+
+                val expected = ActionComponentData(
+                    paymentData = null,
+                    details = submitFingerprintResult.details,
                 )
-                whenever(threeDS2Service.createTransaction(anyOrNull(), any())) doReturn TestTransaction(authReqParams)
-                val submitFingerprintResult = SubmitFingerprintResult.Completed(JSONObject())
-                whenever(submitFingerprintRepository.submitFingerprint(any(), any(), anyOrNull())) doReturn
-                    Result.success(submitFingerprintResult)
-
-                delegate.initialize(CoroutineScope(dispatcher))
-
-                delegate.detailsFlow.test {
-                    val encodedJson = base64Encoder.encode(TEST_FINGERPRINT_TOKEN)
-                    delegate.identifyShopper(Activity(), encodedJson, true)
-
-                    val expected = ActionComponentData(
-                        paymentData = null,
-                        details = submitFingerprintResult.details,
-                    )
-                    assertEquals(expected, awaitItem())
-                }
+                assertEquals(expected, awaitItem())
             }
+        }
 
         @Test
-        fun `fingerprint is submitted automatically and result is redirect, then redirect should be handled`(
-            dispatcher: TestDispatcher
-        ) =
+        fun `fingerprint is submitted automatically and result is redirect, then redirect should be handled`() =
             runTest {
                 val authReqParams = TestAuthenticationRequestParameters(
                     deviceData = "deviceData",
@@ -276,7 +264,7 @@ internal class DefaultAdyen3DS2DelegateTest(
                 whenever(submitFingerprintRepository.submitFingerprint(any(), any(), anyOrNull())) doReturn
                     Result.success(submitFingerprintResult)
 
-                delegate.initialize(CoroutineScope(dispatcher))
+                delegate.initialize(this)
 
                 val encodedJson = base64Encoder.encode(TEST_FINGERPRINT_TOKEN)
                 delegate.identifyShopper(Activity(), encodedJson, true)
@@ -285,60 +273,56 @@ internal class DefaultAdyen3DS2DelegateTest(
             }
 
         @Test
-        fun `fingerprint is submitted automatically and it fails, then an exception is emitted`(
-            dispatcher: TestDispatcher
-        ) =
-            runTest {
-                val authReqParams = TestAuthenticationRequestParameters(
-                    deviceData = "deviceData",
-                    sdkTransactionID = "sdkTransactionID",
-                    sdkAppID = "sdkAppID",
-                    sdkReferenceNumber = "sdkReferenceNumber",
-                    sdkEphemeralPublicKey = "{}",
-                    messageVersion = "messageVersion",
-                )
-                whenever(threeDS2Service.createTransaction(anyOrNull(), any())) doReturn TestTransaction(authReqParams)
-                val error = IOException("test")
-                whenever(submitFingerprintRepository.submitFingerprint(any(), any(), anyOrNull())) doReturn
-                    Result.failure(error)
+        fun `fingerprint is submitted automatically and it fails, then an exception is emitted`() = runTest {
+            val authReqParams = TestAuthenticationRequestParameters(
+                deviceData = "deviceData",
+                sdkTransactionID = "sdkTransactionID",
+                sdkAppID = "sdkAppID",
+                sdkReferenceNumber = "sdkReferenceNumber",
+                sdkEphemeralPublicKey = "{}",
+                messageVersion = "messageVersion",
+            )
+            whenever(threeDS2Service.createTransaction(anyOrNull(), any())) doReturn TestTransaction(authReqParams)
+            val error = IOException("test")
+            whenever(submitFingerprintRepository.submitFingerprint(any(), any(), anyOrNull())) doReturn
+                Result.failure(error)
 
-                delegate.initialize(CoroutineScope(dispatcher))
+            delegate.initialize(this)
 
-                delegate.exceptionFlow.test {
-                    val encodedJson = base64Encoder.encode(TEST_FINGERPRINT_TOKEN)
-                    delegate.identifyShopper(Activity(), encodedJson, true)
-                    assertEquals(error, awaitItem().cause)
-                }
+            delegate.exceptionFlow.test {
+                val encodedJson = base64Encoder.encode(TEST_FINGERPRINT_TOKEN)
+                delegate.identifyShopper(Activity(), encodedJson, true)
+                assertEquals(error, awaitItem().cause)
             }
+        }
 
         @Test
-        fun `fingerprint is not submitted automatically, then details are emitted`(dispatcher: TestDispatcher) =
-            runTest {
-                val authReqParams = TestAuthenticationRequestParameters(
-                    deviceData = "deviceData",
-                    sdkTransactionID = "sdkTransactionID",
-                    sdkAppID = "sdkAppID",
-                    sdkReferenceNumber = "sdkReferenceNumber",
-                    sdkEphemeralPublicKey = "{}",
-                    messageVersion = "messageVersion",
+        fun `fingerprint is not submitted automatically, then details are emitted`() = runTest {
+            val authReqParams = TestAuthenticationRequestParameters(
+                deviceData = "deviceData",
+                sdkTransactionID = "sdkTransactionID",
+                sdkAppID = "sdkAppID",
+                sdkReferenceNumber = "sdkReferenceNumber",
+                sdkEphemeralPublicKey = "{}",
+                messageVersion = "messageVersion",
+            )
+            whenever(threeDS2Service.createTransaction(anyOrNull(), any())) doReturn TestTransaction(authReqParams)
+            val fingerprintDetails = JSONObject("{\"finger\":\"print\"}")
+            whenever(adyen3DS2Serializer.createFingerprintDetails(any())) doReturn fingerprintDetails
+
+            delegate.initialize(this)
+
+            delegate.detailsFlow.test {
+                val encodedJson = base64Encoder.encode(TEST_FINGERPRINT_TOKEN)
+                delegate.identifyShopper(Activity(), encodedJson, false)
+
+                val expected = ActionComponentData(
+                    paymentData = null,
+                    details = fingerprintDetails,
                 )
-                whenever(threeDS2Service.createTransaction(anyOrNull(), any())) doReturn TestTransaction(authReqParams)
-                val fingerprintDetails = JSONObject("{\"finger\":\"print\"}")
-                whenever(adyen3DS2Serializer.createFingerprintDetails(any())) doReturn fingerprintDetails
-
-                delegate.initialize(CoroutineScope(dispatcher))
-
-                delegate.detailsFlow.test {
-                    val encodedJson = base64Encoder.encode(TEST_FINGERPRINT_TOKEN)
-                    delegate.identifyShopper(Activity(), encodedJson, false)
-
-                    val expected = ActionComponentData(
-                        paymentData = null,
-                        details = fingerprintDetails,
-                    )
-                    assertEquals(expected, awaitItem())
-                }
+                assertEquals(expected, awaitItem())
             }
+        }
     }
 
     @Nested
@@ -355,8 +339,8 @@ internal class DefaultAdyen3DS2DelegateTest(
         }
 
         @Test
-        fun `token can't be decoded, then an exception is emitted`(dispatcher: TestDispatcher) = runTest {
-            initializeTransaction(dispatcher)
+        fun `token can't be decoded, then an exception is emitted`() = runTest {
+            initializeTransaction(this)
 
             delegate.exceptionFlow.test {
                 delegate.challengeShopper(Activity(), base64Encoder.encode("token"))
@@ -366,8 +350,8 @@ internal class DefaultAdyen3DS2DelegateTest(
         }
 
         @Test
-        fun `everything is good, then challenge should be executed`(dispatcher: TestDispatcher) = runTest {
-            val transaction = initializeTransaction(dispatcher)
+        fun `everything is good, then challenge should be executed`() = runTest {
+            val transaction = initializeTransaction(this)
 
             delegate.challengeShopper(Activity(), base64Encoder.encode("{}"))
 
@@ -375,8 +359,8 @@ internal class DefaultAdyen3DS2DelegateTest(
         }
 
         @Test
-        fun `challenge fails, then an exception is emitted`(dispatcher: TestDispatcher) = runTest {
-            initializeTransaction(dispatcher).apply {
+        fun `challenge fails, then an exception is emitted`() = runTest {
+            initializeTransaction(this).apply {
                 shouldThrowError = true
             }
 
@@ -387,7 +371,7 @@ internal class DefaultAdyen3DS2DelegateTest(
             }
         }
 
-        private fun initializeTransaction(dispatcher: TestDispatcher): TestTransaction {
+        private fun initializeTransaction(scope: CoroutineScope): TestTransaction {
             val authReqParams = TestAuthenticationRequestParameters(
                 deviceData = "deviceData",
                 sdkTransactionID = "sdkTransactionID",
@@ -399,7 +383,7 @@ internal class DefaultAdyen3DS2DelegateTest(
             val transaction = TestTransaction(authReqParams)
             whenever(threeDS2Service.createTransaction(anyOrNull(), any())) doReturn transaction
 
-            delegate.initialize(CoroutineScope(dispatcher))
+            delegate.initialize(scope)
 
             val encodedJson = base64Encoder.encode(TEST_FINGERPRINT_TOKEN)
             delegate.identifyShopper(Activity(), encodedJson, false)
@@ -563,13 +547,8 @@ internal class DefaultAdyen3DS2DelegateTest(
 
         override fun getAuthenticationRequestParameters(): AuthenticationRequestParameters? = authReqParameters
 
-        @Suppress("OVERRIDE_DEPRECATION", "DEPRECATION")
-        override fun doChallenge(p0: Activity?, p1: ChallengeParameters?, p2: ChallengeStatusReceiver?, p3: Int) {
-            timesDoChallengeCalled++
-            if (shouldThrowError) {
-                throw InvalidInputException("test", null)
-            }
-        }
+        @Suppress("OVERRIDE_DEPRECATION", "deprecation")
+        override fun doChallenge(p0: Activity?, p1: ChallengeParameters?, p2: ChallengeStatusReceiver?, p3: Int) = Unit
 
         override fun doChallenge(
             currentActivity: Activity?,

--- a/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2DelegateTest.kt
+++ b/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2DelegateTest.kt
@@ -96,7 +96,7 @@ internal class DefaultAdyen3DS2DelegateTest(
             adyen3DS2Serializer = adyen3DS2Serializer,
             redirectHandler = redirectHandler,
             threeDS2Service = threeDS2Service,
-            defaultDispatcher = UnconfinedTestDispatcher(),
+            coroutineDispatcher = UnconfinedTestDispatcher(),
             base64Encoder = base64Encoder,
             application = Application(),
         )

--- a/card/src/main/java/com/adyen/checkout/card/internal/data/api/BinLookupService.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/data/api/BinLookupService.kt
@@ -20,13 +20,13 @@ import kotlinx.coroutines.withContext
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class BinLookupService(
     private val httpClient: HttpClient,
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
 
     suspend fun makeBinLookup(
         request: BinLookupRequest,
         clientKey: String,
-    ): BinLookupResponse = withContext(ioDispatcher) {
+    ): BinLookupResponse = withContext(coroutineDispatcher) {
         httpClient.post(
             path = "v2/bin/binLookup",
             queryParameters = mapOf("clientKey" to clientKey),

--- a/card/src/main/java/com/adyen/checkout/card/internal/data/api/BinLookupService.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/data/api/BinLookupService.kt
@@ -13,24 +13,26 @@ import com.adyen.checkout.card.internal.data.model.BinLookupRequest
 import com.adyen.checkout.card.internal.data.model.BinLookupResponse
 import com.adyen.checkout.core.internal.data.api.HttpClient
 import com.adyen.checkout.core.internal.data.api.post
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class BinLookupService(
     private val httpClient: HttpClient,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
 
     suspend fun makeBinLookup(
         request: BinLookupRequest,
         clientKey: String,
-    ): BinLookupResponse = withContext(Dispatchers.IO) {
+    ): BinLookupResponse = withContext(ioDispatcher) {
         httpClient.post(
             path = "v2/bin/binLookup",
             queryParameters = mapOf("clientKey" to clientKey),
             body = request,
             requestSerializer = BinLookupRequest.SERIALIZER,
-            responseSerializer = BinLookupResponse.SERIALIZER
+            responseSerializer = BinLookupResponse.SERIALIZER,
         )
     }
 }

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/DefaultCashAppPayDelegate.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/DefaultCashAppPayDelegate.kt
@@ -64,7 +64,7 @@ constructor(
     private val order: OrderRequest?,
     override val componentParams: CashAppPayComponentParams,
     private val cashAppPayFactory: CashAppPayFactory,
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : CashAppPayDelegate, ButtonDelegate, CashAppPayListener {
 
     private val inputData = CashAppPayInputData()
@@ -213,7 +213,7 @@ constructor(
 
         _viewFlow.tryEmit(PaymentInProgressViewType)
 
-        coroutineScope.launch(ioDispatcher) {
+        coroutineScope.launch(coroutineDispatcher) {
             cashAppPay.createCustomerRequest(actions, componentParams.returnUrl)
         }
     }

--- a/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/DefaultCashAppPayDelegateTest.kt
+++ b/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/DefaultCashAppPayDelegateTest.kt
@@ -484,7 +484,7 @@ internal class DefaultCashAppPayDelegateTest(
             context = Application(),
         ),
         cashAppPayFactory = cashAppPayFactory,
-        ioDispatcher = UnconfinedTestDispatcher(),
+        coroutineDispatcher = UnconfinedTestDispatcher(),
     )
 
     private fun createCheckoutConfiguration(

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsService.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsService.kt
@@ -20,13 +20,13 @@ import kotlinx.coroutines.withContext
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class AnalyticsService(
     private val httpClient: HttpClient,
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
 
     internal suspend fun setupAnalytics(
         request: AnalyticsSetupRequest,
         clientKey: String,
-    ): AnalyticsSetupResponse = withContext(ioDispatcher) {
+    ): AnalyticsSetupResponse = withContext(coroutineDispatcher) {
         httpClient.post(
             path = "v3/analytics",
             queryParameters = mapOf("clientKey" to clientKey),

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsService.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsService.kt
@@ -13,24 +13,26 @@ import com.adyen.checkout.components.core.internal.data.model.AnalyticsSetupRequ
 import com.adyen.checkout.components.core.internal.data.model.AnalyticsSetupResponse
 import com.adyen.checkout.core.internal.data.api.HttpClient
 import com.adyen.checkout.core.internal.data.api.post
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class AnalyticsService(
     private val httpClient: HttpClient,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
 
     internal suspend fun setupAnalytics(
         request: AnalyticsSetupRequest,
         clientKey: String,
-    ): AnalyticsSetupResponse = withContext(Dispatchers.IO) {
+    ): AnalyticsSetupResponse = withContext(ioDispatcher) {
         httpClient.post(
             path = "v3/analytics",
             queryParameters = mapOf("clientKey" to clientKey),
             body = request,
             requestSerializer = AnalyticsSetupRequest.SERIALIZER,
-            responseSerializer = AnalyticsSetupResponse.SERIALIZER
+            responseSerializer = AnalyticsSetupResponse.SERIALIZER,
         )
     }
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/OrderStatusService.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/OrderStatusService.kt
@@ -13,24 +13,26 @@ import com.adyen.checkout.components.core.internal.data.model.OrderStatusRequest
 import com.adyen.checkout.components.core.internal.data.model.OrderStatusResponse
 import com.adyen.checkout.core.internal.data.api.HttpClient
 import com.adyen.checkout.core.internal.data.api.post
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class OrderStatusService(
     private val httpClient: HttpClient,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
 
     internal suspend fun getOrderStatus(
         request: OrderStatusRequest,
         clientKey: String
-    ): OrderStatusResponse = withContext(Dispatchers.IO) {
+    ): OrderStatusResponse = withContext(ioDispatcher) {
         httpClient.post(
             path = "v1/order/status",
             queryParameters = mapOf("clientKey" to clientKey),
             body = request,
             requestSerializer = OrderStatusRequest.SERIALIZER,
-            responseSerializer = OrderStatusResponse.SERIALIZER
+            responseSerializer = OrderStatusResponse.SERIALIZER,
         )
     }
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/OrderStatusService.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/OrderStatusService.kt
@@ -20,13 +20,13 @@ import kotlinx.coroutines.withContext
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class OrderStatusService(
     private val httpClient: HttpClient,
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
 
     internal suspend fun getOrderStatus(
         request: OrderStatusRequest,
         clientKey: String
-    ): OrderStatusResponse = withContext(ioDispatcher) {
+    ): OrderStatusResponse = withContext(coroutineDispatcher) {
         httpClient.post(
             path = "v1/order/status",
             queryParameters = mapOf("clientKey" to clientKey),

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/PublicKeyService.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/PublicKeyService.kt
@@ -19,12 +19,12 @@ import kotlinx.coroutines.withContext
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class PublicKeyService(
     private val httpClient: HttpClient,
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
 
     internal suspend fun getPublicKey(
         clientKey: String
-    ): PublicKeyResponse = withContext(ioDispatcher) {
+    ): PublicKeyResponse = withContext(coroutineDispatcher) {
         httpClient.get(
             "v1/clientKeys/$clientKey",
             PublicKeyResponse.SERIALIZER

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/PublicKeyService.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/PublicKeyService.kt
@@ -12,17 +12,19 @@ import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.core.internal.data.model.PublicKeyResponse
 import com.adyen.checkout.core.internal.data.api.HttpClient
 import com.adyen.checkout.core.internal.data.api.get
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class PublicKeyService(
     private val httpClient: HttpClient,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
 
     internal suspend fun getPublicKey(
         clientKey: String
-    ): PublicKeyResponse = withContext(Dispatchers.IO) {
+    ): PublicKeyResponse = withContext(ioDispatcher) {
         httpClient.get(
             "v1/clientKeys/$clientKey",
             PublicKeyResponse.SERIALIZER

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/StatusRepository.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/StatusRepository.kt
@@ -41,7 +41,7 @@ interface StatusRepository {
 class DefaultStatusRepository(
     private val statusService: StatusService,
     private val clientKey: String,
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : StatusRepository {
 
     private var delay: Long = 0
@@ -75,7 +75,7 @@ class DefaultStatusRepository(
         )
     }
 
-    private suspend fun fetchStatus(paymentData: String) = withContext(ioDispatcher) {
+    private suspend fun fetchStatus(paymentData: String) = withContext(coroutineDispatcher) {
         runSuspendCatching {
             statusService.checkStatus(clientKey, StatusRequest(paymentData))
         }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/StatusRepository.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/StatusRepository.kt
@@ -15,6 +15,7 @@ import com.adyen.checkout.components.core.internal.util.StatusResponseUtils
 import com.adyen.checkout.core.internal.util.LogUtil
 import com.adyen.checkout.core.internal.util.Logger
 import com.adyen.checkout.core.internal.util.runSuspendCatching
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.currentCoroutineContext
@@ -37,9 +38,10 @@ interface StatusRepository {
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class DefaultStatusRepository constructor(
+class DefaultStatusRepository(
     private val statusService: StatusService,
     private val clientKey: String,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : StatusRepository {
 
     private var delay: Long = 0
@@ -73,7 +75,7 @@ class DefaultStatusRepository constructor(
         )
     }
 
-    private suspend fun fetchStatus(paymentData: String) = withContext(Dispatchers.IO) {
+    private suspend fun fetchStatus(paymentData: String) = withContext(ioDispatcher) {
         runSuspendCatching {
             statusService.checkStatus(clientKey, StatusRequest(paymentData))
         }
@@ -89,10 +91,12 @@ class DefaultStatusRepository constructor(
                 delay = POLLING_DELAY_FAST
                 true
             }
+
             elapsedTime <= maxPollingDuration -> {
                 delay = POLLING_DELAY_SLOW
                 true
             }
+
             else -> false
         }
     }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModel.kt
@@ -46,6 +46,7 @@ import com.adyen.checkout.giftcard.internal.util.GiftCardBalanceUtils
 import com.adyen.checkout.googlepay.GooglePayComponent
 import com.adyen.checkout.sessions.core.internal.data.model.SessionDetails
 import com.adyen.checkout.sessions.core.internal.data.model.mapToModel
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -57,6 +58,7 @@ internal class DropInViewModel(
     private val bundleHandler: DropInSavedStateHandleContainer,
     private val orderStatusRepository: OrderStatusRepository,
     internal val analyticsRepository: AnalyticsRepository,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ViewModel() {
 
     private val eventChannel: Channel<DropInActivityEvent> = bufferedChannel()
@@ -309,7 +311,7 @@ internal class DropInViewModel(
     }
 
     fun handleOrderCreated(orderResponse: OrderResponse) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(ioDispatcher) {
             handleOrderResponse(orderResponse)
             if (currentOrder != null) {
                 partialPaymentRequested()
@@ -364,7 +366,7 @@ internal class DropInViewModel(
     }
 
     fun handlePaymentMethodsUpdate(paymentMethodsApiResponse: PaymentMethodsApiResponse, order: OrderResponse?) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(ioDispatcher) {
             handleOrderResponse(order)
             this@DropInViewModel.paymentMethodsApiResponse = paymentMethodsApiResponse
             sendEvent(DropInActivityEvent.ShowPaymentMethods)

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModel.kt
@@ -58,7 +58,7 @@ internal class DropInViewModel(
     private val bundleHandler: DropInSavedStateHandleContainer,
     private val orderStatusRepository: OrderStatusRepository,
     internal val analyticsRepository: AnalyticsRepository,
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ViewModel() {
 
     private val eventChannel: Channel<DropInActivityEvent> = bufferedChannel()
@@ -311,7 +311,7 @@ internal class DropInViewModel(
     }
 
     fun handleOrderCreated(orderResponse: OrderResponse) {
-        viewModelScope.launch(ioDispatcher) {
+        viewModelScope.launch(coroutineDispatcher) {
             handleOrderResponse(orderResponse)
             if (currentOrder != null) {
                 partialPaymentRequested()
@@ -366,7 +366,7 @@ internal class DropInViewModel(
     }
 
     fun handlePaymentMethodsUpdate(paymentMethodsApiResponse: PaymentMethodsApiResponse, order: OrderResponse?) {
-        viewModelScope.launch(ioDispatcher) {
+        viewModelScope.launch(coroutineDispatcher) {
             handleOrderResponse(order)
             this@DropInViewModel.paymentMethodsApiResponse = paymentMethodsApiResponse
             sendEvent(DropInActivityEvent.ShowPaymentMethods)

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/CheckoutSessionInitializer.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/CheckoutSessionInitializer.kt
@@ -26,7 +26,7 @@ internal class CheckoutSessionInitializer(
     private val sessionModel: SessionModel,
     configuration: Configuration,
     private val order: Order?,
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
     private val httpClient = HttpClientFactory.getHttpClient(configuration.environment)
     private val sessionService = SessionService(httpClient)
@@ -34,7 +34,7 @@ internal class CheckoutSessionInitializer(
 
     // TODO: Once Backend provides the correct amount in the SessionSetupResponse use that in SessionDetails instead of
     //  override Amount
-    suspend fun setupSession(overrideAmount: Amount?): CheckoutSessionResult = withContext(ioDispatcher) {
+    suspend fun setupSession(overrideAmount: Amount?): CheckoutSessionResult = withContext(coroutineDispatcher) {
         sessionRepository.setupSession(
             sessionModel = sessionModel,
             order = order,

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/CheckoutSessionInitializer.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/CheckoutSessionInitializer.kt
@@ -18,6 +18,7 @@ import com.adyen.checkout.sessions.core.CheckoutSessionResult
 import com.adyen.checkout.sessions.core.SessionModel
 import com.adyen.checkout.sessions.core.internal.data.api.SessionRepository
 import com.adyen.checkout.sessions.core.internal.data.api.SessionService
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -25,6 +26,7 @@ internal class CheckoutSessionInitializer(
     private val sessionModel: SessionModel,
     configuration: Configuration,
     private val order: Order?,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
     private val httpClient = HttpClientFactory.getHttpClient(configuration.environment)
     private val sessionService = SessionService(httpClient)
@@ -32,7 +34,7 @@ internal class CheckoutSessionInitializer(
 
     // TODO: Once Backend provides the correct amount in the SessionSetupResponse use that in SessionDetails instead of
     //  override Amount
-    suspend fun setupSession(overrideAmount: Amount?): CheckoutSessionResult = withContext(Dispatchers.IO) {
+    suspend fun setupSession(overrideAmount: Amount?): CheckoutSessionResult = withContext(ioDispatcher) {
         sessionRepository.setupSession(
             sessionModel = sessionModel,
             order = order,
@@ -41,13 +43,13 @@ internal class CheckoutSessionInitializer(
                 return@withContext CheckoutSessionResult.Success(
                     CheckoutSession(
                         sessionSetupResponse.copy(amount = overrideAmount ?: sessionSetupResponse.amount),
-                        order
-                    )
+                        order,
+                    ),
                 )
             },
             onFailure = {
                 return@withContext CheckoutSessionResult.Error(CheckoutException("Failed to fetch session", it))
-            }
+            },
         )
     }
 }

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/data/api/SessionService.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/data/api/SessionService.kt
@@ -23,19 +23,21 @@ import com.adyen.checkout.sessions.core.internal.data.model.SessionOrderResponse
 import com.adyen.checkout.sessions.core.internal.data.model.SessionPaymentsRequest
 import com.adyen.checkout.sessions.core.internal.data.model.SessionPaymentsResponse
 import com.adyen.checkout.sessions.core.internal.data.model.SessionSetupRequest
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class SessionService(
     private val httpClient: HttpClient,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
 
     suspend fun setupSession(
         request: SessionSetupRequest,
         sessionId: String,
         clientKey: String,
-    ): SessionSetupResponse = withContext(Dispatchers.IO) {
+    ): SessionSetupResponse = withContext(ioDispatcher) {
         httpClient.post(
             path = "v1/sessions/$sessionId/setup",
             queryParameters = mapOf("clientKey" to clientKey),
@@ -49,7 +51,7 @@ class SessionService(
         request: SessionPaymentsRequest,
         sessionId: String,
         clientKey: String,
-    ): SessionPaymentsResponse = withContext(Dispatchers.IO) {
+    ): SessionPaymentsResponse = withContext(ioDispatcher) {
         httpClient.post(
             path = "v1/sessions/$sessionId/payments",
             queryParameters = mapOf("clientKey" to clientKey),
@@ -63,7 +65,7 @@ class SessionService(
         request: SessionDetailsRequest,
         sessionId: String,
         clientKey: String,
-    ): SessionDetailsResponse = withContext(Dispatchers.IO) {
+    ): SessionDetailsResponse = withContext(ioDispatcher) {
         httpClient.post(
             path = "v1/sessions/$sessionId/paymentDetails",
             queryParameters = mapOf("clientKey" to clientKey),
@@ -77,7 +79,7 @@ class SessionService(
         request: SessionBalanceRequest,
         sessionId: String,
         clientKey: String,
-    ): SessionBalanceResponse = withContext(Dispatchers.IO) {
+    ): SessionBalanceResponse = withContext(ioDispatcher) {
         httpClient.post(
             path = "v1/sessions/$sessionId/paymentMethodBalance",
             queryParameters = mapOf("clientKey" to clientKey),
@@ -91,7 +93,7 @@ class SessionService(
         request: SessionOrderRequest,
         sessionId: String,
         clientKey: String,
-    ): SessionOrderResponse = withContext(Dispatchers.IO) {
+    ): SessionOrderResponse = withContext(ioDispatcher) {
         httpClient.post(
             path = "v1/sessions/$sessionId/orders",
             queryParameters = mapOf("clientKey" to clientKey),
@@ -105,7 +107,7 @@ class SessionService(
         request: SessionCancelOrderRequest,
         sessionId: String,
         clientKey: String,
-    ): SessionCancelOrderResponse = withContext(Dispatchers.IO) {
+    ): SessionCancelOrderResponse = withContext(ioDispatcher) {
         httpClient.post(
             path = "v1/sessions/$sessionId/orders/cancel",
             queryParameters = mapOf("clientKey" to clientKey),

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/data/api/SessionService.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/data/api/SessionService.kt
@@ -30,14 +30,14 @@ import kotlinx.coroutines.withContext
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class SessionService(
     private val httpClient: HttpClient,
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
 
     suspend fun setupSession(
         request: SessionSetupRequest,
         sessionId: String,
         clientKey: String,
-    ): SessionSetupResponse = withContext(ioDispatcher) {
+    ): SessionSetupResponse = withContext(coroutineDispatcher) {
         httpClient.post(
             path = "v1/sessions/$sessionId/setup",
             queryParameters = mapOf("clientKey" to clientKey),
@@ -51,7 +51,7 @@ class SessionService(
         request: SessionPaymentsRequest,
         sessionId: String,
         clientKey: String,
-    ): SessionPaymentsResponse = withContext(ioDispatcher) {
+    ): SessionPaymentsResponse = withContext(coroutineDispatcher) {
         httpClient.post(
             path = "v1/sessions/$sessionId/payments",
             queryParameters = mapOf("clientKey" to clientKey),
@@ -65,7 +65,7 @@ class SessionService(
         request: SessionDetailsRequest,
         sessionId: String,
         clientKey: String,
-    ): SessionDetailsResponse = withContext(ioDispatcher) {
+    ): SessionDetailsResponse = withContext(coroutineDispatcher) {
         httpClient.post(
             path = "v1/sessions/$sessionId/paymentDetails",
             queryParameters = mapOf("clientKey" to clientKey),
@@ -79,7 +79,7 @@ class SessionService(
         request: SessionBalanceRequest,
         sessionId: String,
         clientKey: String,
-    ): SessionBalanceResponse = withContext(ioDispatcher) {
+    ): SessionBalanceResponse = withContext(coroutineDispatcher) {
         httpClient.post(
             path = "v1/sessions/$sessionId/paymentMethodBalance",
             queryParameters = mapOf("clientKey" to clientKey),
@@ -93,7 +93,7 @@ class SessionService(
         request: SessionOrderRequest,
         sessionId: String,
         clientKey: String,
-    ): SessionOrderResponse = withContext(ioDispatcher) {
+    ): SessionOrderResponse = withContext(coroutineDispatcher) {
         httpClient.post(
             path = "v1/sessions/$sessionId/orders",
             queryParameters = mapOf("clientKey" to clientKey),
@@ -107,7 +107,7 @@ class SessionService(
         request: SessionCancelOrderRequest,
         sessionId: String,
         clientKey: String,
-    ): SessionCancelOrderResponse = withContext(ioDispatcher) {
+    ): SessionCancelOrderResponse = withContext(coroutineDispatcher) {
         httpClient.post(
             path = "v1/sessions/$sessionId/orders/cancel",
             queryParameters = mapOf("clientKey" to clientKey),

--- a/test-core/src/main/java/com/adyen/checkout/test/TestDispatcherExtension.kt
+++ b/test-core/src/main/java/com/adyen/checkout/test/TestDispatcherExtension.kt
@@ -9,65 +9,29 @@
 package com.adyen.checkout.test
 
 import androidx.annotation.RestrictTo
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.extension.AfterEachCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
-import org.junit.jupiter.api.extension.ParameterContext
-import org.junit.jupiter.api.extension.ParameterResolutionException
-import org.junit.jupiter.api.extension.ParameterResolver
 
 /**
  * JUnit 5 extension that replaces [Dispatchers.Main] with a test dispatcher. This gives control over how the dispatcher
  * executes it's work.
- *
- * Example:
- * ```
- * @ExtendWith(TestDispatcherExtension::class)
- * internal class ExampleTest {
- *
- *     @Test
- *     fun test(dispatcher: CoroutineDispatcher) = runTest(dispatcher) {
- *         ...
- *     }
- * }
- * ```
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 @RestrictTo(RestrictTo.Scope.TESTS)
-class TestDispatcherExtension : BeforeEachCallback, AfterEachCallback, ParameterResolver {
+class TestDispatcherExtension : BeforeEachCallback, AfterEachCallback {
 
     override fun beforeEach(context: ExtensionContext) {
         val testDispatcher = UnconfinedTestDispatcher()
         Dispatchers.setMain(testDispatcher)
-        context.getStore(NAMESPACE).put(DISPATCHER, testDispatcher)
     }
 
     override fun afterEach(context: ExtensionContext) {
         Dispatchers.resetMain()
-        context.getStore(NAMESPACE).remove(DISPATCHER, TestDispatcher::class.java)
-    }
-
-    @Throws(ParameterResolutionException::class)
-    @Suppress("NewApi")
-    override fun supportsParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): Boolean =
-        // It's safe to ignore the warning on getType(), because this code is used in JVM unit tests and not
-        // android related.
-        parameterContext.parameter.type.isAssignableFrom(CoroutineDispatcher::class.java) ||
-            parameterContext.parameter.type.isAssignableFrom(TestDispatcher::class.java)
-
-    @Throws(ParameterResolutionException::class)
-    override fun resolveParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): Any =
-        extensionContext.getStore(NAMESPACE).get(DISPATCHER)
-
-    companion object {
-        private val NAMESPACE = ExtensionContext.Namespace.create("com.adyen.checkout")
-        private const val DISPATCHER = "dispatcher"
     }
 }

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/data/api/AddressService.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/data/api/AddressService.kt
@@ -19,11 +19,11 @@ import kotlinx.coroutines.withContext
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class AddressService(
     private val httpClient: HttpClient,
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
     suspend fun getCountries(
         shopperLocale: String
-    ): List<AddressItem> = withContext(ioDispatcher) {
+    ): List<AddressItem> = withContext(coroutineDispatcher) {
         httpClient.getList(
             path = "datasets/countries/$shopperLocale.json",
             responseSerializer = AddressItem.SERIALIZER,
@@ -33,7 +33,7 @@ class AddressService(
     suspend fun getStates(
         shopperLocale: String,
         countryCode: String
-    ): List<AddressItem> = withContext(ioDispatcher) {
+    ): List<AddressItem> = withContext(coroutineDispatcher) {
         httpClient.getList(
             path = "datasets/states/$countryCode/$shopperLocale.json",
             responseSerializer = AddressItem.SERIALIZER,

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/data/api/AddressService.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/data/api/AddressService.kt
@@ -12,16 +12,18 @@ import androidx.annotation.RestrictTo
 import com.adyen.checkout.core.internal.data.api.HttpClient
 import com.adyen.checkout.core.internal.data.api.getList
 import com.adyen.checkout.ui.core.internal.data.model.AddressItem
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class AddressService(
     private val httpClient: HttpClient,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
     suspend fun getCountries(
         shopperLocale: String
-    ): List<AddressItem> = withContext(Dispatchers.IO) {
+    ): List<AddressItem> = withContext(ioDispatcher) {
         httpClient.getList(
             path = "datasets/countries/$shopperLocale.json",
             responseSerializer = AddressItem.SERIALIZER,
@@ -31,7 +33,7 @@ class AddressService(
     suspend fun getStates(
         shopperLocale: String,
         countryCode: String
-    ): List<AddressItem> = withContext(Dispatchers.IO) {
+    ): List<AddressItem> = withContext(ioDispatcher) {
         httpClient.getList(
             path = "datasets/states/$countryCode/$shopperLocale.json",
             responseSerializer = AddressItem.SERIALIZER,

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/data/api/DefaultAddressRepository.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/data/api/DefaultAddressRepository.kt
@@ -27,7 +27,7 @@ import java.util.Locale
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class DefaultAddressRepository(
     private val addressService: AddressService,
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : AddressRepository {
 
     private val statesChannel: Channel<List<AddressItem>> = bufferedChannel()
@@ -65,7 +65,7 @@ class DefaultAddressRepository(
         countryCode: String,
         coroutineScope: CoroutineScope
     ) {
-        coroutineScope.launch(ioDispatcher) {
+        coroutineScope.launch(coroutineDispatcher) {
             val states = getStates(
                 shopperLocale = shopperLocale,
                 countryCode = countryCode,
@@ -94,7 +94,7 @@ class DefaultAddressRepository(
     }
 
     private fun fetchCountryList(shopperLocale: Locale, coroutineScope: CoroutineScope) {
-        coroutineScope.launch(ioDispatcher) {
+        coroutineScope.launch(coroutineDispatcher) {
             val countries = getCountries(
                 shopperLocale = shopperLocale,
             ).fold(


### PR DESCRIPTION
## Description
Inject coroutines dispatchers instead of using them directly. This makes the code better testable.

Bonus:
- Reduced complexity of `DefaultAdyen3DS2Delegate` methods
- Removed dispatcher injection from `TestDispatcherExtension`
  - It was only used in one test and there were warnings about it