### PR TITLE
Apply shopper locale if provided to the sessions API call

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Configuration.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Adyen3DS2Configuration.kt
@@ -47,7 +47,11 @@ class Adyen3DS2Configuration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -61,7 +61,7 @@ CheckoutConfiguration(
   - Seven-Eleven: Payment method type: **econtext_seven_eleven**
 
 ## Deprecated
-- When creating a configuration, the `Builder` constructors with a `Context` are now deprecated. You can omit the `context` parameter, the shopper locale will default to the primary device locale.
+- When creating a configuration, the `Builder` constructors with a `Context` are now deprecated. You can omit the `context` parameter.
 - The `PermissionException` is deprecated. Handle permissions through `ActionComponentCallback`, `SessionComponentCallback` or `ComponentCallback` callbacks.
 - The styles for vouchers have been changed:
   - The `AdyenCheckout.Voucher.Description.Bacs` style will not work anymore. Use `AdyenCheckout.Voucher.Simple.Description` instead.
@@ -74,5 +74,5 @@ CheckoutConfiguration(
 - `AdyenLogger.setLogLevel(logLevel: Int)` is deprecated. Use `AdyenLogger.setLogLevel(level: AdyenLogLevel)` instead.
 
 ## Changed
-- When creating a configuration, the shopper locale parameter is now optional. If not set, the primary device locale will be used.
+- When creating a configuration, the shopper locale parameter is now optional. If not set, the shopper locale will match the value passed to the API with the sessions flow, or the primary user locale on the device otherwise.
 - In drop-in all actions will start in expanded mode

--- a/ach/src/main/java/com/adyen/checkout/ach/ACHDirectDebitConfiguration.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/ACHDirectDebitConfiguration.kt
@@ -53,7 +53,11 @@ class ACHDirectDebitConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/ach/src/test/java/com/adyen/checkout/ach/internal/ui/model/ACHDirectDebitComponentParamsMapperTest.kt
+++ b/ach/src/test/java/com/adyen/checkout/ach/internal/ui/model/ACHDirectDebitComponentParamsMapperTest.kt
@@ -186,6 +186,7 @@ internal class ACHDirectDebitComponentParamsMapperTest {
             installmentConfiguration = null,
             amount = null,
             returnUrl = "",
+            shopperLocale = null,
         )
 
         val params = achDirectDebitComponentParamsMapper.mapToParams(configuration, DEVICE_LOCALE, null, sessionParams)
@@ -221,6 +222,7 @@ internal class ACHDirectDebitComponentParamsMapperTest {
             installmentConfiguration = null,
             amount = sessionsValue,
             returnUrl = "",
+            shopperLocale = null,
         )
 
         val dropInOverrideParams = dropInValue?.let { DropInOverrideParams(it, null) }
@@ -240,11 +242,44 @@ internal class ACHDirectDebitComponentParamsMapperTest {
         assertEquals(expected, params)
     }
 
+    @ParameterizedTest
+    @MethodSource("shopperLocaleSource")
+    fun `shopper locale should match value set in configuration then sessions then device locale`(
+        configurationValue: Locale?,
+        sessionsValue: Locale?,
+        deviceLocaleValue: Locale,
+        expectedValue: Locale,
+    ) {
+        val configuration = createCheckoutConfiguration(shopperLocale = configurationValue)
+
+        val sessionParams = SessionParams(
+            enableStoreDetails = null,
+            installmentConfiguration = null,
+            amount = null,
+            returnUrl = "",
+            shopperLocale = sessionsValue,
+        )
+
+        val params = achDirectDebitComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = deviceLocaleValue,
+            dropInOverrideParams = null,
+            componentSessionParams = sessionParams,
+        )
+
+        val expected = getAchComponentParams(
+            shopperLocale = expectedValue,
+        )
+
+        assertEquals(expected, params)
+    }
+
     private fun createCheckoutConfiguration(
         amount: Amount? = null,
+        shopperLocale: Locale? = null,
         configuration: ACHDirectDebitConfiguration.Builder.() -> Unit = {}
     ) = CheckoutConfiguration(
-        shopperLocale = Locale.US,
+        shopperLocale = shopperLocale,
         environment = Environment.TEST,
         clientKey = TEST_CLIENT_KEY_1,
         amount = amount,
@@ -254,7 +289,7 @@ internal class ACHDirectDebitComponentParamsMapperTest {
 
     @Suppress("LongParameterList")
     private fun getAchComponentParams(
-        shopperLocale: Locale = Locale.US,
+        shopperLocale: Locale = DEVICE_LOCALE,
         environment: Environment = Environment.TEST,
         clientKey: String = TEST_CLIENT_KEY_1,
         analyticsParams: AnalyticsParams = AnalyticsParams(AnalyticsParamsLevel.ALL),
@@ -303,6 +338,15 @@ internal class ACHDirectDebitComponentParamsMapperTest {
             arguments(Amount("EUR", 100), Amount("USD", 200), Amount("CAD", 300), Amount("CAD", 300)),
             arguments(Amount("EUR", 100), Amount("USD", 200), null, Amount("USD", 200)),
             arguments(Amount("EUR", 100), null, null, Amount("EUR", 100)),
+        )
+
+        @JvmStatic
+        fun shopperLocaleSource() = listOf(
+            // configurationValue, sessionsValue, deviceLocaleValue, expectedValue
+            arguments(null, null, Locale.US, Locale.US),
+            arguments(Locale.GERMAN, null, Locale.US, Locale.GERMAN),
+            arguments(null, Locale.CHINESE, Locale.US, Locale.CHINESE),
+            arguments(Locale.GERMAN, Locale.CHINESE, Locale.US, Locale.GERMAN),
         )
     }
 }

--- a/action-core/src/main/java/com/adyen/checkout/action/core/GenericActionConfiguration.kt
+++ b/action-core/src/main/java/com/adyen/checkout/action/core/GenericActionConfiguration.kt
@@ -63,7 +63,11 @@ class GenericActionConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/await/src/main/java/com/adyen/checkout/await/AwaitConfiguration.kt
+++ b/await/src/main/java/com/adyen/checkout/await/AwaitConfiguration.kt
@@ -37,7 +37,11 @@ class AwaitConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitConfiguration.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitConfiguration.kt
@@ -49,7 +49,11 @@ class BacsDirectDebitConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcConfiguration.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcConfiguration.kt
@@ -55,7 +55,11 @@ class BcmcConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/blik/src/main/java/com/adyen/checkout/blik/BlikConfiguration.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/BlikConfiguration.kt
@@ -48,7 +48,11 @@ class BlikConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/boleto/src/main/java/com/adyen/checkout/boleto/BoletoConfiguration.kt
+++ b/boleto/src/main/java/com/adyen/checkout/boleto/BoletoConfiguration.kt
@@ -49,7 +49,11 @@ class BoletoConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/boleto/src/test/java/com/adyen/checkout/boleto/internal/ui/model/BoletoComponentParamsMapperTest.kt
+++ b/boleto/src/test/java/com/adyen/checkout/boleto/internal/ui/model/BoletoComponentParamsMapperTest.kt
@@ -131,6 +131,7 @@ internal class BoletoComponentParamsMapperTest {
             installmentConfiguration = null,
             amount = sessionsValue,
             returnUrl = "",
+            shopperLocale = null,
         )
 
         val params = mapParams(
@@ -147,11 +148,44 @@ internal class BoletoComponentParamsMapperTest {
         assertEquals(expected, params)
     }
 
+    @ParameterizedTest
+    @MethodSource("shopperLocaleSource")
+    fun `shopper locale should match value set in configuration then sessions then device locale`(
+        configurationValue: Locale?,
+        sessionsValue: Locale?,
+        deviceLocaleValue: Locale,
+        expectedValue: Locale,
+    ) {
+        val configuration = createCheckoutConfiguration(shopperLocale = configurationValue)
+
+        val sessionParams = SessionParams(
+            enableStoreDetails = null,
+            installmentConfiguration = null,
+            amount = null,
+            returnUrl = "",
+            shopperLocale = sessionsValue,
+        )
+
+        val params = boletoComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = deviceLocaleValue,
+            dropInOverrideParams = null,
+            componentSessionParams = sessionParams,
+        )
+
+        val expected = getBoletoComponentParams(
+            shopperLocale = expectedValue,
+        )
+
+        assertEquals(expected, params)
+    }
+
     private fun createCheckoutConfiguration(
         amount: Amount? = null,
+        shopperLocale: Locale? = null,
         configuration: BoletoConfiguration.Builder.() -> Unit = {}
     ) = CheckoutConfiguration(
-        shopperLocale = Locale.US,
+        shopperLocale = shopperLocale,
         environment = Environment.TEST,
         clientKey = TEST_CLIENT_KEY_1,
         amount = amount,
@@ -162,7 +196,7 @@ internal class BoletoComponentParamsMapperTest {
     @Suppress("LongParameterList")
     private fun getBoletoComponentParams(
         isSubmitButtonVisible: Boolean = true,
-        shopperLocale: Locale = Locale.US,
+        shopperLocale: Locale = DEVICE_LOCALE,
         environment: Environment = Environment.TEST,
         clientKey: String = TEST_CLIENT_KEY_1,
         analyticsParams: AnalyticsParams = AnalyticsParams(AnalyticsParamsLevel.ALL),
@@ -215,6 +249,15 @@ internal class BoletoComponentParamsMapperTest {
             arguments(Amount("EUR", 100), Amount("USD", 200), Amount("CAD", 300), Amount("CAD", 300)),
             arguments(Amount("EUR", 100), Amount("USD", 200), null, Amount("USD", 200)),
             arguments(Amount("EUR", 100), null, null, Amount("EUR", 100)),
+        )
+
+        @JvmStatic
+        fun shopperLocaleSource() = listOf(
+            // configurationValue, sessionsValue, deviceLocaleValue, expectedValue
+            arguments(null, null, Locale.US, Locale.US),
+            arguments(Locale.GERMAN, null, Locale.US, Locale.GERMAN),
+            arguments(null, Locale.CHINESE, Locale.US, Locale.CHINESE),
+            arguments(Locale.GERMAN, Locale.CHINESE, Locale.US, Locale.GERMAN),
         )
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
@@ -70,7 +70,11 @@ class CardConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapperTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapperTest.kt
@@ -267,6 +267,7 @@ internal class CardComponentParamsMapperTest {
             installmentConfiguration = null,
             amount = null,
             returnUrl = "",
+            shopperLocale = null,
         )
 
         val params = cardComponentParamsMapper.mapToParams(
@@ -302,6 +303,7 @@ internal class CardComponentParamsMapperTest {
             installmentConfiguration = null,
             amount = null,
             returnUrl = "",
+            shopperLocale = null,
         )
 
         val params = cardComponentParamsMapper.mapToParams(
@@ -349,6 +351,7 @@ internal class CardComponentParamsMapperTest {
             installmentConfiguration = installmentConfiguration,
             amount = null,
             returnUrl = "",
+            shopperLocale = null,
         )
         val cardComponentParamsMapper = CardComponentParamsMapper(
             CommonComponentParamsMapper(),
@@ -441,6 +444,7 @@ internal class CardComponentParamsMapperTest {
             installmentConfiguration = null,
             amount = sessionsValue,
             returnUrl = "",
+            shopperLocale = null,
         )
 
         val params = cardComponentParamsMapper.mapToParams(
@@ -459,11 +463,45 @@ internal class CardComponentParamsMapperTest {
         assertEquals(expected, params)
     }
 
+    @ParameterizedTest
+    @MethodSource("shopperLocaleSource")
+    fun `shopper locale should match value set in configuration then sessions then device locale`(
+        configurationValue: Locale?,
+        sessionsValue: Locale?,
+        deviceLocaleValue: Locale,
+        expectedValue: Locale,
+    ) {
+        val configuration = createCheckoutConfiguration(shopperLocale = configurationValue)
+
+        val sessionParams = SessionParams(
+            enableStoreDetails = null,
+            installmentConfiguration = null,
+            amount = null,
+            returnUrl = "",
+            shopperLocale = sessionsValue,
+        )
+
+        val params = cardComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = deviceLocaleValue,
+            dropInOverrideParams = null,
+            componentSessionParams = sessionParams,
+            paymentMethod = PaymentMethod(),
+        )
+
+        val expected = getCardComponentParams(
+            shopperLocale = expectedValue,
+        )
+
+        assertEquals(expected, params)
+    }
+
     private fun createCheckoutConfiguration(
         amount: Amount? = null,
+        shopperLocale: Locale? = null,
         configuration: CardConfiguration.Builder.() -> Unit = {},
     ) = CheckoutConfiguration(
-        shopperLocale = DEVICE_LOCALE,
+        shopperLocale = shopperLocale,
         environment = Environment.TEST,
         clientKey = TEST_CLIENT_KEY_1,
         amount = amount,
@@ -534,6 +572,15 @@ internal class CardComponentParamsMapperTest {
             arguments(Amount("EUR", 100), Amount("USD", 200), Amount("CAD", 300), Amount("CAD", 300)),
             arguments(Amount("EUR", 100), Amount("USD", 200), null, Amount("USD", 200)),
             arguments(Amount("EUR", 100), null, null, Amount("EUR", 100)),
+        )
+
+        @JvmStatic
+        fun shopperLocaleSource() = listOf(
+            // configurationValue, sessionsValue, deviceLocaleValue, expectedValue
+            arguments(null, null, Locale.US, Locale.US),
+            arguments(Locale.GERMAN, null, Locale.US, Locale.GERMAN),
+            arguments(null, Locale.CHINESE, Locale.US, Locale.CHINESE),
+            arguments(Locale.GERMAN, Locale.CHINESE, Locale.US, Locale.GERMAN),
         )
     }
 }

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/CashAppPayConfiguration.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/CashAppPayConfiguration.kt
@@ -55,7 +55,11 @@ private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/CommonComponentParamsMapper.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/CommonComponentParamsMapper.kt
@@ -23,7 +23,7 @@ class CommonComponentParamsMapper {
     ): CommonComponentParamsMapperData {
         val sessionParams: SessionParams? = dropInOverrideParams?.sessionParams ?: componentSessionParams
         val commonComponentParams = CommonComponentParams(
-            shopperLocale = checkoutConfiguration.shopperLocale ?: deviceLocale,
+            shopperLocale = checkoutConfiguration.shopperLocale ?: sessionParams?.shopperLocale ?: deviceLocale,
             environment = checkoutConfiguration.environment,
             clientKey = checkoutConfiguration.clientKey,
             analyticsParams = AnalyticsParams(checkoutConfiguration.analyticsConfiguration),

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/SessionParams.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/SessionParams.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.components.core.internal.ui.model
 
 import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.core.Amount
+import java.util.Locale
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class SessionParams(
@@ -17,4 +18,5 @@ data class SessionParams(
     val installmentConfiguration: SessionInstallmentConfiguration?,
     val amount: Amount?,
     val returnUrl: String?,
+    val shopperLocale: Locale?,
 )

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/ui/model/ButtonComponentParamsMapperTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/ui/model/ButtonComponentParamsMapperTest.kt
@@ -94,6 +94,7 @@ internal class ButtonComponentParamsMapperTest {
             installmentConfiguration = null,
             amount = sessionsValue,
             returnUrl = "",
+            shopperLocale = null,
         )
         val params = buttonComponentParamsMapper.mapToParams(
             checkoutConfiguration = configuration,
@@ -111,11 +112,45 @@ internal class ButtonComponentParamsMapperTest {
         assertEquals(expected, params)
     }
 
+    @ParameterizedTest
+    @MethodSource("shopperLocaleSource")
+    fun `shopper locale should match value set in configuration then sessions then device locale`(
+        configurationValue: Locale?,
+        sessionsValue: Locale?,
+        deviceLocaleValue: Locale,
+        expectedValue: Locale,
+    ) {
+        val configuration = createCheckoutConfiguration(shopperLocale = configurationValue)
+
+        val sessionParams = SessionParams(
+            enableStoreDetails = null,
+            installmentConfiguration = null,
+            amount = null,
+            returnUrl = "",
+            shopperLocale = sessionsValue,
+        )
+
+        val params = buttonComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = deviceLocaleValue,
+            dropInOverrideParams = null,
+            componentSessionParams = sessionParams,
+            componentConfiguration = configuration.getConfiguration(TEST_CONFIGURATION_KEY),
+        )
+
+        val expected = getButtonComponentParams(
+            shopperLocale = expectedValue,
+        )
+
+        assertEquals(expected, params)
+    }
+
     private fun createCheckoutConfiguration(
         amount: Amount? = null,
+        shopperLocale: Locale? = null,
         configuration: ButtonTestConfiguration.Builder.() -> Unit = {},
     ) = CheckoutConfiguration(
-        shopperLocale = Locale.US,
+        shopperLocale = shopperLocale,
         environment = Environment.TEST,
         clientKey = TEST_CLIENT_KEY_1,
         amount = amount,
@@ -128,7 +163,7 @@ internal class ButtonComponentParamsMapperTest {
 
     @Suppress("LongParameterList")
     private fun getButtonComponentParams(
-        shopperLocale: Locale = Locale.US,
+        shopperLocale: Locale = DEVICE_LOCALE,
         environment: Environment = Environment.TEST,
         clientKey: String = TEST_CLIENT_KEY_1,
         analyticsParams: AnalyticsParams = AnalyticsParams(AnalyticsParamsLevel.ALL),
@@ -161,6 +196,15 @@ internal class ButtonComponentParamsMapperTest {
             arguments(Amount("EUR", 100), Amount("USD", 200), Amount("CAD", 300), Amount("CAD", 300)),
             arguments(Amount("EUR", 100), Amount("USD", 200), null, Amount("USD", 200)),
             arguments(Amount("EUR", 100), null, null, Amount("EUR", 100)),
+        )
+
+        @JvmStatic
+        fun shopperLocaleSource() = listOf(
+            // configurationValue, sessionsValue, deviceLocaleValue, expectedValue
+            arguments(null, null, Locale.US, Locale.US),
+            arguments(Locale.GERMAN, null, Locale.US, Locale.GERMAN),
+            arguments(null, Locale.CHINESE, Locale.US, Locale.CHINESE),
+            arguments(Locale.GERMAN, Locale.CHINESE, Locale.US, Locale.GERMAN),
         )
     }
 }

--- a/convenience-stores-jp/src/main/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPConfiguration.kt
+++ b/convenience-stores-jp/src/main/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPConfiguration.kt
@@ -42,7 +42,11 @@ class ConvenienceStoresJPConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayConfiguration.kt
+++ b/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayConfiguration.kt
@@ -44,7 +44,11 @@ class DotpayConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropIn.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropIn.kt
@@ -19,11 +19,14 @@ import com.adyen.checkout.core.internal.util.BuildUtils
 import com.adyen.checkout.core.internal.util.adyenLog
 import com.adyen.checkout.dropin.DropIn.registerForDropInResult
 import com.adyen.checkout.dropin.DropIn.startPayment
+import com.adyen.checkout.dropin.internal.ui.model.DropInParamsMapper
 import com.adyen.checkout.dropin.internal.ui.model.DropInResultContractParams
 import com.adyen.checkout.dropin.internal.ui.model.SessionDropInResultContractParams
 import com.adyen.checkout.dropin.internal.util.DropInPrefs
 import com.adyen.checkout.sessions.core.CheckoutSession
 import com.adyen.checkout.sessions.core.CheckoutSessionProvider
+import com.adyen.checkout.sessions.core.internal.ui.model.SessionParamsFactory
+import java.util.Locale
 
 /**
  * Drop-in is our pre-built checkout UI for accepting payments. You only need to integrate through your backend with the
@@ -135,7 +138,10 @@ object DropIn {
             checkoutSession,
             serviceClass,
         )
-        startPayment(context, dropInLauncher, checkoutConfiguration, sessionDropInResultContractParams)
+        val sessionParams = SessionParamsFactory.create(checkoutSession)
+        val shopperLocale = DropInParamsMapper().getShopperLocale(checkoutConfiguration, sessionParams)
+
+        startPayment(context, dropInLauncher, shopperLocale, sessionDropInResultContractParams)
     }
 
     /**
@@ -228,17 +234,19 @@ object DropIn {
             paymentMethodsApiResponse,
             serviceClass,
         )
-        startPayment(context, dropInLauncher, checkoutConfiguration, dropInResultContractParams)
+        val shopperLocale = DropInParamsMapper().getShopperLocale(checkoutConfiguration, null)
+
+        startPayment(context, dropInLauncher, shopperLocale, dropInResultContractParams)
     }
 
     private fun <T> startPayment(
         context: Context,
         dropInLauncher: ActivityResultLauncher<T>,
-        checkoutConfiguration: CheckoutConfiguration,
+        shopperLocale: Locale?,
         params: T,
     ) {
         updateDefaultLogLevel(context)
-        DropInPrefs.setShopperLocale(context, checkoutConfiguration.shopperLocale)
+        DropInPrefs.setShopperLocale(context, shopperLocale)
         dropInLauncher.launch(params)
     }
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropInConfiguration.kt
@@ -110,7 +110,11 @@ class DropInConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModelFactory.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModelFactory.kt
@@ -28,6 +28,7 @@ import com.adyen.checkout.dropin.internal.ui.model.DropInParamsMapper
 import com.adyen.checkout.dropin.internal.ui.model.DropInPaymentMethodInformation
 import com.adyen.checkout.dropin.internal.ui.model.overrideInformation
 import com.adyen.checkout.sessions.core.internal.data.model.SessionDetails
+import com.adyen.checkout.sessions.core.internal.ui.model.SessionParamsFactory
 import java.util.Locale
 
 internal class DropInViewModelFactory(
@@ -79,10 +80,11 @@ internal class DropInViewModelFactory(
         checkoutConfiguration: CheckoutConfiguration,
         sessionDetails: SessionDetails?
     ): DropInParams {
+        val sessionParams = sessionDetails?.let { SessionParamsFactory.create(sessionDetails) }
         return DropInParamsMapper().mapToParams(
             checkoutConfiguration = checkoutConfiguration,
             deviceLocale = deviceLocale,
-            sessionDetails = sessionDetails,
+            sessionParams = sessionParams,
         )
     }
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/model/DropInParamsMapper.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/model/DropInParamsMapper.kt
@@ -10,8 +10,8 @@ package com.adyen.checkout.dropin.internal.ui.model
 
 import com.adyen.checkout.components.core.CheckoutConfiguration
 import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
+import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.dropin.getDropInConfiguration
-import com.adyen.checkout.sessions.core.internal.data.model.SessionDetails
 import java.util.Locale
 
 internal class DropInParamsMapper {
@@ -19,20 +19,24 @@ internal class DropInParamsMapper {
     fun mapToParams(
         checkoutConfiguration: CheckoutConfiguration,
         deviceLocale: Locale,
-        sessionDetails: SessionDetails?,
+        sessionParams: SessionParams?,
     ): DropInParams {
         val dropInConfiguration = checkoutConfiguration.getDropInConfiguration()
         return DropInParams(
-            shopperLocale = checkoutConfiguration.shopperLocale ?: deviceLocale,
+            shopperLocale = getShopperLocale(checkoutConfiguration, sessionParams) ?: deviceLocale,
             environment = checkoutConfiguration.environment,
             clientKey = checkoutConfiguration.clientKey,
             analyticsParams = AnalyticsParams(checkoutConfiguration.analyticsConfiguration),
-            amount = sessionDetails?.amount ?: checkoutConfiguration.amount,
+            amount = sessionParams?.amount ?: checkoutConfiguration.amount,
             showPreselectedStoredPaymentMethod = dropInConfiguration?.showPreselectedStoredPaymentMethod ?: true,
             skipListWhenSinglePaymentMethod = dropInConfiguration?.skipListWhenSinglePaymentMethod ?: false,
             isRemovingStoredPaymentMethodsEnabled = dropInConfiguration?.isRemovingStoredPaymentMethodsEnabled ?: false,
             additionalDataForDropInService = dropInConfiguration?.additionalDataForDropInService,
             overriddenPaymentMethodInformation = dropInConfiguration?.overriddenPaymentMethodInformation.orEmpty(),
         )
+    }
+
+    fun getShopperLocale(checkoutConfiguration: CheckoutConfiguration, sessionParams: SessionParams?): Locale? {
+        return checkoutConfiguration.shopperLocale ?: sessionParams?.shopperLocale
     }
 }

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/PreselectedStoredPaymentViewModelTest.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/PreselectedStoredPaymentViewModelTest.kt
@@ -38,7 +38,7 @@ internal class PreselectedStoredPaymentViewModelTest {
     private val dropInParams = DropInParamsMapper().mapToParams(
         checkoutConfiguration = CheckoutConfiguration(Environment.TEST, TEST_CLIENT_KEY, amount = TEST_AMOUNT),
         deviceLocale = Locale.US,
-        sessionDetails = null,
+        sessionParams = null,
     )
 
     private lateinit var viewModel: PreselectedStoredPaymentViewModel
@@ -65,7 +65,7 @@ internal class PreselectedStoredPaymentViewModelTest {
         val dropInParams = DropInParamsMapper().mapToParams(
             checkoutConfiguration = checkoutConfiguration,
             deviceLocale = Locale.US,
-            sessionDetails = null,
+            sessionParams = null,
         )
 
         viewModel = PreselectedStoredPaymentViewModel(

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/model/DropInParamsMapperTest.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/model/DropInParamsMapperTest.kt
@@ -15,10 +15,10 @@ import com.adyen.checkout.components.core.AnalyticsLevel
 import com.adyen.checkout.components.core.CheckoutConfiguration
 import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
 import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParamsLevel
+import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.dropin.DropInConfiguration
 import com.adyen.checkout.dropin.dropIn
-import com.adyen.checkout.sessions.core.internal.data.model.SessionDetails
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -115,19 +115,18 @@ internal class DropInParamsMapperTest {
     ) {
         val testConfiguration = createCheckoutConfiguration(configurationValue)
 
-        val sessionDetails = SessionDetails(
-            id = "id",
-            sessionData = "session_data",
+        val sessionParams = SessionParams(
+            enableStoreDetails = null,
+            installmentConfiguration = null,
             amount = sessionsValue,
-            expiresAt = "",
             returnUrl = null,
-            sessionSetupConfiguration = null,
+            shopperLocale = null,
         )
 
         val params = dropInParamsMapper.mapToParams(
             checkoutConfiguration = testConfiguration,
             deviceLocale = DEVICE_LOCALE,
-            sessionDetails = sessionDetails,
+            sessionParams = sessionParams,
         )
 
         val expected = getDropInParams(amount = expectedValue)

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/model/DropInParamsMapperTest.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/model/DropInParamsMapperTest.kt
@@ -134,6 +134,37 @@ internal class DropInParamsMapperTest {
         assertEquals(expected, params)
     }
 
+    @ParameterizedTest
+    @MethodSource("shopperLocaleSource")
+    fun `shopper locale should match value set in configuration then sessions then device locale`(
+        configurationValue: Locale?,
+        sessionsValue: Locale?,
+        deviceLocaleValue: Locale,
+        expectedValue: Locale,
+    ) {
+        val configuration = createCheckoutConfiguration(shopperLocale = configurationValue)
+
+        val sessionParams = SessionParams(
+            enableStoreDetails = null,
+            installmentConfiguration = null,
+            amount = null,
+            returnUrl = "",
+            shopperLocale = sessionsValue,
+        )
+
+        val params = dropInParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = deviceLocaleValue,
+            sessionParams = sessionParams,
+        )
+
+        val expected = getDropInParams(
+            shopperLocale = expectedValue,
+        )
+
+        assertEquals(expected, params)
+    }
+
     private fun createCheckoutConfiguration(
         amount: Amount? = null,
         shopperLocale: Locale? = null,
@@ -186,6 +217,15 @@ internal class DropInParamsMapperTest {
             arguments(Amount("EUR", 100), null, Amount("EUR", 100)),
             arguments(null, Amount("CAD", 300), Amount("CAD", 300)),
             arguments(null, null, null),
+        )
+
+        @JvmStatic
+        fun shopperLocaleSource() = listOf(
+            // configurationValue, sessionsValue, deviceLocaleValue, expectedValue
+            arguments(null, null, Locale.US, Locale.US),
+            arguments(Locale.GERMAN, null, Locale.US, Locale.GERMAN),
+            arguments(null, Locale.CHINESE, Locale.US, Locale.CHINESE),
+            arguments(Locale.GERMAN, Locale.CHINESE, Locale.US, Locale.GERMAN),
         )
     }
 }

--- a/econtext/src/main/java/com/adyen/checkout/econtext/internal/EContextConfiguration.kt
+++ b/econtext/src/main/java/com/adyen/checkout/econtext/internal/EContextConfiguration.kt
@@ -37,7 +37,11 @@ abstract class EContextConfiguration : Configuration, ButtonConfiguration {
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/entercash/src/main/java/com/adyen/checkout/entercash/EntercashConfiguration.kt
+++ b/entercash/src/main/java/com/adyen/checkout/entercash/EntercashConfiguration.kt
@@ -44,7 +44,11 @@ class EntercashConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/eps/src/main/java/com/adyen/checkout/eps/EPSConfiguration.kt
+++ b/eps/src/main/java/com/adyen/checkout/eps/EPSConfiguration.kt
@@ -44,7 +44,11 @@ class EPSConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/example-app/src/main/java/com/adyen/checkout/example/data/api/model/PaymentMethodsRequest.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/data/api/model/PaymentMethodsRequest.kt
@@ -18,7 +18,7 @@ data class PaymentMethodsRequest(
     val shopperReference: String,
     val amount: Amount?,
     val countryCode: String,
-    val shopperLocale: String,
+    val shopperLocale: String?,
     val channel: String,
     val splitCardFundingSources: Boolean,
     val order: OrderRequest?,

--- a/example-app/src/main/java/com/adyen/checkout/example/data/api/model/SessionRequest.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/data/api/model/SessionRequest.kt
@@ -18,7 +18,7 @@ data class SessionRequest(
     val shopperReference: String,
     val amount: Amount?,
     val countryCode: String,
-    val shopperLocale: String,
+    val shopperLocale: String?,
     val channel: String,
     val splitCardFundingSources: Boolean,
     val returnUrl: String,

--- a/example-app/src/main/java/com/adyen/checkout/example/data/storage/KeyValueStorage.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/data/storage/KeyValueStorage.kt
@@ -23,7 +23,7 @@ interface KeyValueStorage {
     fun getShopperReference(): String
     fun getAmount(): Amount
     fun getCountry(): String
-    fun getShopperLocale(): String
+    fun getShopperLocale(): String?
     fun isThreeds2Enabled(): Boolean
     fun isExecuteThreeD(): Boolean
     fun getShopperEmail(): String
@@ -63,7 +63,7 @@ internal class DefaultKeyValueStorage(
                 appContext = appContext,
                 stringRes = R.string.amount_value_key,
                 defaultStringRes = R.string.preferences_default_amount_value,
-            ).toLong()
+            ).toLong(),
         )
     }
 
@@ -75,12 +75,8 @@ internal class DefaultKeyValueStorage(
         )
     }
 
-    override fun getShopperLocale(): String {
-        return sharedPreferences.getString(
-            appContext = appContext,
-            stringRes = R.string.shopper_locale_key,
-            defaultStringRes = R.string.preferences_default_shopper_locale,
-        )
+    override fun getShopperLocale(): String? {
+        return sharedPreferences.getString(appContext.getString(R.string.shopper_locale_key), null)
     }
 
     override fun isThreeds2Enabled(): Boolean {
@@ -129,7 +125,7 @@ internal class DefaultKeyValueStorage(
                 appContext = appContext,
                 stringRes = R.string.card_address_form_mode_key,
                 defaultStringRes = R.string.preferences_default_address_form_mode,
-            )
+            ),
         )
     }
 
@@ -147,7 +143,7 @@ internal class DefaultKeyValueStorage(
                 appContext = appContext,
                 stringRes = R.string.card_installment_options_mode_key,
                 defaultStringRes = R.string.preferences_default_installment_options_mode,
-            )
+            ),
         )
     }
 
@@ -177,7 +173,7 @@ internal class DefaultKeyValueStorage(
                 appContext = appContext,
                 stringRes = R.string.analytics_level_key,
                 defaultStringRes = R.string.preferences_default_analytics_level,
-            )
+            ),
         )
     }
 }

--- a/example-app/src/main/java/com/adyen/checkout/example/service/RequestUtils.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/service/RequestUtils.kt
@@ -35,7 +35,7 @@ fun getPaymentMethodRequest(
     shopperReference: String,
     amount: Amount?,
     countryCode: String,
-    shopperLocale: String,
+    shopperLocale: String?,
     splitCardFundingSources: Boolean,
     order: OrderRequest? = null,
 ): PaymentMethodsRequest {
@@ -57,7 +57,7 @@ fun getSessionRequest(
     shopperReference: String,
     amount: Amount?,
     countryCode: String,
-    shopperLocale: String,
+    shopperLocale: String?,
     splitCardFundingSources: Boolean,
     redirectUrl: String,
     isThreeds2Enabled: Boolean,

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/configuration/CheckoutConfigurationProvider.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/configuration/CheckoutConfigurationProvider.kt
@@ -34,10 +34,10 @@ internal class CheckoutConfigurationProvider @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
 
-    private val shopperLocale: Locale
+    private val shopperLocale: Locale?
         get() {
             val shopperLocaleString = keyValueStorage.getShopperLocale()
-            return Locale.forLanguageTag(shopperLocaleString)
+            return shopperLocaleString?.let { Locale.forLanguageTag(it) }
         }
 
     private val amount: Amount get() = keyValueStorage.getAmount()

--- a/example-app/src/main/res/values/strings.xml
+++ b/example-app/src/main/res/values/strings.xml
@@ -80,7 +80,6 @@
     <string name="amount_value_title">Amount (minor units)</string>
 
     <string name="preferences_default_country">NL</string>
-    <string name="preferences_default_shopper_locale">en-US</string>
     <string name="preferences_default_amount_value">1337</string>
     <string name="preferences_default_amount_currency">EUR</string>
     <string name="preferences_default_threeds2_enabled">true</string>

--- a/example-app/src/main/res/xml/preferences.xml
+++ b/example-app/src/main/res/xml/preferences.xml
@@ -58,7 +58,6 @@
             app:useSimpleSummaryProvider="true" />
 
         <EditTextPreference
-            android:defaultValue="@string/preferences_default_shopper_locale"
             android:key="@string/shopper_locale_key"
             android:title="@string/shopper_locale_title"
             app:useSimpleSummaryProvider="true" />

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardConfiguration.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardConfiguration.kt
@@ -50,7 +50,11 @@ class GiftCardConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.kt
@@ -79,7 +79,11 @@ class GooglePayConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/ideal/src/main/java/com/adyen/checkout/ideal/IdealConfiguration.kt
+++ b/ideal/src/main/java/com/adyen/checkout/ideal/IdealConfiguration.kt
@@ -44,7 +44,11 @@ class IdealConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentConfiguration.kt
+++ b/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentConfiguration.kt
@@ -40,7 +40,11 @@ class InstantPaymentConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/mbway/src/main/java/com/adyen/checkout/mbway/MBWayConfiguration.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/MBWayConfiguration.kt
@@ -48,7 +48,11 @@ class MBWayConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/molpay/src/main/java/com/adyen/checkout/molpay/MolpayConfiguration.kt
+++ b/molpay/src/main/java/com/adyen/checkout/molpay/MolpayConfiguration.kt
@@ -43,7 +43,11 @@ class MolpayConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZConfiguration.kt
+++ b/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZConfiguration.kt
@@ -42,7 +42,11 @@ class OnlineBankingCZConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/online-banking-jp/src/main/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPConfiguration.kt
+++ b/online-banking-jp/src/main/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPConfiguration.kt
@@ -42,7 +42,11 @@ class OnlineBankingJPConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLConfiguration.kt
+++ b/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLConfiguration.kt
@@ -45,7 +45,11 @@ class OnlineBankingPLConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKConfiguration.kt
+++ b/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKConfiguration.kt
@@ -42,7 +42,11 @@ class OnlineBankingSKConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingConfiguration.kt
+++ b/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingConfiguration.kt
@@ -44,7 +44,11 @@ class OpenBankingConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankConfiguration.kt
+++ b/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankConfiguration.kt
@@ -41,7 +41,11 @@ class PayByBankConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/payeasy/src/main/java/com/adyen/checkout/payeasy/PayEasyConfiguration.kt
+++ b/payeasy/src/main/java/com/adyen/checkout/payeasy/PayEasyConfiguration.kt
@@ -42,7 +42,11 @@ class PayEasyConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeConfiguration.kt
+++ b/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeConfiguration.kt
@@ -37,7 +37,11 @@ class QRCodeConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/redirect/src/main/java/com/adyen/checkout/redirect/RedirectConfiguration.kt
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/RedirectConfiguration.kt
@@ -37,7 +37,11 @@ class RedirectConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/sepa/src/main/java/com/adyen/checkout/sepa/SepaConfiguration.kt
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/SepaConfiguration.kt
@@ -48,7 +48,11 @@ class SepaConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/SessionSetupResponse.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/SessionSetupResponse.kt
@@ -25,7 +25,8 @@ data class SessionSetupResponse(
     val expiresAt: String,
     val paymentMethodsApiResponse: PaymentMethodsApiResponse?,
     val returnUrl: String?,
-    val configuration: SessionSetupConfiguration?
+    val configuration: SessionSetupConfiguration?,
+    val shopperLocale: String?,
 ) : ModelObject() {
 
     companion object {
@@ -36,6 +37,7 @@ data class SessionSetupResponse(
         private const val PAYMENT_METHODS = "paymentMethods"
         private const val RETURN_URL = "returnUrl"
         private const val CONFIGURATION = "configuration"
+        private const val SHOPPER_LOCALE = "shopperLocale"
 
         @JvmField
         val SERIALIZER: Serializer<SessionSetupResponse> = object : Serializer<SessionSetupResponse> {
@@ -58,6 +60,7 @@ data class SessionSetupResponse(
                         CONFIGURATION,
                         ModelUtils.serializeOpt(modelObject.configuration, SessionSetupConfiguration.SERIALIZER)
                     )
+                    jsonObject.putOpt(SHOPPER_LOCALE, modelObject.shopperLocale)
                 } catch (e: JSONException) {
                     throw ModelSerializationException(SessionSetupResponse::class.java, e)
                 }
@@ -79,7 +82,8 @@ data class SessionSetupResponse(
                         configuration = ModelUtils.deserializeOpt(
                             jsonObject.optJSONObject(CONFIGURATION),
                             SessionSetupConfiguration.SERIALIZER
-                        )
+                        ),
+                        shopperLocale = jsonObject.optString(SHOPPER_LOCALE),
                     )
                 } catch (e: JSONException) {
                     throw ModelSerializationException(SessionSetupResponse::class.java, e)

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/data/model/SessionDetails.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/data/model/SessionDetails.kt
@@ -24,7 +24,8 @@ data class SessionDetails(
     val amount: Amount?,
     val expiresAt: String,
     val returnUrl: String?,
-    val sessionSetupConfiguration: SessionSetupConfiguration?
+    val sessionSetupConfiguration: SessionSetupConfiguration?,
+    val shopperLocale: String?,
 ) : Parcelable
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -35,7 +36,8 @@ fun SessionSetupResponse.mapToDetails(): SessionDetails {
         amount = amount,
         expiresAt = expiresAt,
         returnUrl = returnUrl,
-        sessionSetupConfiguration = configuration
+        sessionSetupConfiguration = configuration,
+        shopperLocale = shopperLocale,
     )
 }
 

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/ui/model/SessionParamsFactory.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/ui/model/SessionParamsFactory.kt
@@ -9,35 +9,28 @@
 package com.adyen.checkout.sessions.core.internal.ui.model
 
 import androidx.annotation.RestrictTo
-import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.components.core.internal.ui.model.SessionInstallmentConfiguration
 import com.adyen.checkout.components.core.internal.ui.model.SessionInstallmentOptionsParams
 import com.adyen.checkout.components.core.internal.ui.model.SessionParams
+import com.adyen.checkout.core.internal.util.LocaleUtil
 import com.adyen.checkout.sessions.core.CheckoutSession
-import com.adyen.checkout.sessions.core.SessionSetupConfiguration
 import com.adyen.checkout.sessions.core.internal.data.model.SessionDetails
+import com.adyen.checkout.sessions.core.internal.data.model.mapToDetails
+import java.util.Locale
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 object SessionParamsFactory {
     // Used for components
     fun create(checkoutSession: CheckoutSession): SessionParams {
-        return create(
-            checkoutSession.sessionSetupResponse.configuration,
-            checkoutSession.sessionSetupResponse.amount,
-            checkoutSession.sessionSetupResponse.returnUrl
-        )
+        return checkoutSession.sessionSetupResponse.mapToDetails().mapToParams()
     }
 
     // Used for Drop-in
     fun create(sessionDetails: SessionDetails): SessionParams {
-        return create(sessionDetails.sessionSetupConfiguration, sessionDetails.amount, sessionDetails.returnUrl)
+        return sessionDetails.mapToParams()
     }
 
-    private fun create(
-        sessionSetupConfiguration: SessionSetupConfiguration?,
-        amount: Amount?,
-        returnUrl: String?,
-    ): SessionParams {
+    private fun SessionDetails.mapToParams(): SessionParams {
         return SessionParams(
             enableStoreDetails = sessionSetupConfiguration?.enableStoreDetails,
             installmentConfiguration = SessionInstallmentConfiguration(
@@ -48,10 +41,19 @@ object SessionParamsFactory {
                         values = it.value?.values,
                     )
                 }?.toMap(),
-                showInstallmentAmount = sessionSetupConfiguration?.showInstallmentAmount
+                showInstallmentAmount = sessionSetupConfiguration?.showInstallmentAmount,
             ),
             amount = amount,
             returnUrl = returnUrl,
+            shopperLocale = getShopperLocale(shopperLocale),
         )
+    }
+
+    private fun getShopperLocale(shopperLocaleString: String?): Locale? {
+        return shopperLocaleString?.let {
+            LocaleUtil.fromLanguageTag(it)
+        }?.takeIf {
+            LocaleUtil.isValidLocale(it)
+        }
     }
 }

--- a/sessions-core/src/test/java/com/adyen/checkout/sessions/core/internal/SessionInteractorTest.kt
+++ b/sessions-core/src/test/java/com/adyen/checkout/sessions/core/internal/SessionInteractorTest.kt
@@ -756,7 +756,8 @@ internal class SessionInteractorTest(
         expiresAt: String = "",
         returnUrl: String = "",
         paymentMethods: PaymentMethodsApiResponse? = PaymentMethodsApiResponse(),
-        configuration: SessionSetupConfiguration? = null
+        configuration: SessionSetupConfiguration? = null,
+        shopperLocale: String? = null,
     ): SessionSetupResponse {
         return SessionSetupResponse(
             id = id,
@@ -766,6 +767,7 @@ internal class SessionInteractorTest(
             paymentMethodsApiResponse = paymentMethods,
             returnUrl = returnUrl,
             configuration = configuration,
+            shopperLocale = shopperLocale,
         )
     }
 

--- a/seven-eleven/src/main/java/com/adyen/checkout/seveneleven/SevenElevenConfiguration.kt
+++ b/seven-eleven/src/main/java/com/adyen/checkout/seveneleven/SevenElevenConfiguration.kt
@@ -42,7 +42,11 @@ class SevenElevenConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/upi/src/main/java/com/adyen/checkout/upi/UPIConfiguration.kt
+++ b/upi/src/main/java/com/adyen/checkout/upi/UPIConfiguration.kt
@@ -48,7 +48,11 @@ class UPIConfiguration(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/voucher/src/main/java/com/adyen/checkout/voucher/VoucherConfiguration.kt
+++ b/voucher/src/main/java/com/adyen/checkout/voucher/VoucherConfiguration.kt
@@ -38,7 +38,11 @@ class VoucherConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionConfiguration.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionConfiguration.kt
@@ -37,7 +37,11 @@ class WeChatPayActionConfiguration private constructor(
 
         /**
          * Initialize a configuration builder with the required fields.
-         * The shopper locale will match the primary user locale on the device.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
          *
          * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
          * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.


### PR DESCRIPTION
## Description
The sessions setup call returns a shopper locale if the merchant set this value in the `/sessions` call. In this PR we read this value and apply it on our end.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-847
