### PR TITLE
Ship kotlin-parcelize-runtime with the SDK

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -60,6 +60,9 @@ CheckoutConfiguration(
   - Online Banking Japan. Payment method type: **econtext_online**.
   - Seven-Eleven: Payment method type: **econtext_seven_eleven**
 
+## Fixed
+- When building `minifyEnabled` and without the `kotlin-parcelize` plugin in your project the build should no longer crash.
+
 ## Deprecated
 - When creating a configuration, the `Builder` constructors with a `Context` are now deprecated. You can omit the `context` parameter.
 - The `PermissionException` is deprecated. Handle permissions through `ActionComponentCallback`, `SessionComponentCallback` or `ComponentCallback` callbacks.

--- a/checkout-core/build.gradle
+++ b/checkout-core/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     api libraries.androidx.annotation
     api libraries.kotlinCoroutines
     implementation libraries.okhttp
+    api libraries.parcelize
 
     //Tests
     testImplementation testLibraries.json

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -127,6 +127,7 @@ ext {
         ],
         okhttp          : "com.squareup.okhttp3:okhttp:$okhttp_version",
         okhttpLogging   : "com.squareup.okhttp3:logging-interceptor:$okhttp_logging_version",
+        parcelize       : "org.jetbrains.kotlin:kotlin-parcelize-runtime:$kotlin_version",
         retrofit        : [
             "com.squareup.retrofit2:retrofit:$retrofit2_version",
             "com.squareup.retrofit2:converter-moshi:$retrofit2_version"


### PR DESCRIPTION
## Description
The parcelize plugin needs this dependency and if the merchant doesn't include it in their project it crashes the build when using R8.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
- [x] Link to related issues: #1483 
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-858
