### PR TITLE
Make configurations optional with the sessions flow

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -75,4 +75,6 @@ CheckoutConfiguration(
 
 ## Changed
 - When creating a configuration, the shopper locale parameter is now optional. If not set, the shopper locale will match the value passed to the API with the sessions flow, or the primary user locale on the device otherwise.
+- With the sessions flow, when starting drop-in (with `DropIn.startPayment`) or creating a component (with `YourComponent.PROVIDER.get`), the configuration parameter is now optional.
+- When `CheckoutSessionProvider.createSession` to create a `CheckoutSession`, you can pass the `environment` and `clientKey` instead of the whole configuration.
 - In drop-in all actions will start in expanded mode

--- a/action-core/src/main/java/com/adyen/checkout/action/core/internal/ActionHandlingPaymentMethodConfigurationBuilder.kt
+++ b/action-core/src/main/java/com/adyen/checkout/action/core/internal/ActionHandlingPaymentMethodConfigurationBuilder.kt
@@ -55,7 +55,11 @@ constructor(
 
     /**
      * Initialize a configuration builder with the required fields.
-     * The shopper locale will match the primary user locale on the device.
+     *
+     * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+     * on the device otherwise. Check out the
+     * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+     * this value.
      *
      * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
      * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/checkout-core/src/main/java/com/adyen/checkout/core/internal/util/LocaleUtil.kt
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/internal/util/LocaleUtil.kt
@@ -8,6 +8,7 @@
 package com.adyen.checkout.core.internal.util
 
 import androidx.annotation.RestrictTo
+import com.adyen.checkout.core.exception.CheckoutException
 import java.util.IllformedLocaleException
 import java.util.Locale
 
@@ -25,6 +26,9 @@ object LocaleUtil {
      */
     @JvmStatic
     fun toLanguageTag(locale: Locale): String {
+        if (!isValidLocale(locale)) {
+            throw CheckoutException("Invalid shopper locale: $locale.")
+        }
         return locale.toLanguageTag()
     }
 

--- a/components-compose/src/main/java/com/adyen/checkout/components/compose/ComposeExtensions.kt
+++ b/components-compose/src/main/java/com/adyen/checkout/components/compose/ComposeExtensions.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 17/5/2023.
  */
 
+@file:Suppress("TooManyFunctions")
+
 package com.adyen.checkout.components.compose
 
 import android.app.Application
@@ -162,6 +164,41 @@ fun <
 }
 
 /**
+ * Get a [PaymentComponent] with a checkout session from a [Composable]. You only need to integrate with the /sessions
+ * endpoint to create a session and the component will automatically handle the rest of the payment flow.
+ *
+ * @param checkoutSession         The [CheckoutSession] object to launch this component.
+ * @param paymentMethod           The corresponding  [PaymentMethod] object.
+ * @param componentCallback       The callback to handle events from the [PaymentComponent].
+ * @param key                     The key to use to identify the [PaymentComponent].
+ *
+ * NOTE: By default only one [PaymentComponent] will be created per lifecycle. Use [key] in case you need to
+ * instantiate multiple [PaymentComponent]s in the same lifecycle.
+ *
+ * @return The Component
+ */
+@Composable
+fun <
+    ComponentT : PaymentComponent,
+    ConfigurationT : Configuration,
+    ComponentStateT : PaymentComponentState<*>,
+    ComponentCallbackT : SessionComponentCallback<ComponentStateT>
+    > SessionPaymentComponentProvider<ComponentT, ConfigurationT, ComponentStateT, ComponentCallbackT>.get(
+    checkoutSession: CheckoutSession,
+    paymentMethod: PaymentMethod,
+    componentCallback: ComponentCallbackT,
+    key: String,
+): ComponentT {
+    return get(
+        checkoutSession = checkoutSession,
+        paymentMethod = paymentMethod,
+        checkoutConfiguration = checkoutSession.getConfiguration(),
+        componentCallback = componentCallback,
+        key = key,
+    )
+}
+
+/**
  * Get a [PaymentComponent]  with a stored payment method and a checkout session from a [Composable]. You only need to
  * integrate with the /sessions endpoint to create a session and the component will automatically handle the rest of
  * the payment flow.
@@ -199,6 +236,42 @@ fun <
         storedPaymentMethod = storedPaymentMethod,
         checkoutConfiguration = checkoutConfiguration,
         application = LocalContext.current.applicationContext as Application,
+        componentCallback = componentCallback,
+        key = key,
+    )
+}
+
+/**
+ * Get a [PaymentComponent]  with a stored payment method and a checkout session from a [Composable]. You only need to
+ * integrate with the /sessions endpoint to create a session and the component will automatically handle the rest of
+ * the payment flow.
+ *
+ * @param checkoutSession         The [CheckoutSession] object to launch this component.
+ * @param storedPaymentMethod     The corresponding  [StoredPaymentMethod] object.
+ * @param componentCallback       The callback to handle events from the [PaymentComponent].
+ * @param key                     The key to use to identify the [PaymentComponent].
+ *
+ * NOTE: By default only one [PaymentComponent] will be created per lifecycle. Use [key] in case you need to
+ * instantiate multiple [PaymentComponent]s in the same lifecycle.
+ *
+ * @return The Component
+ */
+@Composable
+fun <
+    ComponentT : PaymentComponent,
+    ConfigurationT : Configuration,
+    ComponentStateT : PaymentComponentState<*>,
+    ComponentCallbackT : SessionComponentCallback<ComponentStateT>
+    > SessionStoredPaymentComponentProvider<ComponentT, ConfigurationT, ComponentStateT, ComponentCallbackT>.get(
+    checkoutSession: CheckoutSession,
+    storedPaymentMethod: StoredPaymentMethod,
+    componentCallback: ComponentCallbackT,
+    key: String?,
+): ComponentT {
+    return get(
+        checkoutSession = checkoutSession,
+        storedPaymentMethod = storedPaymentMethod,
+        checkoutConfiguration = checkoutSession.getConfiguration(),
         componentCallback = componentCallback,
         key = key,
     )

--- a/components-core/src/main/java/com/adyen/checkout/components/core/CheckoutConfiguration.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/CheckoutConfiguration.kt
@@ -16,6 +16,8 @@ import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.core.internal.Configuration
 import com.adyen.checkout.components.core.internal.util.CheckoutConfigurationMarker
 import com.adyen.checkout.core.Environment
+import com.adyen.checkout.core.exception.CheckoutException
+import com.adyen.checkout.core.internal.util.LocaleUtil
 import kotlinx.parcelize.IgnoredOnParcel
 import java.util.Locale
 
@@ -61,6 +63,15 @@ class CheckoutConfiguration(
 
     init {
         apply(configurationBlock)
+        validateContents()
+    }
+
+    private fun validateContents() {
+        shopperLocale?.let {
+            if (!LocaleUtil.isValidLocale(it)) {
+                throw CheckoutException("Invalid shopper locale: $shopperLocale.")
+            }
+        }
     }
 
     // We need custom parcelization for this class to parcelize availableConfigurations.

--- a/components-core/src/main/java/com/adyen/checkout/components/core/CheckoutConfiguration.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/CheckoutConfiguration.kt
@@ -29,8 +29,8 @@ import java.util.Locale
  * val checkoutConfiguration = CheckoutConfiguration(
  *     environment,
  *     clientKey,
- *     shopperLocale,
- *     amount,
+ *     shopperLocale, // optional
+ *     amount, // not applicable with the Sessions flow
  * ) {
  *     dropIn {
  *         setEnableRemovingStoredPaymentMethods(true)
@@ -43,8 +43,13 @@ import java.util.Locale
  *
  * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
  * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
- * @param shopperLocale The [Locale] used to display information to the shopper. Defaults to the primary device locale.
- * @param amount The amount of the transaction.
+ * @param shopperLocale The [Locale] used to display information to the shopper. By default the shopper locale will
+ * match the value passed to the API with the sessions flow, or the primary user locale on the device otherwise. Check
+ * out the [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+ * this value.
+ * @param amount The amount of the transaction. Not applicable for the sessions flow. Check out the
+ * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set this
+ * value.
  * @param analyticsConfiguration A configuration for the internal analytics of the library.
  * @param configurationBlock A block that allows adding drop-in or payment method specific configurations.
  */

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/BaseConfigurationBuilder.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/BaseConfigurationBuilder.kt
@@ -39,7 +39,11 @@ constructor(
 
     /**
      * Initialize a configuration builder with the required fields.
-     * The shopper locale will match the primary user locale on the device.
+     *
+     * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+     * on the device otherwise. Check out the
+     * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+     * this value.
      *
      * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
      * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.

--- a/drop-in-compose/src/main/java/com/adyen/checkout/dropin/compose/ComposeExtensions.kt
+++ b/drop-in-compose/src/main/java/com/adyen/checkout/dropin/compose/ComposeExtensions.kt
@@ -117,7 +117,7 @@ fun DropIn.startPayment(
 fun DropIn.startPayment(
     dropInLauncher: ActivityResultLauncher<SessionDropInResultContractParams>,
     checkoutSession: CheckoutSession,
-    checkoutConfiguration: CheckoutConfiguration,
+    checkoutConfiguration: CheckoutConfiguration = checkoutSession.getConfiguration(),
     serviceClass: Class<out SessionDropInService> = SessionDropInService::class.java,
 ) {
     val currentContext = LocalContext.current

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropIn.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropIn.kt
@@ -129,7 +129,7 @@ object DropIn {
         context: Context,
         dropInLauncher: ActivityResultLauncher<SessionDropInResultContractParams>,
         checkoutSession: CheckoutSession,
-        checkoutConfiguration: CheckoutConfiguration,
+        checkoutConfiguration: CheckoutConfiguration = checkoutSession.getConfiguration(),
         serviceClass: Class<out SessionDropInService> = SessionDropInService::class.java,
     ) {
         adyenLog(AdyenLogLevel.DEBUG) { "startPayment with sessions" }

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/CheckoutSession.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/CheckoutSession.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.sessions.core
 
 import com.adyen.checkout.components.core.Order
 import com.adyen.checkout.components.core.PaymentMethod
+import com.adyen.checkout.core.Environment
 
 /**
  * A class holding the data required to launch Drop-in or a component with the sessions flow.
@@ -18,6 +19,8 @@ import com.adyen.checkout.components.core.PaymentMethod
 data class CheckoutSession(
     val sessionSetupResponse: SessionSetupResponse,
     val order: Order?,
+    private val environment: Environment,
+    private val clientKey: String,
 ) {
     fun getPaymentMethod(paymentMethodType: String): PaymentMethod? {
         return sessionSetupResponse.paymentMethodsApiResponse?.paymentMethods.orEmpty().firstOrNull {

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/CheckoutSession.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/CheckoutSession.kt
@@ -8,6 +8,8 @@
 
 package com.adyen.checkout.sessions.core
 
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.components.core.CheckoutConfiguration
 import com.adyen.checkout.components.core.Order
 import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.core.Environment
@@ -26,5 +28,13 @@ data class CheckoutSession(
         return sessionSetupResponse.paymentMethodsApiResponse?.paymentMethods.orEmpty().firstOrNull {
             it.type == paymentMethodType
         }
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun getConfiguration(): CheckoutConfiguration {
+        return CheckoutConfiguration(
+            environment = environment,
+            clientKey = clientKey,
+        )
     }
 }

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/CheckoutSessionProvider.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/CheckoutSessionProvider.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.sessions.core
 
 import com.adyen.checkout.components.core.Order
 import com.adyen.checkout.components.core.internal.Configuration
+import com.adyen.checkout.core.Environment
 import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.sessions.core.internal.CheckoutSessionInitializer
 
@@ -32,7 +33,33 @@ object CheckoutSessionProvider {
         configuration: Configuration,
         order: Order? = null,
     ): CheckoutSessionResult {
-        return CheckoutSessionInitializer(sessionModel, configuration, order).setupSession(null)
+        return createSession(
+            sessionModel = sessionModel,
+            environment = configuration.environment,
+            clientKey = configuration.clientKey,
+            order = order,
+        )
+    }
+
+    /**
+     * Allows creating a [CheckoutSession] from the response of the /sessions endpoint.
+     * This is a suspend function that executes a network call on the IO thread.
+     *
+     * @param sessionModel The deserialized JSON response of the /sessions API call. You can use
+     * [SessionModel.SERIALIZER] to deserialize this JSON.
+     * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+     * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+     * @param order An [Order] in case of an ongoing partial payment flow.
+     *
+     * @return The result of the API call.
+     */
+    suspend fun createSession(
+        sessionModel: SessionModel,
+        environment: Environment,
+        clientKey: String,
+        order: Order? = null,
+    ): CheckoutSessionResult {
+        return CheckoutSessionInitializer(sessionModel, environment, clientKey, order).setupSession(null)
     }
 
     /**
@@ -53,6 +80,32 @@ object CheckoutSessionProvider {
         sessionPaymentResult: SessionPaymentResult,
         configuration: Configuration,
     ): CheckoutSessionResult {
+        return createSession(
+            sessionPaymentResult = sessionPaymentResult,
+            environment = configuration.environment,
+            clientKey = configuration.clientKey,
+        )
+    }
+
+    /**
+     * Only to be used for initializing a component for partial payment flow.
+     *
+     * Allows creating a [CheckoutSession] from the response of the /sessions endpoint.
+     * This is a suspend function that executes a network call on the IO thread.
+     *
+     * @param sessionPaymentResult The [SessionPaymentResult] object to initialize the session. You will get this
+     * object via [com.adyen.checkout.giftcard.SessionsGiftCardComponentCallback.onPartialPayment] callback after
+     * a partial payment has been done.
+     * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+     * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+     *
+     * @return The result of the API call.
+     */
+    suspend fun createSession(
+        sessionPaymentResult: SessionPaymentResult,
+        environment: Environment,
+        clientKey: String,
+    ): CheckoutSessionResult {
         if (sessionPaymentResult.sessionId == null) {
             throw CheckoutException("sessionId must not be null to create a session.")
         }
@@ -60,7 +113,7 @@ object CheckoutSessionProvider {
         val order = sessionPaymentResult.order?.let { orderResponse ->
             Order(orderResponse.pspReference, orderResponse.orderData)
         }
-        return CheckoutSessionInitializer(sessionModel, configuration, order)
+        return CheckoutSessionInitializer(sessionModel, environment, clientKey, order)
             .setupSession(sessionPaymentResult.order?.remainingAmount)
     }
 }

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/CheckoutSessionInitializer.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/CheckoutSessionInitializer.kt
@@ -10,7 +10,7 @@ package com.adyen.checkout.sessions.core.internal
 
 import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.components.core.Order
-import com.adyen.checkout.components.core.internal.Configuration
+import com.adyen.checkout.core.Environment
 import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
 import com.adyen.checkout.sessions.core.CheckoutSession
@@ -24,13 +24,14 @@ import kotlinx.coroutines.withContext
 
 internal class CheckoutSessionInitializer(
     private val sessionModel: SessionModel,
-    configuration: Configuration,
+    private val environment: Environment,
+    private val clientKey: String,
     private val order: Order?,
     private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
-    private val httpClient = HttpClientFactory.getHttpClient(configuration.environment)
+    private val httpClient = HttpClientFactory.getHttpClient(environment)
     private val sessionService = SessionService(httpClient)
-    private val sessionRepository = SessionRepository(sessionService, configuration.clientKey)
+    private val sessionRepository = SessionRepository(sessionService, clientKey)
 
     // TODO: Once Backend provides the correct amount in the SessionSetupResponse use that in SessionDetails instead of
     //  override Amount
@@ -44,6 +45,8 @@ internal class CheckoutSessionInitializer(
                     CheckoutSession(
                         sessionSetupResponse.copy(amount = overrideAmount ?: sessionSetupResponse.amount),
                         order,
+                        environment,
+                        clientKey,
                     ),
                 )
             },

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/provider/SessionPaymentComponentProvider.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/provider/SessionPaymentComponentProvider.kt
@@ -74,6 +74,38 @@ interface SessionPaymentComponentProvider<
      * Get a [PaymentComponent] with a checkout session. You only need to integrate with the /sessions endpoint to
      * create a session and the component will automatically handle the rest of the payment flow.
      *
+     * @param fragment          The Fragment to associate the lifecycle.
+     * @param checkoutSession   The [CheckoutSession] object to launch this component.
+     * @param paymentMethod     The corresponding  [PaymentMethod] object.
+     * @param componentCallback The callback to handle events from the [PaymentComponent].
+     * @param key               The key to use to identify the [PaymentComponent].
+     *
+     * NOTE: By default only one [PaymentComponent] will be created per lifecycle. Use [key] in case you need to
+     * instantiate multiple [PaymentComponent]s in the same lifecycle.
+     *
+     * @return The Component
+     */
+    @Suppress("LongParameterList")
+    fun get(
+        fragment: Fragment,
+        checkoutSession: CheckoutSession,
+        paymentMethod: PaymentMethod,
+        componentCallback: ComponentCallbackT,
+        key: String? = null,
+    ): ComponentT {
+        return get(
+            fragment = fragment,
+            checkoutSession = checkoutSession,
+            paymentMethod = paymentMethod,
+            checkoutConfiguration = checkoutSession.getConfiguration(),
+            componentCallback = componentCallback,
+        )
+    }
+
+    /**
+     * Get a [PaymentComponent] with a checkout session. You only need to integrate with the /sessions endpoint to
+     * create a session and the component will automatically handle the rest of the payment flow.
+     *
      * @param activity      The Activity to associate the lifecycle.
      * @param checkoutSession   The [CheckoutSession] object to launch this component.
      * @param paymentMethod     The corresponding  [PaymentMethod] object.
@@ -105,6 +137,38 @@ interface SessionPaymentComponentProvider<
             application = activity.application,
             componentCallback = componentCallback,
             key = key,
+        )
+    }
+
+    /**
+     * Get a [PaymentComponent] with a checkout session. You only need to integrate with the /sessions endpoint to
+     * create a session and the component will automatically handle the rest of the payment flow.
+     *
+     * @param activity      The Activity to associate the lifecycle.
+     * @param checkoutSession   The [CheckoutSession] object to launch this component.
+     * @param paymentMethod     The corresponding  [PaymentMethod] object.
+     * @param componentCallback The callback to handle events from the [PaymentComponent].
+     * @param key               The key to use to identify the [PaymentComponent].
+     *
+     * NOTE: By default only one [PaymentComponent] will be created per lifecycle. Use [key] in case you need to
+     * instantiate multiple [PaymentComponent]s in the same lifecycle.
+     *
+     * @return The Component
+     */
+    @Suppress("LongParameterList")
+    fun get(
+        activity: ComponentActivity,
+        checkoutSession: CheckoutSession,
+        paymentMethod: PaymentMethod,
+        componentCallback: ComponentCallbackT,
+        key: String? = null,
+    ): ComponentT {
+        return get(
+            activity = activity,
+            checkoutSession = checkoutSession,
+            paymentMethod = paymentMethod,
+            checkoutConfiguration = checkoutSession.getConfiguration(),
+            componentCallback = componentCallback,
         )
     }
 

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/provider/SessionStoredPaymentComponentProvider.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/provider/SessionStoredPaymentComponentProvider.kt
@@ -76,6 +76,39 @@ interface SessionStoredPaymentComponentProvider<
      * the /sessions endpoint to create a session and the component will automatically handle the rest of the payment
      * flow.
      *
+     * @param fragment              The Fragment to associate the lifecycle.
+     * @param checkoutSession       The [CheckoutSession] object to launch this component.
+     * @param storedPaymentMethod   The corresponding  [StoredPaymentMethod] object.
+     * @param componentCallback     The callback to handle events from the [PaymentComponent].
+     * @param key                   The key to use to identify the [PaymentComponent].
+     *
+     * NOTE: By default only one [PaymentComponent] will be created per lifecycle. Use [key] in case you need to
+     * instantiate multiple [PaymentComponent]s in the same lifecycle.
+     *
+     * @return The Component
+     */
+    @Suppress("LongParameterList")
+    fun get(
+        fragment: Fragment,
+        checkoutSession: CheckoutSession,
+        storedPaymentMethod: StoredPaymentMethod,
+        componentCallback: ComponentCallbackT,
+        key: String? = null,
+    ): ComponentT {
+        return get(
+            fragment = fragment,
+            checkoutSession = checkoutSession,
+            storedPaymentMethod = storedPaymentMethod,
+            checkoutConfiguration = checkoutSession.getConfiguration(),
+            componentCallback = componentCallback,
+        )
+    }
+
+    /**
+     * Get a [PaymentComponent]  with a stored payment method and a checkout session. You only need to integrate with
+     * the /sessions endpoint to create a session and the component will automatically handle the rest of the payment
+     * flow.
+     *
      * @param activity              The Activity to associate the lifecycle.
      * @param checkoutSession       The [CheckoutSession] object to launch this component.
      * @param storedPaymentMethod   The corresponding  [StoredPaymentMethod] object.
@@ -107,6 +140,39 @@ interface SessionStoredPaymentComponentProvider<
             application = activity.application,
             componentCallback = componentCallback,
             key = key,
+        )
+    }
+
+    /**
+     * Get a [PaymentComponent]  with a stored payment method and a checkout session. You only need to integrate with
+     * the /sessions endpoint to create a session and the component will automatically handle the rest of the payment
+     * flow.
+     *
+     * @param activity              The Activity to associate the lifecycle.
+     * @param checkoutSession       The [CheckoutSession] object to launch this component.
+     * @param storedPaymentMethod   The corresponding  [StoredPaymentMethod] object.
+     * @param componentCallback     The callback to handle events from the [PaymentComponent].
+     * @param key                   The key to use to identify the [PaymentComponent].
+     *
+     * NOTE: By default only one [PaymentComponent] will be created per lifecycle. Use [key] in case you need to
+     * instantiate multiple [PaymentComponent]s in the same lifecycle.
+     *
+     * @return The Component
+     */
+    @Suppress("LongParameterList")
+    fun get(
+        activity: ComponentActivity,
+        checkoutSession: CheckoutSession,
+        storedPaymentMethod: StoredPaymentMethod,
+        componentCallback: ComponentCallbackT,
+        key: String? = null,
+    ): ComponentT {
+        return get(
+            activity = activity,
+            checkoutSession = checkoutSession,
+            storedPaymentMethod = storedPaymentMethod,
+            checkoutConfiguration = checkoutSession.getConfiguration(),
+            componentCallback = componentCallback,
         )
     }
 

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/ui/model/SessionParamsFactory.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/ui/model/SessionParamsFactory.kt
@@ -12,7 +12,9 @@ import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.core.internal.ui.model.SessionInstallmentConfiguration
 import com.adyen.checkout.components.core.internal.ui.model.SessionInstallmentOptionsParams
 import com.adyen.checkout.components.core.internal.ui.model.SessionParams
+import com.adyen.checkout.core.AdyenLogLevel
 import com.adyen.checkout.core.internal.util.LocaleUtil
+import com.adyen.checkout.core.internal.util.adyenLog
 import com.adyen.checkout.sessions.core.CheckoutSession
 import com.adyen.checkout.sessions.core.internal.data.model.SessionDetails
 import com.adyen.checkout.sessions.core.internal.data.model.mapToDetails
@@ -50,10 +52,13 @@ object SessionParamsFactory {
     }
 
     private fun getShopperLocale(shopperLocaleString: String?): Locale? {
-        return shopperLocaleString?.let {
-            LocaleUtil.fromLanguageTag(it)
-        }?.takeIf {
-            LocaleUtil.isValidLocale(it)
+        if (shopperLocaleString == null) return null
+        return runCatching {
+            LocaleUtil.fromLanguageTag(shopperLocaleString)
+        }.getOrElse {
+            // if we cannot parse the locale coming from the API we should not fail the payment
+            adyenLog(AdyenLogLevel.ERROR) { "Failed to parse sessions locale $shopperLocaleString" }
+            null
         }
     }
 }


### PR DESCRIPTION
## Description
- With the sessions flow, when starting drop-in or creating a component, the configuration parameter can be made optional.
- When `CheckoutSessionProvider.createSession` to create a `CheckoutSession`, we can pass the `environment` and `clientKey` instead of the whole configuration.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-853
