### PR TITLE
Support optional shopper locale in configurations

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Configuration.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Configuration.kt
@@ -27,7 +27,7 @@ import java.util.Locale
 @Suppress("LongParameterList")
 @Parcelize
 class Adyen3DS2Configuration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -46,6 +46,18 @@ class Adyen3DS2Configuration private constructor(
         private var threeDSRequestorAppURL: String? = null
 
         /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
+
+        /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
          *
          * @param context A Context
@@ -59,7 +71,7 @@ class Adyen3DS2Configuration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -112,8 +124,9 @@ class Adyen3DS2Configuration private constructor(
 fun CheckoutConfiguration.adyen3DS2(
     configuration: @CheckoutConfigurationMarker Adyen3DS2Configuration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = Adyen3DS2Configuration.Builder(shopperLocale, environment, clientKey)
+    val config = Adyen3DS2Configuration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Configuration.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Configuration.kt
@@ -64,6 +64,7 @@ class Adyen3DS2Configuration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/provider/Adyen3DS2ComponentProvider.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/provider/Adyen3DS2ComponentProvider.kt
@@ -34,11 +34,13 @@ import com.adyen.checkout.components.core.internal.ActionObserverRepository
 import com.adyen.checkout.components.core.internal.DefaultActionComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentDataRepository
 import com.adyen.checkout.components.core.internal.provider.ActionComponentProvider
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.util.AndroidBase64Encoder
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
+import com.adyen.checkout.core.internal.util.LocaleProvider
 import com.adyen.checkout.ui.core.internal.DefaultRedirectHandler
 import com.adyen.threeds2.ThreeDS2Service
 import kotlinx.coroutines.Dispatchers
@@ -46,10 +48,9 @@ import kotlinx.coroutines.Dispatchers
 class Adyen3DS2ComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
-    dropInOverrideParams: DropInOverrideParams? = null,
+    private val dropInOverrideParams: DropInOverrideParams? = null,
+    private val localeProvider: LocaleProvider = LocaleProvider(),
 ) : ActionComponentProvider<Adyen3DS2Component, Adyen3DS2Configuration, Adyen3DS2Delegate> {
-
-    private val componentParamsMapper = Adyen3DS2ComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,
@@ -79,10 +80,13 @@ constructor(
         savedStateHandle: SavedStateHandle,
         application: Application
     ): Adyen3DS2Delegate {
-        val componentParams = componentParamsMapper.mapToParams(
+        val componentParams = Adyen3DS2ComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
             checkoutConfiguration = checkoutConfiguration,
-            sessionParams = null,
+            deviceLocale = localeProvider.getLocale(application),
+            dropInOverrideParams = dropInOverrideParams,
+            componentSessionParams = null,
         )
+
         val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
         val submitFingerprintService = SubmitFingerprintService(httpClient)
         val submitFingerprintRepository = SubmitFingerprintRepository(submitFingerprintService)

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/provider/Adyen3DS2ComponentProvider.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/provider/Adyen3DS2ComponentProvider.kt
@@ -35,7 +35,6 @@ import com.adyen.checkout.components.core.internal.DefaultActionComponentEventHa
 import com.adyen.checkout.components.core.internal.PaymentDataRepository
 import com.adyen.checkout.components.core.internal.provider.ActionComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.internal.util.AndroidBase64Encoder
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
@@ -48,10 +47,9 @@ class Adyen3DS2ComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
 ) : ActionComponentProvider<Adyen3DS2Component, Adyen3DS2Configuration, Adyen3DS2Delegate> {
 
-    private val componentParamsMapper = Adyen3DS2ComponentParamsMapper(dropInOverrideParams, overrideSessionParams)
+    private val componentParamsMapper = Adyen3DS2ComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/model/Adyen3DS2ComponentParams.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/model/Adyen3DS2ComponentParams.kt
@@ -8,21 +8,13 @@
 
 package com.adyen.checkout.adyen3ds2.internal.ui.model
 
-import com.adyen.checkout.components.core.Amount
-import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParams
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
-import com.adyen.checkout.core.Environment
 import com.adyen.threeds2.customization.UiCustomization
-import java.util.Locale
 
 internal data class Adyen3DS2ComponentParams(
-    override val shopperLocale: Locale,
-    override val environment: Environment,
-    override val clientKey: String,
-    override val analyticsParams: AnalyticsParams,
-    override val isCreatedByDropIn: Boolean,
-    override val amount: Amount?,
+    private val commonComponentParams: CommonComponentParams,
     val uiCustomization: UiCustomization?,
     val threeDSRequestorAppURL: String?,
     val deviceParameterBlockList: Set<String>?,
-) : ComponentParams
+) : ComponentParams by commonComponentParams

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/model/Adyen3DS2ComponentParamsMapper.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/model/Adyen3DS2ComponentParamsMapper.kt
@@ -17,7 +17,6 @@ import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 
 internal class Adyen3DS2ComponentParamsMapper(
     private val dropInOverrideParams: DropInOverrideParams?,
-    private val overrideSessionParams: SessionParams?,
 ) {
 
     fun mapToParams(
@@ -27,7 +26,7 @@ internal class Adyen3DS2ComponentParamsMapper(
         return checkoutConfiguration
             .mapToParamsInternal()
             .override(dropInOverrideParams)
-            .override(sessionParams ?: overrideSessionParams)
+            .override(sessionParams ?: dropInOverrideParams?.sessionParams)
     }
 
     private fun CheckoutConfiguration.mapToParamsInternal(): Adyen3DS2ComponentParams {

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/model/Adyen3DS2ComponentParamsMapper.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/model/Adyen3DS2ComponentParamsMapper.kt
@@ -11,56 +11,34 @@ package com.adyen.checkout.adyen3ds2.internal.ui.model
 import androidx.annotation.VisibleForTesting
 import com.adyen.checkout.adyen3ds2.getAdyen3DS2Configuration
 import com.adyen.checkout.components.core.CheckoutConfiguration
-import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.ui.model.SessionParams
+import java.util.Locale
 
 internal class Adyen3DS2ComponentParamsMapper(
-    private val dropInOverrideParams: DropInOverrideParams?,
+    private val commonComponentParamsMapper: CommonComponentParamsMapper,
 ) {
 
     fun mapToParams(
         checkoutConfiguration: CheckoutConfiguration,
-        sessionParams: SessionParams?,
+        deviceLocale: Locale,
+        dropInOverrideParams: DropInOverrideParams?,
+        componentSessionParams: SessionParams?,
     ): Adyen3DS2ComponentParams {
-        return checkoutConfiguration
-            .mapToParamsInternal()
-            .override(dropInOverrideParams)
-            .override(sessionParams ?: dropInOverrideParams?.sessionParams)
-    }
-
-    private fun CheckoutConfiguration.mapToParamsInternal(): Adyen3DS2ComponentParams {
-        val adyen3ds2Configuration = getAdyen3DS2Configuration()
+        val commonComponentParamsMapperData = commonComponentParamsMapper.mapToParams(
+            checkoutConfiguration,
+            deviceLocale,
+            dropInOverrideParams,
+            componentSessionParams,
+        )
+        val adyen3ds2Configuration = checkoutConfiguration.getAdyen3DS2Configuration()
         return Adyen3DS2ComponentParams(
-            shopperLocale = shopperLocale,
-            environment = environment,
-            clientKey = clientKey,
-            analyticsParams = AnalyticsParams(analyticsConfiguration),
-            isCreatedByDropIn = false,
-            amount = amount,
+            commonComponentParams = commonComponentParamsMapperData.commonComponentParams,
             uiCustomization = adyen3ds2Configuration?.uiCustomization,
             threeDSRequestorAppURL = adyen3ds2Configuration?.threeDSRequestorAppURL,
             // Hardcoded for now, but in the feature we could make this configurable
             deviceParameterBlockList = DEVICE_PARAMETER_BLOCK_LIST,
-        )
-    }
-
-    private fun Adyen3DS2ComponentParams.override(
-        dropInOverrideParams: DropInOverrideParams?,
-    ): Adyen3DS2ComponentParams {
-        if (dropInOverrideParams == null) return this
-        return copy(
-            amount = dropInOverrideParams.amount,
-            isCreatedByDropIn = true,
-        )
-    }
-
-    private fun Adyen3DS2ComponentParams.override(
-        sessionParams: SessionParams?
-    ): Adyen3DS2ComponentParams {
-        if (sessionParams == null) return this
-        return copy(
-            amount = sessionParams.amount ?: amount,
         )
     }
 

--- a/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2DelegateTest.kt
+++ b/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2DelegateTest.kt
@@ -27,6 +27,7 @@ import com.adyen.checkout.components.core.action.Threeds2ChallengeAction
 import com.adyen.checkout.components.core.action.Threeds2FingerprintAction
 import com.adyen.checkout.components.core.internal.ActionObserverRepository
 import com.adyen.checkout.components.core.internal.PaymentDataRepository
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.util.JavaBase64Encoder
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.core.exception.ComponentException
@@ -83,12 +84,12 @@ internal class DefaultAdyen3DS2DelegateTest(
     fun setup() {
         redirectHandler = TestRedirectHandler()
         paymentDataRepository = PaymentDataRepository(SavedStateHandle())
-        val configuration = CheckoutConfiguration(Locale.US, Environment.TEST, TEST_CLIENT_KEY)
+        val configuration = CheckoutConfiguration(Environment.TEST, TEST_CLIENT_KEY)
         delegate = DefaultAdyen3DS2Delegate(
             observerRepository = ActionObserverRepository(),
             savedStateHandle = SavedStateHandle(),
-            componentParams = Adyen3DS2ComponentParamsMapper(null, null)
-                .mapToParams(configuration, null)
+            componentParams = Adyen3DS2ComponentParamsMapper(CommonComponentParamsMapper())
+                .mapToParams(configuration, Locale.US, null, null)
                 // Set it to null to avoid a crash in 3DS2 library (they use Android APIs)
                 .copy(deviceParameterBlockList = null),
             submitFingerprintRepository = submitFingerprintRepository,

--- a/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/internal/ui/model/Adyen3DS2ComponentParamsMapperTest.kt
+++ b/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/internal/ui/model/Adyen3DS2ComponentParamsMapperTest.kt
@@ -15,6 +15,8 @@ import com.adyen.checkout.components.core.AnalyticsLevel
 import com.adyen.checkout.components.core.CheckoutConfiguration
 import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
 import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParamsLevel
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParams
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.core.Environment
 import com.adyen.threeds2.customization.UiCustomization
@@ -24,12 +26,13 @@ import java.util.Locale
 
 internal class Adyen3DS2ComponentParamsMapperTest {
 
+    private val adyen3DS2ComponentParamsMapper = Adyen3DS2ComponentParamsMapper(CommonComponentParamsMapper())
+
     @Test
-    fun `when parent configuration is null and custom 3ds2 configuration fields are null then all fields should match`() {
+    fun `when drop-in override params are null and custom 3ds2 configuration fields are null then all fields should match`() {
         val checkoutConfiguration = getCheckoutConfiguration()
 
-        val params = Adyen3DS2ComponentParamsMapper(null, null)
-            .mapToParams(checkoutConfiguration, null)
+        val params = adyen3DS2ComponentParamsMapper.mapToParams(checkoutConfiguration, DEVICE_LOCALE, null, null)
 
         val expected = getAdyen3DS2ComponentParams()
 
@@ -37,7 +40,7 @@ internal class Adyen3DS2ComponentParamsMapperTest {
     }
 
     @Test
-    fun `when parent configuration is null and custom 3ds2 configuration fields are set then all fields should match`() {
+    fun `when drop-in override params are null and custom 3ds2 configuration fields are set then all fields should match`() {
         val uiCustomization = UiCustomization()
 
         val testUrl = "https://adyen.com"
@@ -48,8 +51,7 @@ internal class Adyen3DS2ComponentParamsMapperTest {
             }
         }
 
-        val params = Adyen3DS2ComponentParamsMapper(null, null)
-            .mapToParams(configuration, null)
+        val params = adyen3DS2ComponentParamsMapper.mapToParams(configuration, DEVICE_LOCALE, null, null)
 
         val expected = getAdyen3DS2ComponentParams(
             uiCustomization = uiCustomization,
@@ -60,7 +62,7 @@ internal class Adyen3DS2ComponentParamsMapperTest {
     }
 
     @Test
-    fun `when parent configuration is set then parent configuration fields should override 3ds2 configuration fields`() {
+    fun `when drop-in override params are set then they should override 3ds2 configuration fields`() {
         val checkoutConfiguration = CheckoutConfiguration(
             shopperLocale = Locale.GERMAN,
             environment = Environment.EUROPE,
@@ -72,9 +74,13 @@ internal class Adyen3DS2ComponentParamsMapperTest {
             ),
         )
 
-        val dropInOverrideParams = DropInOverrideParams(Amount("CAD", 123L))
-        val params = Adyen3DS2ComponentParamsMapper(dropInOverrideParams, null)
-            .mapToParams(checkoutConfiguration, null)
+        val dropInOverrideParams = DropInOverrideParams(Amount("CAD", 123L), null)
+        val params = adyen3DS2ComponentParamsMapper.mapToParams(
+            checkoutConfiguration = checkoutConfiguration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = dropInOverrideParams,
+            componentSessionParams = null,
+        )
 
         val expected = getAdyen3DS2ComponentParams(
             shopperLocale = Locale.GERMAN,
@@ -109,12 +115,14 @@ internal class Adyen3DS2ComponentParamsMapperTest {
         uiCustomization: UiCustomization? = null,
         threeDSRequestorAppURL: String? = null,
     ) = Adyen3DS2ComponentParams(
-        shopperLocale = shopperLocale,
-        environment = environment,
-        clientKey = clientKey,
-        analyticsParams = analyticsParams,
-        isCreatedByDropIn = isCreatedByDropIn,
-        amount = amount,
+        commonComponentParams = CommonComponentParams(
+            shopperLocale = shopperLocale,
+            environment = environment,
+            clientKey = clientKey,
+            analyticsParams = analyticsParams,
+            isCreatedByDropIn = isCreatedByDropIn,
+            amount = amount,
+        ),
         uiCustomization = uiCustomization,
         threeDSRequestorAppURL = threeDSRequestorAppURL,
         deviceParameterBlockList = Adyen3DS2ComponentParamsMapper.DEVICE_PARAMETER_BLOCK_LIST,
@@ -123,5 +131,6 @@ internal class Adyen3DS2ComponentParamsMapperTest {
     companion object {
         private const val TEST_CLIENT_KEY_1 = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
         private const val TEST_CLIENT_KEY_2 = "live_qwertyui34566776787zxcvbnmqwerty"
+        private val DEVICE_LOCALE = Locale("nl", "NL")
     }
 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,9 +12,9 @@
 - Creating configurations just became easier. Using a DSL you can now create configurations in a more declarative and concise way:
 ```Kotlin
 CheckoutConfiguration(
-    shopperLocale = shopperLocale,
     environment = environment,
     clientKey = clientKey,
+    shopperLocale = shopperLocale,
     amount = amount,
     analyticsConfiguration = createAnalyticsConfiguration(),
 ) {
@@ -56,6 +56,7 @@ CheckoutConfiguration(
 - Set your own `AdyenLogger` instance with `AdyenLogger.setLogger`. This gives the ability to intercept logs and handle them in your own way.
 
 ## Deprecated
+- When creating a configuration, the `Builder` constructors with a `Context` are now deprecated. You can omit the `context` parameter, the shopper locale will default to the primary device locale.
 - The `PermissionException` is deprecated. Handle permissions through `ActionComponentCallback`, `SessionComponentCallback` or `ComponentCallback` callbacks.
 - The styles for vouchers have been changed:
   - The `AdyenCheckout.Voucher.Description.Bacs` style will not work anymore. Use `AdyenCheckout.Voucher.Simple.Description` instead.
@@ -68,4 +69,5 @@ CheckoutConfiguration(
 - `AdyenLogger.setLogLevel(logLevel: Int)` is deprecated. Use `AdyenLogger.setLogLevel(level: AdyenLogLevel)` instead.
 
 ## Changed
+- When creating a configuration, the shopper locale parameter is now optional. If not set, the primary device locale will be used.
 - In drop-in all actions will start in expanded mode

--- a/ach/src/main/java/com/adyen/checkout/ach/ACHDirectDebitConfiguration.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/ACHDirectDebitConfiguration.kt
@@ -70,6 +70,7 @@ class ACHDirectDebitConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/ach/src/main/java/com/adyen/checkout/ach/ACHDirectDebitConfiguration.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/ACHDirectDebitConfiguration.kt
@@ -29,7 +29,7 @@ import java.util.Locale
 @Parcelize
 @Suppress("LongParameterList")
 class ACHDirectDebitConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -52,6 +52,18 @@ class ACHDirectDebitConfiguration private constructor(
         private var isStorePaymentFieldVisible: Boolean? = null
 
         /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
+
+        /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
          *
          * @param context A Context
@@ -65,7 +77,7 @@ class ACHDirectDebitConfiguration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -138,8 +150,9 @@ class ACHDirectDebitConfiguration private constructor(
 fun CheckoutConfiguration.achDirectDebit(
     configuration: @CheckoutConfigurationMarker ACHDirectDebitConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = ACHDirectDebitConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = ACHDirectDebitConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }
@@ -154,7 +167,7 @@ fun CheckoutConfiguration.getACHDirectDebitConfiguration(): ACHDirectDebitConfig
 }
 
 internal fun ACHDirectDebitConfiguration.toCheckoutConfiguration(): CheckoutConfiguration {
-    return CheckoutConfiguration(shopperLocale, environment, clientKey, amount, analyticsConfiguration) {
+    return CheckoutConfiguration(environment, clientKey, shopperLocale, amount, analyticsConfiguration) {
         addConfiguration(PaymentMethodTypes.ACH, this@toCheckoutConfiguration)
 
         genericActionConfiguration.getAllConfigurations().forEach {

--- a/ach/src/main/java/com/adyen/checkout/ach/internal/provider/ACHDirectDebitComponentProvider.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/internal/provider/ACHDirectDebitComponentProvider.kt
@@ -43,12 +43,14 @@ import com.adyen.checkout.components.core.internal.data.api.DefaultPublicKeyRepo
 import com.adyen.checkout.components.core.internal.data.api.PublicKeyService
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.provider.StoredPaymentComponentProvider
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.core.internal.data.api.HttpClient
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
+import com.adyen.checkout.core.internal.util.LocaleProvider
 import com.adyen.checkout.cse.internal.GenericEncryptorFactory
 import com.adyen.checkout.sessions.core.CheckoutSession
 import com.adyen.checkout.sessions.core.SessionComponentCallback
@@ -70,6 +72,7 @@ class ACHDirectDebitComponentProvider
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
     private val analyticsRepository: AnalyticsRepository? = null,
+    private val localeProvider: LocaleProvider = LocaleProvider(),
 ) :
     PaymentComponentProvider<
         ACHDirectDebitComponent,
@@ -96,8 +99,6 @@ constructor(
         SessionComponentCallback<ACHDirectDebitComponentState>,
         > {
 
-    private val componentParamsMapper = ACHDirectDebitComponentParamsMapper(dropInOverrideParams)
-
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,
         viewModelStoreOwner: ViewModelStoreOwner,
@@ -112,7 +113,13 @@ constructor(
         assertSupported(paymentMethod)
 
         val achFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(checkoutConfiguration, null)
+            val componentParams = ACHDirectDebitComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+                checkoutConfiguration = checkoutConfiguration,
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = null,
+            )
+
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
                 analyticsRepositoryData = AnalyticsRepositoryData(
@@ -192,10 +199,13 @@ constructor(
         assertSupported(paymentMethod)
 
         val achFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(
+            val componentParams = ACHDirectDebitComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
                 checkoutConfiguration = checkoutConfiguration,
-                sessionParams = SessionParamsFactory.create(checkoutSession),
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = SessionParamsFactory.create(checkoutSession),
             )
+
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
                 analyticsRepositoryData = AnalyticsRepositoryData(
@@ -311,7 +321,12 @@ constructor(
         assertSupported(storedPaymentMethod)
 
         val achFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(checkoutConfiguration, null)
+            val componentParams = ACHDirectDebitComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+                checkoutConfiguration = checkoutConfiguration,
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = null,
+            )
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
                 analyticsRepositoryData = AnalyticsRepositoryData(
@@ -390,10 +405,13 @@ constructor(
         assertSupported(storedPaymentMethod)
 
         val achFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(
+            val componentParams = ACHDirectDebitComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
                 checkoutConfiguration = checkoutConfiguration,
-                sessionParams = SessionParamsFactory.create(checkoutSession),
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = SessionParamsFactory.create(checkoutSession),
             )
+
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(

--- a/ach/src/main/java/com/adyen/checkout/ach/internal/provider/ACHDirectDebitComponentProvider.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/internal/provider/ACHDirectDebitComponentProvider.kt
@@ -44,7 +44,6 @@ import com.adyen.checkout.components.core.internal.data.api.PublicKeyService
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.provider.StoredPaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.exception.ComponentException
@@ -70,7 +69,6 @@ class ACHDirectDebitComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
     private val analyticsRepository: AnalyticsRepository? = null,
 ) :
     PaymentComponentProvider<
@@ -98,10 +96,7 @@ constructor(
         SessionComponentCallback<ACHDirectDebitComponentState>,
         > {
 
-    private val componentParamsMapper = ACHDirectDebitComponentParamsMapper(
-        dropInOverrideParams,
-        overrideSessionParams,
-    )
+    private val componentParamsMapper = ACHDirectDebitComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/ach/src/main/java/com/adyen/checkout/ach/internal/ui/model/ACHDirectDebitComponentParams.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/internal/ui/model/ACHDirectDebitComponentParams.kt
@@ -8,22 +8,14 @@
 
 package com.adyen.checkout.ach.internal.ui.model
 
-import com.adyen.checkout.components.core.Amount
-import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
 import com.adyen.checkout.components.core.internal.ui.model.ButtonParams
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParams
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
-import com.adyen.checkout.core.Environment
 import com.adyen.checkout.ui.core.internal.ui.model.AddressParams
-import java.util.Locale
 
 internal data class ACHDirectDebitComponentParams(
-    override val shopperLocale: Locale,
-    override val environment: Environment,
-    override val clientKey: String,
-    override val analyticsParams: AnalyticsParams,
-    override val isCreatedByDropIn: Boolean,
-    override val amount: Amount?,
+    private val commonComponentParams: CommonComponentParams,
     override val isSubmitButtonVisible: Boolean,
     val addressParams: AddressParams,
     val isStorePaymentFieldVisible: Boolean,
-) : ComponentParams, ButtonParams
+) : ComponentParams by commonComponentParams, ButtonParams

--- a/ach/src/main/java/com/adyen/checkout/ach/internal/ui/model/ACHDirectDebitComponentParamsMapper.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/internal/ui/model/ACHDirectDebitComponentParamsMapper.kt
@@ -9,43 +9,55 @@
 package com.adyen.checkout.ach.internal.ui.model
 
 import com.adyen.checkout.ach.ACHDirectDebitAddressConfiguration
+import com.adyen.checkout.ach.ACHDirectDebitConfiguration
 import com.adyen.checkout.ach.getACHDirectDebitConfiguration
 import com.adyen.checkout.components.core.CheckoutConfiguration
-import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParams
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.ui.core.internal.ui.model.AddressParams
+import java.util.Locale
 
 internal class ACHDirectDebitComponentParamsMapper(
-    private val dropInOverrideParams: DropInOverrideParams?,
+    private val commonComponentParamsMapper: CommonComponentParamsMapper,
 ) {
 
     fun mapToParams(
         checkoutConfiguration: CheckoutConfiguration,
-        sessionParams: SessionParams?,
+        deviceLocale: Locale,
+        dropInOverrideParams: DropInOverrideParams?,
+        componentSessionParams: SessionParams?,
     ): ACHDirectDebitComponentParams {
-        return checkoutConfiguration
-            .mapToParamsInternal()
-            .override(dropInOverrideParams)
-            .override(sessionParams ?: dropInOverrideParams?.sessionParams)
+        val commonComponentParamsMapperData = commonComponentParamsMapper.mapToParams(
+            checkoutConfiguration,
+            deviceLocale,
+            dropInOverrideParams,
+            componentSessionParams,
+        )
+        val achDirectDebitConfiguration = checkoutConfiguration.getACHDirectDebitConfiguration()
+        return mapToParams(
+            commonComponentParamsMapperData.commonComponentParams,
+            commonComponentParamsMapperData.sessionParams,
+            achDirectDebitConfiguration,
+        )
     }
 
-    private fun CheckoutConfiguration.mapToParamsInternal(): ACHDirectDebitComponentParams {
-        val achDirectDebitConfiguration = getACHDirectDebitConfiguration()
+    private fun mapToParams(
+        commonComponentParams: CommonComponentParams,
+        sessionParams: SessionParams?,
+        achDirectDebitConfiguration: ACHDirectDebitConfiguration?,
+    ): ACHDirectDebitComponentParams {
         return ACHDirectDebitComponentParams(
-            shopperLocale = shopperLocale,
-            environment = environment,
-            clientKey = clientKey,
-            analyticsParams = AnalyticsParams(analyticsConfiguration),
-            isCreatedByDropIn = false,
-            amount = amount,
+            commonComponentParams = commonComponentParams,
             isSubmitButtonVisible = achDirectDebitConfiguration?.isSubmitButtonVisible ?: true,
             addressParams = achDirectDebitConfiguration?.addressConfiguration?.mapToAddressParam()
                 ?: AddressParams.FullAddress(
                     supportedCountryCodes = DEFAULT_SUPPORTED_COUNTRY_LIST,
                     addressFieldPolicy = AddressFieldPolicyParams.Required,
                 ),
-            isStorePaymentFieldVisible = achDirectDebitConfiguration?.isStorePaymentFieldVisible ?: true,
+            isStorePaymentFieldVisible = sessionParams?.enableStoreDetails
+                ?: achDirectDebitConfiguration?.isStorePaymentFieldVisible ?: true,
         )
     }
 
@@ -62,26 +74,6 @@ internal class ACHDirectDebitComponentParamsMapper(
                 )
             }
         }
-    }
-
-    private fun ACHDirectDebitComponentParams.override(
-        dropInOverrideParams: DropInOverrideParams?,
-    ): ACHDirectDebitComponentParams {
-        if (dropInOverrideParams == null) return this
-        return copy(
-            amount = dropInOverrideParams.amount,
-            isCreatedByDropIn = true,
-        )
-    }
-
-    private fun ACHDirectDebitComponentParams.override(
-        sessionParams: SessionParams? = null
-    ): ACHDirectDebitComponentParams {
-        if (sessionParams == null) return this
-        return copy(
-            isStorePaymentFieldVisible = sessionParams.enableStoreDetails ?: isStorePaymentFieldVisible,
-            amount = sessionParams.amount ?: amount,
-        )
     }
 
     companion object {

--- a/ach/src/main/java/com/adyen/checkout/ach/internal/ui/model/ACHDirectDebitComponentParamsMapper.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/internal/ui/model/ACHDirectDebitComponentParamsMapper.kt
@@ -18,7 +18,6 @@ import com.adyen.checkout.ui.core.internal.ui.model.AddressParams
 
 internal class ACHDirectDebitComponentParamsMapper(
     private val dropInOverrideParams: DropInOverrideParams?,
-    private val overrideSessionParams: SessionParams?,
 ) {
 
     fun mapToParams(
@@ -28,7 +27,7 @@ internal class ACHDirectDebitComponentParamsMapper(
         return checkoutConfiguration
             .mapToParamsInternal()
             .override(dropInOverrideParams)
-            .override(sessionParams ?: overrideSessionParams)
+            .override(sessionParams ?: dropInOverrideParams?.sessionParams)
     }
 
     private fun CheckoutConfiguration.mapToParamsInternal(): ACHDirectDebitComponentParams {

--- a/ach/src/test/java/com/adyen/checkout/ach/internal/ui/DefaultACHDirectDebitDelegateTest.kt
+++ b/ach/src/test/java/com/adyen/checkout/ach/internal/ui/DefaultACHDirectDebitDelegateTest.kt
@@ -25,6 +25,7 @@ import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.data.api.PublicKeyRepository
 import com.adyen.checkout.components.core.internal.test.TestPublicKeyRepository
 import com.adyen.checkout.components.core.internal.ui.model.AddressInputModel
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.FieldState
 import com.adyen.checkout.components.core.internal.ui.model.Validation
 import com.adyen.checkout.components.core.paymentmethod.ACHDirectDebitPaymentMethod
@@ -216,7 +217,12 @@ internal class DefaultACHDirectDebitDelegateTest(
                     ACHDirectDebitAddressConfiguration.FullAddress(DEFAULT_SUPPORTED_COUNTRY_LIST),
                 )
             }
-            val componentParams = ACHDirectDebitComponentParamsMapper(null, null).mapToParams(configuration, null)
+            val componentParams = ACHDirectDebitComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+                checkoutConfiguration = configuration,
+                deviceLocale = DEVICE_LOCALE,
+                dropInOverrideParams = null,
+                componentSessionParams = null,
+            )
             val countryOptions = AddressFormUtils.initializeCountryOptions(
                 shopperLocale = componentParams.shopperLocale,
                 addressParams = componentParams.addressParams,
@@ -692,7 +698,8 @@ internal class DefaultACHDirectDebitDelegateTest(
         addressRepository = addressRepository,
         submitHandler = submitHandler,
         genericEncryptor = genericEncryptor,
-        componentParams = ACHDirectDebitComponentParamsMapper(null, null).mapToParams(configuration, null),
+        componentParams = ACHDirectDebitComponentParamsMapper(CommonComponentParamsMapper())
+            .mapToParams(configuration, DEVICE_LOCALE, null, null),
         order = order,
     )
 
@@ -728,6 +735,7 @@ internal class DefaultACHDirectDebitDelegateTest(
         private val TEST_ORDER = OrderRequest("PSP", "ORDER_DATA")
         private val DEFAULT_SUPPORTED_COUNTRY_LIST = listOf("US", "PR")
         private const val TEST_CHECKOUT_ATTEMPT_ID = "TEST_CHECKOUT_ATTEMPT_ID"
+        private val DEVICE_LOCALE = Locale("nl", "NL")
 
         @JvmStatic
         fun shouldStorePaymentMethodSource() = listOf(

--- a/ach/src/test/java/com/adyen/checkout/ach/internal/ui/StoredACHDirectDebitDelegateTest.kt
+++ b/ach/src/test/java/com/adyen/checkout/ach/internal/ui/StoredACHDirectDebitDelegateTest.kt
@@ -18,6 +18,7 @@ import com.adyen.checkout.components.core.OrderRequest
 import com.adyen.checkout.components.core.StoredPaymentMethod
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.test.TestDispatcherExtension
 import kotlinx.coroutines.CoroutineScope
@@ -112,7 +113,8 @@ internal class StoredACHDirectDebitDelegateTest(
         observerRepository = PaymentObserverRepository(),
         storedPaymentMethod = paymentMethod,
         analyticsRepository = analyticsRepository,
-        componentParams = ACHDirectDebitComponentParamsMapper(null, null).mapToParams(configuration, null),
+        componentParams = ACHDirectDebitComponentParamsMapper(CommonComponentParamsMapper())
+            .mapToParams(configuration, DEVICE_LOCALE, null, null),
         order = order,
     )
 
@@ -133,6 +135,7 @@ internal class StoredACHDirectDebitDelegateTest(
         private val TEST_ORDER = OrderRequest("PSP", "ORDER_DATA")
         private const val STORED_ID = "Stored_id"
         private const val TEST_CHECKOUT_ATTEMPT_ID = "TEST_CHECKOUT_ATTEMPT_ID"
+        private val DEVICE_LOCALE = Locale("nl", "NL")
 
         @JvmStatic
         fun amountSource() = listOf(

--- a/action-core/src/main/java/com/adyen/checkout/action/core/GenericActionConfiguration.kt
+++ b/action-core/src/main/java/com/adyen/checkout/action/core/GenericActionConfiguration.kt
@@ -38,7 +38,7 @@ import kotlin.collections.set
  */
 @Parcelize
 class GenericActionConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -62,6 +62,18 @@ class GenericActionConfiguration private constructor(
         val availableActionConfigs = HashMap<Class<*>, Configuration>()
 
         /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
+
+        /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
          *
          * @param context A Context
@@ -75,7 +87,7 @@ class GenericActionConfiguration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.

--- a/action-core/src/main/java/com/adyen/checkout/action/core/GenericActionConfiguration.kt
+++ b/action-core/src/main/java/com/adyen/checkout/action/core/GenericActionConfiguration.kt
@@ -80,6 +80,7 @@ class GenericActionConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/action-core/src/main/java/com/adyen/checkout/action/core/internal/ActionHandlingPaymentMethodConfigurationBuilder.kt
+++ b/action-core/src/main/java/com/adyen/checkout/action/core/internal/ActionHandlingPaymentMethodConfigurationBuilder.kt
@@ -32,21 +32,40 @@ abstract class ActionHandlingPaymentMethodConfigurationBuilder<
     BuilderT : BaseConfigurationBuilder<ConfigurationT, BuilderT>
     >
 /**
- * Initialize a configuration builder with the required fields.
+ * Initialize a configuration builder with the required fields and a shopper locale.
  *
  * @param shopperLocale The [Locale] of the shopper.
  * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
  * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
  */
 constructor(
-    shopperLocale: Locale,
+    shopperLocale: Locale?,
     environment: Environment,
     clientKey: String
 ) : BaseConfigurationBuilder<ConfigurationT, BuilderT>(shopperLocale, environment, clientKey),
     ActionHandlingConfigurationBuilder<BuilderT> {
 
     protected val genericActionConfigurationBuilder = GenericActionConfiguration.Builder(
-        shopperLocale = shopperLocale,
+        environment = environment,
+        clientKey = clientKey,
+    ).apply {
+        shopperLocale?.let {
+            setShopperLocale(it)
+        }
+    }
+
+    /**
+     * Initialize a configuration builder with the required fields.
+     * The shopper locale will match the primary user locale on the device.
+     *
+     * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+     * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+     */
+    constructor(
+        environment: Environment,
+        clientKey: String
+    ) : this(
+        shopperLocale = null,
         environment = environment,
         clientKey = clientKey,
     )
@@ -65,7 +84,7 @@ constructor(
     ) : this(
         LocaleUtil.getLocale(context),
         environment,
-        clientKey
+        clientKey,
     )
 
     /**

--- a/action-core/src/main/java/com/adyen/checkout/action/core/internal/ActionHandlingPaymentMethodConfigurationBuilder.kt
+++ b/action-core/src/main/java/com/adyen/checkout/action/core/internal/ActionHandlingPaymentMethodConfigurationBuilder.kt
@@ -76,6 +76,7 @@ constructor(
      * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
      * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
      */
+    @Deprecated("You can omit the context parameter")
     constructor(
         @Suppress("unused")
         context: Context,

--- a/action-core/src/main/java/com/adyen/checkout/action/core/internal/ActionHandlingPaymentMethodConfigurationBuilder.kt
+++ b/action-core/src/main/java/com/adyen/checkout/action/core/internal/ActionHandlingPaymentMethodConfigurationBuilder.kt
@@ -15,7 +15,6 @@ import com.adyen.checkout.await.AwaitConfiguration
 import com.adyen.checkout.components.core.internal.BaseConfigurationBuilder
 import com.adyen.checkout.components.core.internal.Configuration
 import com.adyen.checkout.core.Environment
-import com.adyen.checkout.core.internal.util.LocaleUtil
 import com.adyen.checkout.qrcode.QRCodeConfiguration
 import com.adyen.checkout.redirect.RedirectConfiguration
 import com.adyen.checkout.voucher.VoucherConfiguration
@@ -78,11 +77,12 @@ constructor(
      * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
      */
     constructor(
+        @Suppress("unused")
         context: Context,
         environment: Environment,
         clientKey: String
     ) : this(
-        LocaleUtil.getLocale(context),
+        null,
         environment,
         clientKey,
     )

--- a/action-core/src/main/java/com/adyen/checkout/action/core/internal/provider/GenericActionComponentProvider.kt
+++ b/action-core/src/main/java/com/adyen/checkout/action/core/internal/provider/GenericActionComponentProvider.kt
@@ -36,18 +36,19 @@ import com.adyen.checkout.components.core.action.VoucherAction
 import com.adyen.checkout.components.core.internal.ActionObserverRepository
 import com.adyen.checkout.components.core.internal.DefaultActionComponentEventHandler
 import com.adyen.checkout.components.core.internal.provider.ActionComponentProvider
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
+import com.adyen.checkout.core.internal.util.LocaleProvider
 
 class GenericActionComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
+    private val localeProvider: LocaleProvider = LocaleProvider(),
 ) : ActionComponentProvider<GenericActionComponent, GenericActionConfiguration, GenericActionDelegate> {
-
-    private val componentParamsMapper = GenericComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,
@@ -77,7 +78,13 @@ constructor(
         savedStateHandle: SavedStateHandle,
         application: Application
     ): GenericActionDelegate {
-        val componentParams = componentParamsMapper.mapToParams(checkoutConfiguration, null)
+        val componentParams = GenericComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+            checkoutConfiguration = checkoutConfiguration,
+            deviceLocale = localeProvider.getLocale(application),
+            dropInOverrideParams = dropInOverrideParams,
+            componentSessionParams = null,
+        )
+
         return DefaultGenericActionDelegate(
             observerRepository = ActionObserverRepository(),
             savedStateHandle = savedStateHandle,

--- a/action-core/src/main/java/com/adyen/checkout/action/core/internal/provider/GenericActionComponentProvider.kt
+++ b/action-core/src/main/java/com/adyen/checkout/action/core/internal/provider/GenericActionComponentProvider.kt
@@ -47,7 +47,7 @@ constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
 ) : ActionComponentProvider<GenericActionComponent, GenericActionConfiguration, GenericActionDelegate> {
 
-    private val componentParamsMapper = GenericComponentParamsMapper(dropInOverrideParams, null)
+    private val componentParamsMapper = GenericComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,
@@ -83,7 +83,7 @@ constructor(
             savedStateHandle = savedStateHandle,
             checkoutConfiguration = checkoutConfiguration,
             componentParams = componentParams,
-            actionDelegateProvider = ActionDelegateProvider(dropInOverrideParams, null),
+            actionDelegateProvider = ActionDelegateProvider(dropInOverrideParams),
         )
     }
 

--- a/action-core/src/main/java/com/adyen/checkout/action/core/internal/ui/ActionDelegateProvider.kt
+++ b/action-core/src/main/java/com/adyen/checkout/action/core/internal/ui/ActionDelegateProvider.kt
@@ -23,6 +23,7 @@ import com.adyen.checkout.components.core.action.VoucherAction
 import com.adyen.checkout.components.core.internal.ui.ActionDelegate
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.core.exception.CheckoutException
+import com.adyen.checkout.core.internal.util.LocaleProvider
 import com.adyen.checkout.qrcode.internal.provider.QRCodeComponentProvider
 import com.adyen.checkout.redirect.internal.provider.RedirectComponentProvider
 import com.adyen.checkout.voucher.internal.provider.VoucherComponentProvider
@@ -30,6 +31,7 @@ import com.adyen.checkout.wechatpay.internal.provider.WeChatPayActionComponentPr
 
 internal class ActionDelegateProvider(
     private val dropInOverrideParams: DropInOverrideParams?,
+    private val localeProvider: LocaleProvider = LocaleProvider(),
 ) {
 
     fun getDelegate(
@@ -39,12 +41,12 @@ internal class ActionDelegateProvider(
         application: Application,
     ): ActionDelegate {
         val provider = when (action) {
-            is AwaitAction -> AwaitComponentProvider(dropInOverrideParams)
-            is QrCodeAction -> QRCodeComponentProvider(dropInOverrideParams)
-            is RedirectAction -> RedirectComponentProvider(dropInOverrideParams)
-            is BaseThreeds2Action -> Adyen3DS2ComponentProvider(dropInOverrideParams)
-            is VoucherAction -> VoucherComponentProvider(dropInOverrideParams)
-            is SdkAction<*> -> WeChatPayActionComponentProvider(dropInOverrideParams)
+            is AwaitAction -> AwaitComponentProvider(dropInOverrideParams, localeProvider)
+            is QrCodeAction -> QRCodeComponentProvider(dropInOverrideParams, localeProvider)
+            is RedirectAction -> RedirectComponentProvider(dropInOverrideParams, localeProvider)
+            is BaseThreeds2Action -> Adyen3DS2ComponentProvider(dropInOverrideParams, localeProvider)
+            is VoucherAction -> VoucherComponentProvider(dropInOverrideParams, localeProvider)
+            is SdkAction<*> -> WeChatPayActionComponentProvider(dropInOverrideParams, localeProvider)
             else -> throw CheckoutException("Can't find delegate for action: ${action.type}")
         }
 

--- a/action-core/src/main/java/com/adyen/checkout/action/core/internal/ui/ActionDelegateProvider.kt
+++ b/action-core/src/main/java/com/adyen/checkout/action/core/internal/ui/ActionDelegateProvider.kt
@@ -22,7 +22,6 @@ import com.adyen.checkout.components.core.action.SdkAction
 import com.adyen.checkout.components.core.action.VoucherAction
 import com.adyen.checkout.components.core.internal.ui.ActionDelegate
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.qrcode.internal.provider.QRCodeComponentProvider
 import com.adyen.checkout.redirect.internal.provider.RedirectComponentProvider
@@ -31,7 +30,6 @@ import com.adyen.checkout.wechatpay.internal.provider.WeChatPayActionComponentPr
 
 internal class ActionDelegateProvider(
     private val dropInOverrideParams: DropInOverrideParams?,
-    private val overrideSessionParams: SessionParams?,
 ) {
 
     fun getDelegate(
@@ -41,12 +39,12 @@ internal class ActionDelegateProvider(
         application: Application,
     ): ActionDelegate {
         val provider = when (action) {
-            is AwaitAction -> AwaitComponentProvider(dropInOverrideParams, overrideSessionParams)
-            is QrCodeAction -> QRCodeComponentProvider(dropInOverrideParams, overrideSessionParams)
-            is RedirectAction -> RedirectComponentProvider(dropInOverrideParams, overrideSessionParams)
-            is BaseThreeds2Action -> Adyen3DS2ComponentProvider(dropInOverrideParams, overrideSessionParams)
-            is VoucherAction -> VoucherComponentProvider(dropInOverrideParams, overrideSessionParams)
-            is SdkAction<*> -> WeChatPayActionComponentProvider(dropInOverrideParams, overrideSessionParams)
+            is AwaitAction -> AwaitComponentProvider(dropInOverrideParams)
+            is QrCodeAction -> QRCodeComponentProvider(dropInOverrideParams)
+            is RedirectAction -> RedirectComponentProvider(dropInOverrideParams)
+            is BaseThreeds2Action -> Adyen3DS2ComponentProvider(dropInOverrideParams)
+            is VoucherAction -> VoucherComponentProvider(dropInOverrideParams)
+            is SdkAction<*> -> WeChatPayActionComponentProvider(dropInOverrideParams)
             else -> throw CheckoutException("Can't find delegate for action: ${action.type}")
         }
 

--- a/action-core/src/test/java/com/adyen/checkout/action/core/TestActionDelegate.kt
+++ b/action-core/src/test/java/com/adyen/checkout/action/core/TestActionDelegate.kt
@@ -21,6 +21,7 @@ import com.adyen.checkout.components.core.internal.ui.DetailsEmittingDelegate
 import com.adyen.checkout.components.core.internal.ui.IntentHandlingDelegate
 import com.adyen.checkout.components.core.internal.ui.StatusPollingDelegate
 import com.adyen.checkout.components.core.internal.ui.ViewableDelegate
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.OutputData
@@ -69,8 +70,8 @@ internal class TestActionDelegate :
         amount = null,
         analyticsConfiguration = null,
     )
-    override val componentParams: ComponentParams =
-        GenericComponentParamsMapper(null, null).mapToParams(configuration, null)
+    override val componentParams: ComponentParams = GenericComponentParamsMapper(CommonComponentParamsMapper())
+        .mapToParams(configuration, Locale.US, null, null)
 
     var initializeCalled = false
     override fun initialize(coroutineScope: CoroutineScope) {
@@ -114,8 +115,8 @@ internal class Test3DS2Delegate : Adyen3DS2Delegate {
         clientKey = TEST_CLIENT_KEY,
     )
 
-    override val componentParams: ComponentParams =
-        GenericComponentParamsMapper(null, null).mapToParams(configuration, null)
+    override val componentParams: ComponentParams = GenericComponentParamsMapper(CommonComponentParamsMapper())
+        .mapToParams(configuration, Locale.US, null, null)
 
     override val detailsFlow: MutableSharedFlow<ActionComponentData> = MutableSharedFlow(extraBufferCapacity = 1)
 

--- a/action-core/src/test/java/com/adyen/checkout/action/core/internal/ui/ActionDelegateProviderTest.kt
+++ b/action-core/src/test/java/com/adyen/checkout/action/core/internal/ui/ActionDelegateProviderTest.kt
@@ -19,6 +19,7 @@ import com.adyen.checkout.components.core.action.WeChatPaySdkData
 import com.adyen.checkout.components.core.internal.ui.ActionDelegate
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.core.exception.CheckoutException
+import com.adyen.checkout.core.internal.util.LocaleProvider
 import com.adyen.checkout.qrcode.internal.ui.QRCodeDelegate
 import com.adyen.checkout.redirect.internal.ui.RedirectDelegate
 import com.adyen.checkout.voucher.internal.ui.VoucherDelegate
@@ -27,18 +28,28 @@ import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
 import java.util.Locale
 
-internal class ActionDelegateProviderTest {
+@ExtendWith(MockitoExtension::class)
+internal class ActionDelegateProviderTest(
+    @Mock private val localeProvider: LocaleProvider
+) {
 
     private lateinit var actionDelegateProvider: ActionDelegateProvider
 
     @BeforeEach
     fun setup() {
-        actionDelegateProvider = ActionDelegateProvider(null, null)
+        whenever(localeProvider.getLocale(any())) doReturn Locale.US
+        actionDelegateProvider = ActionDelegateProvider(null, localeProvider)
     }
 
     @ParameterizedTest
@@ -47,7 +58,7 @@ internal class ActionDelegateProviderTest {
         action: Action,
         expectedDelegate: Class<ActionDelegate>,
     ) {
-        val configuration = CheckoutConfiguration(Locale.US, Environment.TEST, "")
+        val configuration = CheckoutConfiguration(Environment.TEST, "")
 
         val delegate = actionDelegateProvider.getDelegate(action, configuration, SavedStateHandle(), Application())
 
@@ -56,7 +67,7 @@ internal class ActionDelegateProviderTest {
 
     @Test
     fun `when unknown action is used, then an error will be thrown`() {
-        val configuration = CheckoutConfiguration(Locale.US, Environment.TEST, "")
+        val configuration = CheckoutConfiguration(Environment.TEST, "")
 
         assertThrows<CheckoutException> {
             actionDelegateProvider.getDelegate(UnknownAction(), configuration, SavedStateHandle(), Application())

--- a/action-core/src/test/java/com/adyen/checkout/action/core/ui/DefaultGenericActionDelegateTest.kt
+++ b/action-core/src/test/java/com/adyen/checkout/action/core/ui/DefaultGenericActionDelegateTest.kt
@@ -23,6 +23,7 @@ import com.adyen.checkout.components.core.action.RedirectAction
 import com.adyen.checkout.components.core.action.Threeds2ChallengeAction
 import com.adyen.checkout.components.core.action.Threeds2FingerprintAction
 import com.adyen.checkout.components.core.internal.ActionObserverRepository
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.core.exception.CheckoutException
@@ -66,7 +67,8 @@ internal class DefaultGenericActionDelegateTest(
             ActionObserverRepository(),
             SavedStateHandle(),
             configuration,
-            GenericComponentParamsMapper(null, null).mapToParams(configuration, null),
+            GenericComponentParamsMapper(CommonComponentParamsMapper())
+                .mapToParams(configuration, Locale.US, null, null),
             actionDelegateProvider,
         )
         whenever(activity.application) doReturn Application()

--- a/await/src/main/java/com/adyen/checkout/await/AwaitConfiguration.kt
+++ b/await/src/main/java/com/adyen/checkout/await/AwaitConfiguration.kt
@@ -23,7 +23,7 @@ import java.util.Locale
  */
 @Parcelize
 class AwaitConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -34,6 +34,18 @@ class AwaitConfiguration private constructor(
      * Builder to create an [AwaitConfiguration].
      */
     class Builder : BaseConfigurationBuilder<AwaitConfiguration, Builder> {
+
+        /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
 
         /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
@@ -49,7 +61,7 @@ class AwaitConfiguration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -76,8 +88,9 @@ class AwaitConfiguration private constructor(
 fun CheckoutConfiguration.await(
     configuration: @CheckoutConfigurationMarker AwaitConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = AwaitConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = AwaitConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/await/src/main/java/com/adyen/checkout/await/AwaitConfiguration.kt
+++ b/await/src/main/java/com/adyen/checkout/await/AwaitConfiguration.kt
@@ -54,6 +54,7 @@ class AwaitConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/await/src/main/java/com/adyen/checkout/await/internal/provider/AwaitComponentProvider.kt
+++ b/await/src/main/java/com/adyen/checkout/await/internal/provider/AwaitComponentProvider.kt
@@ -31,19 +31,20 @@ import com.adyen.checkout.components.core.internal.PaymentDataRepository
 import com.adyen.checkout.components.core.internal.data.api.DefaultStatusRepository
 import com.adyen.checkout.components.core.internal.data.api.StatusService
 import com.adyen.checkout.components.core.internal.provider.ActionComponentProvider
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
+import com.adyen.checkout.core.internal.util.LocaleProvider
 
 class AwaitComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
-    dropInOverrideParams: DropInOverrideParams? = null,
+    private val dropInOverrideParams: DropInOverrideParams? = null,
+    private val localeProvider: LocaleProvider = LocaleProvider(),
 ) : ActionComponentProvider<AwaitComponent, AwaitConfiguration, AwaitDelegate> {
-
-    private val componentParamsMapper = GenericComponentParamsMapper(dropInOverrideParams)
 
     override val supportedActionTypes: List<String>
         get() = listOf(AwaitAction.ACTION_TYPE)
@@ -74,7 +75,13 @@ constructor(
         savedStateHandle: SavedStateHandle,
         application: Application
     ): AwaitDelegate {
-        val componentParams = componentParamsMapper.mapToParams(checkoutConfiguration, null)
+        val componentParams = GenericComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+            checkoutConfiguration = checkoutConfiguration,
+            deviceLocale = localeProvider.getLocale(application),
+            dropInOverrideParams = dropInOverrideParams,
+            componentSessionParams = null,
+        )
+
         val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
         val statusService = StatusService(httpClient)
         val statusRepository = DefaultStatusRepository(statusService, componentParams.clientKey)

--- a/await/src/main/java/com/adyen/checkout/await/internal/provider/AwaitComponentProvider.kt
+++ b/await/src/main/java/com/adyen/checkout/await/internal/provider/AwaitComponentProvider.kt
@@ -33,7 +33,6 @@ import com.adyen.checkout.components.core.internal.data.api.StatusService
 import com.adyen.checkout.components.core.internal.provider.ActionComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
@@ -42,10 +41,9 @@ class AwaitComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
 ) : ActionComponentProvider<AwaitComponent, AwaitConfiguration, AwaitDelegate> {
 
-    private val componentParamsMapper = GenericComponentParamsMapper(dropInOverrideParams, overrideSessionParams)
+    private val componentParamsMapper = GenericComponentParamsMapper(dropInOverrideParams)
 
     override val supportedActionTypes: List<String>
         get() = listOf(AwaitAction.ACTION_TYPE)

--- a/await/src/test/java/com/adyen/checkout/await/internal/ui/DefaultAwaitDelegateTest.kt
+++ b/await/src/test/java/com/adyen/checkout/await/internal/ui/DefaultAwaitDelegateTest.kt
@@ -17,6 +17,7 @@ import com.adyen.checkout.components.core.internal.ActionObserverRepository
 import com.adyen.checkout.components.core.internal.PaymentDataRepository
 import com.adyen.checkout.components.core.internal.data.model.StatusResponse
 import com.adyen.checkout.components.core.internal.test.TestStatusRepository
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.core.exception.ComponentException
@@ -48,13 +49,13 @@ internal class DefaultAwaitDelegateTest {
         statusRepository = TestStatusRepository()
         paymentDataRepository = PaymentDataRepository(SavedStateHandle())
         val configuration = CheckoutConfiguration(
-            Locale.US,
             Environment.TEST,
             TEST_CLIENT_KEY,
         )
         delegate = DefaultAwaitDelegate(
             ActionObserverRepository(),
-            GenericComponentParamsMapper(null, null).mapToParams(configuration, null),
+            GenericComponentParamsMapper(CommonComponentParamsMapper())
+                .mapToParams(configuration, Locale.US, null, null),
             statusRepository,
             paymentDataRepository,
         )

--- a/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitConfiguration.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitConfiguration.kt
@@ -66,6 +66,7 @@ class BacsDirectDebitConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitConfiguration.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitConfiguration.kt
@@ -29,7 +29,7 @@ import java.util.Locale
 @Parcelize
 @Suppress("LongParameterList")
 class BacsDirectDebitConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -48,6 +48,18 @@ class BacsDirectDebitConfiguration private constructor(
         private var isSubmitButtonVisible: Boolean? = null
 
         /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
+
+        /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
          *
          * @param context A Context
@@ -61,7 +73,7 @@ class BacsDirectDebitConfiguration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -102,8 +114,9 @@ class BacsDirectDebitConfiguration private constructor(
 fun CheckoutConfiguration.bacsDirectDebit(
     configuration: @CheckoutConfigurationMarker BacsDirectDebitConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = BacsDirectDebitConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = BacsDirectDebitConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/bacs/src/main/java/com/adyen/checkout/bacs/internal/provider/BacsDirectDebitComponentProvider.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/internal/provider/BacsDirectDebitComponentProvider.kt
@@ -36,7 +36,6 @@ import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepo
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.exception.ComponentException
@@ -56,7 +55,6 @@ class BacsDirectDebitComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
     private val analyticsRepository: AnalyticsRepository? = null,
 ) :
     PaymentComponentProvider<
@@ -72,7 +70,7 @@ constructor(
         SessionComponentCallback<BacsDirectDebitComponentState>,
         > {
 
-    private val componentParamsMapper = ButtonComponentParamsMapper(dropInOverrideParams, overrideSessionParams)
+    private val componentParamsMapper = ButtonComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/bacs/src/main/java/com/adyen/checkout/bacs/internal/provider/BacsDirectDebitComponentProvider.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/internal/provider/BacsDirectDebitComponentProvider.kt
@@ -35,11 +35,13 @@ import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
+import com.adyen.checkout.core.internal.util.LocaleProvider
 import com.adyen.checkout.sessions.core.CheckoutSession
 import com.adyen.checkout.sessions.core.SessionComponentCallback
 import com.adyen.checkout.sessions.core.internal.SessionComponentEventHandler
@@ -56,6 +58,7 @@ class BacsDirectDebitComponentProvider
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
     private val analyticsRepository: AnalyticsRepository? = null,
+    private val localeProvider: LocaleProvider = LocaleProvider(),
 ) :
     PaymentComponentProvider<
         BacsDirectDebitComponent,
@@ -69,8 +72,6 @@ constructor(
         BacsDirectDebitComponentState,
         SessionComponentCallback<BacsDirectDebitComponentState>,
         > {
-
-    private val componentParamsMapper = ButtonComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,
@@ -86,10 +87,12 @@ constructor(
         assertSupported(paymentMethod)
 
         val genericFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(
+            val componentParams = ButtonComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
                 checkoutConfiguration = checkoutConfiguration,
-                configuration = checkoutConfiguration.getBacsDirectDebitConfiguration(),
-                sessionParams = null,
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = null,
+                componentConfiguration = checkoutConfiguration.getBacsDirectDebitConfiguration(),
             )
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
@@ -174,11 +177,14 @@ constructor(
         assertSupported(paymentMethod)
 
         val genericFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(
+            val componentParams = ButtonComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
                 checkoutConfiguration = checkoutConfiguration,
-                configuration = checkoutConfiguration.getBacsDirectDebitConfiguration(),
-                sessionParams = SessionParamsFactory.create(checkoutSession),
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = SessionParamsFactory.create(checkoutSession),
+                componentConfiguration = checkoutConfiguration.getBacsDirectDebitConfiguration(),
             )
+
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(

--- a/bacs/src/test/java/com/adyen/checkout/bacs/internal/DefaultBacsDirectDebitDelegateTest.kt
+++ b/bacs/src/test/java/com/adyen/checkout/bacs/internal/DefaultBacsDirectDebitDelegateTest.kt
@@ -25,6 +25,7 @@ import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.FieldState
 import com.adyen.checkout.components.core.internal.ui.model.Validation
 import com.adyen.checkout.core.Environment
@@ -586,10 +587,12 @@ internal class DefaultBacsDirectDebitDelegateTest(
         order: OrderRequest? = TEST_ORDER,
     ) = DefaultBacsDirectDebitDelegate(
         observerRepository = PaymentObserverRepository(),
-        componentParams = ButtonComponentParamsMapper(null, null).mapToParams(
-            configuration,
-            configuration.getBacsDirectDebitConfiguration(),
-            null,
+        componentParams = ButtonComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = Locale.US,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+            componentConfiguration = configuration.getBacsDirectDebitConfiguration(),
         ),
         paymentMethod = PaymentMethod(),
         order = order,

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcConfiguration.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcConfiguration.kt
@@ -72,6 +72,7 @@ class BcmcConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcConfiguration.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcConfiguration.kt
@@ -29,7 +29,7 @@ import java.util.Locale
 @Parcelize
 @Suppress("LongParameterList")
 class BcmcConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -52,6 +52,18 @@ class BcmcConfiguration private constructor(
         private var showStorePaymentField: Boolean? = null
         private var shopperReference: String? = null
         private var isSubmitButtonVisible: Boolean? = null
+
+        /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
 
         /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
@@ -158,8 +170,9 @@ class BcmcConfiguration private constructor(
 fun CheckoutConfiguration.bcmc(
     configuration: @CheckoutConfigurationMarker BcmcConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = BcmcConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = BcmcConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/internal/provider/BcmcComponentProvider.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/internal/provider/BcmcComponentProvider.kt
@@ -39,11 +39,13 @@ import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepo
 import com.adyen.checkout.components.core.internal.data.api.DefaultPublicKeyRepository
 import com.adyen.checkout.components.core.internal.data.api.PublicKeyService
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
+import com.adyen.checkout.core.internal.util.LocaleProvider
 import com.adyen.checkout.cse.internal.CardEncryptorFactory
 import com.adyen.checkout.cse.internal.GenericEncryptorFactory
 import com.adyen.checkout.sessions.core.CheckoutSession
@@ -65,6 +67,7 @@ class BcmcComponentProvider
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
     private val analyticsRepository: AnalyticsRepository? = null,
+    private val localeProvider: LocaleProvider = LocaleProvider(),
 ) :
     PaymentComponentProvider<
         BcmcComponent,
@@ -78,8 +81,6 @@ constructor(
         BcmcComponentState,
         SessionComponentCallback<BcmcComponentState>,
         > {
-
-    private val componentParamsMapper = BcmcComponentParamsMapper(dropInOverrideParams)
 
     @Suppress("LongMethod")
     override fun get(
@@ -96,7 +97,14 @@ constructor(
         assertSupported(paymentMethod)
 
         val bcmcFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(checkoutConfiguration, null, paymentMethod)
+            val componentParams = BcmcComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+                checkoutConfiguration = checkoutConfiguration,
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = null,
+                paymentMethod = paymentMethod,
+            )
+
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
             val publicKeyService = PublicKeyService(httpClient)
             val publicKeyRepository = DefaultPublicKeyRepository(publicKeyService)
@@ -198,11 +206,14 @@ constructor(
     ): BcmcComponent {
         assertSupported(paymentMethod)
         val bcmcFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(
+            val componentParams = BcmcComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
                 checkoutConfiguration = checkoutConfiguration,
-                sessionParams = SessionParamsFactory.create(checkoutSession),
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = SessionParamsFactory.create(checkoutSession),
                 paymentMethod = paymentMethod,
             )
+
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
             val publicKeyService = PublicKeyService(httpClient)
             val publicKeyRepository = DefaultPublicKeyRepository(publicKeyService)

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/internal/provider/BcmcComponentProvider.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/internal/provider/BcmcComponentProvider.kt
@@ -40,7 +40,6 @@ import com.adyen.checkout.components.core.internal.data.api.DefaultPublicKeyRepo
 import com.adyen.checkout.components.core.internal.data.api.PublicKeyService
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.exception.ComponentException
@@ -65,7 +64,6 @@ class BcmcComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
     private val analyticsRepository: AnalyticsRepository? = null,
 ) :
     PaymentComponentProvider<
@@ -81,7 +79,7 @@ constructor(
         SessionComponentCallback<BcmcComponentState>,
         > {
 
-    private val componentParamsMapper = BcmcComponentParamsMapper(dropInOverrideParams, overrideSessionParams)
+    private val componentParamsMapper = BcmcComponentParamsMapper(dropInOverrideParams)
 
     @Suppress("LongMethod")
     override fun get(

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/internal/ui/model/BcmcComponentParamsMapper.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/internal/ui/model/BcmcComponentParamsMapper.kt
@@ -25,7 +25,6 @@ import com.adyen.checkout.ui.core.internal.ui.model.AddressParams
 
 internal class BcmcComponentParamsMapper(
     private val dropInOverrideParams: DropInOverrideParams?,
-    private val overrideSessionParams: SessionParams?,
 ) {
 
     fun mapToParams(
@@ -38,7 +37,7 @@ internal class BcmcComponentParamsMapper(
                 supportedCardBrands = paymentMethod.brands?.map { CardBrand(it) },
             )
             .override(dropInOverrideParams)
-            .override(sessionParams ?: overrideSessionParams)
+            .override(sessionParams ?: dropInOverrideParams?.sessionParams)
     }
 
     private fun CheckoutConfiguration.mapToParamsInternal(supportedCardBrands: List<CardBrand>?): CardComponentParams {

--- a/blik/src/main/java/com/adyen/checkout/blik/BlikConfiguration.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/BlikConfiguration.kt
@@ -65,6 +65,7 @@ class BlikConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/blik/src/main/java/com/adyen/checkout/blik/BlikConfiguration.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/BlikConfiguration.kt
@@ -28,7 +28,7 @@ import java.util.Locale
 @Parcelize
 @Suppress("LongParameterList")
 class BlikConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -47,6 +47,18 @@ class BlikConfiguration private constructor(
         private var isSubmitButtonVisible: Boolean? = null
 
         /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
+
+        /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
          *
          * @param context A Context
@@ -60,7 +72,7 @@ class BlikConfiguration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -101,8 +113,9 @@ class BlikConfiguration private constructor(
 fun CheckoutConfiguration.blik(
     configuration: @CheckoutConfigurationMarker BlikConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = BlikConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = BlikConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/provider/BlikComponentProvider.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/provider/BlikComponentProvider.kt
@@ -39,7 +39,6 @@ import com.adyen.checkout.components.core.internal.provider.PaymentComponentProv
 import com.adyen.checkout.components.core.internal.provider.StoredPaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.exception.ComponentException
@@ -61,7 +60,6 @@ class BlikComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
     private val analyticsRepository: AnalyticsRepository? = null,
 ) :
     PaymentComponentProvider<
@@ -89,7 +87,7 @@ constructor(
         SessionComponentCallback<BlikComponentState>,
         > {
 
-    private val componentParamsMapper = ButtonComponentParamsMapper(dropInOverrideParams, overrideSessionParams)
+    private val componentParamsMapper = ButtonComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/provider/BlikComponentProvider.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/provider/BlikComponentProvider.kt
@@ -38,11 +38,13 @@ import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepo
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.provider.StoredPaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
+import com.adyen.checkout.core.internal.util.LocaleProvider
 import com.adyen.checkout.sessions.core.CheckoutSession
 import com.adyen.checkout.sessions.core.SessionComponentCallback
 import com.adyen.checkout.sessions.core.internal.SessionComponentEventHandler
@@ -61,6 +63,7 @@ class BlikComponentProvider
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
     private val analyticsRepository: AnalyticsRepository? = null,
+    private val localeProvider: LocaleProvider = LocaleProvider(),
 ) :
     PaymentComponentProvider<
         BlikComponent,
@@ -87,8 +90,6 @@ constructor(
         SessionComponentCallback<BlikComponentState>,
         > {
 
-    private val componentParamsMapper = ButtonComponentParamsMapper(dropInOverrideParams)
-
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,
         viewModelStoreOwner: ViewModelStoreOwner,
@@ -103,10 +104,12 @@ constructor(
         assertSupported(paymentMethod)
 
         val genericFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(
+            val componentParams = ButtonComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
                 checkoutConfiguration = checkoutConfiguration,
-                configuration = checkoutConfiguration.getBlikConfiguration(),
-                sessionParams = null,
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = null,
+                componentConfiguration = checkoutConfiguration.getBlikConfiguration(),
             )
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
@@ -190,10 +193,12 @@ constructor(
         assertSupported(storedPaymentMethod)
 
         val genericStoredFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(
+            val componentParams = ButtonComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
                 checkoutConfiguration = checkoutConfiguration,
-                configuration = checkoutConfiguration.getBlikConfiguration(),
-                sessionParams = null,
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = null,
+                componentConfiguration = checkoutConfiguration.getBlikConfiguration(),
             )
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
@@ -278,11 +283,14 @@ constructor(
         assertSupported(paymentMethod)
 
         val genericFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(
+            val componentParams = ButtonComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
                 checkoutConfiguration = checkoutConfiguration,
-                configuration = checkoutConfiguration.getBlikConfiguration(),
-                sessionParams = SessionParamsFactory.create(checkoutSession),
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = SessionParamsFactory.create(checkoutSession),
+                componentConfiguration = checkoutConfiguration.getBlikConfiguration(),
             )
+
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
@@ -387,11 +395,14 @@ constructor(
         assertSupported(storedPaymentMethod)
 
         val genericStoredFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(
+            val componentParams = ButtonComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
                 checkoutConfiguration = checkoutConfiguration,
-                configuration = checkoutConfiguration.getBlikConfiguration(),
-                sessionParams = SessionParamsFactory.create(checkoutSession),
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = SessionParamsFactory.create(checkoutSession),
+                componentConfiguration = checkoutConfiguration.getBlikConfiguration(),
             )
+
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(

--- a/blik/src/test/java/com/adyen/checkout/blik/internal/ui/DefaultBlikDelegateTest.kt
+++ b/blik/src/test/java/com/adyen/checkout/blik/internal/ui/DefaultBlikDelegateTest.kt
@@ -21,6 +21,7 @@ import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.test.LoggingExtension
 import com.adyen.checkout.ui.core.internal.ui.SubmitHandler
@@ -273,10 +274,12 @@ internal class DefaultBlikDelegateTest(
         configuration: CheckoutConfiguration = createCheckoutConfiguration()
     ) = DefaultBlikDelegate(
         observerRepository = PaymentObserverRepository(),
-        componentParams = ButtonComponentParamsMapper(null, null).mapToParams(
-            configuration,
-            configuration.getBlikConfiguration(),
-            null,
+        componentParams = ButtonComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = Locale.US,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+            componentConfiguration = configuration.getBlikConfiguration(),
         ),
         paymentMethod = PaymentMethod(),
         order = TEST_ORDER,

--- a/boleto/src/main/java/com/adyen/checkout/boleto/BoletoConfiguration.kt
+++ b/boleto/src/main/java/com/adyen/checkout/boleto/BoletoConfiguration.kt
@@ -66,6 +66,7 @@ class BoletoConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/boleto/src/main/java/com/adyen/checkout/boleto/BoletoConfiguration.kt
+++ b/boleto/src/main/java/com/adyen/checkout/boleto/BoletoConfiguration.kt
@@ -28,7 +28,7 @@ import java.util.Locale
 @Parcelize
 @Suppress("LongParameterList")
 class BoletoConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -46,6 +46,18 @@ class BoletoConfiguration private constructor(
         ButtonConfigurationBuilder {
         private var isSubmitButtonVisible: Boolean? = null
         private var isEmailVisible: Boolean? = null
+
+        /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
 
         /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
@@ -112,8 +124,9 @@ class BoletoConfiguration private constructor(
 fun CheckoutConfiguration.boleto(
     configuration: @CheckoutConfigurationMarker BoletoConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = BoletoConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = BoletoConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/boleto/src/main/java/com/adyen/checkout/boleto/internal/provider/BoletoComponentProvider.kt
+++ b/boleto/src/main/java/com/adyen/checkout/boleto/internal/provider/BoletoComponentProvider.kt
@@ -35,7 +35,6 @@ import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.exception.ComponentException
@@ -57,7 +56,6 @@ class BoletoComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
     private val analyticsRepository: AnalyticsRepository? = null,
 ) :
     PaymentComponentProvider<
@@ -73,7 +71,7 @@ constructor(
         SessionComponentCallback<BoletoComponentState>,
         > {
 
-    private val componentParamsMapper = BoletoComponentParamsMapper(dropInOverrideParams, overrideSessionParams)
+    private val componentParamsMapper = BoletoComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/boleto/src/main/java/com/adyen/checkout/boleto/internal/provider/BoletoComponentProvider.kt
+++ b/boleto/src/main/java/com/adyen/checkout/boleto/internal/provider/BoletoComponentProvider.kt
@@ -34,11 +34,13 @@ import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepositoryD
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
+import com.adyen.checkout.core.internal.util.LocaleProvider
 import com.adyen.checkout.sessions.core.CheckoutSession
 import com.adyen.checkout.sessions.core.SessionComponentCallback
 import com.adyen.checkout.sessions.core.internal.SessionComponentEventHandler
@@ -57,6 +59,7 @@ class BoletoComponentProvider
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
     private val analyticsRepository: AnalyticsRepository? = null,
+    private val localeProvider: LocaleProvider = LocaleProvider(),
 ) :
     PaymentComponentProvider<
         BoletoComponent,
@@ -70,8 +73,6 @@ constructor(
         BoletoComponentState,
         SessionComponentCallback<BoletoComponentState>,
         > {
-
-    private val componentParamsMapper = BoletoComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,
@@ -87,7 +88,13 @@ constructor(
         assertSupported(paymentMethod)
 
         val boletoFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(checkoutConfiguration, null)
+            val componentParams = BoletoComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+                checkoutConfiguration = checkoutConfiguration,
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = null,
+            )
+
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
@@ -176,10 +183,13 @@ constructor(
         assertSupported(paymentMethod)
 
         val genericFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(
-                configuration = checkoutConfiguration,
-                sessionParams = SessionParamsFactory.create(checkoutSession),
+            val componentParams = BoletoComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+                checkoutConfiguration = checkoutConfiguration,
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = SessionParamsFactory.create(checkoutSession),
             )
+
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(

--- a/boleto/src/main/java/com/adyen/checkout/boleto/internal/ui/model/BoletoComponentParams.kt
+++ b/boleto/src/main/java/com/adyen/checkout/boleto/internal/ui/model/BoletoComponentParams.kt
@@ -8,22 +8,14 @@
 
 package com.adyen.checkout.boleto.internal.ui.model
 
-import com.adyen.checkout.components.core.Amount
-import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
 import com.adyen.checkout.components.core.internal.ui.model.ButtonParams
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParams
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
-import com.adyen.checkout.core.Environment
 import com.adyen.checkout.ui.core.internal.ui.model.AddressParams
-import java.util.Locale
 
 internal data class BoletoComponentParams(
+    private val commonComponentParams: CommonComponentParams,
     override val isSubmitButtonVisible: Boolean,
-    override val shopperLocale: Locale,
-    override val environment: Environment,
-    override val clientKey: String,
-    override val analyticsParams: AnalyticsParams,
-    override val isCreatedByDropIn: Boolean,
-    override val amount: Amount?,
     val addressParams: AddressParams,
     val isEmailVisible: Boolean,
-) : ComponentParams, ButtonParams
+) : ComponentParams by commonComponentParams, ButtonParams

--- a/boleto/src/main/java/com/adyen/checkout/boleto/internal/ui/model/BoletoComponentParamsMapper.kt
+++ b/boleto/src/main/java/com/adyen/checkout/boleto/internal/ui/model/BoletoComponentParamsMapper.kt
@@ -10,60 +10,40 @@ package com.adyen.checkout.boleto.internal.ui.model
 
 import com.adyen.checkout.boleto.getBoletoConfiguration
 import com.adyen.checkout.components.core.CheckoutConfiguration
-import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.ui.core.internal.ui.model.AddressParams
+import java.util.Locale
 
 internal class BoletoComponentParamsMapper(
-    private val dropInOverrideParams: DropInOverrideParams?,
+    private val commonComponentParamsMapper: CommonComponentParamsMapper,
 ) {
 
     fun mapToParams(
-        configuration: CheckoutConfiguration,
-        sessionParams: SessionParams?
+        checkoutConfiguration: CheckoutConfiguration,
+        deviceLocale: Locale,
+        dropInOverrideParams: DropInOverrideParams?,
+        componentSessionParams: SessionParams?,
     ): BoletoComponentParams {
-        return configuration
-            .mapToParamsInternal()
-            .override(dropInOverrideParams)
-            .override(sessionParams ?: dropInOverrideParams?.sessionParams)
-    }
+        val commonComponentParamsMapperData = commonComponentParamsMapper.mapToParams(
+            checkoutConfiguration,
+            deviceLocale,
+            dropInOverrideParams,
+            componentSessionParams,
+        )
+        val boletoConfiguration = checkoutConfiguration.getBoletoConfiguration()
+        val commonComponentParams = commonComponentParamsMapperData.commonComponentParams
 
-    private fun CheckoutConfiguration.mapToParamsInternal(): BoletoComponentParams {
-        val boletoConfiguration = getBoletoConfiguration()
         return BoletoComponentParams(
+            commonComponentParams = commonComponentParams,
             isSubmitButtonVisible = boletoConfiguration?.isSubmitButtonVisible ?: true,
-            shopperLocale = shopperLocale,
-            environment = environment,
-            clientKey = clientKey,
-            analyticsParams = AnalyticsParams(analyticsConfiguration),
-            isCreatedByDropIn = false,
-            amount = amount,
             addressParams = AddressParams.FullAddress(
                 defaultCountryCode = BRAZIL_COUNTRY_CODE,
                 supportedCountryCodes = DEFAULT_SUPPORTED_COUNTRY_LIST,
                 addressFieldPolicy = AddressFieldPolicyParams.Required,
             ),
             isEmailVisible = boletoConfiguration?.isEmailVisible ?: false,
-        )
-    }
-
-    private fun BoletoComponentParams.override(
-        dropInOverrideParams: DropInOverrideParams?,
-    ): BoletoComponentParams {
-        if (dropInOverrideParams == null) return this
-        return copy(
-            amount = dropInOverrideParams.amount,
-            isCreatedByDropIn = true,
-        )
-    }
-
-    private fun BoletoComponentParams.override(
-        sessionParams: SessionParams?
-    ): BoletoComponentParams {
-        if (sessionParams == null) return this
-        return copy(
-            amount = sessionParams.amount ?: amount,
         )
     }
 

--- a/boleto/src/main/java/com/adyen/checkout/boleto/internal/ui/model/BoletoComponentParamsMapper.kt
+++ b/boleto/src/main/java/com/adyen/checkout/boleto/internal/ui/model/BoletoComponentParamsMapper.kt
@@ -17,7 +17,6 @@ import com.adyen.checkout.ui.core.internal.ui.model.AddressParams
 
 internal class BoletoComponentParamsMapper(
     private val dropInOverrideParams: DropInOverrideParams?,
-    private val overrideSessionParams: SessionParams?,
 ) {
 
     fun mapToParams(
@@ -27,7 +26,7 @@ internal class BoletoComponentParamsMapper(
         return configuration
             .mapToParamsInternal()
             .override(dropInOverrideParams)
-            .override(sessionParams ?: overrideSessionParams)
+            .override(sessionParams ?: dropInOverrideParams?.sessionParams)
     }
 
     private fun CheckoutConfiguration.mapToParamsInternal(): BoletoComponentParams {

--- a/boleto/src/test/java/com/adyen/checkout/boleto/internal/ui/DefaultBoletoDelegateTest.kt
+++ b/boleto/src/test/java/com/adyen/checkout/boleto/internal/ui/DefaultBoletoDelegateTest.kt
@@ -21,6 +21,7 @@ import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.ui.model.AddressInputModel
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.test.LoggingExtension
 import com.adyen.checkout.test.extensions.test
@@ -520,7 +521,8 @@ internal class DefaultBoletoDelegateTest(
         observerRepository = PaymentObserverRepository(),
         paymentMethod = paymentMethod,
         order = order,
-        componentParams = BoletoComponentParamsMapper(null, null).mapToParams(configuration, null),
+        componentParams = BoletoComponentParamsMapper(CommonComponentParamsMapper())
+            .mapToParams(configuration, Locale.US, null, null),
         addressRepository = addressRepository,
     )
 

--- a/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
@@ -87,6 +87,7 @@ class CardConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
@@ -30,7 +30,7 @@ import java.util.Locale
 @Parcelize
 @Suppress("LongParameterList")
 class CardConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -67,6 +67,18 @@ class CardConfiguration private constructor(
         private var kcpAuthVisibility: KCPAuthVisibility? = null
         private var installmentConfiguration: InstallmentConfiguration? = null
         private var addressConfiguration: AddressConfiguration? = null
+
+        /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
 
         /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
@@ -301,8 +313,9 @@ class CardConfiguration private constructor(
 fun CheckoutConfiguration.card(
     configuration: @CheckoutConfigurationMarker CardConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = CardConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = CardConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/card/src/main/java/com/adyen/checkout/card/internal/provider/CardComponentProvider.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/provider/CardComponentProvider.kt
@@ -43,7 +43,6 @@ import com.adyen.checkout.components.core.internal.data.api.PublicKeyService
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.provider.StoredPaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.exception.ComponentException
@@ -70,7 +69,6 @@ class CardComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
     private val analyticsRepository: AnalyticsRepository? = null,
 ) :
     PaymentComponentProvider<
@@ -101,7 +99,6 @@ constructor(
     private val componentParamsMapper = CardComponentParamsMapper(
         installmentsParamsMapper = InstallmentsParamsMapper(),
         dropInOverrideParams = dropInOverrideParams,
-        overrideSessionParams = overrideSessionParams,
     )
 
     @Suppress("LongParameterList", "LongMethod")

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/model/CardComponentParams.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/model/CardComponentParams.kt
@@ -12,22 +12,14 @@ import androidx.annotation.RestrictTo
 import com.adyen.checkout.card.CardBrand
 import com.adyen.checkout.card.KCPAuthVisibility
 import com.adyen.checkout.card.SocialSecurityNumberVisibility
-import com.adyen.checkout.components.core.Amount
-import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
 import com.adyen.checkout.components.core.internal.ui.model.ButtonParams
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParams
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
-import com.adyen.checkout.core.Environment
 import com.adyen.checkout.ui.core.internal.ui.model.AddressParams
-import java.util.Locale
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class CardComponentParams(
-    override val shopperLocale: Locale,
-    override val environment: Environment,
-    override val clientKey: String,
-    override val analyticsParams: AnalyticsParams,
-    override val isCreatedByDropIn: Boolean,
-    override val amount: Amount?,
+    private val commonComponentParams: CommonComponentParams,
     override val isSubmitButtonVisible: Boolean,
     val isHolderNameRequired: Boolean,
     val supportedCardBrands: List<CardBrand>,
@@ -39,4 +31,4 @@ data class CardComponentParams(
     val addressParams: AddressParams,
     val cvcVisibility: CVCVisibility,
     val storedCVCVisibility: StoredCVCVisibility
-) : ComponentParams, ButtonParams
+) : ComponentParams by commonComponentParams, ButtonParams

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapper.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapper.kt
@@ -28,7 +28,6 @@ import com.adyen.checkout.ui.core.internal.ui.model.AddressParams
 internal class CardComponentParamsMapper(
     private val installmentsParamsMapper: InstallmentsParamsMapper,
     private val dropInOverrideParams: DropInOverrideParams?,
-    private val overrideSessionParams: SessionParams?,
 ) {
 
     fun mapToParamsDefault(
@@ -62,7 +61,7 @@ internal class CardComponentParamsMapper(
         return checkoutConfiguration
             .mapToParamsInternal(paymentMethod)
             .override(dropInOverrideParams)
-            .override(sessionParams ?: overrideSessionParams)
+            .override(sessionParams ?: dropInOverrideParams?.sessionParams)
     }
 
     private fun CheckoutConfiguration.mapToParamsInternal(

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapper.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapper.kt
@@ -55,7 +55,7 @@ internal class CardComponentParamsMapper(
         deviceLocale: Locale,
         dropInOverrideParams: DropInOverrideParams?,
         componentSessionParams: SessionParams?,
-        @Suppress("UNUSED_PARAMETER") paymentMethod: StoredPaymentMethod,
+        @Suppress("UNUSED_PARAMETER") storedPaymentMethod: StoredPaymentMethod,
     ): CardComponentParams {
         return mapToParamsInternal(
             checkoutConfiguration,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapper.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapper.kt
@@ -14,79 +14,101 @@ import com.adyen.checkout.card.CardConfiguration
 import com.adyen.checkout.card.KCPAuthVisibility
 import com.adyen.checkout.card.SocialSecurityNumberVisibility
 import com.adyen.checkout.card.getCardConfiguration
+import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.components.core.CheckoutConfiguration
 import com.adyen.checkout.components.core.PaymentMethod
-import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
+import com.adyen.checkout.components.core.StoredPaymentMethod
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParams
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.core.AdyenLogLevel
 import com.adyen.checkout.core.internal.util.adyenLog
 import com.adyen.checkout.ui.core.internal.ui.model.AddressFieldPolicy
 import com.adyen.checkout.ui.core.internal.ui.model.AddressParams
+import java.util.Locale
 
 @Suppress("TooManyFunctions")
 internal class CardComponentParamsMapper(
+    private val commonComponentParamsMapper: CommonComponentParamsMapper,
     private val installmentsParamsMapper: InstallmentsParamsMapper,
-    private val dropInOverrideParams: DropInOverrideParams?,
 ) {
 
-    fun mapToParamsDefault(
+    fun mapToParams(
         checkoutConfiguration: CheckoutConfiguration,
+        deviceLocale: Locale,
+        dropInOverrideParams: DropInOverrideParams?,
+        componentSessionParams: SessionParams?,
         paymentMethod: PaymentMethod,
-        sessionParams: SessionParams?,
     ): CardComponentParams {
-        return mapToParams(
+        return mapToParamsInternal(
             checkoutConfiguration,
+            deviceLocale,
+            dropInOverrideParams,
+            componentSessionParams,
             paymentMethod,
-            sessionParams,
         )
     }
 
-    fun mapToParamsStored(
+    fun mapToParams(
         checkoutConfiguration: CheckoutConfiguration,
-        sessionParams: SessionParams?,
+        deviceLocale: Locale,
+        dropInOverrideParams: DropInOverrideParams?,
+        componentSessionParams: SessionParams?,
+        @Suppress("UNUSED_PARAMETER") paymentMethod: StoredPaymentMethod,
     ): CardComponentParams {
-        return mapToParams(
+        return mapToParamsInternal(
             checkoutConfiguration,
+            deviceLocale,
+            dropInOverrideParams,
+            componentSessionParams,
             null,
-            sessionParams,
+        )
+    }
+
+    private fun mapToParamsInternal(
+        checkoutConfiguration: CheckoutConfiguration,
+        deviceLocale: Locale,
+        dropInOverrideParams: DropInOverrideParams?,
+        componentSessionParams: SessionParams?,
+        paymentMethod: PaymentMethod?,
+    ): CardComponentParams {
+        val commonComponentParamsMapperData = commonComponentParamsMapper.mapToParams(
+            checkoutConfiguration,
+            deviceLocale,
+            dropInOverrideParams,
+            componentSessionParams,
+        )
+        val cardConfiguration = checkoutConfiguration.getCardConfiguration()
+        return mapToParams(
+            commonComponentParamsMapperData.commonComponentParams,
+            commonComponentParamsMapperData.sessionParams,
+            cardConfiguration,
+            paymentMethod,
         )
     }
 
     private fun mapToParams(
-        checkoutConfiguration: CheckoutConfiguration,
-        paymentMethod: PaymentMethod?,
+        commonComponentParams: CommonComponentParams,
         sessionParams: SessionParams?,
-    ): CardComponentParams {
-        return checkoutConfiguration
-            .mapToParamsInternal(paymentMethod)
-            .override(dropInOverrideParams)
-            .override(sessionParams ?: dropInOverrideParams?.sessionParams)
-    }
-
-    private fun CheckoutConfiguration.mapToParamsInternal(
+        cardConfiguration: CardConfiguration?,
         paymentMethod: PaymentMethod?,
     ): CardComponentParams {
-        val cardConfiguration = getCardConfiguration()
         return CardComponentParams(
-            shopperLocale = shopperLocale,
-            environment = environment,
-            clientKey = clientKey,
-            analyticsParams = AnalyticsParams(analyticsConfiguration),
-            isCreatedByDropIn = false,
-            amount = amount,
+            commonComponentParams = commonComponentParams,
             isHolderNameRequired = cardConfiguration?.isHolderNameRequired ?: false,
             isSubmitButtonVisible = cardConfiguration?.isSubmitButtonVisible ?: true,
-            supportedCardBrands = getSupportedCardBrands(paymentMethod),
+            supportedCardBrands = getSupportedCardBrands(cardConfiguration, paymentMethod),
             shopperReference = cardConfiguration?.shopperReference,
-            isStorePaymentFieldVisible = cardConfiguration?.isStorePaymentFieldVisible ?: true,
+            isStorePaymentFieldVisible = getStorePaymentFieldVisible(sessionParams, cardConfiguration),
             socialSecurityNumberVisibility = cardConfiguration?.socialSecurityNumberVisibility
                 ?: SocialSecurityNumberVisibility.HIDE,
             kcpAuthVisibility = cardConfiguration?.kcpAuthVisibility ?: KCPAuthVisibility.HIDE,
-            installmentParams = installmentsParamsMapper.mapToInstallmentParams(
-                installmentConfiguration = cardConfiguration?.installmentConfiguration,
-                amount = amount,
-                shopperLocale = shopperLocale,
+            installmentParams = getInstallmentParams(
+                sessionParams,
+                cardConfiguration,
+                commonComponentParams.amount,
+                commonComponentParams.shopperLocale,
             ),
             addressParams = cardConfiguration?.addressConfiguration?.mapToAddressParam() ?: AddressParams.None,
             cvcVisibility = if (cardConfiguration?.isHideCvc == true) {
@@ -107,10 +129,11 @@ internal class CardComponentParamsMapper(
      * Priority is: Custom -> PaymentMethod.brands -> Default
      * remove restricted card type
      */
-    private fun CheckoutConfiguration.getSupportedCardBrands(
+    private fun getSupportedCardBrands(
+        cardConfiguration: CardConfiguration?,
         paymentMethod: PaymentMethod?
     ): List<CardBrand> {
-        val supportedCardBrands = getCardConfiguration()?.supportedCardBrands
+        val supportedCardBrands = cardConfiguration?.supportedCardBrands
         return when {
             !supportedCardBrands.isNullOrEmpty() -> {
                 adyenLog(AdyenLogLevel.VERBOSE) { "Reading supportedCardTypes from configuration" }
@@ -133,6 +156,37 @@ internal class CardComponentParamsMapper(
 
     private fun List<CardBrand>.removeRestrictedCards(): List<CardBrand> {
         return this.filter { !RestrictedCardType.isRestrictedCardType(it.txVariant) }
+    }
+
+    private fun getStorePaymentFieldVisible(
+        sessionParams: SessionParams?,
+        cardConfiguration: CardConfiguration?,
+    ): Boolean {
+        return sessionParams?.enableStoreDetails ?: cardConfiguration?.isStorePaymentFieldVisible ?: true
+    }
+
+    private fun getInstallmentParams(
+        sessionParams: SessionParams?,
+        cardConfiguration: CardConfiguration?,
+        amount: Amount?,
+        shopperLocale: Locale
+    ): InstallmentParams? {
+        return if (sessionParams != null) {
+            // we don't fall back to the original value of installmentParams value on purpose
+            // if sessionParams.installmentOptions is null we want installmentParams to be also null regardless of what
+            // InstallmentConfiguration is passed to the mapper
+            installmentsParamsMapper.mapToInstallmentParams(
+                installmentConfiguration = sessionParams.installmentConfiguration,
+                amount = amount,
+                shopperLocale = shopperLocale,
+            )
+        } else {
+            installmentsParamsMapper.mapToInstallmentParams(
+                installmentConfiguration = cardConfiguration?.installmentConfiguration,
+                amount = amount,
+                shopperLocale = shopperLocale,
+            )
+        }
     }
 
     private fun AddressConfiguration.mapToAddressParam(): AddressParams {
@@ -173,33 +227,5 @@ internal class CardComponentParamsMapper(
                 AddressFieldPolicyParams.Required
             }
         }
-    }
-
-    private fun CardComponentParams.override(
-        dropInOverrideParams: DropInOverrideParams?
-    ): CardComponentParams {
-        if (dropInOverrideParams == null) return this
-        return copy(
-            amount = dropInOverrideParams.amount,
-            isCreatedByDropIn = true,
-        )
-    }
-
-    private fun CardComponentParams.override(
-        sessionParams: SessionParams?
-    ): CardComponentParams {
-        if (sessionParams == null) return this
-        return copy(
-            isStorePaymentFieldVisible = sessionParams.enableStoreDetails ?: isStorePaymentFieldVisible,
-            // we don't fall back to the original value of installmentParams value on purpose
-            // if sessionParams.installmentOptions is null we want installmentParams to be also null regardless of what
-            // InstallmentConfiguration is passed to the mapper
-            installmentParams = installmentsParamsMapper.mapToInstallmentParams(
-                installmentConfiguration = sessionParams.installmentConfiguration,
-                amount = sessionParams.amount ?: amount,
-                shopperLocale = shopperLocale,
-            ),
-            amount = sessionParams.amount ?: amount,
-        )
     }
 }

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegateTest.kt
@@ -50,6 +50,7 @@ import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.data.api.PublicKeyRepository
 import com.adyen.checkout.components.core.internal.test.TestPublicKeyRepository
 import com.adyen.checkout.components.core.internal.ui.model.AddressInputModel
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.FieldState
 import com.adyen.checkout.components.core.internal.ui.model.Validation
 import com.adyen.checkout.core.Environment
@@ -1213,10 +1214,15 @@ internal class DefaultCardDelegateTest(
         addressLookupDelegate: AddressLookupDelegate = this.addressLookupDelegate
     ): DefaultCardDelegate {
         val componentParams = CardComponentParamsMapper(
+            commonComponentParamsMapper = CommonComponentParamsMapper(),
             installmentsParamsMapper = InstallmentsParamsMapper(),
+        ).mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = Locale.US,
             dropInOverrideParams = null,
-            overrideSessionParams = null,
-        ).mapToParamsDefault(configuration, paymentMethod, null)
+            componentSessionParams = null,
+            paymentMethod = paymentMethod,
+        )
 
         return DefaultCardDelegate(
             observerRepository = PaymentObserverRepository(),

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/StoredCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/StoredCardDelegateTest.kt
@@ -39,6 +39,7 @@ import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.data.api.PublicKeyRepository
 import com.adyen.checkout.components.core.internal.test.TestPublicKeyRepository
 import com.adyen.checkout.components.core.internal.ui.model.AddressInputModel
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.FieldState
 import com.adyen.checkout.components.core.internal.ui.model.Validation
 import com.adyen.checkout.components.core.paymentmethod.CardPaymentMethod
@@ -454,10 +455,15 @@ internal class StoredCardDelegateTest(
         order: OrderRequest? = TEST_ORDER,
     ): StoredCardDelegate {
         val componentParams = CardComponentParamsMapper(
+            commonComponentParamsMapper = CommonComponentParamsMapper(),
             installmentsParamsMapper = InstallmentsParamsMapper(),
+        ).mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = Locale.US,
             dropInOverrideParams = null,
-            overrideSessionParams = null,
-        ).mapToParamsStored(configuration, null)
+            componentSessionParams = null,
+            StoredPaymentMethod(),
+        )
 
         return StoredCardDelegate(
             observerRepository = PaymentObserverRepository(),

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/CashAppPayConfiguration.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/CashAppPayConfiguration.kt
@@ -30,7 +30,7 @@ import java.util.Locale
 class CashAppPayConfiguration
 @Suppress("LongParameterList")
 private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -52,6 +52,18 @@ private constructor(
         private var returnUrl: String? = null
         private var showStorePaymentField: Boolean? = null
         private var storePaymentMethod: Boolean? = null
+
+        /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
 
         /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
@@ -170,8 +182,9 @@ private constructor(
 fun CheckoutConfiguration.cashAppPay(
     configuration: @CheckoutConfigurationMarker CashAppPayConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = CashAppPayConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = CashAppPayConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/CashAppPayConfiguration.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/CashAppPayConfiguration.kt
@@ -72,6 +72,7 @@ private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/provider/CashAppPayComponentProvider.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/provider/CashAppPayComponentProvider.kt
@@ -43,7 +43,6 @@ import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepo
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.provider.StoredPaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.exception.ComponentException
@@ -66,7 +65,6 @@ class CashAppPayComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
     private val analyticsRepository: AnalyticsRepository? = null,
 ) :
     PaymentComponentProvider<
@@ -94,7 +92,7 @@ constructor(
         SessionComponentCallback<CashAppPayComponentState>,
         > {
 
-    private val componentParamsMapper = CashAppPayComponentParamsMapper(dropInOverrideParams, overrideSessionParams)
+    private val componentParamsMapper = CashAppPayComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/provider/CashAppPayComponentProvider.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/provider/CashAppPayComponentProvider.kt
@@ -42,12 +42,14 @@ import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.provider.StoredPaymentComponentProvider
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.core.internal.data.api.HttpClient
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
+import com.adyen.checkout.core.internal.util.LocaleProvider
 import com.adyen.checkout.sessions.core.CheckoutSession
 import com.adyen.checkout.sessions.core.SessionComponentCallback
 import com.adyen.checkout.sessions.core.internal.SessionComponentEventHandler
@@ -66,6 +68,7 @@ class CashAppPayComponentProvider
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
     private val analyticsRepository: AnalyticsRepository? = null,
+    private val localeProvider: LocaleProvider = LocaleProvider(),
 ) :
     PaymentComponentProvider<
         CashAppPayComponent,
@@ -92,8 +95,6 @@ constructor(
         SessionComponentCallback<CashAppPayComponentState>,
         > {
 
-    private val componentParamsMapper = CashAppPayComponentParamsMapper(dropInOverrideParams)
-
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,
         viewModelStoreOwner: ViewModelStoreOwner,
@@ -108,9 +109,11 @@ constructor(
         assertSupported(paymentMethod)
 
         val viewModelFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(
-                configuration = checkoutConfiguration,
-                sessionParams = null,
+            val componentParams = CashAppPayComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+                checkoutConfiguration = checkoutConfiguration,
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = null,
                 paymentMethod = paymentMethod,
                 context = application,
             )
@@ -192,12 +195,15 @@ constructor(
         assertSupported(storedPaymentMethod)
 
         val viewModelFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(
-                configuration = checkoutConfiguration,
-                sessionParams = null,
-                paymentMethod = storedPaymentMethod,
+            val componentParams = CashAppPayComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+                checkoutConfiguration = checkoutConfiguration,
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = null,
+                storedPaymentMethod = storedPaymentMethod,
                 context = application,
             )
+
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
                 analyticsRepositoryData = AnalyticsRepositoryData(
                     application = application,
@@ -274,9 +280,11 @@ constructor(
         assertSupported(paymentMethod)
 
         val viewModelFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(
-                configuration = checkoutConfiguration,
-                sessionParams = SessionParamsFactory.create(checkoutSession),
+            val componentParams = CashAppPayComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+                checkoutConfiguration = checkoutConfiguration,
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = SessionParamsFactory.create(checkoutSession),
                 paymentMethod = paymentMethod,
                 context = application,
             )
@@ -369,10 +377,12 @@ constructor(
         assertSupported(storedPaymentMethod)
 
         val viewModelFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(
-                configuration = checkoutConfiguration,
-                sessionParams = SessionParamsFactory.create(checkoutSession),
-                paymentMethod = storedPaymentMethod,
+            val componentParams = CashAppPayComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+                checkoutConfiguration = checkoutConfiguration,
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = SessionParamsFactory.create(checkoutSession),
+                storedPaymentMethod = storedPaymentMethod,
                 context = application,
             )
 

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/model/CashAppPayComponentParams.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/model/CashAppPayComponentParams.kt
@@ -9,28 +9,20 @@
 package com.adyen.checkout.cashapppay.internal.ui.model
 
 import com.adyen.checkout.cashapppay.CashAppPayEnvironment
-import com.adyen.checkout.components.core.Amount
-import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
 import com.adyen.checkout.components.core.internal.ui.model.ButtonParams
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParams
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
-import com.adyen.checkout.core.Environment
-import java.util.Locale
 
 internal data class CashAppPayComponentParams(
+    private val commonComponentParams: CommonComponentParams,
     override val isSubmitButtonVisible: Boolean,
-    override val shopperLocale: Locale,
-    override val environment: Environment,
-    override val clientKey: String,
-    override val analyticsParams: AnalyticsParams,
-    override val isCreatedByDropIn: Boolean,
-    override val amount: Amount?,
     val cashAppPayEnvironment: CashAppPayEnvironment,
     val returnUrl: String?,
     val showStorePaymentField: Boolean,
     val storePaymentMethod: Boolean,
     val clientId: String?,
     val scopeId: String?,
-) : ComponentParams, ButtonParams {
+) : ComponentParams by commonComponentParams, ButtonParams {
 
     fun requireClientId(): String = requireNotNull(clientId)
 }

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/model/CashAppPayComponentParamsMapper.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/model/CashAppPayComponentParamsMapper.kt
@@ -24,7 +24,6 @@ import com.adyen.checkout.core.exception.ComponentException
 
 internal class CashAppPayComponentParamsMapper(
     private val dropInOverrideParams: DropInOverrideParams?,
-    private val overrideSessionParams: SessionParams?,
 ) {
 
     @Suppress("ThrowsCount")
@@ -44,7 +43,7 @@ internal class CashAppPayComponentParamsMapper(
                 ),
             )
             .override(dropInOverrideParams, context)
-            .override(sessionParams ?: overrideSessionParams)
+            .override(sessionParams ?: dropInOverrideParams?.sessionParams)
 
         if (params.returnUrl == null) {
             throw ComponentException(
@@ -64,7 +63,7 @@ internal class CashAppPayComponentParamsMapper(
         // clientId and scopeId are not needed in the stored flow.
         .mapToParamsInternal(null, null)
         .override(dropInOverrideParams, context)
-        .override(sessionParams ?: overrideSessionParams)
+        .override(sessionParams ?: dropInOverrideParams?.sessionParams)
 
     private fun CheckoutConfiguration.mapToParamsInternal(
         clientId: String?,

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/model/CashAppPayComponentParamsMapper.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/model/CashAppPayComponentParamsMapper.kt
@@ -16,34 +16,52 @@ import com.adyen.checkout.cashapppay.getCashAppPayConfiguration
 import com.adyen.checkout.components.core.CheckoutConfiguration
 import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.StoredPaymentMethod
-import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParams
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.core.exception.ComponentException
+import java.util.Locale
 
 internal class CashAppPayComponentParamsMapper(
-    private val dropInOverrideParams: DropInOverrideParams?,
+    private val commonComponentParamsMapper: CommonComponentParamsMapper,
 ) {
 
-    @Suppress("ThrowsCount")
+    @Suppress("ThrowsCount", "LongParameterList")
     fun mapToParams(
-        configuration: CheckoutConfiguration,
-        sessionParams: SessionParams?,
+        checkoutConfiguration: CheckoutConfiguration,
+        deviceLocale: Locale,
+        dropInOverrideParams: DropInOverrideParams?,
+        componentSessionParams: SessionParams?,
         paymentMethod: PaymentMethod,
         context: Context,
     ): CashAppPayComponentParams {
-        val params = configuration
-            .mapToParamsInternal(
-                clientId = paymentMethod.configuration?.clientId ?: throw ComponentException(
-                    "Cannot launch Cash App Pay, clientId is missing in the payment method object.",
-                ),
-                scopeId = paymentMethod.configuration?.scopeId ?: throw ComponentException(
-                    "Cannot launch Cash App Pay, scopeId is missing in the payment method object.",
-                ),
-            )
-            .override(dropInOverrideParams, context)
-            .override(sessionParams ?: dropInOverrideParams?.sessionParams)
+        val clientId = paymentMethod.configuration?.clientId ?: throw ComponentException(
+            "Cannot launch Cash App Pay, clientId is missing in the payment method object.",
+        )
+
+        val scopeId = paymentMethod.configuration?.scopeId ?: throw ComponentException(
+            "Cannot launch Cash App Pay, scopeId is missing in the payment method object.",
+        )
+
+        val commonComponentParamsMapperData = commonComponentParamsMapper.mapToParams(
+            checkoutConfiguration,
+            deviceLocale,
+            dropInOverrideParams,
+            componentSessionParams,
+        )
+
+        val cashAppPayConfiguration = checkoutConfiguration.getCashAppPayConfiguration()
+
+        val params = mapToParamsInternal(
+            commonComponentParams = commonComponentParamsMapperData.commonComponentParams,
+            sessionParams = commonComponentParamsMapperData.sessionParams,
+            cashAppPayConfiguration = cashAppPayConfiguration,
+            clientId = clientId,
+            scopeId = scopeId,
+            context = context,
+        )
 
         if (params.returnUrl == null) {
             throw ComponentException(
@@ -54,40 +72,65 @@ internal class CashAppPayComponentParamsMapper(
         return params
     }
 
+    @Suppress("LongParameterList")
     fun mapToParams(
-        configuration: CheckoutConfiguration,
-        sessionParams: SessionParams?,
-        @Suppress("UNUSED_PARAMETER") paymentMethod: StoredPaymentMethod,
+        checkoutConfiguration: CheckoutConfiguration,
+        deviceLocale: Locale,
+        dropInOverrideParams: DropInOverrideParams?,
+        componentSessionParams: SessionParams?,
+        @Suppress("UNUSED_PARAMETER") storedPaymentMethod: StoredPaymentMethod,
         context: Context,
-    ): CashAppPayComponentParams = configuration
-        // clientId and scopeId are not needed in the stored flow.
-        .mapToParamsInternal(null, null)
-        .override(dropInOverrideParams, context)
-        .override(sessionParams ?: dropInOverrideParams?.sessionParams)
+    ): CashAppPayComponentParams {
+        val commonComponentParamsMapperData = commonComponentParamsMapper.mapToParams(
+            checkoutConfiguration,
+            deviceLocale,
+            dropInOverrideParams,
+            componentSessionParams,
+        )
 
-    private fun CheckoutConfiguration.mapToParamsInternal(
+        val cashAppPayConfiguration = checkoutConfiguration.getCashAppPayConfiguration()
+
+        return mapToParamsInternal(
+            commonComponentParams = commonComponentParamsMapperData.commonComponentParams,
+            sessionParams = commonComponentParamsMapperData.sessionParams,
+            cashAppPayConfiguration = cashAppPayConfiguration,
+            clientId = null,
+            scopeId = null,
+            context = context,
+        )
+    }
+
+    @Suppress("LongParameterList")
+    private fun mapToParamsInternal(
+        commonComponentParams: CommonComponentParams,
+        sessionParams: SessionParams?,
+        cashAppPayConfiguration: CashAppPayConfiguration?,
         clientId: String?,
         scopeId: String?,
+        context: Context,
     ): CashAppPayComponentParams {
-        val cashAppPayConfiguration = getCashAppPayConfiguration()
         return CashAppPayComponentParams(
+            commonComponentParams = commonComponentParams,
             isSubmitButtonVisible = cashAppPayConfiguration?.isSubmitButtonVisible ?: true,
-            shopperLocale = shopperLocale,
-            environment = environment,
-            clientKey = clientKey,
-            analyticsParams = AnalyticsParams(analyticsConfiguration),
-            isCreatedByDropIn = false,
-            amount = amount,
-            cashAppPayEnvironment = getCashAppPayEnvironment(cashAppPayConfiguration),
-            returnUrl = cashAppPayConfiguration?.returnUrl,
-            showStorePaymentField = cashAppPayConfiguration?.showStorePaymentField ?: true,
+            cashAppPayEnvironment = getCashAppPayEnvironment(
+                commonComponentParams.environment,
+                cashAppPayConfiguration,
+            ),
+            returnUrl = getReturnUrl(
+                sessionParams,
+                commonComponentParams.isCreatedByDropIn,
+                cashAppPayConfiguration,
+                context,
+            ),
+            showStorePaymentField = getShowStorePaymentField(sessionParams, cashAppPayConfiguration),
             storePaymentMethod = cashAppPayConfiguration?.storePaymentMethod ?: false,
             clientId = clientId,
             scopeId = scopeId,
         )
     }
 
-    private fun CheckoutConfiguration.getCashAppPayEnvironment(
+    private fun getCashAppPayEnvironment(
+        environment: Environment,
         cashAppPayConfiguration: CashAppPayConfiguration?
     ): CashAppPayEnvironment {
         return when {
@@ -97,27 +140,22 @@ internal class CashAppPayComponentParamsMapper(
         }
     }
 
-    private fun CashAppPayComponentParams.override(
-        dropInOverrideParams: DropInOverrideParams?,
+    private fun getReturnUrl(
+        sessionParams: SessionParams?,
+        isCreatedByDropIn: Boolean,
+        cashAppPayConfiguration: CashAppPayConfiguration?,
         context: Context,
-    ): CashAppPayComponentParams {
-        if (dropInOverrideParams == null) return this
-        return copy(
-            amount = dropInOverrideParams.amount,
-            // Take the configured returnUrl or create a default value for drop-in if it's null
-            returnUrl = returnUrl ?: CashAppPayComponent.getReturnUrl(context),
-            isCreatedByDropIn = true,
-        )
+    ): String? {
+        return sessionParams?.returnUrl
+            ?: cashAppPayConfiguration?.returnUrl
+            // if using drop-in and return url is not set use the return url default value
+            ?: CashAppPayComponent.getReturnUrl(context).takeIf { isCreatedByDropIn }
     }
 
-    private fun CashAppPayComponentParams.override(
+    private fun getShowStorePaymentField(
         sessionParams: SessionParams?,
-    ): CashAppPayComponentParams {
-        if (sessionParams == null) return this
-        return copy(
-            amount = sessionParams.amount ?: amount,
-            showStorePaymentField = sessionParams.enableStoreDetails ?: showStorePaymentField,
-            returnUrl = sessionParams.returnUrl ?: returnUrl,
-        )
+        cashAppPayConfiguration: CashAppPayConfiguration?,
+    ): Boolean {
+        return sessionParams?.enableStoreDetails ?: cashAppPayConfiguration?.showStorePaymentField ?: true
     }
 }

--- a/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/DefaultCashAppPayDelegateTest.kt
+++ b/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/DefaultCashAppPayDelegateTest.kt
@@ -36,6 +36,7 @@ import com.adyen.checkout.components.core.PaymentComponentData
 import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.paymentmethod.CashAppPayPaymentMethod
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.core.exception.ComponentException
@@ -477,9 +478,11 @@ internal class DefaultCashAppPayDelegateTest(
         observerRepository = PaymentObserverRepository(),
         paymentMethod = getPaymentMethod(),
         order = TEST_ORDER,
-        componentParams = CashAppPayComponentParamsMapper(null, null).mapToParams(
-            configuration = configuration,
-            sessionParams = null,
+        componentParams = CashAppPayComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = Locale.US,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
             paymentMethod = getPaymentMethod(),
             context = Application(),
         ),

--- a/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/StoredCashAppPayDelegateTest.kt
+++ b/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/StoredCashAppPayDelegateTest.kt
@@ -19,6 +19,7 @@ import com.adyen.checkout.components.core.PaymentComponentData
 import com.adyen.checkout.components.core.StoredPaymentMethod
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.paymentmethod.CashAppPayPaymentMethod
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.test.extensions.test
@@ -127,10 +128,12 @@ internal class StoredCashAppPayDelegateTest(
             type = TEST_PAYMENT_METHOD_TYPE,
         ),
         order = TEST_ORDER,
-        componentParams = CashAppPayComponentParamsMapper(null, null).mapToParams(
-            configuration = configuration,
-            sessionParams = null,
-            paymentMethod = StoredPaymentMethod(),
+        componentParams = CashAppPayComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = Locale.US,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+            storedPaymentMethod = StoredPaymentMethod(),
             context = Application(),
         ),
     )

--- a/checkout-core/src/main/java/com/adyen/checkout/core/internal/util/LocaleProvider.kt
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/internal/util/LocaleProvider.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 9/2/2024.
+ */
+
+package com.adyen.checkout.core.internal.util
+
+import android.content.Context
+import android.os.Build
+import androidx.annotation.RestrictTo
+import java.util.Locale
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class LocaleProvider {
+
+    fun getLocale(context: Context): Locale {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            context.resources.configuration.locales[0]
+        } else {
+            @Suppress("DEPRECATION")
+            context.resources.configuration.locale
+        }
+    }
+}

--- a/checkout-core/src/main/java/com/adyen/checkout/core/internal/util/LocaleUtil.kt
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/internal/util/LocaleUtil.kt
@@ -7,8 +7,6 @@
  */
 package com.adyen.checkout.core.internal.util
 
-import android.content.Context
-import android.os.Build
 import androidx.annotation.RestrictTo
 import java.util.IllformedLocaleException
 import java.util.Locale
@@ -18,21 +16,6 @@ import java.util.Locale
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 object LocaleUtil {
-
-    /**
-     * Get the current user Locale.
-     * @param context The context
-     * @return The user Locale
-     */
-    @JvmStatic
-    fun getLocale(context: Context): Locale {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            context.resources.configuration.locales[0]
-        } else {
-            @Suppress("DEPRECATION")
-            context.resources.configuration.locale
-        }
-    }
 
     /**
      * Gets the language tag from a Locale.

--- a/components-core/src/main/java/com/adyen/checkout/components/core/CheckoutConfiguration.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/CheckoutConfiguration.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.components.core
 
 import android.annotation.SuppressLint
-import android.content.Context
 import android.os.Parcel
 import android.os.Parcelable
 import android.os.Parcelable.CONTENTS_FILE_DESCRIPTOR
@@ -17,15 +16,14 @@ import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.core.internal.Configuration
 import com.adyen.checkout.components.core.internal.util.CheckoutConfigurationMarker
 import com.adyen.checkout.core.Environment
-import com.adyen.checkout.core.internal.util.LocaleUtil
 import kotlinx.parcelize.IgnoredOnParcel
 import java.util.Locale
 
 @CheckoutConfigurationMarker
 class CheckoutConfiguration(
-    override val shopperLocale: Locale,
     override val environment: Environment,
     override val clientKey: String,
+    override val shopperLocale: Locale? = null,
     override val amount: Amount? = null,
     override val analyticsConfiguration: AnalyticsConfiguration? = null,
     @IgnoredOnParcel
@@ -33,22 +31,6 @@ class CheckoutConfiguration(
 ) : Configuration {
 
     private val availableConfigurations = mutableMapOf<String, Configuration>()
-
-    constructor(
-        context: Context,
-        environment: Environment,
-        clientKey: String,
-        amount: Amount? = null,
-        analyticsConfiguration: AnalyticsConfiguration? = null,
-        configurationBlock: CheckoutConfiguration.() -> Unit = {},
-    ) : this(
-        shopperLocale = LocaleUtil.getLocale(context),
-        environment = environment,
-        clientKey = clientKey,
-        amount = amount,
-        analyticsConfiguration = analyticsConfiguration,
-        configurationBlock = configurationBlock,
-    )
 
     init {
         apply(configurationBlock)
@@ -58,7 +40,9 @@ class CheckoutConfiguration(
     @SuppressLint("ParcelClassLoader")
     @Suppress("UNCHECKED_CAST", "DEPRECATION")
     private constructor(parcel: Parcel) : this(
-        shopperLocale = parcel.readSerializable() as Locale,
+        // the order in which these fields are read from Parcel should match the order in which they are written to
+        // Parcel in the `writeToParcel` function
+        shopperLocale = parcel.readSerializable() as? Locale,
         environment = requireNotNull(parcel.readParcelable(Environment::class.java.classLoader)),
         clientKey = requireNotNull(parcel.readString()),
         amount = parcel.readParcelable(Amount::class.java.classLoader),
@@ -97,6 +81,8 @@ class CheckoutConfiguration(
     }
 
     override fun writeToParcel(dest: Parcel, flags: Int) {
+        // the order in which these fields are written from Parcel should match the order in which they are read from
+        // Parcel in `constructor(parcel: Parcel)`
         dest.writeSerializable(shopperLocale)
         dest.writeParcelable(environment, flags)
         dest.writeString(clientKey)

--- a/components-core/src/main/java/com/adyen/checkout/components/core/CheckoutConfiguration.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/CheckoutConfiguration.kt
@@ -19,6 +19,33 @@ import com.adyen.checkout.core.Environment
 import kotlinx.parcelize.IgnoredOnParcel
 import java.util.Locale
 
+/**
+ * A generic configuration class that allows customizing the Checkout library.
+ * You can use the block parameter to add drop-in or payment method specific configurations. For example:
+ *
+ * ```
+ * val checkoutConfiguration = CheckoutConfiguration(
+ *     environment,
+ *     clientKey,
+ *     shopperLocale,
+ *     amount,
+ * ) {
+ *     dropIn {
+ *         setEnableRemovingStoredPaymentMethods(true)
+ *     }
+ *     card {
+ *         setHolderNameRequired(true)
+ *     }
+ * }
+ * ```
+ *
+ * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+ * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+ * @param shopperLocale The [Locale] used to display information to the shopper. Defaults to the primary device locale.
+ * @param amount The amount of the transaction.
+ * @param analyticsConfiguration A configuration for the internal analytics of the library.
+ * @param configurationBlock A block that allows adding drop-in or payment method specific configurations.
+ */
 @CheckoutConfigurationMarker
 class CheckoutConfiguration(
     override val environment: Environment,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/BaseConfigurationBuilder.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/BaseConfigurationBuilder.kt
@@ -60,6 +60,7 @@ constructor(
      * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
      * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
      */
+    @Deprecated("You can omit the context parameter")
     constructor(
         @Suppress("unused")
         context: Context,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/BaseConfigurationBuilder.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/BaseConfigurationBuilder.kt
@@ -16,14 +16,14 @@ abstract class BaseConfigurationBuilder<
     BuilderT : BaseConfigurationBuilder<ConfigurationT, BuilderT>
     >
 /**
- * Initialize a configuration builder with the required fields.
+ * Initialize a configuration builder with the required fields and a shopper locale.
  *
  * @param shopperLocale The [Locale] of the shopper.
  * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
  * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
  */
 constructor(
-    protected var shopperLocale: Locale,
+    protected var shopperLocale: Locale?,
     protected var environment: Environment,
     protected var clientKey: String
 ) {
@@ -36,6 +36,22 @@ constructor(
             throw CheckoutException("Client key is not valid.")
         }
     }
+
+    /**
+     * Initialize a configuration builder with the required fields.
+     * The shopper locale will match the primary user locale on the device.
+     *
+     * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+     * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+     */
+    constructor(
+        environment: Environment,
+        clientKey: String
+    ) : this(
+        shopperLocale = null,
+        environment = environment,
+        clientKey = clientKey,
+    )
 
     /**
      * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
@@ -51,8 +67,19 @@ constructor(
     ) : this(
         LocaleUtil.getLocale(context),
         environment,
-        clientKey
+        clientKey,
     )
+
+    /**
+     * Allows setting the preferred locale of the shopper.
+     *
+     * @param shopperLocale The [Locale] of the shopper.
+     */
+    fun setShopperLocale(shopperLocale: Locale): BuilderT {
+        this.shopperLocale = shopperLocale
+        @Suppress("UNCHECKED_CAST")
+        return this as BuilderT
+    }
 
     /**
      * Allows configuring the internal analytics of the library.
@@ -93,8 +120,10 @@ constructor(
             throw CheckoutException("Client key does not match the environment.")
         }
 
-        if (!LocaleUtil.isValidLocale(shopperLocale)) {
-            throw CheckoutException("Invalid shopper locale: $shopperLocale.")
+        shopperLocale?.let {
+            if (!LocaleUtil.isValidLocale(it)) {
+                throw CheckoutException("Invalid shopper locale: $shopperLocale.")
+            }
         }
 
         return buildInternal()

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/BaseConfigurationBuilder.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/BaseConfigurationBuilder.kt
@@ -61,11 +61,12 @@ constructor(
      * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
      */
     constructor(
+        @Suppress("unused")
         context: Context,
         environment: Environment,
         clientKey: String
     ) : this(
-        LocaleUtil.getLocale(context),
+        null,
         environment,
         clientKey,
     )

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/Configuration.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/Configuration.kt
@@ -10,9 +10,9 @@ import java.util.Locale
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface Configuration : Parcelable {
 
-    val shopperLocale: Locale
     val environment: Environment
     val clientKey: String
+    val shopperLocale: Locale?
     val analyticsConfiguration: AnalyticsConfiguration?
     val amount: Amount?
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/ButtonComponentParams.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/ButtonComponentParams.kt
@@ -9,17 +9,9 @@
 package com.adyen.checkout.components.core.internal.ui.model
 
 import androidx.annotation.RestrictTo
-import com.adyen.checkout.components.core.Amount
-import com.adyen.checkout.core.Environment
-import java.util.Locale
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class ButtonComponentParams(
-    override val shopperLocale: Locale,
-    override val environment: Environment,
-    override val clientKey: String,
-    override val analyticsParams: AnalyticsParams,
-    override val isCreatedByDropIn: Boolean,
-    override val amount: Amount?,
+    private val commonComponentParams: CommonComponentParams,
     override val isSubmitButtonVisible: Boolean,
-) : ComponentParams, ButtonParams
+) : ComponentParams by commonComponentParams, ButtonParams

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/ButtonComponentParamsMapper.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/ButtonComponentParamsMapper.kt
@@ -8,7 +8,6 @@ import com.adyen.checkout.components.core.internal.Configuration
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class ButtonComponentParamsMapper(
     private val dropInOverrideParams: DropInOverrideParams?,
-    private val overrideSessionParams: SessionParams?,
 ) {
 
     fun mapToParams(
@@ -19,7 +18,7 @@ class ButtonComponentParamsMapper(
         return checkoutConfiguration
             .mapToParamsInternal(configuration)
             .override(dropInOverrideParams)
-            .override(sessionParams ?: overrideSessionParams)
+            .override(sessionParams ?: dropInOverrideParams?.sessionParams)
     }
 
     private fun CheckoutConfiguration.mapToParamsInternal(configuration: Configuration?): ButtonComponentParams {

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/ButtonComponentParamsMapper.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/ButtonComponentParamsMapper.kt
@@ -4,51 +4,29 @@ import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.core.CheckoutConfiguration
 import com.adyen.checkout.components.core.internal.ButtonConfiguration
 import com.adyen.checkout.components.core.internal.Configuration
+import java.util.Locale
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class ButtonComponentParamsMapper(
-    private val dropInOverrideParams: DropInOverrideParams?,
+    private val commonComponentParamsMapper: CommonComponentParamsMapper,
 ) {
 
     fun mapToParams(
         checkoutConfiguration: CheckoutConfiguration,
-        configuration: Configuration?,
-        sessionParams: SessionParams?,
-    ): ButtonComponentParams {
-        return checkoutConfiguration
-            .mapToParamsInternal(configuration)
-            .override(dropInOverrideParams)
-            .override(sessionParams ?: dropInOverrideParams?.sessionParams)
-    }
-
-    private fun CheckoutConfiguration.mapToParamsInternal(configuration: Configuration?): ButtonComponentParams {
-        return ButtonComponentParams(
-            shopperLocale = shopperLocale,
-            environment = environment,
-            clientKey = clientKey,
-            analyticsParams = AnalyticsParams(analyticsConfiguration),
-            isCreatedByDropIn = false,
-            amount = amount,
-            isSubmitButtonVisible = (configuration as? ButtonConfiguration)?.isSubmitButtonVisible ?: true,
-        )
-    }
-
-    private fun ButtonComponentParams.override(
+        deviceLocale: Locale,
         dropInOverrideParams: DropInOverrideParams?,
+        componentSessionParams: SessionParams?,
+        componentConfiguration: Configuration?
     ): ButtonComponentParams {
-        if (dropInOverrideParams == null) return this
-        return copy(
-            amount = dropInOverrideParams.amount,
-            isCreatedByDropIn = true,
+        val commonComponentParamsMapperData = commonComponentParamsMapper.mapToParams(
+            checkoutConfiguration,
+            deviceLocale,
+            dropInOverrideParams,
+            componentSessionParams,
         )
-    }
-
-    private fun ButtonComponentParams.override(
-        sessionParams: SessionParams? = null
-    ): ButtonComponentParams {
-        if (sessionParams == null) return this
-        return copy(
-            amount = sessionParams.amount ?: amount,
+        return ButtonComponentParams(
+            commonComponentParams = commonComponentParamsMapperData.commonComponentParams,
+            isSubmitButtonVisible = (componentConfiguration as? ButtonConfiguration)?.isSubmitButtonVisible ?: true,
         )
     }
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/CommonComponentParams.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/CommonComponentParams.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 15/2/2024.
+ */
+
+package com.adyen.checkout.components.core.internal.ui.model
+
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.components.core.Amount
+import com.adyen.checkout.core.Environment
+import java.util.Locale
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class CommonComponentParams(
+    override val shopperLocale: Locale,
+    override val environment: Environment,
+    override val clientKey: String,
+    override val analyticsParams: AnalyticsParams,
+    override val isCreatedByDropIn: Boolean,
+    override val amount: Amount?,
+) : ComponentParams

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/CommonComponentParamsMapper.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/CommonComponentParamsMapper.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 15/2/2024.
+ */
+
+package com.adyen.checkout.components.core.internal.ui.model
+
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.components.core.CheckoutConfiguration
+import java.util.Locale
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class CommonComponentParamsMapper {
+
+    fun mapToParams(
+        checkoutConfiguration: CheckoutConfiguration,
+        deviceLocale: Locale,
+        dropInOverrideParams: DropInOverrideParams?,
+        componentSessionParams: SessionParams?,
+    ): CommonComponentParamsMapperData {
+        val sessionParams: SessionParams? = dropInOverrideParams?.sessionParams ?: componentSessionParams
+        val commonComponentParams = CommonComponentParams(
+            shopperLocale = checkoutConfiguration.shopperLocale ?: deviceLocale,
+            environment = checkoutConfiguration.environment,
+            clientKey = checkoutConfiguration.clientKey,
+            analyticsParams = AnalyticsParams(checkoutConfiguration.analyticsConfiguration),
+            isCreatedByDropIn = dropInOverrideParams != null,
+            amount = sessionParams?.amount
+                ?: dropInOverrideParams?.amount
+                ?: checkoutConfiguration.amount,
+        )
+        return CommonComponentParamsMapperData(commonComponentParams, sessionParams)
+    }
+}

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/CommonComponentParamsMapperData.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/CommonComponentParamsMapperData.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 15/2/2024.
+ */
+
+package com.adyen.checkout.components.core.internal.ui.model
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class CommonComponentParamsMapperData(
+    val commonComponentParams: CommonComponentParams,
+    val sessionParams: SessionParams?,
+)

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/DropInOverrideParams.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/DropInOverrideParams.kt
@@ -13,5 +13,6 @@ import com.adyen.checkout.components.core.Amount
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class DropInOverrideParams(
-    val amount: Amount?
+    val amount: Amount?,
+    val sessionParams: SessionParams?,
 )

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/GenericComponentParams.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/GenericComponentParams.kt
@@ -9,16 +9,8 @@
 package com.adyen.checkout.components.core.internal.ui.model
 
 import androidx.annotation.RestrictTo
-import com.adyen.checkout.components.core.Amount
-import com.adyen.checkout.core.Environment
-import java.util.Locale
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class GenericComponentParams(
-    override val shopperLocale: Locale,
-    override val environment: Environment,
-    override val clientKey: String,
-    override val analyticsParams: AnalyticsParams,
-    override val isCreatedByDropIn: Boolean,
-    override val amount: Amount?,
-) : ComponentParams
+    private val commonComponentParams: CommonComponentParams,
+) : ComponentParams by commonComponentParams

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/GenericComponentParamsMapper.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/GenericComponentParamsMapper.kt
@@ -10,50 +10,29 @@ package com.adyen.checkout.components.core.internal.ui.model
 
 import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.core.CheckoutConfiguration
-import com.adyen.checkout.components.core.internal.Configuration
+import java.util.Locale
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class GenericComponentParamsMapper(
-    private val dropInOverrideParams: DropInOverrideParams?,
+    private val commonComponentParamsMapper: CommonComponentParamsMapper,
 ) {
 
     fun mapToParams(
-        configuration: CheckoutConfiguration,
-        sessionParams: SessionParams?,
+        checkoutConfiguration: CheckoutConfiguration,
+        deviceLocale: Locale,
+        dropInOverrideParams: DropInOverrideParams?,
+        componentSessionParams: SessionParams?,
     ): GenericComponentParams {
-        return configuration
-            .mapToParamsInternal()
-            .override(dropInOverrideParams)
-            .override(sessionParams ?: dropInOverrideParams?.sessionParams)
-    }
+        val commonComponentParamsMapperData = commonComponentParamsMapper.mapToParams(
+            checkoutConfiguration,
+            deviceLocale,
+            dropInOverrideParams,
+            componentSessionParams,
+        )
+        val commonComponentParams = commonComponentParamsMapperData.commonComponentParams
 
-    private fun Configuration.mapToParamsInternal(): GenericComponentParams {
         return GenericComponentParams(
-            shopperLocale = shopperLocale,
-            environment = environment,
-            clientKey = clientKey,
-            analyticsParams = AnalyticsParams(analyticsConfiguration),
-            isCreatedByDropIn = false,
-            amount = amount,
-        )
-    }
-
-    private fun GenericComponentParams.override(
-        dropInOverrideParams: DropInOverrideParams?
-    ): GenericComponentParams {
-        if (dropInOverrideParams == null) return this
-        return copy(
-            amount = dropInOverrideParams.amount,
-            isCreatedByDropIn = true,
-        )
-    }
-
-    private fun GenericComponentParams.override(
-        sessionParams: SessionParams? = null
-    ): GenericComponentParams {
-        if (sessionParams == null) return this
-        return copy(
-            amount = sessionParams.amount ?: amount,
+            commonComponentParams = commonComponentParams,
         )
     }
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/GenericComponentParamsMapper.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/GenericComponentParamsMapper.kt
@@ -15,7 +15,6 @@ import com.adyen.checkout.components.core.internal.Configuration
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class GenericComponentParamsMapper(
     private val dropInOverrideParams: DropInOverrideParams?,
-    private val overrideSessionParams: SessionParams?,
 ) {
 
     fun mapToParams(
@@ -25,7 +24,7 @@ class GenericComponentParamsMapper(
         return configuration
             .mapToParamsInternal()
             .override(dropInOverrideParams)
-            .override(sessionParams ?: overrideSessionParams)
+            .override(sessionParams ?: dropInOverrideParams?.sessionParams)
     }
 
     private fun Configuration.mapToParamsInternal(): GenericComponentParams {

--- a/components-core/src/test/java/com/adyen/checkout/components/core/ButtonTestConfiguration.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/ButtonTestConfiguration.kt
@@ -1,6 +1,5 @@
 package com.adyen.checkout.components.core
 
-import android.content.Context
 import com.adyen.checkout.components.core.internal.BaseConfigurationBuilder
 import com.adyen.checkout.components.core.internal.ButtonConfiguration
 import com.adyen.checkout.components.core.internal.ButtonConfigurationBuilder
@@ -19,21 +18,14 @@ class ButtonTestConfiguration private constructor(
     override val isSubmitButtonVisible: Boolean?,
 ) : Configuration, ButtonConfiguration {
 
-    class Builder : BaseConfigurationBuilder<ButtonTestConfiguration, Builder>, ButtonConfigurationBuilder {
+    class Builder(
+        shopperLocale: Locale?,
+        environment: Environment,
+        clientKey: String
+    ) : BaseConfigurationBuilder<ButtonTestConfiguration, Builder>(shopperLocale, environment, clientKey),
+        ButtonConfigurationBuilder {
 
         private var isSubmitButtonVisible: Boolean? = null
-
-        constructor(context: Context, environment: Environment, clientKey: String) : super(
-            context,
-            environment,
-            clientKey
-        )
-
-        constructor(
-            shopperLocale: Locale?,
-            environment: Environment,
-            clientKey: String
-        ) : super(shopperLocale, environment, clientKey)
 
         override fun setSubmitButtonVisible(isSubmitButtonVisible: Boolean): ButtonConfigurationBuilder {
             this.isSubmitButtonVisible = isSubmitButtonVisible

--- a/components-core/src/test/java/com/adyen/checkout/components/core/ButtonTestConfiguration.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/ButtonTestConfiguration.kt
@@ -11,7 +11,7 @@ import java.util.Locale
 
 @Parcelize
 class ButtonTestConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -30,7 +30,7 @@ class ButtonTestConfiguration private constructor(
         )
 
         constructor(
-            shopperLocale: Locale,
+            shopperLocale: Locale?,
             environment: Environment,
             clientKey: String
         ) : super(shopperLocale, environment, clientKey)

--- a/components-core/src/test/java/com/adyen/checkout/components/core/TestConfiguration.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/TestConfiguration.kt
@@ -17,7 +17,7 @@ import java.util.Locale
 
 @Parcelize
 class TestConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -33,7 +33,7 @@ class TestConfiguration private constructor(
         )
 
         constructor(
-            shopperLocale: Locale,
+            shopperLocale: Locale?,
             environment: Environment,
             clientKey: String
         ) : super(shopperLocale, environment, clientKey)

--- a/components-core/src/test/java/com/adyen/checkout/components/core/TestConfiguration.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/TestConfiguration.kt
@@ -8,7 +8,6 @@
 
 package com.adyen.checkout.components.core
 
-import android.content.Context
 import com.adyen.checkout.components.core.internal.BaseConfigurationBuilder
 import com.adyen.checkout.components.core.internal.Configuration
 import com.adyen.checkout.core.Environment
@@ -24,19 +23,8 @@ class TestConfiguration private constructor(
     override val amount: Amount?
 ) : Configuration {
 
-    class Builder : BaseConfigurationBuilder<TestConfiguration, Builder> {
-
-        constructor(context: Context, environment: Environment, clientKey: String) : super(
-            context,
-            environment,
-            clientKey
-        )
-
-        constructor(
-            shopperLocale: Locale?,
-            environment: Environment,
-            clientKey: String
-        ) : super(shopperLocale, environment, clientKey)
+    class Builder(shopperLocale: Locale?, environment: Environment, clientKey: String) :
+        BaseConfigurationBuilder<TestConfiguration, Builder>(shopperLocale, environment, clientKey) {
 
         override fun buildInternal(): TestConfiguration {
             return TestConfiguration(
@@ -44,7 +32,7 @@ class TestConfiguration private constructor(
                 environment = environment,
                 clientKey = clientKey,
                 analyticsConfiguration = analyticsConfiguration,
-                amount = amount
+                amount = amount,
             )
         }
     }

--- a/convenience-stores-jp/src/main/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPConfiguration.kt
+++ b/convenience-stores-jp/src/main/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPConfiguration.kt
@@ -59,6 +59,7 @@ class ConvenienceStoresJPConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/convenience-stores-jp/src/main/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPConfiguration.kt
+++ b/convenience-stores-jp/src/main/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPConfiguration.kt
@@ -26,7 +26,7 @@ import java.util.Locale
 @Suppress("LongParameterList")
 @Parcelize
 class ConvenienceStoresJPConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -39,6 +39,18 @@ class ConvenienceStoresJPConfiguration private constructor(
      * Builder to create a [ConvenienceStoresJPConfiguration].
      */
     class Builder : EContextConfiguration.Builder<ConvenienceStoresJPConfiguration, Builder> {
+
+        /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
 
         /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
@@ -54,7 +66,7 @@ class ConvenienceStoresJPConfiguration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -83,8 +95,9 @@ class ConvenienceStoresJPConfiguration private constructor(
 fun CheckoutConfiguration.convenienceStoresJP(
     configuration: @CheckoutConfigurationMarker ConvenienceStoresJPConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = ConvenienceStoresJPConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = ConvenienceStoresJPConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/convenience-stores-jp/src/main/java/com/adyen/checkout/conveniencestoresjp/internal/provider/ConvenienceStoresJPComponentProvider.kt
+++ b/convenience-stores-jp/src/main/java/com/adyen/checkout/conveniencestoresjp/internal/provider/ConvenienceStoresJPComponentProvider.kt
@@ -16,7 +16,6 @@ import com.adyen.checkout.components.core.PaymentComponentData
 import com.adyen.checkout.components.core.internal.ComponentEventHandler
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.paymentmethod.ConvenienceStoresJPPaymentMethod
 import com.adyen.checkout.conveniencestoresjp.ConvenienceStoresJPComponent
 import com.adyen.checkout.conveniencestoresjp.ConvenienceStoresJPComponentState
@@ -30,7 +29,6 @@ class ConvenienceStoresJPComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
     analyticsRepository: AnalyticsRepository? = null,
 ) : EContextComponentProvider<
     ConvenienceStoresJPComponent,
@@ -40,7 +38,6 @@ constructor(
     >(
     componentClass = ConvenienceStoresJPComponent::class.java,
     dropInOverrideParams = dropInOverrideParams,
-    overrideSessionParams = overrideSessionParams,
     analyticsRepository = analyticsRepository,
 ) {
 

--- a/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayConfiguration.kt
+++ b/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayConfiguration.kt
@@ -26,7 +26,7 @@ import java.util.Locale
 @Parcelize
 @Suppress("LongParameterList")
 class DotpayConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -43,6 +43,18 @@ class DotpayConfiguration private constructor(
     class Builder : IssuerListBuilder<DotpayConfiguration, Builder> {
 
         /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
+
+        /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
          *
          * @param context A context
@@ -56,7 +68,7 @@ class DotpayConfiguration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -87,8 +99,9 @@ class DotpayConfiguration private constructor(
 fun CheckoutConfiguration.dotpay(
     configuration: @CheckoutConfigurationMarker DotpayConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = DotpayConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = DotpayConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayConfiguration.kt
+++ b/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayConfiguration.kt
@@ -61,6 +61,7 @@ class DotpayConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/dotpay/src/main/java/com/adyen/checkout/dotpay/internal/provider/DotpayComponentProvider.kt
+++ b/dotpay/src/main/java/com/adyen/checkout/dotpay/internal/provider/DotpayComponentProvider.kt
@@ -16,7 +16,6 @@ import com.adyen.checkout.components.core.PaymentComponentData
 import com.adyen.checkout.components.core.internal.ComponentEventHandler
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.paymentmethod.DotpayPaymentMethod
 import com.adyen.checkout.dotpay.DotpayComponent
 import com.adyen.checkout.dotpay.DotpayComponentState
@@ -30,12 +29,10 @@ class DotpayComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
     analyticsRepository: AnalyticsRepository? = null,
 ) : IssuerListComponentProvider<DotpayComponent, DotpayConfiguration, DotpayPaymentMethod, DotpayComponentState>(
     componentClass = DotpayComponent::class.java,
     dropInOverrideParams = dropInOverrideParams,
-    overrideSessionParams = overrideSessionParams,
     analyticsRepository = analyticsRepository,
 ) {
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
@@ -140,6 +140,7 @@ class DropInConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
@@ -59,7 +59,7 @@ import kotlin.collections.set
 @Parcelize
 @Suppress("LongParameterList")
 class DropInConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -107,6 +107,18 @@ class DropInConfiguration private constructor(
         private var skipListWhenSinglePaymentMethod: Boolean? = null
         private var isRemovingStoredPaymentMethodsEnabled: Boolean? = null
         private var additionalDataForDropInService: Bundle? = null
+
+        /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
 
         /**
          * Create a [DropInConfiguration]
@@ -446,8 +458,9 @@ private const val DROP_IN_CONFIG_KEY = "DROP_IN_CONFIG_KEY"
 fun CheckoutConfiguration.dropIn(
     configuration: @CheckoutConfigurationMarker Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = Builder(shopperLocale, environment, clientKey)
+    val config = Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/provider/ComponentProvider.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/provider/ComponentProvider.kt
@@ -38,7 +38,6 @@ import com.adyen.checkout.components.core.StoredPaymentMethod
 import com.adyen.checkout.components.core.internal.PaymentComponent
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
-import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.conveniencestoresjp.ConvenienceStoresJPComponent
 import com.adyen.checkout.conveniencestoresjp.ConvenienceStoresJPComponentState
 import com.adyen.checkout.conveniencestoresjp.internal.provider.ConvenienceStoresJPComponentProvider
@@ -48,6 +47,7 @@ import com.adyen.checkout.dotpay.DotpayComponentState
 import com.adyen.checkout.dotpay.internal.provider.DotpayComponentProvider
 import com.adyen.checkout.dropin.internal.ui.model.DropInComponentParams
 import com.adyen.checkout.dropin.internal.ui.model.DropInComponentParamsMapper
+import com.adyen.checkout.dropin.internal.ui.model.DropInOverrideParamsFactory
 import com.adyen.checkout.dropin.internal.util.checkCompileOnly
 import com.adyen.checkout.entercash.EntercashComponent
 import com.adyen.checkout.entercash.EntercashComponentState
@@ -98,7 +98,6 @@ import com.adyen.checkout.sepa.SepaComponent
 import com.adyen.checkout.sepa.SepaComponentState
 import com.adyen.checkout.sepa.internal.provider.SepaComponentProvider
 import com.adyen.checkout.sessions.core.internal.data.model.SessionDetails
-import com.adyen.checkout.sessions.core.internal.data.model.mapToParams
 import com.adyen.checkout.seveneleven.SevenElevenComponent
 import com.adyen.checkout.seveneleven.SevenElevenComponentState
 import com.adyen.checkout.seveneleven.internal.provider.SevenElevenComponentProvider
@@ -124,11 +123,10 @@ internal fun getComponentFor(
     analyticsRepository: AnalyticsRepository,
     onRedirect: () -> Unit,
 ): PaymentComponent {
-    val dropInOverrideParams = DropInOverrideParams(amount)
-    val sessionParams = sessionDetails?.mapToParams(amount)
+    val dropInOverrideParams = DropInOverrideParamsFactory.create(amount, sessionDetails)
     return when {
         checkCompileOnly { ACHDirectDebitComponent.PROVIDER.isPaymentMethodSupported(storedPaymentMethod) } -> {
-            ACHDirectDebitComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            ACHDirectDebitComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 storedPaymentMethod = storedPaymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -138,7 +136,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { CardComponent.PROVIDER.isPaymentMethodSupported(storedPaymentMethod) } -> {
-            CardComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            CardComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 storedPaymentMethod = storedPaymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -148,7 +146,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { CashAppPayComponent.PROVIDER.isPaymentMethodSupported(storedPaymentMethod) } -> {
-            CashAppPayComponentProvider(dropInOverrideParams, sessionParams).get(
+            CashAppPayComponentProvider(dropInOverrideParams).get(
                 fragment = fragment,
                 storedPaymentMethod = storedPaymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -158,7 +156,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { BlikComponent.PROVIDER.isPaymentMethodSupported(storedPaymentMethod) } -> {
-            BlikComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            BlikComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 storedPaymentMethod = storedPaymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -193,11 +191,10 @@ internal fun getComponentFor(
     analyticsRepository: AnalyticsRepository,
     onRedirect: () -> Unit,
 ): PaymentComponent {
-    val dropInOverrideParams = DropInOverrideParams(amount)
-    val sessionParams = sessionDetails?.mapToParams(amount)
+    val dropInOverrideParams = DropInOverrideParamsFactory.create(amount, sessionDetails)
     return when {
         checkCompileOnly { ACHDirectDebitComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
-            ACHDirectDebitComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            ACHDirectDebitComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -206,7 +203,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { BacsDirectDebitComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
-            BacsDirectDebitComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            BacsDirectDebitComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -215,7 +212,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { BcmcComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
-            BcmcComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            BcmcComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -224,7 +221,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { BlikComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
-            BlikComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            BlikComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -233,7 +230,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { BoletoComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
-            BoletoComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            BoletoComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -242,7 +239,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { CardComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
-            CardComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            CardComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -251,7 +248,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { CashAppPayComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
-            CashAppPayComponentProvider(dropInOverrideParams, sessionParams).get(
+            CashAppPayComponentProvider(dropInOverrideParams).get(
                 fragment = fragment,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -260,7 +257,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { ConvenienceStoresJPComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
-            ConvenienceStoresJPComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            ConvenienceStoresJPComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -269,7 +266,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { DotpayComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
-            DotpayComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            DotpayComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -278,7 +275,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { EntercashComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
-            EntercashComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            EntercashComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -287,7 +284,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { EPSComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
-            EPSComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            EPSComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -296,7 +293,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { GiftCardComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
-            GiftCardComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            GiftCardComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -305,7 +302,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { GooglePayComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
-            GooglePayComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            GooglePayComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -314,7 +311,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { IdealComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
-            IdealComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            IdealComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -323,7 +320,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { InstantPaymentComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
-            InstantPaymentComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            InstantPaymentComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -332,7 +329,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { MBWayComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
-            MBWayComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            MBWayComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -341,7 +338,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { MolpayComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
-            MolpayComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            MolpayComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -350,7 +347,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { OnlineBankingCZComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
-            OnlineBankingCZComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            OnlineBankingCZComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -359,7 +356,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { OnlineBankingJPComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
-            OnlineBankingJPComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            OnlineBankingJPComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -368,7 +365,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { OnlineBankingPLComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
-            OnlineBankingPLComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            OnlineBankingPLComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -377,7 +374,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { OnlineBankingSKComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
-            OnlineBankingSKComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            OnlineBankingSKComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -386,7 +383,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { OpenBankingComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
-            OpenBankingComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            OpenBankingComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -395,7 +392,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { PayByBankComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
-            PayByBankComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            PayByBankComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -404,7 +401,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { PayEasyComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
-            PayEasyComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            PayEasyComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -413,7 +410,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { SepaComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
-            SepaComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            SepaComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -422,7 +419,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { SevenElevenComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
-            SevenElevenComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            SevenElevenComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
@@ -431,7 +428,7 @@ internal fun getComponentFor(
         }
 
         checkCompileOnly { UPIComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
-            UPIComponentProvider(dropInOverrideParams, sessionParams, analyticsRepository).get(
+            UPIComponentProvider(dropInOverrideParams, analyticsRepository).get(
                 fragment = fragment,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/provider/ComponentProvider.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/provider/ComponentProvider.kt
@@ -30,7 +30,6 @@ import com.adyen.checkout.card.internal.provider.CardComponentProvider
 import com.adyen.checkout.cashapppay.CashAppPayComponent
 import com.adyen.checkout.cashapppay.CashAppPayComponentState
 import com.adyen.checkout.cashapppay.internal.provider.CashAppPayComponentProvider
-import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.components.core.CheckoutConfiguration
 import com.adyen.checkout.components.core.ComponentCallback
 import com.adyen.checkout.components.core.PaymentMethod
@@ -38,6 +37,7 @@ import com.adyen.checkout.components.core.StoredPaymentMethod
 import com.adyen.checkout.components.core.internal.PaymentComponent
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
+import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.conveniencestoresjp.ConvenienceStoresJPComponent
 import com.adyen.checkout.conveniencestoresjp.ConvenienceStoresJPComponentState
 import com.adyen.checkout.conveniencestoresjp.internal.provider.ConvenienceStoresJPComponentProvider
@@ -45,9 +45,6 @@ import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.dotpay.DotpayComponent
 import com.adyen.checkout.dotpay.DotpayComponentState
 import com.adyen.checkout.dotpay.internal.provider.DotpayComponentProvider
-import com.adyen.checkout.dropin.internal.ui.model.DropInComponentParams
-import com.adyen.checkout.dropin.internal.ui.model.DropInComponentParamsMapper
-import com.adyen.checkout.dropin.internal.ui.model.DropInOverrideParamsFactory
 import com.adyen.checkout.dropin.internal.util.checkCompileOnly
 import com.adyen.checkout.entercash.EntercashComponent
 import com.adyen.checkout.entercash.EntercashComponentState
@@ -97,7 +94,6 @@ import com.adyen.checkout.payeasy.internal.provider.PayEasyComponentProvider
 import com.adyen.checkout.sepa.SepaComponent
 import com.adyen.checkout.sepa.SepaComponentState
 import com.adyen.checkout.sepa.internal.provider.SepaComponentProvider
-import com.adyen.checkout.sessions.core.internal.data.model.SessionDetails
 import com.adyen.checkout.seveneleven.SevenElevenComponent
 import com.adyen.checkout.seveneleven.SevenElevenComponentState
 import com.adyen.checkout.seveneleven.internal.provider.SevenElevenComponentProvider
@@ -117,13 +113,11 @@ internal fun getComponentFor(
     fragment: Fragment,
     storedPaymentMethod: StoredPaymentMethod,
     checkoutConfiguration: CheckoutConfiguration,
-    amount: Amount?,
+    dropInOverrideParams: DropInOverrideParams,
     componentCallback: ComponentCallback<*>,
-    sessionDetails: SessionDetails?,
     analyticsRepository: AnalyticsRepository,
     onRedirect: () -> Unit,
 ): PaymentComponent {
-    val dropInOverrideParams = DropInOverrideParamsFactory.create(amount, sessionDetails)
     return when {
         checkCompileOnly { ACHDirectDebitComponent.PROVIDER.isPaymentMethodSupported(storedPaymentMethod) } -> {
             ACHDirectDebitComponentProvider(dropInOverrideParams, analyticsRepository).get(
@@ -185,13 +179,11 @@ internal fun getComponentFor(
     fragment: Fragment,
     paymentMethod: PaymentMethod,
     checkoutConfiguration: CheckoutConfiguration,
-    amount: Amount?,
+    dropInOverrideParams: DropInOverrideParams,
     componentCallback: ComponentCallback<*>,
-    sessionDetails: SessionDetails?,
     analyticsRepository: AnalyticsRepository,
     onRedirect: () -> Unit,
 ): PaymentComponent {
-    val dropInOverrideParams = DropInOverrideParamsFactory.create(amount, sessionDetails)
     return when {
         checkCompileOnly { ACHDirectDebitComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
             ACHDirectDebitComponentProvider(dropInOverrideParams, analyticsRepository).get(
@@ -442,8 +434,4 @@ internal fun getComponentFor(
     }.apply {
         setOnRedirectListener(onRedirect)
     }
-}
-
-internal fun CheckoutConfiguration.mapToParams(amount: Amount?): DropInComponentParams {
-    return DropInComponentParamsMapper().mapToParams(this, amount)
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/provider/PaymentMethodAvailabilityProvider.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/provider/PaymentMethodAvailabilityProvider.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.dropin.internal.provider
 
 import android.app.Application
-import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.components.core.CheckoutConfiguration
 import com.adyen.checkout.components.core.ComponentAvailableCallback
 import com.adyen.checkout.components.core.PaymentMethod
@@ -17,13 +16,12 @@ import com.adyen.checkout.components.core.PaymentMethodTypes
 import com.adyen.checkout.components.core.internal.AlwaysAvailablePaymentMethod
 import com.adyen.checkout.components.core.internal.NotAvailablePaymentMethod
 import com.adyen.checkout.components.core.internal.PaymentMethodAvailabilityCheck
+import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.core.AdyenLogLevel
 import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.core.internal.util.adyenLog
 import com.adyen.checkout.core.internal.util.runCompileOnly
-import com.adyen.checkout.dropin.internal.ui.model.DropInOverrideParamsFactory
 import com.adyen.checkout.googlepay.internal.provider.GooglePayComponentProvider
-import com.adyen.checkout.sessions.core.internal.data.model.SessionDetails
 import com.adyen.checkout.wechatpay.WeChatPayProvider
 
 @Suppress("LongParameterList")
@@ -31,8 +29,7 @@ internal fun checkPaymentMethodAvailability(
     application: Application,
     paymentMethod: PaymentMethod,
     checkoutConfiguration: CheckoutConfiguration,
-    overrideAmount: Amount?,
-    sessionDetails: SessionDetails?,
+    dropInOverrideParams: DropInOverrideParams,
     callback: ComponentAvailableCallback,
 ) {
     try {
@@ -42,7 +39,7 @@ internal fun checkPaymentMethodAvailability(
 
         val type = paymentMethod.type ?: throw CheckoutException("PaymentMethod type is null")
 
-        val availabilityCheck = getPaymentMethodAvailabilityCheck(type, overrideAmount, sessionDetails)
+        val availabilityCheck = getPaymentMethodAvailabilityCheck(type, dropInOverrideParams)
 
         availabilityCheck.isAvailable(application, paymentMethod, checkoutConfiguration, callback)
     } catch (e: CheckoutException) {
@@ -58,13 +55,11 @@ internal fun checkPaymentMethodAvailability(
  */
 private fun getPaymentMethodAvailabilityCheck(
     paymentMethodType: String,
-    overrideAmount: Amount?,
-    sessionDetails: SessionDetails?,
+    dropInOverrideParams: DropInOverrideParams,
 ): PaymentMethodAvailabilityCheck<*> {
     val availabilityCheck = when (paymentMethodType) {
         PaymentMethodTypes.GOOGLE_PAY,
         PaymentMethodTypes.GOOGLE_PAY_LEGACY -> runCompileOnly {
-            val dropInOverrideParams = DropInOverrideParamsFactory.create(overrideAmount, sessionDetails)
             GooglePayComponentProvider(dropInOverrideParams)
         }
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/ActionComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/ActionComponentDialogFragment.kt
@@ -34,7 +34,6 @@ import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.core.internal.util.adyenLog
 import com.adyen.checkout.dropin.R
 import com.adyen.checkout.dropin.databinding.FragmentGenericActionComponentBinding
-import com.adyen.checkout.dropin.internal.ui.model.DropInOverrideParamsFactory
 import com.adyen.checkout.dropin.internal.util.arguments
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import kotlinx.coroutines.flow.launchIn
@@ -94,10 +93,7 @@ internal class ActionComponentDialogFragment :
         binding.header.isVisible = false
 
         try {
-            val dropInOverrideParams = DropInOverrideParamsFactory.create(
-                amount = dropInViewModel.amount,
-                sessionDetails = dropInViewModel.sessionDetails,
-            )
+            val dropInOverrideParams = dropInViewModel.getDropInOverrideParams()
             actionComponent = GenericActionComponentProvider(dropInOverrideParams).get(
                 fragment = this,
                 checkoutConfiguration = checkoutConfiguration,

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/ActionComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/ActionComponentDialogFragment.kt
@@ -27,7 +27,6 @@ import com.adyen.checkout.components.core.ActionComponentData
 import com.adyen.checkout.components.core.CheckoutConfiguration
 import com.adyen.checkout.components.core.ComponentError
 import com.adyen.checkout.components.core.action.Action
-import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.core.AdyenLogLevel
 import com.adyen.checkout.core.PermissionHandlerCallback
 import com.adyen.checkout.core.exception.CancellationException
@@ -35,6 +34,7 @@ import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.core.internal.util.adyenLog
 import com.adyen.checkout.dropin.R
 import com.adyen.checkout.dropin.databinding.FragmentGenericActionComponentBinding
+import com.adyen.checkout.dropin.internal.ui.model.DropInOverrideParamsFactory
 import com.adyen.checkout.dropin.internal.util.arguments
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import kotlinx.coroutines.flow.launchIn
@@ -94,7 +94,11 @@ internal class ActionComponentDialogFragment :
         binding.header.isVisible = false
 
         try {
-            actionComponent = GenericActionComponentProvider(DropInOverrideParams(dropInViewModel.amount)).get(
+            val dropInOverrideParams = DropInOverrideParamsFactory.create(
+                amount = dropInViewModel.amount,
+                sessionDetails = dropInViewModel.sessionDetails,
+            )
+            actionComponent = GenericActionComponentProvider(dropInOverrideParams).get(
                 fragment = this,
                 checkoutConfiguration = checkoutConfiguration,
                 callback = this,

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/BaseComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/BaseComponentDialogFragment.kt
@@ -107,9 +107,8 @@ internal abstract class BaseComponentDialogFragment :
                     fragment = this,
                     storedPaymentMethod = storedPaymentMethod,
                     checkoutConfiguration = dropInViewModel.checkoutConfiguration,
-                    amount = dropInViewModel.amount,
+                    dropInOverrideParams = dropInViewModel.getDropInOverrideParams(),
                     componentCallback = this,
-                    sessionDetails = dropInViewModel.sessionDetails,
                     analyticsRepository = dropInViewModel.analyticsRepository,
                     onRedirect = protocol::onRedirect,
                 )
@@ -117,9 +116,8 @@ internal abstract class BaseComponentDialogFragment :
                 getComponentFor(
                     fragment = this,
                     paymentMethod = paymentMethod,
-                    sessionDetails = dropInViewModel.sessionDetails,
                     checkoutConfiguration = dropInViewModel.checkoutConfiguration,
-                    amount = dropInViewModel.amount,
+                    dropInOverrideParams = dropInViewModel.getDropInOverrideParams(),
                     componentCallback = this,
                     analyticsRepository = dropInViewModel.analyticsRepository,
                     onRedirect = protocol::onRedirect,

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInActivity.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInActivity.kt
@@ -177,7 +177,7 @@ internal class DropInActivity :
 
         // We need to get the Locale from sharedPrefs because attachBaseContext is called before onCreate, so we don't
         // have the Config object yet.
-        val locale = DropInPrefs.getShopperLocale(baseContext)
+        val locale = DropInPrefs.getShopperLocale(baseContext) ?: return baseContext
         return baseContext.createLocalizedContext(locale)
     }
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInActivity.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInActivity.kt
@@ -172,6 +172,7 @@ internal class DropInActivity :
             getFragmentByTag(GIFT_CARD_PAYMENT_CONFIRMATION_FRAGMENT_TAG) == null
     }
 
+    @Suppress("ReturnCount")
     private fun createLocalizedContext(baseContext: Context?): Context? {
         if (baseContext == null) return null
 
@@ -218,7 +219,7 @@ internal class DropInActivity :
             context = this,
             connection = serviceConnection,
             merchantService = dropInViewModel.serviceComponentName,
-            additionalData = dropInViewModel.dropInComponentParams.additionalDataForDropInService,
+            additionalData = dropInViewModel.dropInParams.additionalDataForDropInService,
         )
         if (bound) {
             serviceBound = true

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInSavedStateHandleContainer.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInSavedStateHandleContainer.kt
@@ -31,7 +31,6 @@ internal class DropInSavedStateHandleContainer(
 
     var checkoutConfiguration: CheckoutConfiguration? by SavedStateHandleProperty(CHECKOUT_CONFIGURATION_KEY)
     var serviceComponentName: ComponentName? by SavedStateHandleProperty(DROP_IN_SERVICE_KEY)
-    var amount: Amount? by SavedStateHandleProperty(AMOUNT)
     var sessionDetails: SessionDetails? by SavedStateHandleProperty(SESSION_KEY)
     var isSessionsFlowTakenOver: Boolean? by SavedStateHandleProperty(IS_SESSIONS_FLOW_TAKEN_OVER_KEY)
     var paymentMethodsApiResponse: PaymentMethodsApiResponse? by SavedStateHandleProperty(PAYMENT_METHODS_RESPONSE_KEY)
@@ -53,7 +52,6 @@ internal object DropInBundleHandler {
             putExtra(PAYMENT_METHODS_RESPONSE_KEY, paymentMethodsApiResponse)
             putExtra(CHECKOUT_CONFIGURATION_KEY, checkoutConfiguration)
             putExtra(DROP_IN_SERVICE_KEY, service)
-            putExtra(AMOUNT, checkoutConfiguration.amount)
         }
     }
 
@@ -71,7 +69,6 @@ internal object DropInBundleHandler {
         )
         intent.apply {
             putExtra(SESSION_KEY, checkoutSession.sessionSetupResponse.mapToDetails())
-            putExtra(AMOUNT, checkoutSession.sessionSetupResponse.amount)
         }
     }
 
@@ -101,4 +98,3 @@ private const val IS_WAITING_FOR_RESULT_KEY = "IS_WAITING_FOR_RESULT_KEY"
 private const val CACHED_GIFT_CARD = "CACHED_GIFT_CARD"
 private const val CURRENT_ORDER = "CURRENT_ORDER"
 private const val PARTIAL_PAYMENT_AMOUNT = "PARTIAL_PAYMENT_AMOUNT"
-private const val AMOUNT = "AMOUNT"

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModel.kt
@@ -52,6 +52,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import java.util.Locale
 
 @Suppress("TooManyFunctions")
 internal class DropInViewModel(

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModel.kt
@@ -26,16 +26,17 @@ import com.adyen.checkout.components.core.PaymentMethodsApiResponse
 import com.adyen.checkout.components.core.StoredPaymentMethod
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.data.api.OrderStatusRepository
+import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.util.bufferedChannel
 import com.adyen.checkout.components.core.paymentmethod.GiftCardPaymentMethod
 import com.adyen.checkout.core.AdyenLogLevel
 import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.core.internal.util.adyenLog
 import com.adyen.checkout.dropin.R
-import com.adyen.checkout.dropin.internal.provider.mapToParams
 import com.adyen.checkout.dropin.internal.ui.model.DropInActivityEvent
-import com.adyen.checkout.dropin.internal.ui.model.DropInComponentParams
 import com.adyen.checkout.dropin.internal.ui.model.DropInDestination
+import com.adyen.checkout.dropin.internal.ui.model.DropInOverrideParamsFactory
+import com.adyen.checkout.dropin.internal.ui.model.DropInParams
 import com.adyen.checkout.dropin.internal.ui.model.GiftCardPaymentConfirmationData
 import com.adyen.checkout.dropin.internal.ui.model.OrderModel
 import com.adyen.checkout.dropin.internal.util.checkCompileOnly
@@ -52,32 +53,34 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
-import java.util.Locale
 
 @Suppress("TooManyFunctions")
 internal class DropInViewModel(
     private val bundleHandler: DropInSavedStateHandleContainer,
     private val orderStatusRepository: OrderStatusRepository,
     internal val analyticsRepository: AnalyticsRepository,
+    private val initialDropInParams: DropInParams,
     private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ViewModel() {
 
     private val eventChannel: Channel<DropInActivityEvent> = bufferedChannel()
     internal val eventsFlow = eventChannel.receiveAsFlow()
 
+    // this should only be used when initializing components, for drop-in related configurations use dropInParams
     val checkoutConfiguration: CheckoutConfiguration = requireNotNull(bundleHandler.checkoutConfiguration)
 
-    val dropInComponentParams: DropInComponentParams get() = checkoutConfiguration.mapToParams(amount)
+    val dropInParams: DropInParams
+        get() {
+            if (overrideAmount == null) return initialDropInParams
+            return initialDropInParams.copy(amount = overrideAmount)
+        }
+
+    // this is needed for partial payments, the amount has to be updated manually to override the initial amount
+    private var overrideAmount: Amount? = null
 
     val serviceComponentName: ComponentName = requireNotNull(bundleHandler.serviceComponentName)
 
-    var amount: Amount?
-        get() = bundleHandler.amount
-        private set(value) {
-            bundleHandler.amount = value
-        }
-
-    internal var sessionDetails: SessionDetails?
+    private var sessionDetails: SessionDetails?
         get() = bundleHandler.sessionDetails
         private set(value) {
             bundleHandler.sessionDetails = value
@@ -135,7 +138,7 @@ internal class DropInViewModel(
 
     fun shouldShowPreselectedStored(): Boolean {
         return getStoredPaymentMethods().any { it.isStoredPaymentSupported() } &&
-            dropInComponentParams.showPreselectedStoredPaymentMethod
+            dropInParams.showPreselectedStoredPaymentMethod
     }
 
     fun getPreselectedStoredPaymentMethod(): StoredPaymentMethod {
@@ -149,7 +152,7 @@ internal class DropInViewModel(
     }
 
     fun shouldSkipToSinglePaymentMethod(): Boolean {
-        if (!dropInComponentParams.skipListWhenSinglePaymentMethod) return false
+        if (!dropInParams.skipListWhenSinglePaymentMethod) return false
 
         val noStored = getStoredPaymentMethods().isEmpty()
         val singlePm = getPaymentMethods().size == 1
@@ -166,8 +169,19 @@ internal class DropInViewModel(
         return noStored && singlePm && paymentMethodHasComponent
     }
 
-    private fun getInitialAmount(): Amount? {
-        return sessionDetails?.amount ?: checkoutConfiguration.amount
+    /**
+     * @return A class needed to initialize components inside drop-in.
+     */
+    fun getDropInOverrideParams(): DropInOverrideParams {
+        val amount = dropInParams.amount
+        return DropInOverrideParamsFactory.create(
+            amount = amount,
+            // when creating a component, the sessions amount has priority over the drop-in amount
+            // but after a partial payment is successful the sessions amount is not updated to the remaining amount
+            // this is due to the backend not returning the updated amount value in the sessions setup call
+            // therefore we modify the amount ourselves here before passing it to the components
+            sessionDetails = sessionDetails?.copy(amount = amount),
+        )
     }
 
     fun onCreated() {
@@ -184,8 +198,8 @@ internal class DropInViewModel(
 
         val event = DropInActivityEvent.SessionServiceConnected(
             sessionModel = sessionModel,
-            clientKey = dropInComponentParams.clientKey,
-            environment = dropInComponentParams.environment,
+            clientKey = dropInParams.clientKey,
+            environment = dropInParams.environment,
             isFlowTakenOver = isSessionsFlowTakenOver,
         )
         sendEvent(event)
@@ -247,7 +261,7 @@ internal class DropInViewModel(
         val giftCardBalanceResult = GiftCardBalanceUtils.checkBalance(
             balance = balanceResult.balance,
             transactionLimit = balanceResult.transactionLimit,
-            amountToBePaid = amount,
+            amountToBePaid = dropInParams.amount,
         )
         val cachedGiftCardComponentState =
             cachedGiftCardComponentState ?: throw CheckoutException("Failed to retrieved cached gift card object")
@@ -303,7 +317,7 @@ internal class DropInViewModel(
         return GiftCardPaymentConfirmationData(
             amountPaid = giftCardBalanceStatus.amountPaid,
             remainingBalance = giftCardBalanceStatus.remainingBalance,
-            shopperLocale = dropInComponentParams.shopperLocale,
+            shopperLocale = dropInParams.shopperLocale,
             brand = giftCardComponentState.data.paymentMethod?.brand.orEmpty(),
             lastFourDigits = giftCardComponentState.lastFourDigits.orEmpty(),
         )
@@ -322,14 +336,13 @@ internal class DropInViewModel(
         val orderModel = getOrderDetails(orderResponse)
         if (orderModel == null) {
             currentOrder = null
-            amount = getInitialAmount()
-            adyenLog(AdyenLogLevel.DEBUG) { "handleOrderResponse - Amount reverted: $amount" }
+            overrideAmount = null
+            adyenLog(AdyenLogLevel.DEBUG) { "handleOrderResponse - Amount reverted: ${dropInParams.amount}" }
             adyenLog(AdyenLogLevel.DEBUG) { "handleOrderResponse - Order cancelled" }
         } else {
             currentOrder = orderModel
-            amount = orderModel.remainingAmount
-            sessionDetails = sessionDetails?.copy(amount = orderModel.remainingAmount)
-            adyenLog(AdyenLogLevel.DEBUG) { "handleOrderResponse - New amount set: $amount" }
+            overrideAmount = orderModel.remainingAmount
+            adyenLog(AdyenLogLevel.DEBUG) { "handleOrderResponse - New amount set: ${dropInParams.amount}" }
             adyenLog(AdyenLogLevel.DEBUG) { "handleOrderResponse - Order cached" }
         }
     }
@@ -342,9 +355,9 @@ internal class DropInViewModel(
                 adyenLog(AdyenLogLevel.DEBUG) { "Payment amount already set: $existingAmount" }
             }
 
-            amount != null -> {
-                paymentComponentState.data.amount = amount
-                adyenLog(AdyenLogLevel.DEBUG) { "Payment amount set: $amount" }
+            dropInParams.amount != null -> {
+                paymentComponentState.data.amount = dropInParams.amount
+                adyenLog(AdyenLogLevel.DEBUG) { "Payment amount set: ${dropInParams.amount}" }
             }
 
             else -> {
@@ -391,7 +404,7 @@ internal class DropInViewModel(
     private suspend fun getOrderDetails(orderResponse: OrderResponse?): OrderModel? {
         if (orderResponse == null) return null
 
-        return orderStatusRepository.getOrderStatus(dropInComponentParams.clientKey, orderResponse.orderData)
+        return orderStatusRepository.getOrderStatus(dropInParams.clientKey, orderResponse.orderData)
             .fold(
                 onSuccess = { statusResponse ->
                     OrderModel(

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModelFactory.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModelFactory.kt
@@ -12,7 +12,6 @@ import androidx.activity.ComponentActivity
 import androidx.lifecycle.AbstractSavedStateViewModelFactory
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.components.core.CheckoutConfiguration
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsMapper
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepositoryData
@@ -21,57 +20,70 @@ import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepo
 import com.adyen.checkout.components.core.internal.data.api.OrderStatusRepository
 import com.adyen.checkout.components.core.internal.data.api.OrderStatusService
 import com.adyen.checkout.components.core.internal.data.model.AnalyticsSource
-import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
 import com.adyen.checkout.components.core.internal.util.screenWidthPixels
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
-import com.adyen.checkout.core.internal.util.LocaleUtil
-import com.adyen.checkout.dropin.getDropInConfiguration
+import com.adyen.checkout.core.internal.util.LocaleProvider
+import com.adyen.checkout.dropin.internal.ui.model.DropInParams
+import com.adyen.checkout.dropin.internal.ui.model.DropInParamsMapper
 import com.adyen.checkout.dropin.internal.ui.model.DropInPaymentMethodInformation
 import com.adyen.checkout.dropin.internal.ui.model.overrideInformation
+import com.adyen.checkout.sessions.core.internal.data.model.SessionDetails
 import java.util.Locale
 
 internal class DropInViewModelFactory(
-    activity: ComponentActivity
+    activity: ComponentActivity,
+    localeProvider: LocaleProvider = LocaleProvider(),
 ) : AbstractSavedStateViewModelFactory(activity, activity.intent.extras) {
 
     private val packageName: String = activity.packageName
     private val screenWidth: Int = activity.screenWidthPixels
-    private val deviceLocale: Locale = LocaleUtil.getLocale(activity)
+    private val deviceLocale: Locale = localeProvider.getLocale(activity)
 
     override fun <T : ViewModel> create(key: String, modelClass: Class<T>, handle: SavedStateHandle): T {
         val bundleHandler = DropInSavedStateHandleContainer(handle)
 
-        val checkoutConfiguration: CheckoutConfiguration = requireNotNull(bundleHandler.checkoutConfiguration)
-        val overriddenPaymentMethodInformation =
-            checkoutConfiguration.getDropInConfiguration()?.overriddenPaymentMethodInformation.orEmpty()
-        bundleHandler.overridePaymentMethodInformation(overriddenPaymentMethodInformation)
+        val dropInParams = getDropInParams(
+            checkoutConfiguration = requireNotNull(bundleHandler.checkoutConfiguration),
+            sessionDetails = bundleHandler.sessionDetails,
+        )
 
-        val amount: Amount? = bundleHandler.amount
+        bundleHandler.overridePaymentMethodInformation(dropInParams.overriddenPaymentMethodInformation)
+
         val paymentMethods = bundleHandler.paymentMethodsApiResponse?.paymentMethods?.mapNotNull { it.type }.orEmpty()
-        val session = bundleHandler.sessionDetails
 
-        val httpClient = HttpClientFactory.getHttpClient(checkoutConfiguration.environment)
+        val httpClient = HttpClientFactory.getHttpClient(dropInParams.environment)
         val orderStatusRepository = OrderStatusRepository(OrderStatusService(httpClient))
         val analyticsRepository = DefaultAnalyticsRepository(
             analyticsRepositoryData = AnalyticsRepositoryData(
-                level = AnalyticsParams(checkoutConfiguration.analyticsConfiguration).level,
+                level = dropInParams.analyticsParams.level,
                 packageName = packageName,
-                locale = checkoutConfiguration.shopperLocale ?: deviceLocale,
+                locale = dropInParams.shopperLocale,
                 source = AnalyticsSource.DropIn(),
-                clientKey = checkoutConfiguration.clientKey,
-                amount = amount,
+                clientKey = dropInParams.clientKey,
+                amount = dropInParams.amount,
                 screenWidth = screenWidth,
                 paymentMethods = paymentMethods,
-                sessionId = session?.id,
+                sessionId = bundleHandler.sessionDetails?.id,
             ),
             analyticsService = AnalyticsService(
-                HttpClientFactory.getAnalyticsHttpClient(checkoutConfiguration.environment),
+                httpClient = HttpClientFactory.getAnalyticsHttpClient(dropInParams.environment),
             ),
             analyticsMapper = AnalyticsMapper(),
         )
 
         @Suppress("UNCHECKED_CAST")
-        return DropInViewModel(bundleHandler, orderStatusRepository, analyticsRepository) as T
+        return DropInViewModel(bundleHandler, orderStatusRepository, analyticsRepository, dropInParams) as T
+    }
+
+    private fun getDropInParams(
+        checkoutConfiguration: CheckoutConfiguration,
+        sessionDetails: SessionDetails?
+    ): DropInParams {
+        return DropInParamsMapper().mapToParams(
+            checkoutConfiguration = checkoutConfiguration,
+            deviceLocale = deviceLocale,
+            sessionDetails = sessionDetails,
+        )
     }
 }
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModelFactory.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModelFactory.kt
@@ -24,9 +24,11 @@ import com.adyen.checkout.components.core.internal.data.model.AnalyticsSource
 import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
 import com.adyen.checkout.components.core.internal.util.screenWidthPixels
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
+import com.adyen.checkout.core.internal.util.LocaleUtil
 import com.adyen.checkout.dropin.getDropInConfiguration
 import com.adyen.checkout.dropin.internal.ui.model.DropInPaymentMethodInformation
 import com.adyen.checkout.dropin.internal.ui.model.overrideInformation
+import java.util.Locale
 
 internal class DropInViewModelFactory(
     activity: ComponentActivity
@@ -34,6 +36,7 @@ internal class DropInViewModelFactory(
 
     private val packageName: String = activity.packageName
     private val screenWidth: Int = activity.screenWidthPixels
+    private val deviceLocale: Locale = LocaleUtil.getLocale(activity)
 
     override fun <T : ViewModel> create(key: String, modelClass: Class<T>, handle: SavedStateHandle): T {
         val bundleHandler = DropInSavedStateHandleContainer(handle)
@@ -53,7 +56,7 @@ internal class DropInViewModelFactory(
             analyticsRepositoryData = AnalyticsRepositoryData(
                 level = AnalyticsParams(checkoutConfiguration.analyticsConfiguration).level,
                 packageName = packageName,
-                locale = checkoutConfiguration.shopperLocale,
+                locale = checkoutConfiguration.shopperLocale ?: deviceLocale,
                 source = AnalyticsSource.DropIn(),
                 clientKey = checkoutConfiguration.clientKey,
                 amount = amount,

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/GiftCardComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/GiftCardComponentDialogFragment.kt
@@ -71,9 +71,8 @@ internal class GiftCardComponentDialogFragment : DropInBottomSheetDialogFragment
                 fragment = this,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = dropInViewModel.checkoutConfiguration,
-                amount = dropInViewModel.amount,
+                dropInOverrideParams = dropInViewModel.getDropInOverrideParams(),
                 componentCallback = this,
-                sessionDetails = dropInViewModel.sessionDetails,
                 analyticsRepository = dropInViewModel.analyticsRepository,
                 onRedirect = protocol::onRedirect,
             ) as GiftCardComponent

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/GiftCardPaymentConfirmationDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/GiftCardPaymentConfirmationDialogFragment.kt
@@ -80,7 +80,7 @@ internal class GiftCardPaymentConfirmationDialogFragment : DropInBottomSheetDial
                 amount = it.amount,
                 transactionLimit = it.transactionLimit,
                 shopperLocale = giftCardPaymentConfirmationData.shopperLocale,
-                environment = dropInViewModel.dropInComponentParams.environment,
+                environment = dropInViewModel.dropInParams.environment,
             )
         }
         val currentPaymentMethod = GiftCardPaymentMethodModel(
@@ -89,7 +89,7 @@ internal class GiftCardPaymentConfirmationDialogFragment : DropInBottomSheetDial
             amount = null,
             transactionLimit = null,
             shopperLocale = null,
-            environment = dropInViewModel.dropInComponentParams.environment,
+            environment = dropInViewModel.dropInParams.environment,
         )
 
         val paymentMethods = alreadyPaidMethods + currentPaymentMethod

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/GooglePayComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/GooglePayComponentDialogFragment.kt
@@ -74,9 +74,8 @@ internal class GooglePayComponentDialogFragment :
                 fragment = this,
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = dropInViewModel.checkoutConfiguration,
-                amount = dropInViewModel.amount,
+                dropInOverrideParams = dropInViewModel.getDropInOverrideParams(),
                 componentCallback = this,
-                sessionDetails = dropInViewModel.sessionDetails,
                 analyticsRepository = dropInViewModel.analyticsRepository,
                 onRedirect = protocol::onRedirect,
             ) as GooglePayComponent

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodListDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodListDialogFragment.kt
@@ -65,9 +65,8 @@ internal class PaymentMethodListDialogFragment :
                 storedPaymentMethods = dropInViewModel.getStoredPaymentMethods(),
                 order = dropInViewModel.currentOrder,
                 checkoutConfiguration = dropInViewModel.checkoutConfiguration,
-                dropInComponentParams = dropInViewModel.dropInComponentParams,
-                overrideAmount = dropInViewModel.amount,
-                sessionDetails = dropInViewModel.sessionDetails,
+                dropInParams = dropInViewModel.dropInParams,
+                dropInOverrideParams = dropInViewModel.getDropInOverrideParams(),
             )
         }
         _binding = FragmentPaymentMethodsListBinding.inflate(inflater, container, false)
@@ -157,9 +156,8 @@ internal class PaymentMethodListDialogFragment :
             fragment = this,
             storedPaymentMethod = storedPaymentMethod,
             checkoutConfiguration = dropInViewModel.checkoutConfiguration,
-            amount = dropInViewModel.amount,
+            dropInOverrideParams = dropInViewModel.getDropInOverrideParams(),
             componentCallback = paymentMethodsListViewModel,
-            sessionDetails = dropInViewModel.sessionDetails,
             analyticsRepository = dropInViewModel.analyticsRepository,
             onRedirect = protocol::onRedirect,
         )
@@ -179,8 +177,8 @@ internal class PaymentMethodListDialogFragment :
             }
             .setPositiveButton(
                 PayButtonFormatter.getPayButtonText(
-                    amount = dropInViewModel.amount,
-                    locale = dropInViewModel.dropInComponentParams.shopperLocale,
+                    amount = dropInViewModel.dropInParams.amount,
+                    locale = dropInViewModel.dropInParams.shopperLocale,
                     localizedContext = requireContext(),
                 ),
             ) { dialog, _ ->

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodsListViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodsListViewModel.kt
@@ -28,6 +28,7 @@ import com.adyen.checkout.core.internal.util.adyenLog
 import com.adyen.checkout.dropin.R
 import com.adyen.checkout.dropin.internal.provider.checkPaymentMethodAvailability
 import com.adyen.checkout.dropin.internal.ui.model.DropInComponentParams
+import com.adyen.checkout.dropin.internal.ui.model.DropInOverrideParamsFactory
 import com.adyen.checkout.dropin.internal.ui.model.GiftCardPaymentMethodModel
 import com.adyen.checkout.dropin.internal.ui.model.OrderModel
 import com.adyen.checkout.dropin.internal.ui.model.PaymentMethodHeader
@@ -38,7 +39,6 @@ import com.adyen.checkout.dropin.internal.ui.model.StoredPaymentMethodModel
 import com.adyen.checkout.dropin.internal.util.isStoredPaymentSupported
 import com.adyen.checkout.dropin.internal.util.mapStoredModel
 import com.adyen.checkout.sessions.core.internal.data.model.SessionDetails
-import com.adyen.checkout.sessions.core.internal.data.model.mapToParams
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -78,7 +78,6 @@ internal class PaymentMethodsListViewModel(
     }
 
     private fun setupPaymentMethods(paymentMethods: List<PaymentMethod>) {
-        val sessionParams = sessionDetails?.mapToParams(checkoutConfiguration.amount)
         paymentMethods.forEach { paymentMethod ->
             val type = requireNotNull(paymentMethod.type) { "PaymentMethod type is null" }
 
@@ -90,7 +89,7 @@ internal class PaymentMethodsListViewModel(
                         paymentMethod = paymentMethod,
                         checkoutConfiguration = checkoutConfiguration,
                         overrideAmount = overrideAmount,
-                        sessionParams = sessionParams,
+                        sessionDetails = sessionDetails,
                         callback = this,
                     )
                 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodsListViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodsListViewModel.kt
@@ -11,7 +11,6 @@ package com.adyen.checkout.dropin.internal.ui
 import android.app.Application
 import androidx.lifecycle.ViewModel
 import com.adyen.checkout.components.core.ActionComponentData
-import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.components.core.CheckoutConfiguration
 import com.adyen.checkout.components.core.ComponentAvailableCallback
 import com.adyen.checkout.components.core.ComponentCallback
@@ -21,13 +20,14 @@ import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.PaymentMethodTypes
 import com.adyen.checkout.components.core.StoredPaymentMethod
 import com.adyen.checkout.components.core.internal.data.model.OrderPaymentMethod
+import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.util.CurrencyUtils
 import com.adyen.checkout.components.core.internal.util.bufferedChannel
 import com.adyen.checkout.core.AdyenLogLevel
 import com.adyen.checkout.core.internal.util.adyenLog
 import com.adyen.checkout.dropin.R
 import com.adyen.checkout.dropin.internal.provider.checkPaymentMethodAvailability
-import com.adyen.checkout.dropin.internal.ui.model.DropInComponentParams
+import com.adyen.checkout.dropin.internal.ui.model.DropInParams
 import com.adyen.checkout.dropin.internal.ui.model.GiftCardPaymentMethodModel
 import com.adyen.checkout.dropin.internal.ui.model.OrderModel
 import com.adyen.checkout.dropin.internal.ui.model.PaymentMethodHeader
@@ -37,7 +37,6 @@ import com.adyen.checkout.dropin.internal.ui.model.PaymentMethodNote
 import com.adyen.checkout.dropin.internal.ui.model.StoredPaymentMethodModel
 import com.adyen.checkout.dropin.internal.util.isStoredPaymentSupported
 import com.adyen.checkout.dropin.internal.util.mapStoredModel
-import com.adyen.checkout.sessions.core.internal.data.model.SessionDetails
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -51,9 +50,8 @@ internal class PaymentMethodsListViewModel(
     storedPaymentMethods: List<StoredPaymentMethod>,
     private val order: OrderModel?,
     private val checkoutConfiguration: CheckoutConfiguration,
-    private val dropInComponentParams: DropInComponentParams,
-    private val overrideAmount: Amount?,
-    private val sessionDetails: SessionDetails?,
+    private val dropInParams: DropInParams,
+    private val dropInOverrideParams: DropInOverrideParams,
 ) : ViewModel(), ComponentAvailableCallback, ComponentCallback<PaymentComponentState<*>> {
 
     private val _paymentMethodsFlow = MutableStateFlow<List<PaymentMethodListItem>>(emptyList())
@@ -87,8 +85,7 @@ internal class PaymentMethodsListViewModel(
                         application = application,
                         paymentMethod = paymentMethod,
                         checkoutConfiguration = checkoutConfiguration,
-                        overrideAmount = overrideAmount,
-                        sessionDetails = sessionDetails,
+                        dropInOverrideParams = dropInOverrideParams,
                         callback = this,
                     )
                 }
@@ -130,7 +127,7 @@ internal class PaymentMethodsListViewModel(
             }
             // payment notes
             order?.remainingAmount?.let { remainingAmount ->
-                val value = CurrencyUtils.formatAmount(remainingAmount, dropInComponentParams.shopperLocale)
+                val value = CurrencyUtils.formatAmount(remainingAmount, dropInParams.shopperLocale)
                 add(
                     PaymentMethodNote(application.getString(R.string.checkout_giftcard_pay_remaining_amount, value)),
                 )
@@ -215,8 +212,8 @@ internal class PaymentMethodsListViewModel(
         mapNotNull { storedPaymentMethod ->
             if (storedPaymentMethod.isStoredPaymentSupported()) {
                 storedPaymentMethod.mapStoredModel(
-                    dropInComponentParams.isRemovingStoredPaymentMethodsEnabled,
-                    dropInComponentParams.environment,
+                    dropInParams.isRemovingStoredPaymentMethodsEnabled,
+                    dropInParams.environment,
                 )
             } else {
                 null
@@ -237,7 +234,7 @@ internal class PaymentMethodsListViewModel(
             name = name.orEmpty(),
             icon = icon.orEmpty(),
             drawIconBorder = drawIconBorder,
-            environment = dropInComponentParams.environment,
+            environment = dropInParams.environment,
         )
     }
 
@@ -248,8 +245,8 @@ internal class PaymentMethodsListViewModel(
                 lastFour = it.lastFour,
                 amount = it.amount,
                 transactionLimit = it.transactionLimit,
-                shopperLocale = dropInComponentParams.shopperLocale,
-                environment = dropInComponentParams.environment,
+                shopperLocale = dropInParams.shopperLocale,
+                environment = dropInParams.environment,
             )
         }
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodsListViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodsListViewModel.kt
@@ -28,7 +28,6 @@ import com.adyen.checkout.core.internal.util.adyenLog
 import com.adyen.checkout.dropin.R
 import com.adyen.checkout.dropin.internal.provider.checkPaymentMethodAvailability
 import com.adyen.checkout.dropin.internal.ui.model.DropInComponentParams
-import com.adyen.checkout.dropin.internal.ui.model.DropInOverrideParamsFactory
 import com.adyen.checkout.dropin.internal.ui.model.GiftCardPaymentMethodModel
 import com.adyen.checkout.dropin.internal.ui.model.OrderModel
 import com.adyen.checkout.dropin.internal.ui.model.PaymentMethodHeader
@@ -131,7 +130,7 @@ internal class PaymentMethodsListViewModel(
             }
             // payment notes
             order?.remainingAmount?.let { remainingAmount ->
-                val value = CurrencyUtils.formatAmount(remainingAmount, checkoutConfiguration.shopperLocale)
+                val value = CurrencyUtils.formatAmount(remainingAmount, dropInComponentParams.shopperLocale)
                 add(
                     PaymentMethodNote(application.getString(R.string.checkout_giftcard_pay_remaining_amount, value)),
                 )
@@ -217,7 +216,7 @@ internal class PaymentMethodsListViewModel(
             if (storedPaymentMethod.isStoredPaymentSupported()) {
                 storedPaymentMethod.mapStoredModel(
                     dropInComponentParams.isRemovingStoredPaymentMethodsEnabled,
-                    checkoutConfiguration.environment,
+                    dropInComponentParams.environment,
                 )
             } else {
                 null
@@ -238,7 +237,7 @@ internal class PaymentMethodsListViewModel(
             name = name.orEmpty(),
             icon = icon.orEmpty(),
             drawIconBorder = drawIconBorder,
-            environment = checkoutConfiguration.environment,
+            environment = dropInComponentParams.environment,
         )
     }
 
@@ -249,8 +248,8 @@ internal class PaymentMethodsListViewModel(
                 lastFour = it.lastFour,
                 amount = it.amount,
                 transactionLimit = it.transactionLimit,
-                shopperLocale = checkoutConfiguration.shopperLocale,
-                environment = checkoutConfiguration.environment,
+                shopperLocale = dropInComponentParams.shopperLocale,
+                environment = dropInComponentParams.environment,
             )
         }
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PreselectedStoredPaymentMethodFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PreselectedStoredPaymentMethodFragment.kt
@@ -43,8 +43,7 @@ internal class PreselectedStoredPaymentMethodFragment : DropInBottomSheetDialogF
     private val storedPaymentViewModel: PreselectedStoredPaymentViewModel by viewModelsFactory {
         PreselectedStoredPaymentViewModel(
             storedPaymentMethod,
-            dropInViewModel.amount,
-            dropInViewModel.dropInComponentParams,
+            dropInViewModel.dropInParams,
         )
     }
 
@@ -78,9 +77,8 @@ internal class PreselectedStoredPaymentMethodFragment : DropInBottomSheetDialogF
                 fragment = this,
                 storedPaymentMethod = storedPaymentMethod,
                 checkoutConfiguration = dropInViewModel.checkoutConfiguration,
-                amount = dropInViewModel.amount,
+                dropInOverrideParams = dropInViewModel.getDropInOverrideParams(),
                 componentCallback = storedPaymentViewModel,
-                sessionDetails = dropInViewModel.sessionDetails,
                 analyticsRepository = dropInViewModel.analyticsRepository,
                 onRedirect = protocol::onRedirect,
             )
@@ -93,7 +91,7 @@ internal class PreselectedStoredPaymentMethodFragment : DropInBottomSheetDialogF
         binding.paymentMethodsListHeader.paymentMethodHeaderTitle.setText(R.string.store_payment_methods_header)
 
         val isRemovingStoredPaymentMethodsEnabled =
-            dropInViewModel.dropInComponentParams.isRemovingStoredPaymentMethodsEnabled
+            dropInViewModel.dropInParams.isRemovingStoredPaymentMethodsEnabled
         binding.storedPaymentMethodItem.swipeToRevealLayout.setDragLocked(!isRemovingStoredPaymentMethodsEnabled)
         if (isRemovingStoredPaymentMethodsEnabled) {
             binding.storedPaymentMethodItem.paymentMethodItemUnderlayButton.setOnClickListener {
@@ -124,7 +122,7 @@ internal class PreselectedStoredPaymentMethodFragment : DropInBottomSheetDialogF
                 binding.storedPaymentMethodItem.textViewTitle.text =
                     requireActivity().getString(R.string.last_four_digits_format, storedPaymentMethodModel.lastFour)
                 binding.storedPaymentMethodItem.imageViewLogo.loadLogo(
-                    environment = dropInViewModel.dropInComponentParams.environment,
+                    environment = dropInViewModel.dropInParams.environment,
                     txVariant = storedPaymentMethodModel.imageId,
                 )
                 binding.storedPaymentMethodItem.textViewDetail.text =
@@ -139,7 +137,7 @@ internal class PreselectedStoredPaymentMethodFragment : DropInBottomSheetDialogF
                         storedPaymentMethodModel.lastFour,
                     )
                 binding.storedPaymentMethodItem.imageViewLogo.loadLogo(
-                    environment = dropInViewModel.dropInComponentParams.environment,
+                    environment = dropInViewModel.dropInParams.environment,
                     txVariant = storedPaymentMethodModel.imageId,
                 )
                 binding.storedPaymentMethodItem.textViewDetail.isVisible = false
@@ -151,7 +149,7 @@ internal class PreselectedStoredPaymentMethodFragment : DropInBottomSheetDialogF
                     !storedPaymentMethodModel.description.isNullOrEmpty()
                 binding.storedPaymentMethodItem.textViewDetail.text = storedPaymentMethodModel.description
                 binding.storedPaymentMethodItem.imageViewLogo.loadLogo(
-                    environment = dropInViewModel.dropInComponentParams.environment,
+                    environment = dropInViewModel.dropInParams.environment,
                     txVariant = storedPaymentMethodModel.imageId,
                 )
             }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PreselectedStoredPaymentViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PreselectedStoredPaymentViewModel.kt
@@ -18,7 +18,7 @@ import com.adyen.checkout.components.core.PaymentComponentState
 import com.adyen.checkout.components.core.StoredPaymentMethod
 import com.adyen.checkout.components.core.internal.util.bufferedChannel
 import com.adyen.checkout.dropin.R
-import com.adyen.checkout.dropin.internal.ui.model.DropInComponentParams
+import com.adyen.checkout.dropin.internal.ui.model.DropInParams
 import com.adyen.checkout.dropin.internal.ui.model.StoredPaymentMethodModel
 import com.adyen.checkout.dropin.internal.util.mapStoredModel
 import kotlinx.coroutines.channels.Channel
@@ -29,8 +29,7 @@ import java.util.Locale
 
 internal class PreselectedStoredPaymentViewModel(
     private val storedPaymentMethod: StoredPaymentMethod,
-    private val amount: Amount?,
-    private val dropInComponentParams: DropInComponentParams,
+    private val dropInParams: DropInParams,
 ) : ViewModel(), ComponentCallback<PaymentComponentState<*>> {
 
     private val _uiStateFlow = MutableStateFlow(getInitialUIState())
@@ -43,8 +42,8 @@ internal class PreselectedStoredPaymentViewModel(
 
     private fun getInitialUIState(): PreselectedStoredState {
         val storedPaymentMethodModel = storedPaymentMethod.mapStoredModel(
-            dropInComponentParams.isRemovingStoredPaymentMethodsEnabled,
-            dropInComponentParams.environment,
+            dropInParams.isRemovingStoredPaymentMethodsEnabled,
+            dropInParams.environment,
         )
         return PreselectedStoredState(
             storedPaymentMethodModel = storedPaymentMethodModel,
@@ -77,7 +76,7 @@ internal class PreselectedStoredPaymentViewModel(
             ButtonState.ContinueButton()
         } else {
             // component does not require user input -> treat it as a normal Pay button
-            ButtonState.PayButton(amount, dropInComponentParams.shopperLocale)
+            ButtonState.PayButton(dropInParams.amount, dropInParams.shopperLocale)
         }
     }
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/model/DropInComponentParamsMapper.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/model/DropInComponentParamsMapper.kt
@@ -12,6 +12,7 @@ import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.components.core.CheckoutConfiguration
 import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
 import com.adyen.checkout.dropin.getDropInConfiguration
+import java.util.Locale
 
 internal class DropInComponentParamsMapper {
 
@@ -21,7 +22,7 @@ internal class DropInComponentParamsMapper {
     ): DropInComponentParams {
         val dropInConfiguration = checkoutConfiguration.getDropInConfiguration()
         return DropInComponentParams(
-            shopperLocale = checkoutConfiguration.shopperLocale,
+            shopperLocale = checkoutConfiguration.shopperLocale ?: Locale.US, // TODO fix
             environment = checkoutConfiguration.environment,
             clientKey = checkoutConfiguration.clientKey,
             analyticsParams = AnalyticsParams(checkoutConfiguration.analyticsConfiguration),

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/model/DropInOverrideParamsFactory.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/model/DropInOverrideParamsFactory.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 8/2/2024.
+ */
+
+package com.adyen.checkout.dropin.internal.ui.model
+
+import com.adyen.checkout.components.core.Amount
+import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
+import com.adyen.checkout.sessions.core.internal.data.model.SessionDetails
+import com.adyen.checkout.sessions.core.internal.ui.model.SessionParamsFactory
+
+internal object DropInOverrideParamsFactory {
+    fun create(amount: Amount?, sessionDetails: SessionDetails?): DropInOverrideParams {
+        return DropInOverrideParams(
+            amount = amount,
+            sessionParams = sessionDetails?.let { SessionParamsFactory.create(sessionDetails) },
+        )
+    }
+}

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/model/DropInParams.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/model/DropInParams.kt
@@ -11,19 +11,18 @@ package com.adyen.checkout.dropin.internal.ui.model
 import android.os.Bundle
 import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
-import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
 import com.adyen.checkout.core.Environment
 import java.util.Locale
 
-internal data class DropInComponentParams(
-    override val shopperLocale: Locale,
-    override val environment: Environment,
-    override val clientKey: String,
-    override val analyticsParams: AnalyticsParams,
-    override val isCreatedByDropIn: Boolean,
-    override val amount: Amount?,
+internal data class DropInParams(
+    val shopperLocale: Locale,
+    val environment: Environment,
+    val clientKey: String,
+    val analyticsParams: AnalyticsParams,
+    val amount: Amount?,
     val showPreselectedStoredPaymentMethod: Boolean,
     val skipListWhenSinglePaymentMethod: Boolean,
     val isRemovingStoredPaymentMethodsEnabled: Boolean,
     val additionalDataForDropInService: Bundle?,
-) : ComponentParams
+    val overriddenPaymentMethodInformation: Map<String, DropInPaymentMethodInformation>,
+)

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/model/DropInParamsMapper.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/model/DropInParamsMapper.kt
@@ -8,30 +8,31 @@
 
 package com.adyen.checkout.dropin.internal.ui.model
 
-import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.components.core.CheckoutConfiguration
 import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
 import com.adyen.checkout.dropin.getDropInConfiguration
+import com.adyen.checkout.sessions.core.internal.data.model.SessionDetails
 import java.util.Locale
 
-internal class DropInComponentParamsMapper {
+internal class DropInParamsMapper {
 
     fun mapToParams(
         checkoutConfiguration: CheckoutConfiguration,
-        overrideAmount: Amount?,
-    ): DropInComponentParams {
+        deviceLocale: Locale,
+        sessionDetails: SessionDetails?,
+    ): DropInParams {
         val dropInConfiguration = checkoutConfiguration.getDropInConfiguration()
-        return DropInComponentParams(
-            shopperLocale = checkoutConfiguration.shopperLocale ?: Locale.US, // TODO fix
+        return DropInParams(
+            shopperLocale = checkoutConfiguration.shopperLocale ?: deviceLocale,
             environment = checkoutConfiguration.environment,
             clientKey = checkoutConfiguration.clientKey,
             analyticsParams = AnalyticsParams(checkoutConfiguration.analyticsConfiguration),
-            isCreatedByDropIn = true,
-            amount = overrideAmount,
+            amount = sessionDetails?.amount ?: checkoutConfiguration.amount,
             showPreselectedStoredPaymentMethod = dropInConfiguration?.showPreselectedStoredPaymentMethod ?: true,
             skipListWhenSinglePaymentMethod = dropInConfiguration?.skipListWhenSinglePaymentMethod ?: false,
             isRemovingStoredPaymentMethodsEnabled = dropInConfiguration?.isRemovingStoredPaymentMethodsEnabled ?: false,
             additionalDataForDropInService = dropInConfiguration?.additionalDataForDropInService,
+            overriddenPaymentMethodInformation = dropInConfiguration?.overriddenPaymentMethodInformation.orEmpty(),
         )
     }
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/util/DropInPrefs.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/util/DropInPrefs.kt
@@ -19,9 +19,9 @@ internal object DropInPrefs {
     private const val DROP_IN_PREFS = "drop-in-shared-prefs"
     private const val LOCALE_PREF = "drop-in-locale"
 
-    fun setShopperLocale(context: Context, shopperLocale: Locale) {
+    fun setShopperLocale(context: Context, shopperLocale: Locale?) {
         adyenLog(AdyenLogLevel.VERBOSE) { "setShopperLocale: $shopperLocale" }
-        val localeTag = LocaleUtil.toLanguageTag(shopperLocale)
+        val localeTag = shopperLocale?.let { LocaleUtil.toLanguageTag(shopperLocale) }
         adyenLog(AdyenLogLevel.DEBUG) { "Storing shopper locale tag: $localeTag" }
         return context
             .getSharedPreferences(DROP_IN_PREFS, Context.MODE_PRIVATE)
@@ -30,13 +30,13 @@ internal object DropInPrefs {
             .apply()
     }
 
-    fun getShopperLocale(context: Context): Locale {
+    fun getShopperLocale(context: Context): Locale? {
         adyenLog(AdyenLogLevel.VERBOSE) { "getShopperLocale" }
         val localeTag = context
             .getSharedPreferences(DROP_IN_PREFS, Context.MODE_PRIVATE)
             .getString(LOCALE_PREF, null)
-            .orEmpty()
-        adyenLog(AdyenLogLevel.DEBUG) { "Fetching shopper locale tag: $localeTag" }
+        adyenLog(AdyenLogLevel.DEBUG) { "Fetched shopper locale tag: $localeTag" }
+        if (localeTag == null) return null
         val locale = LocaleUtil.fromLanguageTag(localeTag)
         adyenLog(AdyenLogLevel.DEBUG) { "Parsed locale: $locale" }
         return locale

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodsListViewModelTest.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodsListViewModelTest.kt
@@ -14,11 +14,12 @@ import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.components.core.CheckoutConfiguration
 import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.StoredPaymentMethod
+import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.dropin.internal.ConfigurationProvider
 import com.adyen.checkout.dropin.internal.DataProvider
 import com.adyen.checkout.dropin.internal.Helpers.mapToPaymentMethodModelList
 import com.adyen.checkout.dropin.internal.Helpers.mapToStoredPaymentMethodsModelList
-import com.adyen.checkout.dropin.internal.provider.mapToParams
+import com.adyen.checkout.dropin.internal.ui.model.DropInParamsMapper
 import com.adyen.checkout.dropin.internal.ui.model.GiftCardPaymentMethodModel
 import com.adyen.checkout.dropin.internal.ui.model.OrderModel
 import com.adyen.checkout.dropin.internal.ui.model.PaymentMethodHeader
@@ -40,6 +41,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.whenever
+import java.util.Locale
 
 @ExtendWith(MockitoExtension::class, TestDispatcherExtension::class)
 internal class PaymentMethodsListViewModelTest(
@@ -192,8 +194,7 @@ internal class PaymentMethodsListViewModelTest(
         storedPaymentMethods = storedPaymentMethods,
         order = order,
         checkoutConfiguration = checkoutConfiguration,
-        dropInComponentParams = checkoutConfiguration.mapToParams(amount),
-        sessionDetails = null,
-        overrideAmount = amount,
+        dropInParams = DropInParamsMapper().mapToParams(checkoutConfiguration, Locale.US, null),
+        dropInOverrideParams = DropInOverrideParams(amount, null),
     )
 }

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/PreselectedStoredPaymentViewModelTest.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/PreselectedStoredPaymentViewModelTest.kt
@@ -18,7 +18,7 @@ import com.adyen.checkout.components.core.StoredPaymentMethod
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.dropin.dropIn
-import com.adyen.checkout.dropin.internal.provider.mapToParams
+import com.adyen.checkout.dropin.internal.ui.model.DropInParamsMapper
 import com.adyen.checkout.dropin.internal.ui.model.GenericStoredModel
 import com.adyen.checkout.test.TestDispatcherExtension
 import kotlinx.coroutines.test.runTest
@@ -35,8 +35,11 @@ import java.util.Locale
 @ExtendWith(MockitoExtension::class, TestDispatcherExtension::class)
 internal class PreselectedStoredPaymentViewModelTest {
     private val storedPaymentMethod = StoredPaymentMethod()
-    private val dropInComponentParams =
-        CheckoutConfiguration(Locale.US, Environment.TEST, TEST_CLIENT_KEY).mapToParams(Amount())
+    private val dropInParams = DropInParamsMapper().mapToParams(
+        checkoutConfiguration = CheckoutConfiguration(Environment.TEST, TEST_CLIENT_KEY, amount = TEST_AMOUNT),
+        deviceLocale = Locale.US,
+        sessionDetails = null,
+    )
 
     private lateinit var viewModel: PreselectedStoredPaymentViewModel
 
@@ -44,15 +47,13 @@ internal class PreselectedStoredPaymentViewModelTest {
     fun setup() {
         viewModel = PreselectedStoredPaymentViewModel(
             storedPaymentMethod,
-            TEST_AMOUNT,
-            dropInComponentParams,
+            dropInParams,
         )
     }
 
     @Test
     fun `when view model is initialized then uiStateFlow has a matching initial value`() = runTest {
-        val dropInComponentParams = CheckoutConfiguration(
-            Locale.US,
+        val checkoutConfiguration = CheckoutConfiguration(
             Environment.TEST,
             TEST_CLIENT_KEY,
         ) {
@@ -60,12 +61,16 @@ internal class PreselectedStoredPaymentViewModelTest {
                 setEnableRemovingStoredPaymentMethods(true)
             }
         }
-            .mapToParams(Amount())
+
+        val dropInParams = DropInParamsMapper().mapToParams(
+            checkoutConfiguration = checkoutConfiguration,
+            deviceLocale = Locale.US,
+            sessionDetails = null,
+        )
 
         viewModel = PreselectedStoredPaymentViewModel(
             storedPaymentMethod,
-            TEST_AMOUNT,
-            dropInComponentParams,
+            dropInParams,
         )
 
         viewModel.uiStateFlow.test {

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/model/DropInParamsMapperTest.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/model/DropInParamsMapperTest.kt
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2024 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 12/2/2024.
+ */
+
+package com.adyen.checkout.dropin.internal.ui.model
+
+import android.os.Bundle
+import com.adyen.checkout.components.core.Amount
+import com.adyen.checkout.components.core.AnalyticsConfiguration
+import com.adyen.checkout.components.core.AnalyticsLevel
+import com.adyen.checkout.components.core.CheckoutConfiguration
+import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
+import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParamsLevel
+import com.adyen.checkout.core.Environment
+import com.adyen.checkout.dropin.DropInConfiguration
+import com.adyen.checkout.dropin.dropIn
+import com.adyen.checkout.sessions.core.internal.data.model.SessionDetails
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.Locale
+
+internal class DropInParamsMapperTest {
+
+    private val dropInParamsMapper = DropInParamsMapper()
+
+    @Test
+    fun `when created without specific drop-in or checkout configurations, then params should have default values`() {
+        val configuration = createCheckoutConfiguration()
+
+        val params = dropInParamsMapper.mapToParams(configuration, DEVICE_LOCALE, null)
+
+        val expected = getDropInParams()
+
+        assertEquals(expected, params)
+    }
+
+    @Test
+    fun `when specific drop-in configurations are set then params should match these values`() {
+        val additionalData = Bundle().apply {
+            putString("key", "value")
+        }
+        val overridePaymentMethod = "TYPE" to "NAME"
+        val configuration = createCheckoutConfiguration {
+            setShowPreselectedStoredPaymentMethod(false)
+            setSkipListWhenSinglePaymentMethod(true)
+            setEnableRemovingStoredPaymentMethods(true)
+            setAdditionalDataForDropInService(additionalData)
+            overridePaymentMethodName(overridePaymentMethod.first, overridePaymentMethod.second)
+        }
+
+        val params = dropInParamsMapper.mapToParams(configuration, DEVICE_LOCALE, null)
+
+        val expectedOverriddenPaymentMethodInformation = with(overridePaymentMethod) {
+            hashMapOf(first to DropInPaymentMethodInformation(second))
+        }
+        val expected = getDropInParams(
+            showPreselectedStoredPaymentMethod = false,
+            skipListWhenSinglePaymentMethod = true,
+            isRemovingStoredPaymentMethodsEnabled = true,
+            additionalDataForDropInService = additionalData,
+            overriddenPaymentMethodInformation = expectedOverriddenPaymentMethodInformation,
+        )
+
+        assertEquals(expected, params)
+    }
+
+    @Test
+    fun `when both checkout and drop-in configurations are set then params should match checkout configuration`() {
+        val configuration = CheckoutConfiguration(
+            shopperLocale = Locale.GERMAN,
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+            amount = Amount(
+                currency = "EUR",
+                value = 49_00L,
+            ),
+            analyticsConfiguration = AnalyticsConfiguration(AnalyticsLevel.NONE),
+        ) {
+            dropIn {
+                setShopperLocale(Locale.US)
+                setAmount(Amount("USD", 12))
+                setAnalyticsConfiguration(AnalyticsConfiguration(AnalyticsLevel.ALL))
+            }
+        }
+
+        val params = dropInParamsMapper.mapToParams(configuration, DEVICE_LOCALE, null)
+
+        val expected = getDropInParams(
+            shopperLocale = Locale.GERMAN,
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+            analyticsParams = AnalyticsParams(AnalyticsParamsLevel.NONE),
+            amount = Amount(
+                currency = "EUR",
+                value = 49_00L,
+            ),
+        )
+
+        assertEquals(expected, params)
+    }
+
+    @ParameterizedTest
+    @MethodSource("amountSource")
+    fun `amount should match value set in sessions then configuration`(
+        configurationValue: Amount?,
+        sessionsValue: Amount?,
+        expectedValue: Amount?,
+    ) {
+        val testConfiguration = createCheckoutConfiguration(configurationValue)
+
+        val sessionDetails = SessionDetails(
+            id = "id",
+            sessionData = "session_data",
+            amount = sessionsValue,
+            expiresAt = "",
+            returnUrl = null,
+            sessionSetupConfiguration = null,
+        )
+
+        val params = dropInParamsMapper.mapToParams(
+            checkoutConfiguration = testConfiguration,
+            deviceLocale = DEVICE_LOCALE,
+            sessionDetails = sessionDetails,
+        )
+
+        val expected = getDropInParams(amount = expectedValue)
+
+        assertEquals(expected, params)
+    }
+
+    private fun createCheckoutConfiguration(
+        amount: Amount? = null,
+        shopperLocale: Locale? = null,
+        configurationBlock: DropInConfiguration.Builder.() -> Unit = {}
+    ) = CheckoutConfiguration(
+        environment = Environment.TEST,
+        clientKey = TEST_CLIENT_KEY_1,
+        shopperLocale = shopperLocale,
+        amount = amount,
+    ) {
+        dropIn(configurationBlock)
+    }
+
+    @Suppress("LongParameterList")
+    private fun getDropInParams(
+        environment: Environment = Environment.TEST,
+        clientKey: String = TEST_CLIENT_KEY_1,
+        shopperLocale: Locale = DEVICE_LOCALE,
+        analyticsParams: AnalyticsParams = AnalyticsParams(AnalyticsParamsLevel.ALL),
+        amount: Amount? = null,
+        showPreselectedStoredPaymentMethod: Boolean = true,
+        skipListWhenSinglePaymentMethod: Boolean = false,
+        isRemovingStoredPaymentMethodsEnabled: Boolean = false,
+        additionalDataForDropInService: Bundle? = null,
+        overriddenPaymentMethodInformation: Map<String, DropInPaymentMethodInformation> = emptyMap(),
+    ): DropInParams {
+        return DropInParams(
+            environment = environment,
+            clientKey = clientKey,
+            shopperLocale = shopperLocale,
+            analyticsParams = analyticsParams,
+            amount = amount,
+            showPreselectedStoredPaymentMethod = showPreselectedStoredPaymentMethod,
+            skipListWhenSinglePaymentMethod = skipListWhenSinglePaymentMethod,
+            isRemovingStoredPaymentMethodsEnabled = isRemovingStoredPaymentMethodsEnabled,
+            additionalDataForDropInService = additionalDataForDropInService,
+            overriddenPaymentMethodInformation = overriddenPaymentMethodInformation,
+        )
+    }
+
+    companion object {
+        private const val TEST_CLIENT_KEY_1 = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
+        private const val TEST_CLIENT_KEY_2 = "live_qwertyui34566776787zxcvbnmqwerty"
+        private val DEVICE_LOCALE = Locale("nl", "NL")
+
+        @JvmStatic
+        fun amountSource() = listOf(
+            // configurationValue, sessionsValue, expectedValue
+            arguments(Amount("EUR", 100), Amount("CAD", 300), Amount("CAD", 300)),
+            arguments(Amount("EUR", 100), null, Amount("EUR", 100)),
+            arguments(null, Amount("CAD", 300), Amount("CAD", 300)),
+            arguments(null, null, null),
+        )
+    }
+}

--- a/econtext/src/main/java/com/adyen/checkout/econtext/internal/EContextConfiguration.kt
+++ b/econtext/src/main/java/com/adyen/checkout/econtext/internal/EContextConfiguration.kt
@@ -36,6 +36,18 @@ abstract class EContextConfiguration : Configuration, ButtonConfiguration {
         protected var isSubmitButtonVisible: Boolean? = null
 
         /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
+
+        /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
          *
          * @param context A context
@@ -49,7 +61,7 @@ abstract class EContextConfiguration : Configuration, ButtonConfiguration {
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.

--- a/econtext/src/main/java/com/adyen/checkout/econtext/internal/EContextConfiguration.kt
+++ b/econtext/src/main/java/com/adyen/checkout/econtext/internal/EContextConfiguration.kt
@@ -54,6 +54,7 @@ abstract class EContextConfiguration : Configuration, ButtonConfiguration {
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/econtext/src/main/java/com/adyen/checkout/econtext/internal/provider/EContextComponentProvider.kt
+++ b/econtext/src/main/java/com/adyen/checkout/econtext/internal/provider/EContextComponentProvider.kt
@@ -33,12 +33,14 @@ import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.components.core.paymentmethod.EContextPaymentMethod
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
+import com.adyen.checkout.core.internal.util.LocaleProvider
 import com.adyen.checkout.econtext.internal.EContextComponent
 import com.adyen.checkout.econtext.internal.EContextConfiguration
 import com.adyen.checkout.econtext.internal.ui.DefaultEContextDelegate
@@ -66,6 +68,7 @@ constructor(
     private val componentClass: Class<ComponentT>,
     private val dropInOverrideParams: DropInOverrideParams?,
     private val analyticsRepository: AnalyticsRepository?,
+    private val localeProvider: LocaleProvider = LocaleProvider(),
 ) : PaymentComponentProvider<ComponentT, ConfigurationT, ComponentStateT, ComponentCallback<ComponentStateT>>,
     SessionPaymentComponentProvider<
         ComponentT,
@@ -73,8 +76,6 @@ constructor(
         ComponentStateT,
         SessionComponentCallback<ComponentStateT>,
         > {
-
-    private val componentParamsMapper = ButtonComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,
@@ -91,10 +92,12 @@ constructor(
 
         val genericFactory: ViewModelProvider.Factory =
             viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-                val componentParams = componentParamsMapper.mapToParams(
+                val componentParams = ButtonComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
                     checkoutConfiguration = checkoutConfiguration,
-                    configuration = getConfiguration(checkoutConfiguration),
-                    sessionParams = null,
+                    deviceLocale = localeProvider.getLocale(application),
+                    dropInOverrideParams = dropInOverrideParams,
+                    componentSessionParams = null,
+                    componentConfiguration = getConfiguration(checkoutConfiguration),
                 )
 
                 val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
@@ -179,11 +182,14 @@ constructor(
 
         val genericFactory: ViewModelProvider.Factory =
             viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-                val componentParams = componentParamsMapper.mapToParams(
+                val componentParams = ButtonComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
                     checkoutConfiguration = checkoutConfiguration,
-                    configuration = getConfiguration(checkoutConfiguration),
-                    sessionParams = SessionParamsFactory.create(checkoutSession),
+                    deviceLocale = localeProvider.getLocale(application),
+                    dropInOverrideParams = dropInOverrideParams,
+                    componentSessionParams = SessionParamsFactory.create(checkoutSession),
+                    componentConfiguration = getConfiguration(checkoutConfiguration),
                 )
+
                 val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
                 val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(

--- a/econtext/src/main/java/com/adyen/checkout/econtext/internal/provider/EContextComponentProvider.kt
+++ b/econtext/src/main/java/com/adyen/checkout/econtext/internal/provider/EContextComponentProvider.kt
@@ -34,7 +34,6 @@ import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepo
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.components.core.paymentmethod.EContextPaymentMethod
@@ -66,7 +65,6 @@ abstract class EContextComponentProvider<
 constructor(
     private val componentClass: Class<ComponentT>,
     private val dropInOverrideParams: DropInOverrideParams?,
-    overrideSessionParams: SessionParams?,
     private val analyticsRepository: AnalyticsRepository?,
 ) : PaymentComponentProvider<ComponentT, ConfigurationT, ComponentStateT, ComponentCallback<ComponentStateT>>,
     SessionPaymentComponentProvider<
@@ -76,7 +74,7 @@ constructor(
         SessionComponentCallback<ComponentStateT>,
         > {
 
-    private val componentParamsMapper = ButtonComponentParamsMapper(dropInOverrideParams, overrideSessionParams)
+    private val componentParamsMapper = ButtonComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextConfiguration.kt
+++ b/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextConfiguration.kt
@@ -8,7 +8,6 @@
 
 package com.adyen.checkout.econtext
 
-import android.content.Context
 import com.adyen.checkout.action.core.GenericActionConfiguration
 import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.components.core.AnalyticsConfiguration
@@ -30,19 +29,10 @@ private constructor(
     override val genericActionConfiguration: GenericActionConfiguration
 ) : EContextConfiguration() {
 
-    class Builder : EContextConfiguration.Builder<TestEContextConfiguration, Builder> {
+    class Builder(shopperLocale: Locale?, environment: Environment, clientKey: String) :
+        EContextConfiguration.Builder<TestEContextConfiguration, Builder>(environment, clientKey) {
 
-        constructor(context: Context, environment: Environment, clientKey: String) : super(
-            context,
-            environment,
-            clientKey,
-        )
-
-        constructor(
-            shopperLocale: Locale?,
-            environment: Environment,
-            clientKey: String
-        ) : super(environment, clientKey) {
+        init {
             shopperLocale?.let { setShopperLocale(it) }
         }
 

--- a/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextConfiguration.kt
+++ b/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextConfiguration.kt
@@ -22,7 +22,7 @@ internal class TestEContextConfiguration
 @Suppress("LongParameterList")
 private constructor(
     override val isSubmitButtonVisible: Boolean?,
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -35,14 +35,16 @@ private constructor(
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,
-            clientKey
+            clientKey,
         )
 
         constructor(
-            shopperLocale: Locale,
+            shopperLocale: Locale?,
             environment: Environment,
             clientKey: String
-        ) : super(shopperLocale, environment, clientKey)
+        ) : super(environment, clientKey) {
+            shopperLocale?.let { setShopperLocale(it) }
+        }
 
         public override fun buildInternal(): TestEContextConfiguration {
             return TestEContextConfiguration(

--- a/econtext/src/test/java/com/adyen/checkout/econtext/internal/ui/DefaultEContextDelegateTest.kt
+++ b/econtext/src/test/java/com/adyen/checkout/econtext/internal/ui/DefaultEContextDelegateTest.kt
@@ -17,6 +17,7 @@ import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.FieldState
 import com.adyen.checkout.components.core.internal.ui.model.Validation
 import com.adyen.checkout.core.Environment
@@ -283,12 +284,12 @@ internal class DefaultEContextDelegateTest(
         order: Order = TEST_ORDER
     ) = DefaultEContextDelegate(
         observerRepository = PaymentObserverRepository(),
-        componentParams = ButtonComponentParamsMapper(null, null).mapToParams(
+        componentParams = ButtonComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
             checkoutConfiguration = configuration,
-            configuration = configuration.getConfiguration(
-                TEST_CONFIGURATION_KEY,
-            ),
-            sessionParams = null,
+            deviceLocale = Locale.US,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+            componentConfiguration = configuration.getConfiguration(TEST_CONFIGURATION_KEY),
         ),
         paymentMethod = PaymentMethod(),
         order = order,

--- a/entercash/src/main/java/com/adyen/checkout/entercash/EntercashConfiguration.kt
+++ b/entercash/src/main/java/com/adyen/checkout/entercash/EntercashConfiguration.kt
@@ -61,6 +61,7 @@ class EntercashConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/entercash/src/main/java/com/adyen/checkout/entercash/EntercashConfiguration.kt
+++ b/entercash/src/main/java/com/adyen/checkout/entercash/EntercashConfiguration.kt
@@ -26,7 +26,7 @@ import java.util.Locale
 @Parcelize
 @Suppress("LongParameterList")
 class EntercashConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -43,6 +43,18 @@ class EntercashConfiguration private constructor(
     class Builder : IssuerListBuilder<EntercashConfiguration, Builder> {
 
         /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
+
+        /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
          *
          * @param context A context
@@ -56,7 +68,7 @@ class EntercashConfiguration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -87,8 +99,9 @@ class EntercashConfiguration private constructor(
 fun CheckoutConfiguration.entercash(
     configuration: @CheckoutConfigurationMarker EntercashConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = EntercashConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = EntercashConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/entercash/src/main/java/com/adyen/checkout/entercash/internal/provider/EntercashComponentProvider.kt
+++ b/entercash/src/main/java/com/adyen/checkout/entercash/internal/provider/EntercashComponentProvider.kt
@@ -16,7 +16,6 @@ import com.adyen.checkout.components.core.PaymentComponentData
 import com.adyen.checkout.components.core.internal.ComponentEventHandler
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.paymentmethod.EntercashPaymentMethod
 import com.adyen.checkout.entercash.EntercashComponent
 import com.adyen.checkout.entercash.EntercashComponentState
@@ -30,7 +29,6 @@ class EntercashComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
     analyticsRepository: AnalyticsRepository? = null,
 ) : IssuerListComponentProvider<
     EntercashComponent,
@@ -40,7 +38,6 @@ constructor(
     >(
     componentClass = EntercashComponent::class.java,
     dropInOverrideParams = dropInOverrideParams,
-    overrideSessionParams = overrideSessionParams,
     analyticsRepository = analyticsRepository,
 ) {
 

--- a/eps/src/main/java/com/adyen/checkout/eps/EPSConfiguration.kt
+++ b/eps/src/main/java/com/adyen/checkout/eps/EPSConfiguration.kt
@@ -26,7 +26,7 @@ import java.util.Locale
 @Parcelize
 @Suppress("LongParameterList")
 class EPSConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -41,6 +41,18 @@ class EPSConfiguration private constructor(
      * Builder to create an [EPSConfiguration].
      */
     class Builder : IssuerListBuilder<EPSConfiguration, Builder> {
+
+        /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
 
         /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
@@ -67,7 +79,7 @@ class EPSConfiguration private constructor(
         }
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -98,8 +110,9 @@ class EPSConfiguration private constructor(
 fun CheckoutConfiguration.eps(
     configuration: @CheckoutConfigurationMarker EPSConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = EPSConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = EPSConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/eps/src/main/java/com/adyen/checkout/eps/EPSConfiguration.kt
+++ b/eps/src/main/java/com/adyen/checkout/eps/EPSConfiguration.kt
@@ -61,6 +61,7 @@ class EPSConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/eps/src/main/java/com/adyen/checkout/eps/internal/provider/EPSComponentProvider.kt
+++ b/eps/src/main/java/com/adyen/checkout/eps/internal/provider/EPSComponentProvider.kt
@@ -16,7 +16,6 @@ import com.adyen.checkout.components.core.PaymentComponentData
 import com.adyen.checkout.components.core.internal.ComponentEventHandler
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.paymentmethod.EPSPaymentMethod
 import com.adyen.checkout.eps.EPSComponent
 import com.adyen.checkout.eps.EPSComponentState
@@ -30,12 +29,10 @@ class EPSComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
     analyticsRepository: AnalyticsRepository? = null,
 ) : IssuerListComponentProvider<EPSComponent, EPSConfiguration, EPSPaymentMethod, EPSComponentState>(
     componentClass = EPSComponent::class.java,
     dropInOverrideParams = dropInOverrideParams,
-    overrideSessionParams = overrideSessionParams,
     analyticsRepository = analyticsRepository,
     hideIssuerLogosDefaultValue = true,
 ) {

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/configuration/CheckoutConfigurationProvider.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/configuration/CheckoutConfigurationProvider.kt
@@ -48,9 +48,9 @@ internal class CheckoutConfigurationProvider @Inject constructor(
 
     val checkoutConfig: CheckoutConfiguration
         get() = CheckoutConfiguration(
-            shopperLocale = shopperLocale,
             environment = environment,
             clientKey = clientKey,
+            shopperLocale = shopperLocale,
             amount = amount,
             analyticsConfiguration = getAnalyticsConfiguration(),
         ) {

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardConfiguration.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardConfiguration.kt
@@ -28,7 +28,7 @@ import java.util.Locale
 @Parcelize
 @Suppress("LongParameterList")
 class GiftCardConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -49,6 +49,18 @@ class GiftCardConfiguration private constructor(
         private var isSubmitButtonVisible: Boolean? = null
 
         /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
+
+        /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
          *
          * @param context A context
@@ -62,7 +74,7 @@ class GiftCardConfiguration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -117,8 +129,9 @@ class GiftCardConfiguration private constructor(
 fun CheckoutConfiguration.giftCard(
     configuration: @CheckoutConfigurationMarker GiftCardConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = GiftCardConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = GiftCardConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardConfiguration.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardConfiguration.kt
@@ -67,6 +67,7 @@ class GiftCardConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/provider/GiftCardComponentProvider.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/provider/GiftCardComponentProvider.kt
@@ -27,11 +27,13 @@ import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepo
 import com.adyen.checkout.components.core.internal.data.api.DefaultPublicKeyRepository
 import com.adyen.checkout.components.core.internal.data.api.PublicKeyService
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
+import com.adyen.checkout.core.internal.util.LocaleProvider
 import com.adyen.checkout.cse.internal.CardEncryptorFactory
 import com.adyen.checkout.giftcard.GiftCardComponent
 import com.adyen.checkout.giftcard.GiftCardComponentCallback
@@ -58,6 +60,7 @@ class GiftCardComponentProvider
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
     private val analyticsRepository: AnalyticsRepository? = null,
+    private val localeProvider: LocaleProvider = LocaleProvider(),
 ) :
     PaymentComponentProvider<
         GiftCardComponent,
@@ -71,8 +74,6 @@ constructor(
         GiftCardComponentState,
         SessionsGiftCardComponentCallback,
         > {
-
-    private val componentParamsMapper = GiftCardComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,
@@ -89,7 +90,13 @@ constructor(
 
         val cardEncryptor = CardEncryptorFactory.provide()
         val giftCardFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(checkoutConfiguration, null)
+            val componentParams = GiftCardComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+                checkoutConfiguration = checkoutConfiguration,
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = null,
+            )
+
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
             val publicKeyService = PublicKeyService(httpClient)
 
@@ -178,10 +185,13 @@ constructor(
 
         val cardEncryptor = CardEncryptorFactory.provide()
         val giftCardFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(
-                configuration = checkoutConfiguration,
-                sessionParams = SessionParamsFactory.create(checkoutSession),
+            val componentParams = GiftCardComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+                checkoutConfiguration = checkoutConfiguration,
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = SessionParamsFactory.create(checkoutSession),
             )
+
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
             val publicKeyService = PublicKeyService(httpClient)
 

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/provider/GiftCardComponentProvider.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/provider/GiftCardComponentProvider.kt
@@ -28,7 +28,6 @@ import com.adyen.checkout.components.core.internal.data.api.DefaultPublicKeyRepo
 import com.adyen.checkout.components.core.internal.data.api.PublicKeyService
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.exception.ComponentException
@@ -58,7 +57,6 @@ class GiftCardComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
     private val analyticsRepository: AnalyticsRepository? = null,
 ) :
     PaymentComponentProvider<
@@ -74,7 +72,7 @@ constructor(
         SessionsGiftCardComponentCallback,
         > {
 
-    private val componentParamsMapper = GiftCardComponentParamsMapper(dropInOverrideParams, overrideSessionParams)
+    private val componentParamsMapper = GiftCardComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/ui/model/GiftCardComponentParams.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/ui/model/GiftCardComponentParams.kt
@@ -8,20 +8,12 @@
 
 package com.adyen.checkout.giftcard.internal.ui.model
 
-import com.adyen.checkout.components.core.Amount
-import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
 import com.adyen.checkout.components.core.internal.ui.model.ButtonParams
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParams
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
-import com.adyen.checkout.core.Environment
-import java.util.Locale
 
 internal data class GiftCardComponentParams(
-    override val shopperLocale: Locale,
-    override val environment: Environment,
-    override val clientKey: String,
-    override val analyticsParams: AnalyticsParams,
-    override val isCreatedByDropIn: Boolean,
-    override val amount: Amount?,
+    private val commonComponentParams: CommonComponentParams,
     override val isSubmitButtonVisible: Boolean,
     val isPinRequired: Boolean,
-) : ComponentParams, ButtonParams
+) : ComponentParams by commonComponentParams, ButtonParams

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/ui/model/GiftCardComponentParamsMapper.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/ui/model/GiftCardComponentParamsMapper.kt
@@ -16,7 +16,6 @@ import com.adyen.checkout.giftcard.getGiftCardConfiguration
 
 internal class GiftCardComponentParamsMapper(
     private val dropInOverrideParams: DropInOverrideParams?,
-    private val overrideSessionParams: SessionParams?,
 ) {
 
     fun mapToParams(
@@ -26,7 +25,7 @@ internal class GiftCardComponentParamsMapper(
         return configuration
             .mapToParamsInternal()
             .override(dropInOverrideParams)
-            .override(sessionParams ?: overrideSessionParams)
+            .override(sessionParams ?: dropInOverrideParams?.sessionParams)
     }
 
     private fun CheckoutConfiguration.mapToParamsInternal(): GiftCardComponentParams {

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/ui/model/GiftCardComponentParamsMapper.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/ui/model/GiftCardComponentParamsMapper.kt
@@ -9,55 +9,35 @@
 package com.adyen.checkout.giftcard.internal.ui.model
 
 import com.adyen.checkout.components.core.CheckoutConfiguration
-import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.giftcard.getGiftCardConfiguration
+import java.util.Locale
 
 internal class GiftCardComponentParamsMapper(
-    private val dropInOverrideParams: DropInOverrideParams?,
+    private val commonComponentParamsMapper: CommonComponentParamsMapper,
 ) {
 
     fun mapToParams(
-        configuration: CheckoutConfiguration,
-        sessionParams: SessionParams?,
+        checkoutConfiguration: CheckoutConfiguration,
+        deviceLocale: Locale,
+        dropInOverrideParams: DropInOverrideParams?,
+        componentSessionParams: SessionParams?,
     ): GiftCardComponentParams {
-        return configuration
-            .mapToParamsInternal()
-            .override(dropInOverrideParams)
-            .override(sessionParams ?: dropInOverrideParams?.sessionParams)
-    }
+        val commonComponentParamsMapperData = commonComponentParamsMapper.mapToParams(
+            checkoutConfiguration,
+            deviceLocale,
+            dropInOverrideParams,
+            componentSessionParams,
+        )
+        val commonComponentParams = commonComponentParamsMapperData.commonComponentParams
+        val giftCardConfiguration = checkoutConfiguration.getGiftCardConfiguration()
 
-    private fun CheckoutConfiguration.mapToParamsInternal(): GiftCardComponentParams {
-        val giftCardConfiguration = getGiftCardConfiguration()
         return GiftCardComponentParams(
-            shopperLocale = shopperLocale,
-            environment = environment,
-            clientKey = clientKey,
-            analyticsParams = AnalyticsParams(analyticsConfiguration),
-            isCreatedByDropIn = false,
-            amount = amount,
+            commonComponentParams = commonComponentParams,
             isSubmitButtonVisible = giftCardConfiguration?.isSubmitButtonVisible ?: true,
             isPinRequired = giftCardConfiguration?.isPinRequired ?: true,
-        )
-    }
-
-    private fun GiftCardComponentParams.override(
-        dropInOverrideParams: DropInOverrideParams?,
-    ): GiftCardComponentParams {
-        if (dropInOverrideParams == null) return this
-        return copy(
-            amount = dropInOverrideParams.amount,
-            isCreatedByDropIn = true,
-        )
-    }
-
-    private fun GiftCardComponentParams.override(
-        sessionParams: SessionParams? = null
-    ): GiftCardComponentParams {
-        if (sessionParams == null) return this
-        return copy(
-            amount = sessionParams.amount ?: amount,
         )
     }
 }

--- a/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/ui/DefaultGiftCardDelegateTest.kt
+++ b/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/ui/DefaultGiftCardDelegateTest.kt
@@ -17,6 +17,7 @@ import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.test.TestPublicKeyRepository
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.cse.internal.test.TestCardEncryptor
 import com.adyen.checkout.giftcard.GiftCardAction
@@ -404,7 +405,8 @@ internal class DefaultGiftCardDelegateTest(
         paymentMethod = PaymentMethod(),
         order = order,
         publicKeyRepository = publicKeyRepository,
-        componentParams = GiftCardComponentParamsMapper(null, null).mapToParams(configuration, null),
+        componentParams = GiftCardComponentParamsMapper(CommonComponentParamsMapper())
+            .mapToParams(configuration, Locale.US, null, null),
         cardEncryptor = cardEncryptor,
         analyticsRepository = analyticsRepository,
         submitHandler = submitHandler,

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.kt
@@ -96,6 +96,7 @@ class GooglePayConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.kt
@@ -30,7 +30,7 @@ import java.util.Locale
 @Parcelize
 @Suppress("LongParameterList")
 class GooglePayConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -78,6 +78,18 @@ class GooglePayConfiguration private constructor(
         private var totalPriceStatus: String? = null
 
         /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
+
+        /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
          *
          * @param context A context
@@ -91,7 +103,7 @@ class GooglePayConfiguration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -393,8 +405,9 @@ class GooglePayConfiguration private constructor(
 fun CheckoutConfiguration.googlePay(
     configuration: @CheckoutConfigurationMarker GooglePayConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = GooglePayConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = GooglePayConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/provider/GooglePayComponentProvider.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/provider/GooglePayComponentProvider.kt
@@ -29,6 +29,7 @@ import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepositoryD
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
@@ -36,6 +37,7 @@ import com.adyen.checkout.core.AdyenLogLevel
 import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
+import com.adyen.checkout.core.internal.util.LocaleProvider
 import com.adyen.checkout.core.internal.util.adyenLog
 import com.adyen.checkout.googlepay.GooglePayComponent
 import com.adyen.checkout.googlepay.GooglePayComponentState
@@ -63,6 +65,7 @@ class GooglePayComponentProvider
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
     private val analyticsRepository: AnalyticsRepository? = null,
+    private val localeProvider: LocaleProvider = LocaleProvider(),
 ) :
     PaymentComponentProvider<
         GooglePayComponent,
@@ -78,8 +81,6 @@ constructor(
         >,
     PaymentMethodAvailabilityCheck<GooglePayConfiguration> {
 
-    private val componentParamsMapper = GooglePayComponentParamsMapper(dropInOverrideParams)
-
     @Suppress("LongMethod")
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,
@@ -93,9 +94,14 @@ constructor(
         key: String?,
     ): GooglePayComponent {
         assertSupported(paymentMethod)
-
-        val componentParams = componentParamsMapper.mapToParams(checkoutConfiguration, paymentMethod, null)
         val googlePayFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
+            val componentParams = GooglePayComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+                checkoutConfiguration = checkoutConfiguration,
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = null,
+                paymentMethod = paymentMethod,
+            )
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
                 analyticsRepositoryData = AnalyticsRepositoryData(
@@ -177,13 +183,15 @@ constructor(
         key: String?
     ): GooglePayComponent {
         assertSupported(paymentMethod)
-
-        val componentParams = componentParamsMapper.mapToParams(
-            configuration = checkoutConfiguration,
-            paymentMethod = paymentMethod,
-            sessionParams = SessionParamsFactory.create(checkoutSession),
-        )
         val googlePayFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
+            val componentParams = GooglePayComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+                checkoutConfiguration = checkoutConfiguration,
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = SessionParamsFactory.create(checkoutSession),
+                paymentMethod = paymentMethod,
+            )
+
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
@@ -286,7 +294,14 @@ constructor(
             return
         }
         val callbackWeakReference = WeakReference(callback)
-        val componentParams = componentParamsMapper.mapToParams(checkoutConfiguration, paymentMethod, null)
+        val componentParams = GooglePayComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+            checkoutConfiguration = checkoutConfiguration,
+            deviceLocale = localeProvider.getLocale(application),
+            dropInOverrideParams = dropInOverrideParams,
+            componentSessionParams = null,
+            paymentMethod = paymentMethod,
+        )
+
         val paymentsClient = Wallet.getPaymentsClient(application, GooglePayUtils.createWalletOptions(componentParams))
         val readyToPayRequest = GooglePayUtils.createIsReadyToPayRequest(componentParams)
         val readyToPayTask = paymentsClient.isReadyToPay(readyToPayRequest)

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/provider/GooglePayComponentProvider.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/provider/GooglePayComponentProvider.kt
@@ -30,7 +30,6 @@ import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.AdyenLogLevel
@@ -63,7 +62,6 @@ class GooglePayComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
     private val analyticsRepository: AnalyticsRepository? = null,
 ) :
     PaymentComponentProvider<
@@ -80,7 +78,7 @@ constructor(
         >,
     PaymentMethodAvailabilityCheck<GooglePayConfiguration> {
 
-    private val componentParamsMapper = GooglePayComponentParamsMapper(dropInOverrideParams, overrideSessionParams)
+    private val componentParamsMapper = GooglePayComponentParamsMapper(dropInOverrideParams)
 
     @Suppress("LongMethod")
     override fun get(

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParams.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParams.kt
@@ -9,20 +9,14 @@
 package com.adyen.checkout.googlepay.internal.ui.model
 
 import com.adyen.checkout.components.core.Amount
-import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParams
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
-import com.adyen.checkout.core.Environment
 import com.adyen.checkout.googlepay.BillingAddressParameters
 import com.adyen.checkout.googlepay.MerchantInfo
 import com.adyen.checkout.googlepay.ShippingAddressParameters
-import java.util.Locale
 
 internal data class GooglePayComponentParams(
-    override val shopperLocale: Locale,
-    override val environment: Environment,
-    override val clientKey: String,
-    override val analyticsParams: AnalyticsParams,
-    override val isCreatedByDropIn: Boolean,
+    private val commonComponentParams: CommonComponentParams,
     override val amount: Amount,
     val gatewayMerchantId: String,
     val googlePayEnvironment: Int,
@@ -40,4 +34,4 @@ internal data class GooglePayComponentParams(
     val shippingAddressParameters: ShippingAddressParameters?,
     val isBillingAddressRequired: Boolean,
     val billingAddressParameters: BillingAddressParameters?,
-) : ComponentParams
+) : ComponentParams by commonComponentParams

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParamsMapper.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParamsMapper.kt
@@ -27,7 +27,6 @@ import com.google.android.gms.wallet.WalletConstants
 
 internal class GooglePayComponentParamsMapper(
     private val dropInOverrideParams: DropInOverrideParams?,
-    private val overrideSessionParams: SessionParams?,
 ) {
 
     fun mapToParams(
@@ -38,7 +37,7 @@ internal class GooglePayComponentParamsMapper(
         return configuration
             .mapToParamsInternal(paymentMethod)
             .override(dropInOverrideParams)
-            .override(sessionParams ?: overrideSessionParams)
+            .override(sessionParams ?: dropInOverrideParams?.sessionParams)
     }
 
     private fun CheckoutConfiguration.mapToParamsInternal(

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/DefaultGooglePayDelegateTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/DefaultGooglePayDelegateTest.kt
@@ -16,6 +16,7 @@ import com.adyen.checkout.components.core.OrderRequest
 import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.paymentmethod.GooglePayPaymentMethod
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.googlepay.GooglePayConfiguration
@@ -173,11 +174,8 @@ internal class DefaultGooglePayDelegateTest(
             observerRepository = PaymentObserverRepository(),
             paymentMethod = PaymentMethod(),
             order = TEST_ORDER,
-            componentParams = GooglePayComponentParamsMapper(null, null).mapToParams(
-                configuration,
-                paymentMethod,
-                null,
-            ),
+            componentParams = GooglePayComponentParamsMapper(CommonComponentParamsMapper())
+                .mapToParams(configuration, Locale.US, null, null, paymentMethod),
             analyticsRepository = analyticsRepository,
         )
     }

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParamsMapperTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParamsMapperTest.kt
@@ -16,6 +16,8 @@ import com.adyen.checkout.components.core.Configuration
 import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
 import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParamsLevel
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParams
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.core.Environment
@@ -41,12 +43,19 @@ import java.util.Locale
 @ExtendWith(LoggingExtension::class)
 internal class GooglePayComponentParamsMapperTest {
 
+    private val googlePayComponentParamsMapper = GooglePayComponentParamsMapper(CommonComponentParamsMapper())
+
     @Test
-    fun `when parent configuration is null and custom google pay configuration fields are null then all fields should match`() {
+    fun `when drop-in override params are null and custom google pay configuration fields are null then all fields should match`() {
         val configuration = createCheckoutConfiguration()
 
-        val params =
-            GooglePayComponentParamsMapper(null, null).mapToParams(configuration, PaymentMethod(), null)
+        val params = googlePayComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+            paymentMethod = PaymentMethod(),
+        )
 
         val expected = getGooglePayComponentParams()
 
@@ -54,7 +63,7 @@ internal class GooglePayComponentParamsMapperTest {
     }
 
     @Test
-    fun `when parent configuration is null and custom google pay configuration fields are set then all fields should match`() {
+    fun `when drop-in override params are null and custom google pay configuration fields are set then all fields should match`() {
         val amount = Amount("EUR", 1337)
         val merchantInfo = MerchantInfo("MERCHANT_NAME", "MERCHANT_ID")
         val allowedAuthMethods = listOf("AUTH1", "AUTH2", "AUTH3")
@@ -88,7 +97,13 @@ internal class GooglePayComponentParamsMapperTest {
             }
         }
 
-        val params = GooglePayComponentParamsMapper(null, null).mapToParams(configuration, PaymentMethod(), null)
+        val params = googlePayComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+            paymentMethod = PaymentMethod(),
+        )
 
         val expected = getGooglePayComponentParams(
             shopperLocale = Locale.FRANCE,
@@ -117,7 +132,7 @@ internal class GooglePayComponentParamsMapperTest {
     }
 
     @Test
-    fun `when parent configuration is set then parent configuration fields should override google pay configuration fields`() {
+    fun `when drop-in override params are set then they should override google pay configuration fields`() {
         val configuration = CheckoutConfiguration(
             shopperLocale = Locale.GERMAN,
             environment = Environment.EUROPE,
@@ -135,11 +150,13 @@ internal class GooglePayComponentParamsMapperTest {
             }
         }
 
-        val dropInOverrideParams = DropInOverrideParams(Amount("CAD", 123L))
-        val params = GooglePayComponentParamsMapper(dropInOverrideParams, null).mapToParams(
-            configuration,
-            PaymentMethod(),
-            null,
+        val dropInOverrideParams = DropInOverrideParams(Amount("CAD", 123L), null)
+        val params = googlePayComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = dropInOverrideParams,
+            componentSessionParams = null,
+            paymentMethod = PaymentMethod(),
         )
 
         val expected = getGooglePayComponentParams(
@@ -170,7 +187,13 @@ internal class GooglePayComponentParamsMapperTest {
             ),
         )
 
-        val params = GooglePayComponentParamsMapper(null, null).mapToParams(configuration, paymentMethod, null)
+        val params = googlePayComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+            paymentMethod = paymentMethod,
+        )
 
         val expected = getGooglePayComponentParams(
             gatewayMerchantId = "GATEWAY_MERCHANT_ID_1",
@@ -195,7 +218,13 @@ internal class GooglePayComponentParamsMapperTest {
             ),
         )
 
-        val params = GooglePayComponentParamsMapper(null, null).mapToParams(configuration, paymentMethod, null)
+        val params = googlePayComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+            paymentMethod = paymentMethod,
+        )
 
         val expected = getGooglePayComponentParams(
             gatewayMerchantId = "GATEWAY_MERCHANT_ID_2",
@@ -215,7 +244,13 @@ internal class GooglePayComponentParamsMapperTest {
         }
 
         assertThrows<ComponentException> {
-            GooglePayComponentParamsMapper(null, null).mapToParams(configuration, PaymentMethod(), null)
+            googlePayComponentParamsMapper.mapToParams(
+                checkoutConfiguration = configuration,
+                deviceLocale = DEVICE_LOCALE,
+                dropInOverrideParams = null,
+                componentSessionParams = null,
+                paymentMethod = PaymentMethod(),
+            )
         }
     }
 
@@ -227,7 +262,13 @@ internal class GooglePayComponentParamsMapperTest {
             brands = listOf("mc", "amex", "maestro", "discover"),
         )
 
-        val params = GooglePayComponentParamsMapper(null, null).mapToParams(configuration, paymentMethod, null)
+        val params = googlePayComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+            paymentMethod = paymentMethod,
+        )
 
         val expected = getGooglePayComponentParams(
             allowedCardNetworks = listOf("MASTERCARD", "AMEX", "DISCOVER"),
@@ -242,7 +283,13 @@ internal class GooglePayComponentParamsMapperTest {
             setGooglePayEnvironment(WalletConstants.ENVIRONMENT_PRODUCTION)
         }
 
-        val params = GooglePayComponentParamsMapper(null, null).mapToParams(configuration, PaymentMethod(), null)
+        val params = googlePayComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+            paymentMethod = PaymentMethod(),
+        )
 
         val expected = getGooglePayComponentParams(
             googlePayEnvironment = WalletConstants.ENVIRONMENT_PRODUCTION,
@@ -255,7 +302,13 @@ internal class GooglePayComponentParamsMapperTest {
     fun `when google pay environment is not set and environment is TEST then google pay environment should be ENVIRONMENT_TEST`() {
         val configuration = createCheckoutConfiguration()
 
-        val params = GooglePayComponentParamsMapper(null, null).mapToParams(configuration, PaymentMethod(), null)
+        val params = googlePayComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+            paymentMethod = PaymentMethod(),
+        )
 
         val expected = getGooglePayComponentParams(
             googlePayEnvironment = WalletConstants.ENVIRONMENT_TEST,
@@ -276,7 +329,13 @@ internal class GooglePayComponentParamsMapperTest {
             }
         }
 
-        val params = GooglePayComponentParamsMapper(null, null).mapToParams(configuration, PaymentMethod(), null)
+        val params = googlePayComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+            paymentMethod = PaymentMethod(),
+        )
 
         val expected = getGooglePayComponentParams(
             shopperLocale = Locale.CHINA,
@@ -289,13 +348,15 @@ internal class GooglePayComponentParamsMapperTest {
     }
 
     @Test
-    fun `when amount is not set in parent configuration and google pay configuration then params amount should have 0 USD DEFAULT_VALUE`() {
+    fun `when amount is not set in checkout configuration and google pay configuration then params amount should have 0 USD DEFAULT_VALUE`() {
         val configuration = createCheckoutConfiguration(amount = null)
 
-        val params = GooglePayComponentParamsMapper(null, null).mapToParams(
-            configuration,
-            PaymentMethod(),
-            null,
+        val params = googlePayComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+            paymentMethod = PaymentMethod(),
         )
 
         val expected = getGooglePayComponentParams(
@@ -310,16 +371,18 @@ internal class GooglePayComponentParamsMapperTest {
     }
 
     @Test
-    fun `when parent configuration is set with empty amount then params amount should have 0 USD DEFAULT_VALUE`() {
-        // Google Pay Config is set with an amount which will be overridden by parent configuration
+    fun `when checkout configuration is used with null amount then params amount should have 0 USD DEFAULT_VALUE`() {
+        // Google Pay Config is set with an amount which will be overridden by checkout configuration params
         val configuration = createCheckoutConfiguration(amount = null) {
             setAmount(Amount(currency = "TRY", value = 40_00L))
         }
 
-        val params = GooglePayComponentParamsMapper(null, null).mapToParams(
-            configuration,
-            PaymentMethod(),
-            null,
+        val params = googlePayComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+            paymentMethod = PaymentMethod(),
         )
 
         val expected = getGooglePayComponentParams(
@@ -335,7 +398,7 @@ internal class GooglePayComponentParamsMapperTest {
 
     @ParameterizedTest
     @MethodSource("amountSource")
-    fun `amount should match value set in sessions if it exists, then should match drop in value, then configuration`(
+    fun `amount should match value set in sessions then drop in then component configuration`(
         configurationValue: Amount,
         dropInValue: Amount?,
         sessionsValue: Amount?,
@@ -343,17 +406,19 @@ internal class GooglePayComponentParamsMapperTest {
     ) {
         val configuration = createCheckoutConfiguration(configurationValue)
 
-        val dropInOverrideParams = dropInValue?.let { DropInOverrideParams(it) }
-
-        val params = GooglePayComponentParamsMapper(dropInOverrideParams, null).mapToParams(
-            configuration = configuration,
+        val dropInOverrideParams = dropInValue?.let { DropInOverrideParams(it, null) }
+        val sessionParams = SessionParams(
+            enableStoreDetails = null,
+            installmentConfiguration = null,
+            amount = sessionsValue,
+            returnUrl = "",
+        )
+        val params = googlePayComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = dropInOverrideParams,
+            componentSessionParams = sessionParams,
             paymentMethod = PaymentMethod(),
-            sessionParams = SessionParams(
-                enableStoreDetails = null,
-                installmentConfiguration = null,
-                amount = sessionsValue,
-                returnUrl = "",
-            ),
         )
 
         val expected = getGooglePayComponentParams(
@@ -388,7 +453,7 @@ internal class GooglePayComponentParamsMapperTest {
         isCreatedByDropIn: Boolean = false,
         gatewayMerchantId: String = TEST_GATEWAY_MERCHANT_ID,
         googlePayEnvironment: Int = WalletConstants.ENVIRONMENT_TEST,
-        amount: Amount = Amount("USD", 0),
+        amount: Amount? = null,
         totalPriceStatus: String = "FINAL",
         countryCode: String? = null,
         merchantInfo: MerchantInfo? = null,
@@ -404,14 +469,17 @@ internal class GooglePayComponentParamsMapperTest {
         isBillingAddressRequired: Boolean = false,
         billingAddressParameters: BillingAddressParameters? = null,
     ) = GooglePayComponentParams(
-        shopperLocale = shopperLocale,
-        environment = environment,
-        clientKey = clientKey,
-        analyticsParams = analyticsParams,
-        isCreatedByDropIn = isCreatedByDropIn,
+        commonComponentParams = CommonComponentParams(
+            shopperLocale = shopperLocale,
+            environment = environment,
+            clientKey = clientKey,
+            analyticsParams = analyticsParams,
+            isCreatedByDropIn = isCreatedByDropIn,
+            amount = amount,
+        ),
         gatewayMerchantId = gatewayMerchantId,
         googlePayEnvironment = googlePayEnvironment,
-        amount = amount,
+        amount = amount ?: Amount("USD", 0),
         totalPriceStatus = totalPriceStatus,
         countryCode = countryCode,
         merchantInfo = merchantInfo,
@@ -432,6 +500,7 @@ internal class GooglePayComponentParamsMapperTest {
         private const val TEST_CLIENT_KEY_1 = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
         private const val TEST_CLIENT_KEY_2 = "live_qwertyui34566776787zxcvbnmqwerty"
         private const val TEST_GATEWAY_MERCHANT_ID = "TEST_GATEWAY_MERCHANT_ID"
+        private val DEVICE_LOCALE = Locale("nl", "NL")
 
         @JvmStatic
         fun amountSource() = listOf(

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/util/GooglePayUtilsTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/util/GooglePayUtilsTest.kt
@@ -11,6 +11,7 @@ package com.adyen.checkout.googlepay.internal.util
 import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
 import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParamsLevel
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParams
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.googlepay.BillingAddressParameters
 import com.adyen.checkout.googlepay.MerchantInfo
@@ -238,11 +239,14 @@ internal class GooglePayUtilsTest {
 
     private fun getEmptyGooglePayComponentParams(): GooglePayComponentParams {
         return GooglePayComponentParams(
-            shopperLocale = Locale.US,
-            environment = Environment.TEST,
-            clientKey = "CLIENT_KEY",
-            analyticsParams = AnalyticsParams(AnalyticsParamsLevel.ALL),
-            isCreatedByDropIn = false,
+            commonComponentParams = CommonComponentParams(
+                shopperLocale = Locale.US,
+                environment = Environment.TEST,
+                clientKey = "CLIENT_KEY",
+                analyticsParams = AnalyticsParams(AnalyticsParamsLevel.ALL),
+                isCreatedByDropIn = false,
+                amount = null,
+            ),
             amount = Amount("USD", 0),
             gatewayMerchantId = "",
             googlePayEnvironment = WalletConstants.ENVIRONMENT_TEST,
@@ -265,11 +269,14 @@ internal class GooglePayUtilsTest {
 
     private fun getCustomGooglePayComponentParams(): GooglePayComponentParams {
         return GooglePayComponentParams(
-            shopperLocale = Locale.GERMAN,
-            environment = Environment.EUROPE,
-            clientKey = "CLIENT_KEY_CUSTOM",
-            analyticsParams = AnalyticsParams(AnalyticsParamsLevel.NONE),
-            isCreatedByDropIn = true,
+            commonComponentParams = CommonComponentParams(
+                shopperLocale = Locale.GERMAN,
+                environment = Environment.EUROPE,
+                clientKey = "CLIENT_KEY_CUSTOM",
+                analyticsParams = AnalyticsParams(AnalyticsParamsLevel.NONE),
+                isCreatedByDropIn = true,
+                amount = Amount("EUR", 13_37),
+            ),
             amount = Amount("EUR", 13_37),
             gatewayMerchantId = "GATEWAY_MERCHANT_ID",
             googlePayEnvironment = WalletConstants.ENVIRONMENT_PRODUCTION,

--- a/ideal/src/main/java/com/adyen/checkout/ideal/IdealConfiguration.kt
+++ b/ideal/src/main/java/com/adyen/checkout/ideal/IdealConfiguration.kt
@@ -61,6 +61,7 @@ class IdealConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/ideal/src/main/java/com/adyen/checkout/ideal/IdealConfiguration.kt
+++ b/ideal/src/main/java/com/adyen/checkout/ideal/IdealConfiguration.kt
@@ -26,7 +26,7 @@ import java.util.Locale
 @Parcelize
 @Suppress("LongParameterList")
 class IdealConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -43,6 +43,18 @@ class IdealConfiguration private constructor(
     class Builder : IssuerListBuilder<IdealConfiguration, Builder> {
 
         /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
+
+        /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
          *
          * @param context A context
@@ -56,7 +68,7 @@ class IdealConfiguration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -87,8 +99,9 @@ class IdealConfiguration private constructor(
 fun CheckoutConfiguration.ideal(
     configuration: @CheckoutConfigurationMarker IdealConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = IdealConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = IdealConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/ideal/src/main/java/com/adyen/checkout/ideal/internal/provider/IdealComponentProvider.kt
+++ b/ideal/src/main/java/com/adyen/checkout/ideal/internal/provider/IdealComponentProvider.kt
@@ -16,7 +16,6 @@ import com.adyen.checkout.components.core.PaymentComponentData
 import com.adyen.checkout.components.core.internal.ComponentEventHandler
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.paymentmethod.IdealPaymentMethod
 import com.adyen.checkout.ideal.IdealComponent
 import com.adyen.checkout.ideal.IdealComponentState
@@ -30,12 +29,10 @@ class IdealComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
     analyticsRepository: AnalyticsRepository? = null,
 ) : IssuerListComponentProvider<IdealComponent, IdealConfiguration, IdealPaymentMethod, IdealComponentState>(
     componentClass = IdealComponent::class.java,
     dropInOverrideParams = dropInOverrideParams,
-    overrideSessionParams = overrideSessionParams,
     analyticsRepository = analyticsRepository,
 ) {
 

--- a/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentConfiguration.kt
+++ b/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentConfiguration.kt
@@ -25,7 +25,7 @@ import java.util.Locale
  */
 @Parcelize
 class InstantPaymentConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -37,6 +37,18 @@ class InstantPaymentConfiguration private constructor(
      * Builder to create an [InstantPaymentConfiguration].
      */
     class Builder : ActionHandlingPaymentMethodConfigurationBuilder<InstantPaymentConfiguration, Builder> {
+
+        /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
 
         /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
@@ -52,7 +64,7 @@ class InstantPaymentConfiguration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -83,8 +95,9 @@ fun CheckoutConfiguration.instantPayment(
     paymentMethod: String = GLOBAL_INSTANT_CONFIG_KEY,
     configuration: @CheckoutConfigurationMarker InstantPaymentConfiguration.Builder.() -> Unit = {},
 ): CheckoutConfiguration {
-    val config = InstantPaymentConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = InstantPaymentConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentConfiguration.kt
+++ b/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentConfiguration.kt
@@ -57,6 +57,7 @@ class InstantPaymentConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/instant/src/main/java/com/adyen/checkout/instant/internal/provider/InstantPaymentComponentProvider.kt
+++ b/instant/src/main/java/com/adyen/checkout/instant/internal/provider/InstantPaymentComponentProvider.kt
@@ -31,7 +31,6 @@ import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepo
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.exception.ComponentException
@@ -55,7 +54,6 @@ class InstantPaymentComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
     private val analyticsRepository: AnalyticsRepository? = null,
 ) :
     PaymentComponentProvider<
@@ -71,7 +69,7 @@ constructor(
         SessionComponentCallback<InstantComponentState>,
         > {
 
-    private val componentParamsMapper = GenericComponentParamsMapper(dropInOverrideParams, overrideSessionParams)
+    private val componentParamsMapper = GenericComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/instant/src/main/java/com/adyen/checkout/instant/internal/provider/InstantPaymentComponentProvider.kt
+++ b/instant/src/main/java/com/adyen/checkout/instant/internal/provider/InstantPaymentComponentProvider.kt
@@ -29,12 +29,14 @@ import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepositoryD
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
+import com.adyen.checkout.core.internal.util.LocaleProvider
 import com.adyen.checkout.instant.InstantComponentState
 import com.adyen.checkout.instant.InstantPaymentComponent
 import com.adyen.checkout.instant.InstantPaymentConfiguration
@@ -55,6 +57,7 @@ class InstantPaymentComponentProvider
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
     private val analyticsRepository: AnalyticsRepository? = null,
+    private val localeProvider: LocaleProvider = LocaleProvider(),
 ) :
     PaymentComponentProvider<
         InstantPaymentComponent,
@@ -68,8 +71,6 @@ constructor(
         InstantComponentState,
         SessionComponentCallback<InstantComponentState>,
         > {
-
-    private val componentParamsMapper = GenericComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,
@@ -85,7 +86,12 @@ constructor(
         assertSupported(paymentMethod)
 
         val genericFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(checkoutConfiguration, null)
+            val componentParams = GenericComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+                checkoutConfiguration = checkoutConfiguration,
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = null,
+            )
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
                 analyticsRepositoryData = AnalyticsRepositoryData(
@@ -168,10 +174,13 @@ constructor(
         assertSupported(paymentMethod)
 
         val genericFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(
-                configuration = checkoutConfiguration,
-                sessionParams = SessionParamsFactory.create(checkoutSession),
+            val componentParams = GenericComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+                checkoutConfiguration = checkoutConfiguration,
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = SessionParamsFactory.create(checkoutSession),
             )
+
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(

--- a/instant/src/test/java/com/adyen/checkout/instant/internal/ui/DefaultInstantPaymentDelegateTest.kt
+++ b/instant/src/test/java/com/adyen/checkout/instant/internal/ui/DefaultInstantPaymentDelegateTest.kt
@@ -15,6 +15,7 @@ import com.adyen.checkout.components.core.OrderRequest
 import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.test.LoggingExtension
@@ -118,7 +119,8 @@ class DefaultInstantPaymentDelegateTest(
             observerRepository = PaymentObserverRepository(),
             paymentMethod = PaymentMethod(type = TYPE),
             order = TEST_ORDER,
-            componentParams = GenericComponentParamsMapper(null, null).mapToParams(configuration, null),
+            componentParams = GenericComponentParamsMapper(CommonComponentParamsMapper())
+                .mapToParams(configuration, Locale.US, null, null),
             analyticsRepository = analyticsRepository,
         )
     }

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/IssuerListConfiguration.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/IssuerListConfiguration.kt
@@ -37,10 +37,15 @@ abstract class IssuerListConfiguration : Configuration, ButtonConfiguration {
         protected open var hideIssuerLogos: Boolean? = null
         protected open var isSubmitButtonVisible: Boolean? = null
 
+        protected constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
+
         protected constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,
-            clientKey
+            clientKey,
         )
 
         protected constructor(

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/IssuerListConfiguration.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/IssuerListConfiguration.kt
@@ -42,6 +42,7 @@ abstract class IssuerListConfiguration : Configuration, ButtonConfiguration {
             clientKey,
         )
 
+        @Deprecated("You can omit the context parameter")
         protected constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/provider/IssuerListComponentProvider.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/provider/IssuerListComponentProvider.kt
@@ -34,7 +34,6 @@ import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.components.core.paymentmethod.IssuerListPaymentMethod
@@ -68,7 +67,6 @@ abstract class IssuerListComponentProvider<
 constructor(
     private val componentClass: Class<ComponentT>,
     private val dropInOverrideParams: DropInOverrideParams?,
-    overrideSessionParams: SessionParams?,
     private val analyticsRepository: AnalyticsRepository?,
     hideIssuerLogosDefaultValue: Boolean = false,
 ) :
@@ -82,7 +80,6 @@ constructor(
 
     private val componentParamsMapper = IssuerListComponentParamsMapper(
         dropInOverrideParams = dropInOverrideParams,
-        overrideSessionParams = overrideSessionParams,
         hideIssuerLogosDefaultValue = hideIssuerLogosDefaultValue,
     )
 

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/provider/IssuerListComponentProvider.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/provider/IssuerListComponentProvider.kt
@@ -33,12 +33,14 @@ import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepositoryD
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.components.core.paymentmethod.IssuerListPaymentMethod
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
+import com.adyen.checkout.core.internal.util.LocaleProvider
 import com.adyen.checkout.issuerlist.internal.IssuerListComponent
 import com.adyen.checkout.issuerlist.internal.IssuerListConfiguration
 import com.adyen.checkout.issuerlist.internal.ui.DefaultIssuerListDelegate
@@ -68,7 +70,8 @@ constructor(
     private val componentClass: Class<ComponentT>,
     private val dropInOverrideParams: DropInOverrideParams?,
     private val analyticsRepository: AnalyticsRepository?,
-    hideIssuerLogosDefaultValue: Boolean = false,
+    private val hideIssuerLogosDefaultValue: Boolean = false,
+    private val localeProvider: LocaleProvider = LocaleProvider(),
 ) :
     PaymentComponentProvider<ComponentT, ConfigurationT, ComponentStateT, ComponentCallback<ComponentStateT>>,
     SessionPaymentComponentProvider<
@@ -77,11 +80,6 @@ constructor(
         ComponentStateT,
         SessionComponentCallback<ComponentStateT>,
         > {
-
-    private val componentParamsMapper = IssuerListComponentParamsMapper(
-        dropInOverrideParams = dropInOverrideParams,
-        hideIssuerLogosDefaultValue = hideIssuerLogosDefaultValue,
-    )
 
     final override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,
@@ -97,10 +95,13 @@ constructor(
         assertSupported(paymentMethod)
 
         val genericFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(
+            val componentParams = IssuerListComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
                 checkoutConfiguration = checkoutConfiguration,
-                configuration = getConfiguration(checkoutConfiguration),
-                sessionParams = null,
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = null,
+                hideIssuerLogosDefaultValue = hideIssuerLogosDefaultValue,
+                componentConfiguration = getConfiguration(checkoutConfiguration),
             )
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
@@ -183,10 +184,13 @@ constructor(
         assertSupported(paymentMethod)
 
         val genericFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(
+            val componentParams = IssuerListComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
                 checkoutConfiguration = checkoutConfiguration,
-                configuration = getConfiguration(checkoutConfiguration),
-                sessionParams = SessionParamsFactory.create(checkoutSession),
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = SessionParamsFactory.create(checkoutSession),
+                hideIssuerLogosDefaultValue = hideIssuerLogosDefaultValue,
+                componentConfiguration = getConfiguration(checkoutConfiguration),
             )
 
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/ui/model/IssuerListComponentParams.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/ui/model/IssuerListComponentParams.kt
@@ -9,23 +9,15 @@
 package com.adyen.checkout.issuerlist.internal.ui.model
 
 import androidx.annotation.RestrictTo
-import com.adyen.checkout.components.core.Amount
-import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
 import com.adyen.checkout.components.core.internal.ui.model.ButtonParams
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParams
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
-import com.adyen.checkout.core.Environment
 import com.adyen.checkout.issuerlist.IssuerListViewType
-import java.util.Locale
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class IssuerListComponentParams(
-    override val shopperLocale: Locale,
-    override val environment: Environment,
-    override val clientKey: String,
-    override val analyticsParams: AnalyticsParams,
-    override val isCreatedByDropIn: Boolean,
-    override val amount: Amount?,
+    private val commonComponentParams: CommonComponentParams,
     override val isSubmitButtonVisible: Boolean,
     val viewType: IssuerListViewType,
     val hideIssuerLogos: Boolean,
-) : ComponentParams, ButtonParams
+) : ComponentParams by commonComponentParams, ButtonParams

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/ui/model/IssuerListComponentParamsMapper.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/ui/model/IssuerListComponentParamsMapper.kt
@@ -19,7 +19,6 @@ import com.adyen.checkout.issuerlist.internal.IssuerListConfiguration
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class IssuerListComponentParamsMapper(
     private val dropInOverrideParams: DropInOverrideParams?,
-    private val overrideSessionParams: SessionParams?,
     private val hideIssuerLogosDefaultValue: Boolean = false,
 ) {
 
@@ -31,7 +30,7 @@ class IssuerListComponentParamsMapper(
         return checkoutConfiguration
             .mapToParamsInternal(configuration)
             .override(dropInOverrideParams)
-            .override(sessionParams ?: overrideSessionParams)
+            .override(sessionParams ?: dropInOverrideParams?.sessionParams)
     }
 
     private fun CheckoutConfiguration.mapToParamsInternal(

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/ui/model/IssuerListComponentParamsMapper.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/ui/model/IssuerListComponentParamsMapper.kt
@@ -10,61 +10,38 @@ package com.adyen.checkout.issuerlist.internal.ui.model
 
 import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.core.CheckoutConfiguration
-import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.issuerlist.IssuerListViewType
 import com.adyen.checkout.issuerlist.internal.IssuerListConfiguration
+import java.util.Locale
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class IssuerListComponentParamsMapper(
-    private val dropInOverrideParams: DropInOverrideParams?,
-    private val hideIssuerLogosDefaultValue: Boolean = false,
+    private val commonComponentParamsMapper: CommonComponentParamsMapper,
 ) {
 
+    @Suppress("LongParameterList")
     fun mapToParams(
         checkoutConfiguration: CheckoutConfiguration,
-        configuration: IssuerListConfiguration?,
-        sessionParams: SessionParams?,
-    ): IssuerListComponentParams {
-        return checkoutConfiguration
-            .mapToParamsInternal(configuration)
-            .override(dropInOverrideParams)
-            .override(sessionParams ?: dropInOverrideParams?.sessionParams)
-    }
-
-    private fun CheckoutConfiguration.mapToParamsInternal(
-        configuration: IssuerListConfiguration?
-    ): IssuerListComponentParams {
-        return IssuerListComponentParams(
-            shopperLocale = shopperLocale,
-            environment = environment,
-            clientKey = clientKey,
-            analyticsParams = AnalyticsParams(analyticsConfiguration),
-            isCreatedByDropIn = false,
-            amount = amount,
-            isSubmitButtonVisible = configuration?.isSubmitButtonVisible ?: true,
-            viewType = configuration?.viewType ?: IssuerListViewType.RECYCLER_VIEW,
-            hideIssuerLogos = configuration?.hideIssuerLogos ?: hideIssuerLogosDefaultValue,
-        )
-    }
-
-    private fun IssuerListComponentParams.override(
+        deviceLocale: Locale,
         dropInOverrideParams: DropInOverrideParams?,
+        componentSessionParams: SessionParams?,
+        componentConfiguration: IssuerListConfiguration?,
+        hideIssuerLogosDefaultValue: Boolean,
     ): IssuerListComponentParams {
-        if (dropInOverrideParams == null) return this
-        return copy(
-            amount = dropInOverrideParams.amount,
-            isCreatedByDropIn = true,
+        val commonComponentParamsMapperData = commonComponentParamsMapper.mapToParams(
+            checkoutConfiguration,
+            deviceLocale,
+            dropInOverrideParams,
+            componentSessionParams,
         )
-    }
-
-    private fun IssuerListComponentParams.override(
-        sessionParams: SessionParams?,
-    ): IssuerListComponentParams {
-        if (sessionParams == null) return this
-        return copy(
-            amount = sessionParams.amount ?: amount,
+        return IssuerListComponentParams(
+            commonComponentParams = commonComponentParamsMapperData.commonComponentParams,
+            isSubmitButtonVisible = componentConfiguration?.isSubmitButtonVisible ?: true,
+            viewType = componentConfiguration?.viewType ?: IssuerListViewType.RECYCLER_VIEW,
+            hideIssuerLogos = componentConfiguration?.hideIssuerLogos ?: hideIssuerLogosDefaultValue,
         )
     }
 }

--- a/issuer-list/src/test/java/com/adyen/checkout/issuerlist/internal/ui/DefaultIssuerListDelegateTest.kt
+++ b/issuer-list/src/test/java/com/adyen/checkout/issuerlist/internal/ui/DefaultIssuerListDelegateTest.kt
@@ -15,6 +15,7 @@ import com.adyen.checkout.components.core.OrderRequest
 import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.issuerlist.IssuerListViewType
 import com.adyen.checkout.issuerlist.TestIssuerComponentState
@@ -169,10 +170,13 @@ internal class DefaultIssuerListDelegateTest(
 
         delegate = DefaultIssuerListDelegate(
             observerRepository = PaymentObserverRepository(),
-            componentParams = IssuerListComponentParamsMapper(null, null).mapToParams(
+            componentParams = IssuerListComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
                 checkoutConfiguration = configuration,
-                configuration = configuration.getConfiguration(TEST_CONFIGURATION_KEY),
-                sessionParams = null,
+                deviceLocale = Locale.US,
+                dropInOverrideParams = null,
+                componentSessionParams = null,
+                componentConfiguration = configuration.getConfiguration(TEST_CONFIGURATION_KEY),
+                hideIssuerLogosDefaultValue = false,
             ),
             paymentMethod = PaymentMethod(),
             order = TEST_ORDER,
@@ -201,10 +205,13 @@ internal class DefaultIssuerListDelegateTest(
 
         delegate = DefaultIssuerListDelegate(
             observerRepository = PaymentObserverRepository(),
-            componentParams = IssuerListComponentParamsMapper(null, null).mapToParams(
+            componentParams = IssuerListComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
                 checkoutConfiguration = configuration,
-                configuration = configuration.getConfiguration(TEST_CONFIGURATION_KEY),
-                sessionParams = null,
+                deviceLocale = Locale.US,
+                dropInOverrideParams = null,
+                componentSessionParams = null,
+                componentConfiguration = configuration.getConfiguration(TEST_CONFIGURATION_KEY),
+                hideIssuerLogosDefaultValue = false,
             ),
             paymentMethod = PaymentMethod(),
             order = TEST_ORDER,
@@ -308,10 +315,13 @@ internal class DefaultIssuerListDelegateTest(
         configuration: CheckoutConfiguration = createCheckoutConfiguration(),
     ) = DefaultIssuerListDelegate(
         observerRepository = PaymentObserverRepository(),
-        componentParams = IssuerListComponentParamsMapper(null, null).mapToParams(
+        componentParams = IssuerListComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
             checkoutConfiguration = configuration,
-            configuration = configuration.getConfiguration(TEST_CONFIGURATION_KEY),
-            sessionParams = null,
+            deviceLocale = Locale.US,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+            componentConfiguration = configuration.getConfiguration(TEST_CONFIGURATION_KEY),
+            hideIssuerLogosDefaultValue = false,
         ),
         paymentMethod = PaymentMethod(),
         order = TEST_ORDER,

--- a/issuer-list/src/test/java/com/adyen/checkout/issuerlist/utils/TestIssuerListConfiguration.kt
+++ b/issuer-list/src/test/java/com/adyen/checkout/issuerlist/utils/TestIssuerListConfiguration.kt
@@ -8,7 +8,6 @@
 
 package com.adyen.checkout.issuerlist.utils
 
-import android.content.Context
 import com.adyen.checkout.action.core.GenericActionConfiguration
 import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.components.core.AnalyticsConfiguration
@@ -33,19 +32,10 @@ private constructor(
     override val genericActionConfiguration: GenericActionConfiguration,
 ) : IssuerListConfiguration() {
 
-    class Builder : IssuerListBuilder<TestIssuerListConfiguration, Builder> {
+    class Builder(shopperLocale: Locale?, environment: Environment, clientKey: String) :
+        IssuerListBuilder<TestIssuerListConfiguration, Builder>(environment, clientKey) {
 
-        constructor(context: Context, environment: Environment, clientKey: String) : super(
-            context,
-            environment,
-            clientKey,
-        )
-
-        constructor(
-            shopperLocale: Locale?,
-            environment: Environment,
-            clientKey: String
-        ) : super(environment, clientKey) {
+        init {
             shopperLocale?.let { setShopperLocale(it) }
         }
 

--- a/issuer-list/src/test/java/com/adyen/checkout/issuerlist/utils/TestIssuerListConfiguration.kt
+++ b/issuer-list/src/test/java/com/adyen/checkout/issuerlist/utils/TestIssuerListConfiguration.kt
@@ -22,7 +22,7 @@ import java.util.Locale
 class TestIssuerListConfiguration
 @Suppress("LongParameterList")
 private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -38,14 +38,16 @@ private constructor(
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,
-            clientKey
+            clientKey,
         )
 
         constructor(
-            shopperLocale: Locale,
+            shopperLocale: Locale?,
             environment: Environment,
             clientKey: String
-        ) : super(shopperLocale, environment, clientKey)
+        ) : super(environment, clientKey) {
+            shopperLocale?.let { setShopperLocale(it) }
+        }
 
         public override fun buildInternal(): TestIssuerListConfiguration {
             return TestIssuerListConfiguration(

--- a/mbway/src/main/java/com/adyen/checkout/mbway/MBWayConfiguration.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/MBWayConfiguration.kt
@@ -28,7 +28,7 @@ import java.util.Locale
 @Parcelize
 @Suppress("LongParameterList")
 class MBWayConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -47,6 +47,18 @@ class MBWayConfiguration private constructor(
         private var isSubmitButtonVisible: Boolean? = null
 
         /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
+
+        /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
          *
          * @param context A context
@@ -60,7 +72,7 @@ class MBWayConfiguration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -101,8 +113,9 @@ class MBWayConfiguration private constructor(
 fun CheckoutConfiguration.mbWay(
     configuration: @CheckoutConfigurationMarker MBWayConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = MBWayConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = MBWayConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/mbway/src/main/java/com/adyen/checkout/mbway/MBWayConfiguration.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/MBWayConfiguration.kt
@@ -65,6 +65,7 @@ class MBWayConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/provider/MBWayComponentProvider.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/provider/MBWayComponentProvider.kt
@@ -29,11 +29,13 @@ import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
+import com.adyen.checkout.core.internal.util.LocaleProvider
 import com.adyen.checkout.mbway.MBWayComponent
 import com.adyen.checkout.mbway.MBWayComponentState
 import com.adyen.checkout.mbway.MBWayConfiguration
@@ -56,6 +58,7 @@ class MBWayComponentProvider
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
     private val analyticsRepository: AnalyticsRepository? = null,
+    private val localeProvider: LocaleProvider = LocaleProvider(),
 ) :
     PaymentComponentProvider<
         MBWayComponent,
@@ -69,8 +72,6 @@ constructor(
         MBWayComponentState,
         SessionComponentCallback<MBWayComponentState>,
         > {
-
-    private val componentParamsMapper = ButtonComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,
@@ -86,10 +87,12 @@ constructor(
         assertSupported(paymentMethod)
 
         val genericFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(
+            val componentParams = ButtonComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
                 checkoutConfiguration = checkoutConfiguration,
-                configuration = checkoutConfiguration.getMBWayConfiguration(),
-                sessionParams = null,
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = null,
+                componentConfiguration = checkoutConfiguration.getMBWayConfiguration(),
             )
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
@@ -174,11 +177,14 @@ constructor(
         assertSupported(paymentMethod)
 
         val genericFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(
+            val componentParams = ButtonComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
                 checkoutConfiguration = checkoutConfiguration,
-                configuration = checkoutConfiguration.getMBWayConfiguration(),
-                sessionParams = SessionParamsFactory.create(checkoutSession),
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = SessionParamsFactory.create(checkoutSession),
+                componentConfiguration = checkoutConfiguration.getMBWayConfiguration(),
             )
+
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/provider/MBWayComponentProvider.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/provider/MBWayComponentProvider.kt
@@ -30,7 +30,6 @@ import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepo
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.exception.ComponentException
@@ -56,7 +55,6 @@ class MBWayComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
     private val analyticsRepository: AnalyticsRepository? = null,
 ) :
     PaymentComponentProvider<
@@ -72,7 +70,7 @@ constructor(
         SessionComponentCallback<MBWayComponentState>,
         > {
 
-    private val componentParamsMapper = ButtonComponentParamsMapper(dropInOverrideParams, overrideSessionParams)
+    private val componentParamsMapper = ButtonComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/DefaultMBWayDelegateTest.kt
+++ b/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/DefaultMBWayDelegateTest.kt
@@ -16,6 +16,7 @@ import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.mbway.MBWayComponentState
 import com.adyen.checkout.mbway.MBWayConfiguration
@@ -281,10 +282,12 @@ internal class DefaultMBWayDelegateTest(
         observerRepository = PaymentObserverRepository(),
         paymentMethod = PaymentMethod(),
         order = TEST_ORDER,
-        componentParams = ButtonComponentParamsMapper(null, null).mapToParams(
+        componentParams = ButtonComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
             checkoutConfiguration = configuration,
-            configuration = configuration.getMBWayConfiguration(),
-            sessionParams = null,
+            deviceLocale = Locale.US,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+            componentConfiguration = configuration.getMBWayConfiguration(),
         ),
         analyticsRepository = analyticsRepository,
         submitHandler = submitHandler,

--- a/molpay/src/main/java/com/adyen/checkout/molpay/MolpayConfiguration.kt
+++ b/molpay/src/main/java/com/adyen/checkout/molpay/MolpayConfiguration.kt
@@ -25,7 +25,7 @@ import java.util.Locale
 @Parcelize
 @Suppress("LongParameterList")
 class MolpayConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -42,6 +42,18 @@ class MolpayConfiguration private constructor(
     class Builder : IssuerListBuilder<MolpayConfiguration, Builder> {
 
         /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
+
+        /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
          *
          * @param context A context
@@ -55,7 +67,7 @@ class MolpayConfiguration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -86,8 +98,9 @@ class MolpayConfiguration private constructor(
 fun CheckoutConfiguration.molpay(
     configuration: @CheckoutConfigurationMarker MolpayConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = MolpayConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = MolpayConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/molpay/src/main/java/com/adyen/checkout/molpay/MolpayConfiguration.kt
+++ b/molpay/src/main/java/com/adyen/checkout/molpay/MolpayConfiguration.kt
@@ -60,6 +60,7 @@ class MolpayConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/molpay/src/main/java/com/adyen/checkout/molpay/internal/provider/MolpayComponentProvider.kt
+++ b/molpay/src/main/java/com/adyen/checkout/molpay/internal/provider/MolpayComponentProvider.kt
@@ -16,7 +16,6 @@ import com.adyen.checkout.components.core.PaymentComponentData
 import com.adyen.checkout.components.core.internal.ComponentEventHandler
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.paymentmethod.MolpayPaymentMethod
 import com.adyen.checkout.issuerlist.internal.provider.IssuerListComponentProvider
 import com.adyen.checkout.issuerlist.internal.ui.IssuerListDelegate
@@ -30,12 +29,10 @@ class MolpayComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
     analyticsRepository: AnalyticsRepository? = null,
 ) : IssuerListComponentProvider<MolpayComponent, MolpayConfiguration, MolpayPaymentMethod, MolpayComponentState>(
     componentClass = MolpayComponent::class.java,
     dropInOverrideParams = dropInOverrideParams,
-    overrideSessionParams = overrideSessionParams,
     analyticsRepository = analyticsRepository,
 ) {
 

--- a/online-banking-core/src/main/java/com/adyen/checkout/onlinebankingcore/internal/OnlineBankingConfiguration.kt
+++ b/online-banking-core/src/main/java/com/adyen/checkout/onlinebankingcore/internal/OnlineBankingConfiguration.kt
@@ -32,6 +32,8 @@ abstract class OnlineBankingConfiguration : Configuration, ButtonConfiguration {
 
         protected open var isSubmitButtonVisible: Boolean? = null
 
+        protected constructor(environment: Environment, clientKey: String) : super(environment, clientKey)
+
         protected constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/online-banking-core/src/main/java/com/adyen/checkout/onlinebankingcore/internal/OnlineBankingConfiguration.kt
+++ b/online-banking-core/src/main/java/com/adyen/checkout/onlinebankingcore/internal/OnlineBankingConfiguration.kt
@@ -34,6 +34,7 @@ abstract class OnlineBankingConfiguration : Configuration, ButtonConfiguration {
 
         protected constructor(environment: Environment, clientKey: String) : super(environment, clientKey)
 
+        @Deprecated("You can omit the context parameter")
         protected constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/online-banking-core/src/main/java/com/adyen/checkout/onlinebankingcore/internal/provider/OnlineBankingComponentProvider.kt
+++ b/online-banking-core/src/main/java/com/adyen/checkout/onlinebankingcore/internal/provider/OnlineBankingComponentProvider.kt
@@ -34,7 +34,6 @@ import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepo
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.components.core.paymentmethod.IssuerListPaymentMethod
@@ -67,7 +66,6 @@ abstract class OnlineBankingComponentProvider<
 constructor(
     private val componentClass: Class<ComponentT>,
     private val dropInOverrideParams: DropInOverrideParams?,
-    overrideSessionParams: SessionParams?,
     private val analyticsRepository: AnalyticsRepository?,
 ) :
     PaymentComponentProvider<ComponentT, ConfigurationT, ComponentStateT, ComponentCallback<ComponentStateT>>,
@@ -78,7 +76,7 @@ constructor(
         SessionComponentCallback<ComponentStateT>,
         > {
 
-    private val componentParamsMapper = ButtonComponentParamsMapper(dropInOverrideParams, overrideSessionParams)
+    private val componentParamsMapper = ButtonComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/internal/ui/DefaultOnlineBankingDelegateTest.kt
+++ b/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/internal/ui/DefaultOnlineBankingDelegateTest.kt
@@ -17,6 +17,7 @@ import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.onlinebankingcore.internal.ui.model.OnlineBankingModel
 import com.adyen.checkout.onlinebankingcore.internal.ui.model.OnlineBankingOutputData
@@ -263,11 +264,14 @@ internal class DefaultOnlineBankingDelegateTest(
         paymentMethod = PaymentMethod(),
         order = order,
         analyticsRepository = analyticsRepository,
-        componentParams = ButtonComponentParamsMapper(null, null).mapToParams(
-            checkoutConfiguration = configuration,
-            configuration = configuration.getConfiguration(TEST_CONFIGURATION_KEY),
-            sessionParams = null,
-        ),
+        componentParams = ButtonComponentParamsMapper(CommonComponentParamsMapper())
+            .mapToParams(
+                checkoutConfiguration = configuration,
+                deviceLocale = Locale.US,
+                dropInOverrideParams = null,
+                componentSessionParams = null,
+                componentConfiguration = configuration.getConfiguration(TEST_CONFIGURATION_KEY),
+            ),
         termsAndConditionsUrl = TEST_URL,
         paymentMethodFactory = { TestOnlineBankingPaymentMethod() },
         submitHandler = submitHandler,

--- a/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/utils/TestOnlineBankingConfiguration.kt
+++ b/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/utils/TestOnlineBankingConfiguration.kt
@@ -8,7 +8,6 @@
 
 package com.adyen.checkout.onlinebankingcore.utils
 
-import android.content.Context
 import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.components.core.AnalyticsConfiguration
 import com.adyen.checkout.components.core.internal.BaseConfigurationBuilder
@@ -30,21 +29,14 @@ internal class TestOnlineBankingConfiguration private constructor(
 ) : Configuration,
     ButtonConfiguration {
 
-    class Builder : BaseConfigurationBuilder<TestOnlineBankingConfiguration, Builder>, ButtonConfigurationBuilder {
+    class Builder(
+        shopperLocale: Locale?,
+        environment: Environment,
+        clientKey: String
+    ) : BaseConfigurationBuilder<TestOnlineBankingConfiguration, Builder>(shopperLocale, environment, clientKey),
+        ButtonConfigurationBuilder {
 
         private var isSubmitButtonVisible: Boolean? = null
-
-        constructor(context: Context, environment: Environment, clientKey: String) : super(
-            context,
-            environment,
-            clientKey,
-        )
-
-        constructor(
-            shopperLocale: Locale?,
-            environment: Environment,
-            clientKey: String
-        ) : super(shopperLocale, environment, clientKey)
 
         override fun setSubmitButtonVisible(isSubmitButtonVisible: Boolean): Builder {
             this.isSubmitButtonVisible = isSubmitButtonVisible

--- a/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/utils/TestOnlineBankingConfiguration.kt
+++ b/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/utils/TestOnlineBankingConfiguration.kt
@@ -21,7 +21,7 @@ import java.util.Locale
 
 @Parcelize
 internal class TestOnlineBankingConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -37,11 +37,11 @@ internal class TestOnlineBankingConfiguration private constructor(
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,
-            clientKey
+            clientKey,
         )
 
         constructor(
-            shopperLocale: Locale,
+            shopperLocale: Locale?,
             environment: Environment,
             clientKey: String
         ) : super(shopperLocale, environment, clientKey)

--- a/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZConfiguration.kt
+++ b/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZConfiguration.kt
@@ -26,7 +26,7 @@ import java.util.Locale
 @Suppress("LongParameterList")
 @Parcelize
 class OnlineBankingCZConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -39,6 +39,18 @@ class OnlineBankingCZConfiguration private constructor(
      * Builder to create an [OnlineBankingCZConfiguration].
      */
     class Builder : OnlineBankingConfigurationBuilder<OnlineBankingCZConfiguration, Builder> {
+
+        /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
 
         /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
@@ -54,7 +66,7 @@ class OnlineBankingCZConfiguration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -83,8 +95,9 @@ class OnlineBankingCZConfiguration private constructor(
 fun CheckoutConfiguration.onlineBankingCZ(
     configuration: @CheckoutConfigurationMarker OnlineBankingCZConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = OnlineBankingCZConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = OnlineBankingCZConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZConfiguration.kt
+++ b/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZConfiguration.kt
@@ -59,6 +59,7 @@ class OnlineBankingCZConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/internal/provider/OnlineBankingCZComponentProvider.kt
+++ b/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/internal/provider/OnlineBankingCZComponentProvider.kt
@@ -16,7 +16,6 @@ import com.adyen.checkout.components.core.PaymentComponentData
 import com.adyen.checkout.components.core.internal.ComponentEventHandler
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.paymentmethod.OnlineBankingCZPaymentMethod
 import com.adyen.checkout.onlinebankingcore.internal.provider.OnlineBankingComponentProvider
 import com.adyen.checkout.onlinebankingcore.internal.ui.OnlineBankingDelegate
@@ -30,7 +29,6 @@ class OnlineBankingCZComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
     analyticsRepository: AnalyticsRepository? = null,
 ) : OnlineBankingComponentProvider<
     OnlineBankingCZComponent,
@@ -40,7 +38,6 @@ constructor(
     >(
     componentClass = OnlineBankingCZComponent::class.java,
     dropInOverrideParams = dropInOverrideParams,
-    overrideSessionParams = overrideSessionParams,
     analyticsRepository = analyticsRepository,
 ) {
 

--- a/online-banking-jp/src/main/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPConfiguration.kt
+++ b/online-banking-jp/src/main/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPConfiguration.kt
@@ -26,7 +26,7 @@ import java.util.Locale
 @Suppress("LongParameterList")
 @Parcelize
 class OnlineBankingJPConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -39,6 +39,18 @@ class OnlineBankingJPConfiguration private constructor(
      * Builder to create an [OnlineBankingJPConfiguration].
      */
     class Builder : EContextConfiguration.Builder<OnlineBankingJPConfiguration, Builder> {
+
+        /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
 
         /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
@@ -54,7 +66,7 @@ class OnlineBankingJPConfiguration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -83,8 +95,9 @@ class OnlineBankingJPConfiguration private constructor(
 fun CheckoutConfiguration.onlineBankingJP(
     configuration: @CheckoutConfigurationMarker OnlineBankingJPConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = OnlineBankingJPConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = OnlineBankingJPConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/online-banking-jp/src/main/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPConfiguration.kt
+++ b/online-banking-jp/src/main/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPConfiguration.kt
@@ -59,6 +59,7 @@ class OnlineBankingJPConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/online-banking-jp/src/main/java/com/adyen/checkout/onlinebankingjp/internal/provider/OnlineBankingJPComponentProvider.kt
+++ b/online-banking-jp/src/main/java/com/adyen/checkout/onlinebankingjp/internal/provider/OnlineBankingJPComponentProvider.kt
@@ -16,7 +16,6 @@ import com.adyen.checkout.components.core.PaymentComponentData
 import com.adyen.checkout.components.core.internal.ComponentEventHandler
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.paymentmethod.OnlineBankingJPPaymentMethod
 import com.adyen.checkout.econtext.internal.provider.EContextComponentProvider
 import com.adyen.checkout.econtext.internal.ui.EContextDelegate
@@ -30,7 +29,6 @@ class OnlineBankingJPComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
     analyticsRepository: AnalyticsRepository? = null,
 ) : EContextComponentProvider<
     OnlineBankingJPComponent,
@@ -40,7 +38,6 @@ constructor(
     >(
     componentClass = OnlineBankingJPComponent::class.java,
     dropInOverrideParams = dropInOverrideParams,
-    overrideSessionParams = overrideSessionParams,
     analyticsRepository = analyticsRepository,
 ) {
 

--- a/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLConfiguration.kt
+++ b/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLConfiguration.kt
@@ -27,7 +27,7 @@ import java.util.Locale
 @Parcelize
 @Suppress("LongParameterList")
 class OnlineBankingPLConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -44,6 +44,18 @@ class OnlineBankingPLConfiguration private constructor(
     class Builder : IssuerListBuilder<OnlineBankingPLConfiguration, Builder> {
 
         /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
+
+        /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
          *
          * @param context A context
@@ -57,7 +69,7 @@ class OnlineBankingPLConfiguration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -88,8 +100,9 @@ class OnlineBankingPLConfiguration private constructor(
 fun CheckoutConfiguration.onlineBankingPL(
     configuration: @CheckoutConfigurationMarker OnlineBankingPLConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = OnlineBankingPLConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = OnlineBankingPLConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLConfiguration.kt
+++ b/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLConfiguration.kt
@@ -62,6 +62,7 @@ class OnlineBankingPLConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/internal/provider/OnlineBankingPLComponentProvider.kt
+++ b/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/internal/provider/OnlineBankingPLComponentProvider.kt
@@ -16,7 +16,6 @@ import com.adyen.checkout.components.core.PaymentComponentData
 import com.adyen.checkout.components.core.internal.ComponentEventHandler
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.paymentmethod.OnlineBankingPLPaymentMethod
 import com.adyen.checkout.issuerlist.internal.provider.IssuerListComponentProvider
 import com.adyen.checkout.issuerlist.internal.ui.IssuerListDelegate
@@ -30,7 +29,6 @@ class OnlineBankingPLComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
     analyticsRepository: AnalyticsRepository? = null,
 ) : IssuerListComponentProvider<
     OnlineBankingPLComponent,
@@ -40,7 +38,6 @@ constructor(
     >(
     componentClass = OnlineBankingPLComponent::class.java,
     dropInOverrideParams = dropInOverrideParams,
-    overrideSessionParams = overrideSessionParams,
     analyticsRepository = analyticsRepository,
 ) {
 

--- a/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKConfiguration.kt
+++ b/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKConfiguration.kt
@@ -59,6 +59,7 @@ class OnlineBankingSKConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKConfiguration.kt
+++ b/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKConfiguration.kt
@@ -26,7 +26,7 @@ import java.util.Locale
 @Suppress("LongParameterList")
 @Parcelize
 class OnlineBankingSKConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -39,6 +39,18 @@ class OnlineBankingSKConfiguration private constructor(
      * Builder to create an [OnlineBankingSKConfiguration].
      */
     class Builder : OnlineBankingConfigurationBuilder<OnlineBankingSKConfiguration, Builder> {
+
+        /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
 
         /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
@@ -54,7 +66,7 @@ class OnlineBankingSKConfiguration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -83,8 +95,9 @@ class OnlineBankingSKConfiguration private constructor(
 fun CheckoutConfiguration.onlineBankingSK(
     configuration: @CheckoutConfigurationMarker OnlineBankingSKConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = OnlineBankingSKConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = OnlineBankingSKConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/internal/provider/OnlineBankingSKComponentProvider.kt
+++ b/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/internal/provider/OnlineBankingSKComponentProvider.kt
@@ -16,7 +16,6 @@ import com.adyen.checkout.components.core.PaymentComponentData
 import com.adyen.checkout.components.core.internal.ComponentEventHandler
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.paymentmethod.OnlineBankingSKPaymentMethod
 import com.adyen.checkout.onlinebankingcore.internal.provider.OnlineBankingComponentProvider
 import com.adyen.checkout.onlinebankingcore.internal.ui.OnlineBankingDelegate
@@ -30,7 +29,6 @@ class OnlineBankingSKComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
     analyticsRepository: AnalyticsRepository? = null,
 ) : OnlineBankingComponentProvider<
     OnlineBankingSKComponent,
@@ -40,7 +38,6 @@ constructor(
     >(
     componentClass = OnlineBankingSKComponent::class.java,
     dropInOverrideParams = dropInOverrideParams,
-    overrideSessionParams = overrideSessionParams,
     analyticsRepository = analyticsRepository,
 ) {
 

--- a/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingConfiguration.kt
+++ b/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingConfiguration.kt
@@ -61,6 +61,7 @@ class OpenBankingConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingConfiguration.kt
+++ b/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingConfiguration.kt
@@ -26,7 +26,7 @@ import java.util.Locale
 @Parcelize
 @Suppress("LongParameterList")
 class OpenBankingConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -43,6 +43,18 @@ class OpenBankingConfiguration private constructor(
     class Builder : IssuerListBuilder<OpenBankingConfiguration, Builder> {
 
         /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
+
+        /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
          *
          * @param context A context
@@ -56,7 +68,7 @@ class OpenBankingConfiguration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -87,8 +99,9 @@ class OpenBankingConfiguration private constructor(
 fun CheckoutConfiguration.openBanking(
     configuration: @CheckoutConfigurationMarker OpenBankingConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = OpenBankingConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = OpenBankingConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/openbanking/src/main/java/com/adyen/checkout/openbanking/internal/provider/OpenBankingComponentProvider.kt
+++ b/openbanking/src/main/java/com/adyen/checkout/openbanking/internal/provider/OpenBankingComponentProvider.kt
@@ -16,7 +16,6 @@ import com.adyen.checkout.components.core.PaymentComponentData
 import com.adyen.checkout.components.core.internal.ComponentEventHandler
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.paymentmethod.OpenBankingPaymentMethod
 import com.adyen.checkout.issuerlist.internal.provider.IssuerListComponentProvider
 import com.adyen.checkout.issuerlist.internal.ui.IssuerListDelegate
@@ -30,7 +29,6 @@ class OpenBankingComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
     analyticsRepository: AnalyticsRepository? = null,
 ) : IssuerListComponentProvider<
     OpenBankingComponent,
@@ -40,7 +38,6 @@ constructor(
     >(
     componentClass = OpenBankingComponent::class.java,
     dropInOverrideParams = dropInOverrideParams,
-    overrideSessionParams = overrideSessionParams,
     analyticsRepository = analyticsRepository,
 ) {
 

--- a/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankConfiguration.kt
+++ b/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankConfiguration.kt
@@ -58,6 +58,7 @@ class PayByBankConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankConfiguration.kt
+++ b/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankConfiguration.kt
@@ -26,7 +26,7 @@ import java.util.Locale
  */
 @Parcelize
 class PayByBankConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -38,6 +38,19 @@ class PayByBankConfiguration private constructor(
      * Builder to create a [PayByBankConfiguration].
      */
     class Builder : ActionHandlingPaymentMethodConfigurationBuilder<PayByBankConfiguration, Builder> {
+
+        /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
+
         /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
          *
@@ -52,7 +65,7 @@ class PayByBankConfiguration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -80,8 +93,9 @@ class PayByBankConfiguration private constructor(
 fun CheckoutConfiguration.payByBank(
     configuration: @CheckoutConfigurationMarker PayByBankConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = PayByBankConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = PayByBankConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/paybybank/src/main/java/com/adyen/checkout/paybybank/internal/provider/PayByBankComponentProvider.kt
+++ b/paybybank/src/main/java/com/adyen/checkout/paybybank/internal/provider/PayByBankComponentProvider.kt
@@ -30,7 +30,6 @@ import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepo
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.exception.ComponentException
@@ -55,7 +54,6 @@ class PayByBankComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
     private val analyticsRepository: AnalyticsRepository? = null,
 ) :
     PaymentComponentProvider<
@@ -71,7 +69,7 @@ constructor(
         SessionComponentCallback<PayByBankComponentState>,
         > {
 
-    private val componentParamsMapper = GenericComponentParamsMapper(dropInOverrideParams, overrideSessionParams)
+    private val componentParamsMapper = GenericComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/paybybank/src/main/java/com/adyen/checkout/paybybank/internal/provider/PayByBankComponentProvider.kt
+++ b/paybybank/src/main/java/com/adyen/checkout/paybybank/internal/provider/PayByBankComponentProvider.kt
@@ -28,12 +28,14 @@ import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepositoryD
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
+import com.adyen.checkout.core.internal.util.LocaleProvider
 import com.adyen.checkout.paybybank.PayByBankComponent
 import com.adyen.checkout.paybybank.PayByBankComponentState
 import com.adyen.checkout.paybybank.PayByBankConfiguration
@@ -55,6 +57,7 @@ class PayByBankComponentProvider
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
     private val analyticsRepository: AnalyticsRepository? = null,
+    private val localeProvider: LocaleProvider = LocaleProvider(),
 ) :
     PaymentComponentProvider<
         PayByBankComponent,
@@ -68,8 +71,6 @@ constructor(
         PayByBankComponentState,
         SessionComponentCallback<PayByBankComponentState>,
         > {
-
-    private val componentParamsMapper = GenericComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,
@@ -85,7 +86,12 @@ constructor(
         assertSupported(paymentMethod)
 
         val genericFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(checkoutConfiguration, null)
+            val componentParams = GenericComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+                checkoutConfiguration = checkoutConfiguration,
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = null,
+            )
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
                 analyticsRepositoryData = AnalyticsRepositoryData(
@@ -169,10 +175,13 @@ constructor(
         assertSupported(paymentMethod)
 
         val genericFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(
-                configuration = checkoutConfiguration,
-                sessionParams = SessionParamsFactory.create(checkoutSession),
+            val componentParams = GenericComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+                checkoutConfiguration = checkoutConfiguration,
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = SessionParamsFactory.create(checkoutSession),
             )
+
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(

--- a/paybybank/src/test/java/com/adyen/checkout/paybybank/internal/ui/DefaultPayByBankDelegateTest.kt
+++ b/paybybank/src/test/java/com/adyen/checkout/paybybank/internal/ui/DefaultPayByBankDelegateTest.kt
@@ -17,6 +17,7 @@ import com.adyen.checkout.components.core.OrderRequest
 import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.issuerlist.internal.ui.model.IssuerModel
@@ -285,7 +286,8 @@ internal class DefaultPayByBankDelegateTest(
     ): DefaultPayByBankDelegate {
         return DefaultPayByBankDelegate(
             observerRepository = PaymentObserverRepository(),
-            componentParams = GenericComponentParamsMapper(null, null).mapToParams(configuration, null),
+            componentParams = GenericComponentParamsMapper(CommonComponentParamsMapper())
+                .mapToParams(configuration, Locale.US, null, null),
             paymentMethod = PaymentMethod(
                 issuers = issuers,
             ),

--- a/payeasy/src/main/java/com/adyen/checkout/payeasy/PayEasyConfiguration.kt
+++ b/payeasy/src/main/java/com/adyen/checkout/payeasy/PayEasyConfiguration.kt
@@ -26,7 +26,7 @@ import java.util.Locale
 @Suppress("LongParameterList")
 @Parcelize
 class PayEasyConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -39,6 +39,18 @@ class PayEasyConfiguration private constructor(
      * Builder to create a [PayEasyConfiguration].
      */
     class Builder : EContextConfiguration.Builder<PayEasyConfiguration, Builder> {
+
+        /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
 
         /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
@@ -54,7 +66,7 @@ class PayEasyConfiguration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -83,8 +95,9 @@ class PayEasyConfiguration private constructor(
 fun CheckoutConfiguration.payEasy(
     configuration: @CheckoutConfigurationMarker PayEasyConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = PayEasyConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = PayEasyConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/payeasy/src/main/java/com/adyen/checkout/payeasy/PayEasyConfiguration.kt
+++ b/payeasy/src/main/java/com/adyen/checkout/payeasy/PayEasyConfiguration.kt
@@ -59,6 +59,7 @@ class PayEasyConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/payeasy/src/main/java/com/adyen/checkout/payeasy/internal/provider/PayEasyComponentProvider.kt
+++ b/payeasy/src/main/java/com/adyen/checkout/payeasy/internal/provider/PayEasyComponentProvider.kt
@@ -16,7 +16,6 @@ import com.adyen.checkout.components.core.PaymentComponentData
 import com.adyen.checkout.components.core.internal.ComponentEventHandler
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.paymentmethod.PayEasyPaymentMethod
 import com.adyen.checkout.econtext.internal.provider.EContextComponentProvider
 import com.adyen.checkout.econtext.internal.ui.EContextDelegate
@@ -30,12 +29,10 @@ class PayEasyComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
     analyticsRepository: AnalyticsRepository? = null,
 ) : EContextComponentProvider<PayEasyComponent, PayEasyConfiguration, PayEasyPaymentMethod, PayEasyComponentState>(
     componentClass = PayEasyComponent::class.java,
     dropInOverrideParams = dropInOverrideParams,
-    overrideSessionParams = overrideSessionParams,
     analyticsRepository = analyticsRepository,
 ) {
 

--- a/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeConfiguration.kt
+++ b/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeConfiguration.kt
@@ -54,6 +54,7 @@ class QRCodeConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeConfiguration.kt
+++ b/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeConfiguration.kt
@@ -23,7 +23,7 @@ import java.util.Locale
  */
 @Parcelize
 class QRCodeConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -34,6 +34,18 @@ class QRCodeConfiguration private constructor(
      * Builder to create a [QRCodeConfiguration].
      */
     class Builder : BaseConfigurationBuilder<QRCodeConfiguration, Builder> {
+
+        /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
 
         /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
@@ -49,7 +61,7 @@ class QRCodeConfiguration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -76,8 +88,9 @@ class QRCodeConfiguration private constructor(
 fun CheckoutConfiguration.qrCode(
     configuration: @CheckoutConfigurationMarker QRCodeConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = QRCodeConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = QRCodeConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/qr-code/src/main/java/com/adyen/checkout/qrcode/internal/provider/QRCodeComponentProvider.kt
+++ b/qr-code/src/main/java/com/adyen/checkout/qrcode/internal/provider/QRCodeComponentProvider.kt
@@ -27,7 +27,6 @@ import com.adyen.checkout.components.core.internal.data.api.StatusService
 import com.adyen.checkout.components.core.internal.provider.ActionComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
@@ -44,10 +43,9 @@ class QRCodeComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
 ) : ActionComponentProvider<QRCodeComponent, QRCodeConfiguration, QRCodeDelegate> {
 
-    private val componentParamsMapper = GenericComponentParamsMapper(dropInOverrideParams, overrideSessionParams)
+    private val componentParamsMapper = GenericComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/qr-code/src/main/java/com/adyen/checkout/qrcode/internal/provider/QRCodeComponentProvider.kt
+++ b/qr-code/src/main/java/com/adyen/checkout/qrcode/internal/provider/QRCodeComponentProvider.kt
@@ -25,11 +25,13 @@ import com.adyen.checkout.components.core.internal.PaymentDataRepository
 import com.adyen.checkout.components.core.internal.data.api.DefaultStatusRepository
 import com.adyen.checkout.components.core.internal.data.api.StatusService
 import com.adyen.checkout.components.core.internal.provider.ActionComponentProvider
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
+import com.adyen.checkout.core.internal.util.LocaleProvider
 import com.adyen.checkout.qrcode.QRCodeComponent
 import com.adyen.checkout.qrcode.QRCodeConfiguration
 import com.adyen.checkout.qrcode.internal.QRCodeCountDownTimer
@@ -42,10 +44,9 @@ import com.adyen.checkout.ui.core.internal.util.ImageSaver
 class QRCodeComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
-    dropInOverrideParams: DropInOverrideParams? = null,
+    private val dropInOverrideParams: DropInOverrideParams? = null,
+    private val localeProvider: LocaleProvider = LocaleProvider(),
 ) : ActionComponentProvider<QRCodeComponent, QRCodeConfiguration, QRCodeDelegate> {
-
-    private val componentParamsMapper = GenericComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,
@@ -74,7 +75,13 @@ constructor(
         savedStateHandle: SavedStateHandle,
         application: Application
     ): QRCodeDelegate {
-        val componentParams = componentParamsMapper.mapToParams(checkoutConfiguration, null)
+        val componentParams = GenericComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+            checkoutConfiguration = checkoutConfiguration,
+            deviceLocale = localeProvider.getLocale(application),
+            dropInOverrideParams = dropInOverrideParams,
+            componentSessionParams = null,
+        )
+
         val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
         val statusService = StatusService(httpClient)
         val statusRepository = DefaultStatusRepository(statusService, componentParams.clientKey)

--- a/qr-code/src/test/java/com/adyen/checkout/qrcode/internal/ui/DefaultQRCodeDelegateTest.kt
+++ b/qr-code/src/test/java/com/adyen/checkout/qrcode/internal/ui/DefaultQRCodeDelegateTest.kt
@@ -25,6 +25,7 @@ import com.adyen.checkout.components.core.internal.PaymentDataRepository
 import com.adyen.checkout.components.core.internal.data.api.StatusRepository
 import com.adyen.checkout.components.core.internal.data.model.StatusResponse
 import com.adyen.checkout.components.core.internal.test.TestStatusRepository
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParams
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.TimerData
@@ -84,7 +85,6 @@ internal class DefaultQRCodeDelegateTest(
         redirectHandler = TestRedirectHandler()
         paymentDataRepository = PaymentDataRepository(SavedStateHandle())
         val configuration = CheckoutConfiguration(
-            Locale.US,
             Environment.TEST,
             TEST_CLIENT_KEY,
         ) {
@@ -92,7 +92,8 @@ internal class DefaultQRCodeDelegateTest(
         }
         delegate = createDelegate(
             observerRepository = ActionObserverRepository(),
-            componentParams = GenericComponentParamsMapper(null, null).mapToParams(configuration, null),
+            componentParams = GenericComponentParamsMapper(CommonComponentParamsMapper())
+                .mapToParams(configuration, Locale.US, null, null),
             statusRepository = statusRepository,
             statusCountDownTimer = countDownTimer,
             redirectHandler = redirectHandler,

--- a/redirect/src/main/java/com/adyen/checkout/redirect/RedirectConfiguration.kt
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/RedirectConfiguration.kt
@@ -54,6 +54,7 @@ class RedirectConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/redirect/src/main/java/com/adyen/checkout/redirect/RedirectConfiguration.kt
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/RedirectConfiguration.kt
@@ -23,7 +23,7 @@ import java.util.Locale
  */
 @Parcelize
 class RedirectConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -34,6 +34,18 @@ class RedirectConfiguration private constructor(
      * Builder to create a [RedirectConfiguration].
      */
     class Builder : BaseConfigurationBuilder<RedirectConfiguration, Builder> {
+
+        /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
 
         /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
@@ -49,7 +61,7 @@ class RedirectConfiguration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -76,8 +88,9 @@ class RedirectConfiguration private constructor(
 fun CheckoutConfiguration.redirect(
     configuration: @CheckoutConfigurationMarker RedirectConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = RedirectConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = RedirectConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/redirect/src/main/java/com/adyen/checkout/redirect/internal/provider/RedirectComponentProvider.kt
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/internal/provider/RedirectComponentProvider.kt
@@ -25,7 +25,6 @@ import com.adyen.checkout.components.core.internal.PaymentDataRepository
 import com.adyen.checkout.components.core.internal.provider.ActionComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.redirect.RedirectComponent
@@ -39,10 +38,9 @@ class RedirectComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
 ) : ActionComponentProvider<RedirectComponent, RedirectConfiguration, RedirectDelegate> {
 
-    private val componentParamsMapper = GenericComponentParamsMapper(dropInOverrideParams, overrideSessionParams)
+    private val componentParamsMapper = GenericComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/redirect/src/main/java/com/adyen/checkout/redirect/internal/provider/RedirectComponentProvider.kt
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/internal/provider/RedirectComponentProvider.kt
@@ -23,10 +23,12 @@ import com.adyen.checkout.components.core.internal.ActionObserverRepository
 import com.adyen.checkout.components.core.internal.DefaultActionComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentDataRepository
 import com.adyen.checkout.components.core.internal.provider.ActionComponentProvider
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
+import com.adyen.checkout.core.internal.util.LocaleProvider
 import com.adyen.checkout.redirect.RedirectComponent
 import com.adyen.checkout.redirect.RedirectConfiguration
 import com.adyen.checkout.redirect.internal.ui.DefaultRedirectDelegate
@@ -37,10 +39,9 @@ import com.adyen.checkout.ui.core.internal.DefaultRedirectHandler
 class RedirectComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
-    dropInOverrideParams: DropInOverrideParams? = null,
+    private val dropInOverrideParams: DropInOverrideParams? = null,
+    private val localeProvider: LocaleProvider = LocaleProvider(),
 ) : ActionComponentProvider<RedirectComponent, RedirectConfiguration, RedirectDelegate> {
-
-    private val componentParamsMapper = GenericComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,
@@ -69,7 +70,13 @@ constructor(
         savedStateHandle: SavedStateHandle,
         application: Application
     ): RedirectDelegate {
-        val componentParams = componentParamsMapper.mapToParams(checkoutConfiguration, null)
+        val componentParams = GenericComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+            checkoutConfiguration = checkoutConfiguration,
+            deviceLocale = localeProvider.getLocale(application),
+            dropInOverrideParams = dropInOverrideParams,
+            componentSessionParams = null,
+        )
+
         val redirectHandler = DefaultRedirectHandler()
         val paymentDataRepository = PaymentDataRepository(savedStateHandle)
         return DefaultRedirectDelegate(

--- a/redirect/src/test/java/com/adyen/checkout/redirect/internal/ui/DefaultRedirectDelegateTest.kt
+++ b/redirect/src/test/java/com/adyen/checkout/redirect/internal/ui/DefaultRedirectDelegateTest.kt
@@ -16,6 +16,7 @@ import com.adyen.checkout.components.core.CheckoutConfiguration
 import com.adyen.checkout.components.core.action.RedirectAction
 import com.adyen.checkout.components.core.internal.ActionObserverRepository
 import com.adyen.checkout.components.core.internal.PaymentDataRepository
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.core.exception.ComponentException
@@ -38,7 +39,6 @@ internal class DefaultRedirectDelegateTest {
     @BeforeEach
     fun beforeEach() {
         val configuration = CheckoutConfiguration(
-            Locale.US,
             Environment.TEST,
             TEST_CLIENT_KEY,
         ) {
@@ -48,7 +48,8 @@ internal class DefaultRedirectDelegateTest {
         paymentDataRepository = PaymentDataRepository(SavedStateHandle())
         delegate = DefaultRedirectDelegate(
             ActionObserverRepository(),
-            GenericComponentParamsMapper(null, null).mapToParams(configuration, null),
+            GenericComponentParamsMapper(CommonComponentParamsMapper())
+                .mapToParams(configuration, Locale.US, null, null),
             redirectHandler,
             paymentDataRepository,
         )

--- a/sepa/src/main/java/com/adyen/checkout/sepa/SepaConfiguration.kt
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/SepaConfiguration.kt
@@ -65,6 +65,7 @@ class SepaConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/sepa/src/main/java/com/adyen/checkout/sepa/SepaConfiguration.kt
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/SepaConfiguration.kt
@@ -28,7 +28,7 @@ import java.util.Locale
 @Parcelize
 @Suppress("LongParameterList")
 class SepaConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -47,6 +47,18 @@ class SepaConfiguration private constructor(
         private var isSubmitButtonVisible: Boolean? = null
 
         /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
+
+        /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
          *
          * @param context A context
@@ -60,7 +72,7 @@ class SepaConfiguration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -101,8 +113,9 @@ class SepaConfiguration private constructor(
 fun CheckoutConfiguration.sepa(
     configuration: @CheckoutConfigurationMarker SepaConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = SepaConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = SepaConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/sepa/src/main/java/com/adyen/checkout/sepa/internal/provider/SepaComponentProvider.kt
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/internal/provider/SepaComponentProvider.kt
@@ -30,7 +30,6 @@ import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepo
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.exception.ComponentException
@@ -56,7 +55,6 @@ class SepaComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
     private val analyticsRepository: AnalyticsRepository? = null,
 ) :
     PaymentComponentProvider<
@@ -72,7 +70,7 @@ constructor(
         SessionComponentCallback<SepaComponentState>,
         > {
 
-    private val componentParamsMapper = ButtonComponentParamsMapper(dropInOverrideParams, overrideSessionParams)
+    private val componentParamsMapper = ButtonComponentParamsMapper(dropInOverrideParams)
 
     @Suppress("LongMethod")
     override fun get(

--- a/sepa/src/main/java/com/adyen/checkout/sepa/internal/provider/SepaComponentProvider.kt
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/internal/provider/SepaComponentProvider.kt
@@ -29,11 +29,13 @@ import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
+import com.adyen.checkout.core.internal.util.LocaleProvider
 import com.adyen.checkout.sepa.SepaComponent
 import com.adyen.checkout.sepa.SepaComponentState
 import com.adyen.checkout.sepa.SepaConfiguration
@@ -56,6 +58,7 @@ class SepaComponentProvider
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
     private val analyticsRepository: AnalyticsRepository? = null,
+    private val localeProvider: LocaleProvider = LocaleProvider(),
 ) :
     PaymentComponentProvider<
         SepaComponent,
@@ -69,8 +72,6 @@ constructor(
         SepaComponentState,
         SessionComponentCallback<SepaComponentState>,
         > {
-
-    private val componentParamsMapper = ButtonComponentParamsMapper(dropInOverrideParams)
 
     @Suppress("LongMethod")
     override fun get(
@@ -87,10 +88,12 @@ constructor(
         assertSupported(paymentMethod)
 
         val genericFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(
+            val componentParams = ButtonComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
                 checkoutConfiguration = checkoutConfiguration,
-                configuration = checkoutConfiguration.getSepaConfiguration(),
-                sessionParams = null,
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = null,
+                componentConfiguration = checkoutConfiguration.getSepaConfiguration(),
             )
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
@@ -175,11 +178,14 @@ constructor(
         assertSupported(paymentMethod)
 
         val genericFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(
+            val componentParams = ButtonComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
                 checkoutConfiguration = checkoutConfiguration,
-                configuration = checkoutConfiguration.getSepaConfiguration(),
-                sessionParams = SessionParamsFactory.create(checkoutSession),
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = SessionParamsFactory.create(checkoutSession),
+                componentConfiguration = checkoutConfiguration.getSepaConfiguration(),
             )
+
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(

--- a/sepa/src/test/java/com/adyen/checkout/sepa/internal/ui/DefaultSepaDelegateTest.kt
+++ b/sepa/src/test/java/com/adyen/checkout/sepa/internal/ui/DefaultSepaDelegateTest.kt
@@ -17,6 +17,7 @@ import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.paymentmethod.SepaPaymentMethod
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.sepa.SepaComponentState
@@ -209,10 +210,12 @@ internal class DefaultSepaDelegateTest(
         observerRepository = PaymentObserverRepository(),
         paymentMethod = PaymentMethod(),
         order = order,
-        componentParams = ButtonComponentParamsMapper(null, null).mapToParams(
+        componentParams = ButtonComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
             checkoutConfiguration = configuration,
-            configuration = configuration.getSepaConfiguration(),
-            sessionParams = null,
+            deviceLocale = Locale.US,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+            componentConfiguration = configuration.getSepaConfiguration(),
         ),
         analyticsRepository = analyticsRepository,
         submitHandler = submitHandler,

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/data/model/SessionDetails.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/data/model/SessionDetails.kt
@@ -11,11 +11,9 @@ package com.adyen.checkout.sessions.core.internal.data.model
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.core.Amount
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.sessions.core.SessionModel
 import com.adyen.checkout.sessions.core.SessionSetupConfiguration
 import com.adyen.checkout.sessions.core.SessionSetupResponse
-import com.adyen.checkout.sessions.core.internal.ui.model.SessionParamsFactory
 import kotlinx.parcelize.Parcelize
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -47,10 +45,4 @@ fun SessionDetails.mapToModel(): SessionModel {
         id = id,
         sessionData = sessionData,
     )
-}
-
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-fun SessionDetails.mapToParams(amount: Amount?): SessionParams {
-    // TODO: Once Backend provides the correct amount in the SessionSetupResponse use that in SessionDetails
-    return SessionParamsFactory.create(this.copy(amount = amount))
 }

--- a/seven-eleven/src/main/java/com/adyen/checkout/seveneleven/SevenElevenConfiguration.kt
+++ b/seven-eleven/src/main/java/com/adyen/checkout/seveneleven/SevenElevenConfiguration.kt
@@ -59,6 +59,7 @@ class SevenElevenConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/seven-eleven/src/main/java/com/adyen/checkout/seveneleven/SevenElevenConfiguration.kt
+++ b/seven-eleven/src/main/java/com/adyen/checkout/seveneleven/SevenElevenConfiguration.kt
@@ -26,7 +26,7 @@ import java.util.Locale
 @Suppress("LongParameterList")
 @Parcelize
 class SevenElevenConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -39,6 +39,18 @@ class SevenElevenConfiguration private constructor(
      * Builder to create a [SevenElevenConfiguration].
      */
     class Builder : EContextConfiguration.Builder<SevenElevenConfiguration, Builder> {
+
+        /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
 
         /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
@@ -54,7 +66,7 @@ class SevenElevenConfiguration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -83,8 +95,9 @@ class SevenElevenConfiguration private constructor(
 fun CheckoutConfiguration.sevenEleven(
     configuration: @CheckoutConfigurationMarker SevenElevenConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = SevenElevenConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = SevenElevenConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/seven-eleven/src/main/java/com/adyen/checkout/seveneleven/internal/provider/SevenElevenComponentProvider.kt
+++ b/seven-eleven/src/main/java/com/adyen/checkout/seveneleven/internal/provider/SevenElevenComponentProvider.kt
@@ -16,7 +16,6 @@ import com.adyen.checkout.components.core.PaymentComponentData
 import com.adyen.checkout.components.core.internal.ComponentEventHandler
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.paymentmethod.SevenElevenPaymentMethod
 import com.adyen.checkout.econtext.internal.provider.EContextComponentProvider
 import com.adyen.checkout.econtext.internal.ui.EContextDelegate
@@ -30,7 +29,6 @@ class SevenElevenComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
     analyticsRepository: AnalyticsRepository? = null,
 ) : EContextComponentProvider<
     SevenElevenComponent,
@@ -40,7 +38,6 @@ constructor(
     >(
     componentClass = SevenElevenComponent::class.java,
     dropInOverrideParams = dropInOverrideParams,
-    overrideSessionParams = overrideSessionParams,
     analyticsRepository = analyticsRepository,
 ) {
 

--- a/upi/src/main/java/com/adyen/checkout/upi/UPIConfiguration.kt
+++ b/upi/src/main/java/com/adyen/checkout/upi/UPIConfiguration.kt
@@ -65,6 +65,7 @@ class UPIConfiguration(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/upi/src/main/java/com/adyen/checkout/upi/UPIConfiguration.kt
+++ b/upi/src/main/java/com/adyen/checkout/upi/UPIConfiguration.kt
@@ -28,7 +28,7 @@ import java.util.Locale
 @Parcelize
 @Suppress("LongParameterList")
 class UPIConfiguration(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -47,6 +47,18 @@ class UPIConfiguration(
         private var isSubmitButtonVisible: Boolean? = null
 
         /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
+
+        /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
          *
          * @param context A context
@@ -60,7 +72,7 @@ class UPIConfiguration(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -99,8 +111,9 @@ class UPIConfiguration(
 fun CheckoutConfiguration.upi(
     configuration: @CheckoutConfigurationMarker UPIConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = UPIConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = UPIConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/upi/src/main/java/com/adyen/checkout/upi/internal/provider/UPIComponentProvider.kt
+++ b/upi/src/main/java/com/adyen/checkout/upi/internal/provider/UPIComponentProvider.kt
@@ -30,7 +30,6 @@ import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepo
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.exception.ComponentException
@@ -56,7 +55,6 @@ class UPIComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
     private val analyticsRepository: AnalyticsRepository? = null,
 ) :
     PaymentComponentProvider<UPIComponent, UPIConfiguration, UPIComponentState, ComponentCallback<UPIComponentState>>,
@@ -67,7 +65,7 @@ constructor(
         SessionComponentCallback<UPIComponentState>,
         > {
 
-    private val componentParamsMapper = ButtonComponentParamsMapper(dropInOverrideParams, overrideSessionParams)
+    private val componentParamsMapper = ButtonComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/upi/src/main/java/com/adyen/checkout/upi/internal/provider/UPIComponentProvider.kt
+++ b/upi/src/main/java/com/adyen/checkout/upi/internal/provider/UPIComponentProvider.kt
@@ -29,11 +29,13 @@ import com.adyen.checkout.components.core.internal.data.api.AnalyticsService
 import com.adyen.checkout.components.core.internal.data.api.DefaultAnalyticsRepository
 import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
+import com.adyen.checkout.core.internal.util.LocaleProvider
 import com.adyen.checkout.sessions.core.CheckoutSession
 import com.adyen.checkout.sessions.core.SessionComponentCallback
 import com.adyen.checkout.sessions.core.internal.SessionComponentEventHandler
@@ -56,6 +58,7 @@ class UPIComponentProvider
 constructor(
     private val dropInOverrideParams: DropInOverrideParams? = null,
     private val analyticsRepository: AnalyticsRepository? = null,
+    private val localeProvider: LocaleProvider = LocaleProvider(),
 ) :
     PaymentComponentProvider<UPIComponent, UPIConfiguration, UPIComponentState, ComponentCallback<UPIComponentState>>,
     SessionPaymentComponentProvider<
@@ -64,8 +67,6 @@ constructor(
         UPIComponentState,
         SessionComponentCallback<UPIComponentState>,
         > {
-
-    private val componentParamsMapper = ButtonComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,
@@ -81,10 +82,12 @@ constructor(
         assertSupported(paymentMethod)
 
         val genericFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(
+            val componentParams = ButtonComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
                 checkoutConfiguration = checkoutConfiguration,
-                configuration = checkoutConfiguration.getUPIConfiguration(),
-                sessionParams = null,
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = null,
+                componentConfiguration = checkoutConfiguration.getUPIConfiguration(),
             )
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(
@@ -169,11 +172,14 @@ constructor(
         assertSupported(paymentMethod)
 
         val genericFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = componentParamsMapper.mapToParams(
+            val componentParams = ButtonComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
                 checkoutConfiguration = checkoutConfiguration,
-                configuration = checkoutConfiguration.getUPIConfiguration(),
-                sessionParams = SessionParamsFactory.create(checkoutSession),
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = SessionParamsFactory.create(checkoutSession),
+                componentConfiguration = checkoutConfiguration.getUPIConfiguration(),
             )
+
             val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsRepository = analyticsRepository ?: DefaultAnalyticsRepository(

--- a/upi/src/test/java/com/adyen/checkout/upi/internal/ui/DefaultUPIDelegateTest.kt
+++ b/upi/src/test/java/com/adyen/checkout/upi/internal/ui/DefaultUPIDelegateTest.kt
@@ -18,6 +18,7 @@ import com.adyen.checkout.components.core.PaymentMethodTypes
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.data.api.AnalyticsRepository
 import com.adyen.checkout.components.core.internal.ui.model.ButtonComponentParamsMapper
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.test.LoggingExtension
 import com.adyen.checkout.test.extensions.test
@@ -252,10 +253,12 @@ internal class DefaultUPIDelegateTest(
         observerRepository = PaymentObserverRepository(),
         paymentMethod = PaymentMethod(),
         order = order,
-        componentParams = ButtonComponentParamsMapper(null, null).mapToParams(
+        componentParams = ButtonComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
             checkoutConfiguration = configuration,
-            configuration = configuration.getUPIConfiguration(),
-            sessionParams = null,
+            deviceLocale = Locale.US,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+            componentConfiguration = configuration.getUPIConfiguration(),
         ),
     )
 

--- a/voucher/src/main/java/com/adyen/checkout/voucher/VoucherConfiguration.kt
+++ b/voucher/src/main/java/com/adyen/checkout/voucher/VoucherConfiguration.kt
@@ -24,7 +24,7 @@ import java.util.Locale
  */
 @Parcelize
 class VoucherConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -35,6 +35,18 @@ class VoucherConfiguration private constructor(
      * Builder to create a [VoucherConfiguration].
      */
     class Builder : BaseConfigurationBuilder<VoucherConfiguration, Builder> {
+
+        /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
 
         /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
@@ -50,7 +62,7 @@ class VoucherConfiguration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -77,8 +89,9 @@ class VoucherConfiguration private constructor(
 fun CheckoutConfiguration.voucher(
     configuration: @CheckoutConfigurationMarker VoucherConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = VoucherConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = VoucherConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/voucher/src/main/java/com/adyen/checkout/voucher/VoucherConfiguration.kt
+++ b/voucher/src/main/java/com/adyen/checkout/voucher/VoucherConfiguration.kt
@@ -55,6 +55,7 @@ class VoucherConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/voucher/src/main/java/com/adyen/checkout/voucher/internal/provider/VoucherComponentProvider.kt
+++ b/voucher/src/main/java/com/adyen/checkout/voucher/internal/provider/VoucherComponentProvider.kt
@@ -25,7 +25,6 @@ import com.adyen.checkout.components.core.internal.DefaultActionComponentEventHa
 import com.adyen.checkout.components.core.internal.provider.ActionComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.ui.core.internal.util.ImageSaver
@@ -40,10 +39,9 @@ class VoucherComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
 ) : ActionComponentProvider<VoucherComponent, VoucherConfiguration, VoucherDelegate> {
 
-    private val componentParamsMapper = GenericComponentParamsMapper(dropInOverrideParams, overrideSessionParams)
+    private val componentParamsMapper = GenericComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/voucher/src/main/java/com/adyen/checkout/voucher/internal/provider/VoucherComponentProvider.kt
+++ b/voucher/src/main/java/com/adyen/checkout/voucher/internal/provider/VoucherComponentProvider.kt
@@ -23,10 +23,12 @@ import com.adyen.checkout.components.core.action.VoucherAction
 import com.adyen.checkout.components.core.internal.ActionObserverRepository
 import com.adyen.checkout.components.core.internal.DefaultActionComponentEventHandler
 import com.adyen.checkout.components.core.internal.provider.ActionComponentProvider
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
+import com.adyen.checkout.core.internal.util.LocaleProvider
 import com.adyen.checkout.ui.core.internal.util.ImageSaver
 import com.adyen.checkout.ui.core.internal.util.PdfOpener
 import com.adyen.checkout.voucher.VoucherComponent
@@ -38,10 +40,9 @@ import com.adyen.checkout.voucher.toCheckoutConfiguration
 class VoucherComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
-    dropInOverrideParams: DropInOverrideParams? = null,
+    private val dropInOverrideParams: DropInOverrideParams? = null,
+    private val localeProvider: LocaleProvider = LocaleProvider(),
 ) : ActionComponentProvider<VoucherComponent, VoucherConfiguration, VoucherDelegate> {
-
-    private val componentParamsMapper = GenericComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,
@@ -70,7 +71,13 @@ constructor(
         savedStateHandle: SavedStateHandle,
         application: Application
     ): VoucherDelegate {
-        val componentParams = componentParamsMapper.mapToParams(checkoutConfiguration, null)
+        val componentParams = GenericComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+            checkoutConfiguration = checkoutConfiguration,
+            deviceLocale = localeProvider.getLocale(application),
+            dropInOverrideParams = dropInOverrideParams,
+            componentSessionParams = null,
+        )
+
         return DefaultVoucherDelegate(
             observerRepository = ActionObserverRepository(),
             componentParams = componentParams,

--- a/voucher/src/test/java/com/adyen/checkout/voucher/internal/ui/DefaultVoucherDelegateTest.kt
+++ b/voucher/src/test/java/com/adyen/checkout/voucher/internal/ui/DefaultVoucherDelegateTest.kt
@@ -20,6 +20,7 @@ import com.adyen.checkout.components.core.action.Action
 import com.adyen.checkout.components.core.action.VoucherAction
 import com.adyen.checkout.components.core.internal.ActionComponentEvent
 import com.adyen.checkout.components.core.internal.ActionObserverRepository
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.core.PermissionHandlerCallback
@@ -66,12 +67,13 @@ internal class DefaultVoucherDelegateTest(
 
     @BeforeEach
     fun beforeEach() {
-        val configuration = CheckoutConfiguration(Locale.getDefault(), Environment.TEST, TEST_CLIENT_KEY) {
+        val configuration = CheckoutConfiguration(Environment.TEST, TEST_CLIENT_KEY) {
             voucher()
         }
         delegate = DefaultVoucherDelegate(
             observerRepository,
-            GenericComponentParamsMapper(null, null).mapToParams(configuration, null),
+            GenericComponentParamsMapper(CommonComponentParamsMapper())
+                .mapToParams(configuration, Locale.US, null, null),
             pdfOpener,
             imageSaver,
         )

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionConfiguration.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionConfiguration.kt
@@ -23,7 +23,7 @@ import java.util.Locale
  */
 @Parcelize
 class WeChatPayActionConfiguration private constructor(
-    override val shopperLocale: Locale,
+    override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,
     override val analyticsConfiguration: AnalyticsConfiguration?,
@@ -34,6 +34,18 @@ class WeChatPayActionConfiguration private constructor(
      * Builder to create a [WeChatPayActionConfiguration].
      */
     class Builder : BaseConfigurationBuilder<WeChatPayActionConfiguration, Builder> {
+
+        /**
+         * Initialize a configuration builder with the required fields.
+         * The shopper locale will match the primary user locale on the device.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
 
         /**
          * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
@@ -49,7 +61,7 @@ class WeChatPayActionConfiguration private constructor(
         )
 
         /**
-         * Initialize a configuration builder with the required fields.
+         * Initialize a configuration builder with the required fields and a shopper locale.
          *
          * @param shopperLocale The [Locale] of the shopper.
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
@@ -76,8 +88,9 @@ class WeChatPayActionConfiguration private constructor(
 fun CheckoutConfiguration.weChatPayAction(
     configuration: @CheckoutConfigurationMarker WeChatPayActionConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {
-    val config = WeChatPayActionConfiguration.Builder(shopperLocale, environment, clientKey)
+    val config = WeChatPayActionConfiguration.Builder(environment, clientKey)
         .apply {
+            shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
         }

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionConfiguration.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionConfiguration.kt
@@ -54,6 +54,7 @@ class WeChatPayActionConfiguration private constructor(
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
          */
+        @Deprecated("You can omit the context parameter")
         constructor(context: Context, environment: Environment, clientKey: String) : super(
             context,
             environment,

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/internal/provider/WeChatPayActionComponentProvider.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/internal/provider/WeChatPayActionComponentProvider.kt
@@ -26,7 +26,6 @@ import com.adyen.checkout.components.core.internal.PaymentDataRepository
 import com.adyen.checkout.components.core.internal.provider.ActionComponentProvider
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
-import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
 import com.adyen.checkout.wechatpay.WeChatPayActionComponent
@@ -42,10 +41,9 @@ class WeChatPayActionComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
     dropInOverrideParams: DropInOverrideParams? = null,
-    overrideSessionParams: SessionParams? = null,
 ) : ActionComponentProvider<WeChatPayActionComponent, WeChatPayActionConfiguration, WeChatDelegate> {
 
-    private val componentParamsMapper = GenericComponentParamsMapper(dropInOverrideParams, overrideSessionParams)
+    private val componentParamsMapper = GenericComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/internal/provider/WeChatPayActionComponentProvider.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/internal/provider/WeChatPayActionComponentProvider.kt
@@ -24,10 +24,12 @@ import com.adyen.checkout.components.core.internal.ActionObserverRepository
 import com.adyen.checkout.components.core.internal.DefaultActionComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentDataRepository
 import com.adyen.checkout.components.core.internal.provider.ActionComponentProvider
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
 import com.adyen.checkout.components.core.internal.util.get
 import com.adyen.checkout.components.core.internal.util.viewModelFactory
+import com.adyen.checkout.core.internal.util.LocaleProvider
 import com.adyen.checkout.wechatpay.WeChatPayActionComponent
 import com.adyen.checkout.wechatpay.WeChatPayActionConfiguration
 import com.adyen.checkout.wechatpay.internal.ui.DefaultWeChatDelegate
@@ -40,10 +42,9 @@ import com.tencent.mm.opensdk.openapi.WXAPIFactory
 class WeChatPayActionComponentProvider
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(
-    dropInOverrideParams: DropInOverrideParams? = null,
+    private val dropInOverrideParams: DropInOverrideParams? = null,
+    private val localeProvider: LocaleProvider = LocaleProvider(),
 ) : ActionComponentProvider<WeChatPayActionComponent, WeChatPayActionConfiguration, WeChatDelegate> {
-
-    private val componentParamsMapper = GenericComponentParamsMapper(dropInOverrideParams)
 
     override fun get(
         savedStateRegistryOwner: SavedStateRegistryOwner,
@@ -73,7 +74,13 @@ constructor(
         savedStateHandle: SavedStateHandle,
         application: Application
     ): WeChatDelegate {
-        val componentParams = componentParamsMapper.mapToParams(checkoutConfiguration, null)
+        val componentParams = GenericComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+            checkoutConfiguration = checkoutConfiguration,
+            deviceLocale = localeProvider.getLocale(application),
+            dropInOverrideParams = dropInOverrideParams,
+            componentSessionParams = null,
+        )
+
         val iwxApi: IWXAPI = WXAPIFactory.createWXAPI(application, null, true)
         val requestGenerator = WeChatPayRequestGenerator()
         val paymentDataRepository = PaymentDataRepository(savedStateHandle)

--- a/wechatpay/src/test/java/com/adyen/checkout/wechatpay/internal/ui/DefaultWeChatDelegateTest.kt
+++ b/wechatpay/src/test/java/com/adyen/checkout/wechatpay/internal/ui/DefaultWeChatDelegateTest.kt
@@ -17,6 +17,7 @@ import com.adyen.checkout.components.core.action.SdkAction
 import com.adyen.checkout.components.core.action.WeChatPaySdkData
 import com.adyen.checkout.components.core.internal.ActionObserverRepository
 import com.adyen.checkout.components.core.internal.PaymentDataRepository
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.core.exception.ComponentException
@@ -54,7 +55,6 @@ internal class DefaultWeChatDelegateTest(
     @BeforeEach
     fun beforeEach() {
         val configuration = CheckoutConfiguration(
-            Locale.US,
             Environment.TEST,
             TEST_CLIENT_KEY,
         ) {
@@ -63,7 +63,8 @@ internal class DefaultWeChatDelegateTest(
         paymentDataRepository = PaymentDataRepository(SavedStateHandle())
         delegate = DefaultWeChatDelegate(
             observerRepository = ActionObserverRepository(),
-            componentParams = GenericComponentParamsMapper(null, null).mapToParams(configuration, null),
+            componentParams = GenericComponentParamsMapper(CommonComponentParamsMapper())
+                .mapToParams(configuration, Locale.US, null, null),
             iwxApi = iwxApi,
             payRequestGenerator = weChatRequestGenerator,
             paymentDataRepository = paymentDataRepository,


### PR DESCRIPTION
## Description
Allows creating a configuration without passing a shopper locale. Internally we will use the primary device locale.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-848
