### PR TITLE
Add documentation for configurations that cannot be set with sessions

### DIFF
--- a/ach/src/main/java/com/adyen/checkout/ach/ACHDirectDebitConfiguration.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/ACHDirectDebitConfiguration.kt
@@ -107,6 +107,10 @@ class ACHDirectDebitConfiguration private constructor(
          *
          * Default is true.
          *
+         * Not applicable for the sessions flow. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
+         *
          * @param showStorePaymentField [Boolean]
          * @return [ACHDirectDebitConfiguration.Builder]
          */

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcConfiguration.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcConfiguration.kt
@@ -95,10 +95,11 @@ class BcmcConfiguration private constructor(
         /**
          * Set if the option to store the card for future payments should be shown as an input field.
          *
-         * Default is false.
+         * Default is true.
          *
-         * When using `sessions` show store payment field will be ignored and replaced with the value
-         * sent to `/sessions` call.
+         * Not applicable for the sessions flow. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param showStorePaymentField [Boolean]
          * @return [BcmcConfiguration.Builder]

--- a/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
@@ -140,8 +140,9 @@ class CardConfiguration private constructor(
          *
          * Default is true.
          *
-         * When using `sessions` show store payment field will be ignored and replaced with the value
-         * sent to `/sessions` call.
+         * Not applicable for the sessions flow. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param showStorePaymentField [Boolean]
          * @return [CardConfiguration.Builder]
@@ -223,8 +224,9 @@ class CardConfiguration private constructor(
         /**
          * Configures the installment options to be provided to the shopper.
          *
-         * When using `sessions` installment configuration will be ignored and replaced with the value
-         * sent to `/sessions` call.
+         * Not applicable for the sessions flow. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param installmentConfiguration The configuration object for installment options.
          * @return [CardConfiguration.Builder]

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/CashAppPayConfiguration.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/CashAppPayConfiguration.kt
@@ -95,6 +95,10 @@ private constructor(
          *
          * Sets the required return URL that Cash App Pay will redirect to at the end of the transaction.
          *
+         * Not applicable for the sessions flow. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
+         *
          * @param returnUrl The Cash App Pay environment.
          */
         fun setReturnUrl(returnUrl: String): Builder {
@@ -107,8 +111,9 @@ private constructor(
          *
          * Default is true.
          *
-         * When using `sessions` show store payment field will be ignored and replaced with the value sent to
-         * `/sessions` call.
+         * Not applicable for the sessions flow. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param showStorePaymentField [Boolean]
          * @return [CashAppPayConfiguration.Builder]

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/BaseConfigurationBuilder.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/BaseConfigurationBuilder.kt
@@ -70,6 +70,10 @@ constructor(
      *
      * Default is null.
      *
+     * Not applicable for the sessions flow. Check out the
+     * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+     * this value.
+     *
      * @param amount Amount of the transaction.
      */
     open fun setAmount(amount: Amount): BuilderT {

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.kt
@@ -350,6 +350,10 @@ class GooglePayConfiguration private constructor(
          * [Google Pay docs](https://developers.google.com/pay/api/android/reference/request-objects#TransactionInfo)
          * for more details.
          *
+         * Not applicable for the sessions flow. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
+         *
          * @param amount Amount of the transaction.
          */
         @Suppress("RedundantOverride")


### PR DESCRIPTION
## Description
Some configuration values are ignored in the sessions flow and can only be set in the `/sessions` request. In this PR we clarify that in the code docs of the configurations that are affected.

List of affected configurations:
- `setShowStorePaymentField`
- `setAmount`
- `setReturnUrl`
- `setInstallmentConfigurations`

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-850
