### PR TITLE
Allow shoppers remove stored cards for session integration

### DIFF
--- a/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/internal/ui/model/Adyen3DS2ComponentParamsMapperTest.kt
+++ b/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/internal/ui/model/Adyen3DS2ComponentParamsMapperTest.kt
@@ -18,6 +18,7 @@ import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParamsLevel
 import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParams
 import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
+import com.adyen.checkout.components.core.internal.ui.model.SessionInstallmentConfiguration
 import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.core.Environment
 import com.adyen.threeds2.customization.UiCustomization
@@ -111,12 +112,8 @@ internal class Adyen3DS2ComponentParamsMapperTest {
     ) {
         val configuration = getCheckoutConfiguration(amount = configurationValue)
 
-        val sessionParams = SessionParams(
-            enableStoreDetails = null,
-            installmentConfiguration = null,
+        val sessionParams = createSessionParams(
             amount = sessionsValue,
-            returnUrl = "",
-            shopperLocale = null,
         )
 
         val dropInOverrideParams = dropInValue?.let { DropInOverrideParams(it, null) }
@@ -146,11 +143,7 @@ internal class Adyen3DS2ComponentParamsMapperTest {
     ) {
         val configuration = getCheckoutConfiguration(shopperLocale = configurationValue)
 
-        val sessionParams = SessionParams(
-            enableStoreDetails = null,
-            installmentConfiguration = null,
-            amount = null,
-            returnUrl = "",
+        val sessionParams = createSessionParams(
             shopperLocale = sessionsValue,
         )
 
@@ -178,6 +171,23 @@ internal class Adyen3DS2ComponentParamsMapperTest {
         clientKey = TEST_CLIENT_KEY_1,
         amount = amount,
         configurationBlock = config,
+    )
+
+    @Suppress("LongParameterList")
+    private fun createSessionParams(
+        enableStoreDetails: Boolean? = null,
+        installmentConfiguration: SessionInstallmentConfiguration? = null,
+        showRemovePaymentMethodButton: Boolean? = null,
+        amount: Amount? = null,
+        returnUrl: String? = "",
+        shopperLocale: Locale? = null,
+    ) = SessionParams(
+        enableStoreDetails = enableStoreDetails,
+        installmentConfiguration = installmentConfiguration,
+        showRemovePaymentMethodButton = showRemovePaymentMethodButton,
+        amount = amount,
+        returnUrl = returnUrl,
+        shopperLocale = shopperLocale,
     )
 
     @Suppress("LongParameterList")

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -83,3 +83,4 @@ CheckoutConfiguration(
 - When `CheckoutSessionProvider.createSession` to create a `CheckoutSession`, you can pass the `environment` and `clientKey` instead of the whole configuration.
 - In drop-in all actions will start in expanded mode
 - When using the Google Pay component, it is no longer necessary to manually import the `3ds2` module to handle transactions that require a native 3DS2 challenge. 
+- Removing stored payment methods are being handled internally if you are using Sessions integration. You do not need to override `onRemoveStoredPaymentMethod` function anymore.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -84,3 +84,4 @@ CheckoutConfiguration(
 - In drop-in all actions will start in expanded mode
 - When using the Google Pay component, it is no longer necessary to manually import the `3ds2` module to handle transactions that require a native 3DS2 challenge. 
 - Removing stored payment methods are being handled internally if you are using Sessions integration. You do not need to override `onRemoveStoredPaymentMethod` function anymore.
+- If you are using `DropInServiceResult.Error` without specifying an error message, the default has changed from `Error sending payment. Please try again.` to `An unknown error occurred`.

--- a/ach/src/test/java/com/adyen/checkout/ach/internal/ui/model/ACHDirectDebitComponentParamsMapperTest.kt
+++ b/ach/src/test/java/com/adyen/checkout/ach/internal/ui/model/ACHDirectDebitComponentParamsMapperTest.kt
@@ -20,6 +20,7 @@ import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParamsLevel
 import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParams
 import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
+import com.adyen.checkout.components.core.internal.ui.model.SessionInstallmentConfiguration
 import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.ui.core.internal.ui.model.AddressParams
@@ -181,12 +182,8 @@ internal class ACHDirectDebitComponentParamsMapperTest {
             setShowStorePaymentField(configurationValue)
         }
 
-        val sessionParams = SessionParams(
+        val sessionParams = createSessionParams(
             enableStoreDetails = sessionsValue,
-            installmentConfiguration = null,
-            amount = null,
-            returnUrl = "",
-            shopperLocale = null,
         )
 
         val params = achDirectDebitComponentParamsMapper.mapToParams(configuration, DEVICE_LOCALE, null, sessionParams)
@@ -217,12 +214,8 @@ internal class ACHDirectDebitComponentParamsMapperTest {
     ) {
         val configuration = createCheckoutConfiguration(configurationValue)
 
-        val sessionParams = SessionParams(
-            enableStoreDetails = null,
-            installmentConfiguration = null,
+        val sessionParams = createSessionParams(
             amount = sessionsValue,
-            returnUrl = "",
-            shopperLocale = null,
         )
 
         val dropInOverrideParams = dropInValue?.let { DropInOverrideParams(it, null) }
@@ -252,11 +245,7 @@ internal class ACHDirectDebitComponentParamsMapperTest {
     ) {
         val configuration = createCheckoutConfiguration(shopperLocale = configurationValue)
 
-        val sessionParams = SessionParams(
-            enableStoreDetails = null,
-            installmentConfiguration = null,
-            amount = null,
-            returnUrl = "",
+        val sessionParams = createSessionParams(
             shopperLocale = sessionsValue,
         )
 
@@ -286,6 +275,23 @@ internal class ACHDirectDebitComponentParamsMapperTest {
     ) {
         achDirectDebit(configuration)
     }
+
+    @Suppress("LongParameterList")
+    private fun createSessionParams(
+        enableStoreDetails: Boolean? = null,
+        installmentConfiguration: SessionInstallmentConfiguration? = null,
+        showRemovePaymentMethodButton: Boolean? = null,
+        amount: Amount? = null,
+        returnUrl: String? = "",
+        shopperLocale: Locale? = null,
+    ) = SessionParams(
+        enableStoreDetails = enableStoreDetails,
+        installmentConfiguration = installmentConfiguration,
+        showRemovePaymentMethodButton = showRemovePaymentMethodButton,
+        amount = amount,
+        returnUrl = returnUrl,
+        shopperLocale = shopperLocale,
+    )
 
     @Suppress("LongParameterList")
     private fun getAchComponentParams(

--- a/bcmc/src/test/java/com/adyen/checkout/bcmc/internal/ui/model/BcmcComponentParamsMapperTest.kt
+++ b/bcmc/src/test/java/com/adyen/checkout/bcmc/internal/ui/model/BcmcComponentParamsMapperTest.kt
@@ -27,6 +27,7 @@ import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParamsLevel
 import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParams
 import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
+import com.adyen.checkout.components.core.internal.ui.model.SessionInstallmentConfiguration
 import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.ui.core.internal.ui.model.AddressParams
@@ -130,12 +131,8 @@ internal class BcmcComponentParamsMapperTest {
             setShowStorePaymentField(configurationValue)
         }
 
-        val sessionParams = SessionParams(
+        val sessionParams = createSessionParams(
             enableStoreDetails = sessionsValue,
-            installmentConfiguration = null,
-            amount = null,
-            returnUrl = "",
-            shopperLocale = null,
         )
         val params =
             bcmcComponentParamsMapper.mapToParams(configuration, DEVICE_LOCALE, null, sessionParams, PaymentMethod())
@@ -157,12 +154,8 @@ internal class BcmcComponentParamsMapperTest {
 
         val dropInOverrideParams = dropInValue?.let { DropInOverrideParams(it, null) }
 
-        val sessionParams = SessionParams(
-            enableStoreDetails = null,
-            installmentConfiguration = null,
+        val sessionParams = createSessionParams(
             amount = sessionsValue,
-            returnUrl = "",
-            shopperLocale = null,
         )
         val params = bcmcComponentParamsMapper.mapToParams(
             configuration,
@@ -190,11 +183,7 @@ internal class BcmcComponentParamsMapperTest {
     ) {
         val configuration = createCheckoutConfiguration(shopperLocale = configurationValue)
 
-        val sessionParams = SessionParams(
-            enableStoreDetails = null,
-            installmentConfiguration = null,
-            amount = null,
-            returnUrl = "",
+        val sessionParams = createSessionParams(
             shopperLocale = sessionsValue,
         )
 
@@ -225,6 +214,23 @@ internal class BcmcComponentParamsMapperTest {
     ) {
         bcmc(configuration)
     }
+
+    @Suppress("LongParameterList")
+    private fun createSessionParams(
+        enableStoreDetails: Boolean? = null,
+        installmentConfiguration: SessionInstallmentConfiguration? = null,
+        showRemovePaymentMethodButton: Boolean? = null,
+        amount: Amount? = null,
+        returnUrl: String? = "",
+        shopperLocale: Locale? = null,
+    ) = SessionParams(
+        enableStoreDetails = enableStoreDetails,
+        installmentConfiguration = installmentConfiguration,
+        showRemovePaymentMethodButton = showRemovePaymentMethodButton,
+        amount = amount,
+        returnUrl = returnUrl,
+        shopperLocale = shopperLocale,
+    )
 
     @Suppress("LongParameterList")
     private fun getCardComponentParams(

--- a/boleto/src/test/java/com/adyen/checkout/boleto/internal/ui/model/BoletoComponentParamsMapperTest.kt
+++ b/boleto/src/test/java/com/adyen/checkout/boleto/internal/ui/model/BoletoComponentParamsMapperTest.kt
@@ -19,6 +19,7 @@ import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParamsLevel
 import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParams
 import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
+import com.adyen.checkout.components.core.internal.ui.model.SessionInstallmentConfiguration
 import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.ui.core.internal.ui.model.AddressParams
@@ -126,12 +127,8 @@ internal class BoletoComponentParamsMapperTest {
 
         val dropInOverrideParams = dropInValue?.let { DropInOverrideParams(it, null) }
 
-        val sessionParams = SessionParams(
-            enableStoreDetails = null,
-            installmentConfiguration = null,
+        val sessionParams = createSessionParams(
             amount = sessionsValue,
-            returnUrl = "",
-            shopperLocale = null,
         )
 
         val params = mapParams(
@@ -158,11 +155,7 @@ internal class BoletoComponentParamsMapperTest {
     ) {
         val configuration = createCheckoutConfiguration(shopperLocale = configurationValue)
 
-        val sessionParams = SessionParams(
-            enableStoreDetails = null,
-            installmentConfiguration = null,
-            amount = null,
-            returnUrl = "",
+        val sessionParams = createSessionParams(
             shopperLocale = sessionsValue,
         )
 
@@ -192,6 +185,23 @@ internal class BoletoComponentParamsMapperTest {
     ) {
         boleto(configuration)
     }
+
+    @Suppress("LongParameterList")
+    private fun createSessionParams(
+        enableStoreDetails: Boolean? = null,
+        installmentConfiguration: SessionInstallmentConfiguration? = null,
+        showRemovePaymentMethodButton: Boolean? = null,
+        amount: Amount? = null,
+        returnUrl: String? = "",
+        shopperLocale: Locale? = null,
+    ) = SessionParams(
+        enableStoreDetails = enableStoreDetails,
+        installmentConfiguration = installmentConfiguration,
+        showRemovePaymentMethodButton = showRemovePaymentMethodButton,
+        amount = amount,
+        returnUrl = returnUrl,
+        shopperLocale = shopperLocale,
+    )
 
     @Suppress("LongParameterList")
     private fun getBoletoComponentParams(

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapperTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapperTest.kt
@@ -262,12 +262,8 @@ internal class CardComponentParamsMapperTest {
             setShowStorePaymentField(configurationValue)
         }
 
-        val sessionParams = SessionParams(
+        val sessionParams = createSessionParams(
             enableStoreDetails = sessionsValue,
-            installmentConfiguration = null,
-            amount = null,
-            returnUrl = "",
-            shopperLocale = null,
         )
 
         val params = cardComponentParamsMapper.mapToParams(
@@ -298,13 +294,7 @@ internal class CardComponentParamsMapperTest {
             )
         }
 
-        val sessionParams = SessionParams(
-            enableStoreDetails = null,
-            installmentConfiguration = null,
-            amount = null,
-            returnUrl = "",
-            shopperLocale = null,
-        )
+        val sessionParams = createSessionParams()
 
         val params = cardComponentParamsMapper.mapToParams(
             checkoutConfiguration = configuration,
@@ -346,12 +336,8 @@ internal class CardComponentParamsMapperTest {
         }
 
         val installmentsParamsMapper = InstallmentsParamsMapper()
-        val sessionParams = SessionParams(
-            enableStoreDetails = null,
+        val sessionParams = createSessionParams(
             installmentConfiguration = installmentConfiguration,
-            amount = null,
-            returnUrl = "",
-            shopperLocale = null,
         )
         val cardComponentParamsMapper = CardComponentParamsMapper(
             CommonComponentParamsMapper(),
@@ -439,12 +425,8 @@ internal class CardComponentParamsMapperTest {
 
         val dropInOverrideParams = dropInValue?.let { DropInOverrideParams(it, null) }
 
-        val sessionParams = SessionParams(
-            enableStoreDetails = null,
-            installmentConfiguration = null,
+        val sessionParams = createSessionParams(
             amount = sessionsValue,
-            returnUrl = "",
-            shopperLocale = null,
         )
 
         val params = cardComponentParamsMapper.mapToParams(
@@ -473,11 +455,7 @@ internal class CardComponentParamsMapperTest {
     ) {
         val configuration = createCheckoutConfiguration(shopperLocale = configurationValue)
 
-        val sessionParams = SessionParams(
-            enableStoreDetails = null,
-            installmentConfiguration = null,
-            amount = null,
-            returnUrl = "",
+        val sessionParams = createSessionParams(
             shopperLocale = sessionsValue,
         )
 
@@ -508,6 +486,23 @@ internal class CardComponentParamsMapperTest {
     ) {
         card(configuration)
     }
+
+    @Suppress("LongParameterList")
+    private fun createSessionParams(
+        enableStoreDetails: Boolean? = null,
+        installmentConfiguration: SessionInstallmentConfiguration? = null,
+        showRemovePaymentMethodButton: Boolean? = null,
+        amount: Amount? = null,
+        returnUrl: String? = "",
+        shopperLocale: Locale? = null,
+    ) = SessionParams(
+        enableStoreDetails = enableStoreDetails,
+        installmentConfiguration = installmentConfiguration,
+        showRemovePaymentMethodButton = showRemovePaymentMethodButton,
+        amount = amount,
+        returnUrl = returnUrl,
+        shopperLocale = shopperLocale,
+    )
 
     @Suppress("LongParameterList")
     private fun getCardComponentParams(

--- a/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/model/CashAppPayComponentParamsMapperTest.kt
+++ b/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/model/CashAppPayComponentParamsMapperTest.kt
@@ -24,6 +24,7 @@ import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParamsLevel
 import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParams
 import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
+import com.adyen.checkout.components.core.internal.ui.model.SessionInstallmentConfiguration
 import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.core.exception.ComponentException
@@ -155,12 +156,9 @@ internal class CashAppPayComponentParamsMapperTest {
         val configuration = createCheckoutConfiguration {
             setShowStorePaymentField(configurationValue)
         }
-        val sessionParams = SessionParams(
+        val sessionParams = createSessionParams(
             enableStoreDetails = sessionsValue,
-            installmentConfiguration = null,
-            amount = null,
             returnUrl = TEST_RETURN_URL,
-            shopperLocale = null,
         )
         val params = cashAppPayComponentParamsMapper.mapToParams(
             checkoutConfiguration = configuration,
@@ -189,12 +187,9 @@ internal class CashAppPayComponentParamsMapperTest {
         val configuration = createCheckoutConfiguration(configurationValue)
 
         val dropInOverrideParams = dropInValue?.let { DropInOverrideParams(it, null) }
-        val sessionParams = SessionParams(
-            enableStoreDetails = null,
-            installmentConfiguration = null,
+        val sessionParams = createSessionParams(
             amount = sessionsValue,
             returnUrl = TEST_RETURN_URL,
-            shopperLocale = null,
         )
         val params = cashAppPayComponentParamsMapper.mapToParams(
             checkoutConfiguration = configuration,
@@ -244,7 +239,10 @@ internal class CashAppPayComponentParamsMapperTest {
         ) {
             cashAppPay()
         }
-        val sessionParams = SessionParams(false, null, null, "sessionReturnUrl", null)
+        val sessionParams = createSessionParams(
+            enableStoreDetails = false,
+            returnUrl = "sessionReturnUrl",
+        )
         val params = cashAppPayComponentParamsMapper.mapToParams(
             checkoutConfiguration = configuration,
             deviceLocale = DEVICE_LOCALE,
@@ -361,10 +359,7 @@ internal class CashAppPayComponentParamsMapperTest {
     ) {
         val configuration = createCheckoutConfiguration(shopperLocale = configurationValue)
 
-        val sessionParams = SessionParams(
-            enableStoreDetails = null,
-            installmentConfiguration = null,
-            amount = null,
+        val sessionParams = createSessionParams(
             returnUrl = TEST_RETURN_URL,
             shopperLocale = sessionsValue,
         )
@@ -433,6 +428,23 @@ internal class CashAppPayComponentParamsMapperTest {
             apply(configuration)
         }
     }
+
+    @Suppress("LongParameterList")
+    private fun createSessionParams(
+        enableStoreDetails: Boolean? = null,
+        installmentConfiguration: SessionInstallmentConfiguration? = null,
+        showRemovePaymentMethodButton: Boolean? = null,
+        amount: Amount? = null,
+        returnUrl: String? = "",
+        shopperLocale: Locale? = null,
+    ) = SessionParams(
+        enableStoreDetails = enableStoreDetails,
+        installmentConfiguration = installmentConfiguration,
+        showRemovePaymentMethodButton = showRemovePaymentMethodButton,
+        amount = amount,
+        returnUrl = returnUrl,
+        shopperLocale = shopperLocale,
+    )
 
     private fun getDefaultPaymentMethod() = PaymentMethod(
         configuration = Configuration(clientId = TEST_CLIENT_ID, scopeId = TEST_SCOPE_ID),

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/SessionParams.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/SessionParams.kt
@@ -16,6 +16,7 @@ import java.util.Locale
 data class SessionParams(
     val enableStoreDetails: Boolean?,
     val installmentConfiguration: SessionInstallmentConfiguration?,
+    val showRemovePaymentMethodButton: Boolean?,
     val amount: Amount?,
     val returnUrl: String?,
     val shopperLocale: Locale?,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/SessionParams.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/SessionParams.kt
@@ -14,8 +14,11 @@ import java.util.Locale
 
 /**
  * Object that holds values set during sessions setup call.
- * [SessionParams] values should always have higher priority than values set in client side configurations. Otherwise
- * it can cause server error, since specific configuration is not enabled, but it is being used.
+ * [SessionParams] values by default should have higher priority than values set in client side configurations.
+ * Otherwise it can cause server error, since specific configuration is not enabled, but it is being used.
+ *
+ * Only for some specific cases, if they do not cause server error, client side configurations can have higher priority
+ * than [SessionParams] values.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class SessionParams(

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/SessionParams.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/SessionParams.kt
@@ -12,6 +12,11 @@ import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.core.Amount
 import java.util.Locale
 
+/**
+ * Object that holds values set during sessions setup call.
+ * [SessionParams] values should always have higher priority than values set in client side configurations. Otherwise
+ * it can cause server error, since specific configuration is not enabled, but it is being used.
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class SessionParams(
     val enableStoreDetails: Boolean?,

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/ui/model/ButtonComponentParamsMapperTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/ui/model/ButtonComponentParamsMapperTest.kt
@@ -89,12 +89,8 @@ internal class ButtonComponentParamsMapperTest {
         val configuration = createCheckoutConfiguration(configurationValue)
 
         val dropInOverrideParams = dropInValue?.let { DropInOverrideParams(it, null) }
-        val sessionParams = SessionParams(
-            enableStoreDetails = null,
-            installmentConfiguration = null,
+        val sessionParams = createSessionParams(
             amount = sessionsValue,
-            returnUrl = "",
-            shopperLocale = null,
         )
         val params = buttonComponentParamsMapper.mapToParams(
             checkoutConfiguration = configuration,
@@ -122,11 +118,7 @@ internal class ButtonComponentParamsMapperTest {
     ) {
         val configuration = createCheckoutConfiguration(shopperLocale = configurationValue)
 
-        val sessionParams = SessionParams(
-            enableStoreDetails = null,
-            installmentConfiguration = null,
-            amount = null,
-            returnUrl = "",
+        val sessionParams = createSessionParams(
             shopperLocale = sessionsValue,
         )
 
@@ -160,6 +152,23 @@ internal class ButtonComponentParamsMapperTest {
             .build()
         addConfiguration(TEST_CONFIGURATION_KEY, testConfiguration)
     }
+
+    @Suppress("LongParameterList")
+    private fun createSessionParams(
+        enableStoreDetails: Boolean? = null,
+        installmentConfiguration: SessionInstallmentConfiguration? = null,
+        showRemovePaymentMethodButton: Boolean? = null,
+        amount: Amount? = null,
+        returnUrl: String? = "",
+        shopperLocale: Locale? = null,
+    ) = SessionParams(
+        enableStoreDetails = enableStoreDetails,
+        installmentConfiguration = installmentConfiguration,
+        showRemovePaymentMethodButton = showRemovePaymentMethodButton,
+        amount = amount,
+        returnUrl = returnUrl,
+        shopperLocale = shopperLocale,
+    )
 
     @Suppress("LongParameterList")
     private fun getButtonComponentParams(

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/ui/model/GenericComponentParamsMapperTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/ui/model/GenericComponentParamsMapperTest.kt
@@ -89,12 +89,8 @@ internal class GenericComponentParamsMapperTest {
 
         val dropInOverrideParams = dropInValue?.let { DropInOverrideParams(it, null) }
 
-        val sessionParams = SessionParams(
-            enableStoreDetails = null,
-            installmentConfiguration = null,
+        val sessionParams = createSessionParams(
             amount = sessionsValue,
-            returnUrl = "",
-            shopperLocale = null,
         )
 
         val params = genericComponentParamsMapper.mapToParams(
@@ -122,11 +118,7 @@ internal class GenericComponentParamsMapperTest {
     ) {
         val configuration = createCheckoutConfiguration(shopperLocale = configurationValue)
 
-        val sessionParams = SessionParams(
-            enableStoreDetails = null,
-            installmentConfiguration = null,
-            amount = null,
-            returnUrl = "",
+        val sessionParams = createSessionParams(
             shopperLocale = sessionsValue,
         )
 
@@ -157,6 +149,23 @@ internal class GenericComponentParamsMapperTest {
             .build()
         addConfiguration(TEST_CONFIGURATION_KEY, testConfiguration)
     }
+
+    @Suppress("LongParameterList")
+    private fun createSessionParams(
+        enableStoreDetails: Boolean? = null,
+        installmentConfiguration: SessionInstallmentConfiguration? = null,
+        showRemovePaymentMethodButton: Boolean? = null,
+        amount: Amount? = null,
+        returnUrl: String? = "",
+        shopperLocale: Locale? = null,
+    ) = SessionParams(
+        enableStoreDetails = enableStoreDetails,
+        installmentConfiguration = installmentConfiguration,
+        showRemovePaymentMethodButton = showRemovePaymentMethodButton,
+        amount = amount,
+        returnUrl = returnUrl,
+        shopperLocale = shopperLocale,
+    )
 
     @Suppress("LongParameterList")
     private fun getGenericComponentParams(

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/SessionDropInService.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/SessionDropInService.kt
@@ -12,6 +12,7 @@ import com.adyen.checkout.components.core.ActionComponentData
 import com.adyen.checkout.components.core.OrderRequest
 import com.adyen.checkout.components.core.OrderResponse
 import com.adyen.checkout.components.core.PaymentComponentState
+import com.adyen.checkout.components.core.StoredPaymentMethod
 import com.adyen.checkout.core.AdyenLogLevel
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
@@ -219,6 +220,26 @@ open class SessionDropInService : BaseDropInService(), SessionDropInServiceInter
             }
 
             sendResult(dropInServiceResult)
+        }
+    }
+
+    override fun onRemoveStoredPaymentMethod(storedPaymentMethod: StoredPaymentMethod) {
+        launch {
+            val storedPaymentMethodId = storedPaymentMethod.id.orEmpty()
+            val result = sessionInteractor.removeStoredPaymentMethod(storedPaymentMethodId)
+
+            val serviceResult = when (result) {
+                SessionCallResult.RemoveStoredPaymentMethod.Successful -> RecurringDropInServiceResult.PaymentMethodRemoved(
+                    storedPaymentMethodId,
+                )
+
+                is SessionCallResult.RemoveStoredPaymentMethod.Error -> RecurringDropInServiceResult.Error(
+                    errorDialog = ErrorDialog(),
+                    reason = result.throwable.message,
+                )
+            }
+
+            sendRecurringResult(serviceResult)
         }
     }
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/SessionDropInService.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/SessionDropInService.kt
@@ -229,9 +229,10 @@ open class SessionDropInService : BaseDropInService(), SessionDropInServiceInter
             val result = sessionInteractor.removeStoredPaymentMethod(storedPaymentMethodId)
 
             val serviceResult = when (result) {
-                SessionCallResult.RemoveStoredPaymentMethod.Successful -> RecurringDropInServiceResult.PaymentMethodRemoved(
-                    storedPaymentMethodId,
-                )
+                SessionCallResult.RemoveStoredPaymentMethod.Successful ->
+                    RecurringDropInServiceResult.PaymentMethodRemoved(
+                        storedPaymentMethodId,
+                    )
 
                 is SessionCallResult.RemoveStoredPaymentMethod.Error -> RecurringDropInServiceResult.Error(
                     errorDialog = ErrorDialog(),

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/SessionDropInService.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/SessionDropInService.kt
@@ -89,7 +89,7 @@ open class SessionDropInService : BaseDropInService(), SessionDropInServiceInter
                 is SessionCallResult.Payments.Action -> DropInServiceResult.Action(result.action)
                 is SessionCallResult.Payments.Error ->
                     DropInServiceResult.Error(
-                        errorDialog = ErrorDialog(),
+                        errorDialog = ErrorDialog(message = getString(R.string.payment_failed)),
                         reason = result.throwable.message,
                         dismissDropIn = true,
                     )
@@ -98,7 +98,7 @@ open class SessionDropInService : BaseDropInService(), SessionDropInServiceInter
                 is SessionCallResult.Payments.NotFullyPaidOrder -> updatePaymentMethods(result.result.order)
                 is SessionCallResult.Payments.RefusedPartialPayment ->
                     DropInServiceResult.Error(
-                        errorDialog = ErrorDialog(),
+                        errorDialog = ErrorDialog(message = getString(R.string.payment_failed)),
                         reason = "Payment was refused while making a partial payment",
                     )
 
@@ -124,7 +124,7 @@ open class SessionDropInService : BaseDropInService(), SessionDropInServiceInter
                 is SessionCallResult.Details.Action -> DropInServiceResult.Action(result.action)
                 is SessionCallResult.Details.Error ->
                     DropInServiceResult.Error(
-                        errorDialog = ErrorDialog(),
+                        errorDialog = ErrorDialog(message = getString(R.string.payment_failed)),
                         reason = result.throwable.message,
                         dismissDropIn = true,
                     )
@@ -151,7 +151,7 @@ open class SessionDropInService : BaseDropInService(), SessionDropInServiceInter
             val dropInServiceResult = when (result) {
                 is SessionCallResult.Balance.Error ->
                     BalanceDropInServiceResult.Error(
-                        errorDialog = ErrorDialog(),
+                        errorDialog = ErrorDialog(message = getString(R.string.payment_failed)),
                         reason = result.throwable.message,
                     )
 
@@ -176,7 +176,7 @@ open class SessionDropInService : BaseDropInService(), SessionDropInServiceInter
             val dropInServiceResult = when (result) {
                 is SessionCallResult.CreateOrder.Error ->
                     OrderDropInServiceResult.Error(
-                        errorDialog = ErrorDialog(),
+                        errorDialog = ErrorDialog(message = getString(R.string.payment_failed)),
                         reason = result.throwable.message,
                         dismissDropIn = true,
                     )
@@ -204,7 +204,7 @@ open class SessionDropInService : BaseDropInService(), SessionDropInServiceInter
             val dropInServiceResult = when (result) {
                 is SessionCallResult.CancelOrder.Error ->
                     DropInServiceResult.Error(
-                        errorDialog = ErrorDialog(),
+                        errorDialog = ErrorDialog(message = getString(R.string.unknown_error)),
                         reason = result.throwable.message,
                     )
 
@@ -235,7 +235,7 @@ open class SessionDropInService : BaseDropInService(), SessionDropInServiceInter
                     )
 
                 is SessionCallResult.RemoveStoredPaymentMethod.Error -> RecurringDropInServiceResult.Error(
-                    errorDialog = ErrorDialog(),
+                    errorDialog = ErrorDialog(message = getString(R.string.unknown_error)),
                     reason = result.throwable.message,
                 )
             }
@@ -253,7 +253,7 @@ open class SessionDropInService : BaseDropInService(), SessionDropInServiceInter
 
             is SessionCallResult.UpdatePaymentMethods.Error ->
                 DropInServiceResult.Error(
-                    errorDialog = ErrorDialog(),
+                    errorDialog = ErrorDialog(message = getString(R.string.payment_failed)),
                     reason = result.throwable.message,
                     dismissDropIn = true,
                 )

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInActivity.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInActivity.kt
@@ -183,7 +183,6 @@ internal class DropInActivity :
     }
 
     @Deprecated("Deprecated in Java")
-    @Suppress("deprecation")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         checkGooglePayActivityResult(requestCode, resultCode, data)
@@ -460,7 +459,7 @@ internal class DropInActivity :
         adyenLog(AdyenLogLevel.DEBUG) { "handleDropInServiceResult ERROR - reason: $reason" }
 
         dropInServiceResult.errorDialog?.let { errorDialog ->
-            val errorMessage = errorDialog.message ?: getString(R.string.payment_failed)
+            val errorMessage = errorDialog.message ?: getString(R.string.unknown_error)
             showError(errorDialog.title, errorMessage, reason, dropInServiceResult.dismissDropIn)
         } ?: if (dropInServiceResult.dismissDropIn) {
             terminateWithError(reason)

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/model/DropInParamsMapper.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/model/DropInParamsMapper.kt
@@ -47,5 +47,5 @@ internal class DropInParamsMapper {
     private fun getIsRemovingStoredPaymentMethodsEnabled(
         dropInConfiguration: DropInConfiguration?,
         sessionParams: SessionParams?
-    ) = dropInConfiguration?.isRemovingStoredPaymentMethodsEnabled ?: sessionParams?.showRemovePaymentMethodButton
+    ) = sessionParams?.showRemovePaymentMethodButton ?: dropInConfiguration?.isRemovingStoredPaymentMethodsEnabled
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/model/DropInParamsMapper.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/model/DropInParamsMapper.kt
@@ -11,6 +11,7 @@ package com.adyen.checkout.dropin.internal.ui.model
 import com.adyen.checkout.components.core.CheckoutConfiguration
 import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
 import com.adyen.checkout.components.core.internal.ui.model.SessionParams
+import com.adyen.checkout.dropin.DropInConfiguration
 import com.adyen.checkout.dropin.getDropInConfiguration
 import java.util.Locale
 
@@ -30,7 +31,10 @@ internal class DropInParamsMapper {
             amount = sessionParams?.amount ?: checkoutConfiguration.amount,
             showPreselectedStoredPaymentMethod = dropInConfiguration?.showPreselectedStoredPaymentMethod ?: true,
             skipListWhenSinglePaymentMethod = dropInConfiguration?.skipListWhenSinglePaymentMethod ?: false,
-            isRemovingStoredPaymentMethodsEnabled = dropInConfiguration?.isRemovingStoredPaymentMethodsEnabled ?: false,
+            isRemovingStoredPaymentMethodsEnabled = getIsRemovingStoredPaymentMethodsEnabled(
+                dropInConfiguration,
+                sessionParams,
+            ) ?: false,
             additionalDataForDropInService = dropInConfiguration?.additionalDataForDropInService,
             overriddenPaymentMethodInformation = dropInConfiguration?.overriddenPaymentMethodInformation.orEmpty(),
         )
@@ -39,4 +43,9 @@ internal class DropInParamsMapper {
     fun getShopperLocale(checkoutConfiguration: CheckoutConfiguration, sessionParams: SessionParams?): Locale? {
         return checkoutConfiguration.shopperLocale ?: sessionParams?.shopperLocale
     }
+
+    private fun getIsRemovingStoredPaymentMethodsEnabled(
+        dropInConfiguration: DropInConfiguration?,
+        sessionParams: SessionParams?
+    ) = dropInConfiguration?.isRemovingStoredPaymentMethodsEnabled ?: sessionParams?.showRemovePaymentMethodButton
 }

--- a/drop-in/src/main/res/template/values/strings.xml.tt
+++ b/drop-in/src/main/res/template/values/strings.xml.tt
@@ -11,6 +11,7 @@
     <string name="payment_failed">%%resultMessages.failed%%</string>
     <string name="action_failed">%%resultMessages.Error%%</string>
     <string name="time_out_error">%%resultMessages.timeout%%</string>
+    <string name="unknown_error">%%error.message.unknown%%</string>
     <string name="store_payment_methods_header">%%paymentMethods.storedMethods%%</string>
     <string name="other_payment_methods">%%paymentMethods.otherMethods%%</string>
     <string name="continue_button">%%continue%%</string>

--- a/drop-in/src/main/res/values-ar/strings.xml
+++ b/drop-in/src/main/res/values-ar/strings.xml
@@ -11,6 +11,7 @@
     <string name="payment_failed">خطأ في إرسال المدفوعات. يُرجى المحاولة مرة أخرى.</string>
     <string name="action_failed">حدث خطأ أثناء معالجة مدفوعاتك. يُرجى المحاولة مرة أخرى لاحقًا.</string>
     <string name="time_out_error">انتهت مهلة الطلب. يُرجى المحاولة مرة أخرى.</string>
+    <string name="unknown_error">حدث خطأ غير معروف</string>
     <string name="store_payment_methods_header">طرق الدفع الخاصة بك</string>
     <string name="other_payment_methods">تحديد طريقة أخرى</string>
     <string name="continue_button">متابعة</string>

--- a/drop-in/src/main/res/values-cs-rCZ/strings.xml
+++ b/drop-in/src/main/res/values-cs-rCZ/strings.xml
@@ -11,6 +11,7 @@
     <string name="payment_failed">Chyba při odesílání platby. Zkuste to znovu.</string>
     <string name="action_failed">Při zpracování platby došlo k chybě. Zkuste to znovu později.</string>
     <string name="time_out_error">Vypršení doby požadavku. Zkuste to znovu.</string>
+    <string name="unknown_error">Došlo k neznámé chybě</string>
     <string name="store_payment_methods_header">Vaše způsoby platby</string>
     <string name="other_payment_methods">Vyberte jiný způsob platby</string>
     <string name="continue_button">Pokračovat</string>

--- a/drop-in/src/main/res/values-da-rDK/strings.xml
+++ b/drop-in/src/main/res/values-da-rDK/strings.xml
@@ -11,6 +11,7 @@
     <string name="payment_failed">Fejl ved gennemførelse af betaling. Prøv igen.</string>
     <string name="action_failed">Der opstod en fejl ved behandlingen af betalingen. Prøv igen senere.</string>
     <string name="time_out_error">Anmodning udløbet. Prøv igen.</string>
+    <string name="unknown_error">Der opstod en ukendt fejl</string>
     <string name="store_payment_methods_header">Dine betalingsmåder</string>
     <string name="other_payment_methods">Vælg anden måde</string>
     <string name="continue_button">Fortsæt</string>

--- a/drop-in/src/main/res/values-de-rDE/strings.xml
+++ b/drop-in/src/main/res/values-de-rDE/strings.xml
@@ -11,6 +11,7 @@
     <string name="payment_failed">Fehler beim Senden der Zahlung. Bitte versuchen Sie es erneut.</string>
     <string name="action_failed">Bei der Verarbeitung Ihrer Zahlung ist ein Fehler aufgetreten. Bitte versuchen Sie es später erneut.</string>
     <string name="time_out_error">Zeitüberschreitung bei Anfrage. Bitte versuchen Sie es erneut.</string>
+    <string name="unknown_error">Es ist ein unbekannter Fehler aufgetreten.</string>
     <string name="store_payment_methods_header">Ihre Zahlungsmethoden</string>
     <string name="other_payment_methods">Andere Zahlungsmethoden</string>
     <string name="continue_button">Weiter</string>

--- a/drop-in/src/main/res/values-el-rGR/strings.xml
+++ b/drop-in/src/main/res/values-el-rGR/strings.xml
@@ -11,6 +11,7 @@
     <string name="payment_failed">Σφάλμα κατά την αποστολή πληρωμής. Προσπαθήστε ξανά.</string>
     <string name="action_failed">Προέκυψε σφάλμα κατά την επεξεργασία της πληρωμής σας. Προσπαθήστε ξανά αργότερα.</string>
     <string name="time_out_error">Έληξε το χρονικό όριο του αιτήματος. Προσπαθήστε ξανά.</string>
+    <string name="unknown_error">Προέκυψε άγνωστο σφάλμα</string>
     <string name="store_payment_methods_header">Οι τρόποι πληρωμής σας</string>
     <string name="other_payment_methods">Επιλέξτε άλλον τρόπο</string>
     <string name="continue_button">Συνέχεια</string>

--- a/drop-in/src/main/res/values-es-rES/strings.xml
+++ b/drop-in/src/main/res/values-es-rES/strings.xml
@@ -11,6 +11,7 @@
     <string name="payment_failed">Error al enviar el pago. Por favor, vuelva a intentarlo.</string>
     <string name="action_failed">Se produjo un error al procesar su pago. Inténtelo de nuevo más tarde.</string>
     <string name="time_out_error">Se ha superado el tiempo de espera. Por favor, vuelva a intentarlo.</string>
+    <string name="unknown_error">Se ha producido un error desconocido</string>
     <string name="store_payment_methods_header">Tus metodos de pago</string>
     <string name="other_payment_methods">Otros métodos de pago</string>
     <string name="continue_button">Continuar</string>

--- a/drop-in/src/main/res/values-fi-rFI/strings.xml
+++ b/drop-in/src/main/res/values-fi-rFI/strings.xml
@@ -11,6 +11,7 @@
     <string name="payment_failed">Virhe maksun lähettämisessä. Yritä uudelleen.</string>
     <string name="action_failed">Maksua käsitellessä tapahtui virhe. Yritä myöhemmin uudelleen.</string>
     <string name="time_out_error">Pyydä aikakatkaisu. Yritä uudelleen.</string>
+    <string name="unknown_error">Tapahtui tuntematon virhe</string>
     <string name="store_payment_methods_header">Maksutapasi</string>
     <string name="other_payment_methods">Valitse muu maksutapa</string>
     <string name="continue_button">Jatka</string>

--- a/drop-in/src/main/res/values-fr-rFR/strings.xml
+++ b/drop-in/src/main/res/values-fr-rFR/strings.xml
@@ -11,6 +11,7 @@
     <string name="payment_failed">Erreur lors de l\'envoi du paiement. Veuillez réessayer.</string>
     <string name="action_failed">Une erreur s\'est produite lors du traitement de votre paiement. Veuillez réessayer plus tard.</string>
     <string name="time_out_error">La requête a expiré. Veuillez réessayer.</string>
+    <string name="unknown_error">Une erreur inconnue s\'est produite</string>
     <string name="store_payment_methods_header">Vos modes de paiement</string>
     <string name="other_payment_methods">Autre méthode de paiement</string>
     <string name="continue_button">Continuer</string>

--- a/drop-in/src/main/res/values-hr-rHR/strings.xml
+++ b/drop-in/src/main/res/values-hr-rHR/strings.xml
@@ -11,6 +11,7 @@
     <string name="payment_failed">Greška prilikom slanja plaćanja. Pokušajte ponovno.</string>
     <string name="action_failed">Došlo je do pogreške prilikom obrade plaćanja. Pokušajte ponovno kasnije.</string>
     <string name="time_out_error">Isteklo je vrijeme zahtjeva. Pokušajte ponovno.</string>
+    <string name="unknown_error">Dogodila se nepoznata greška</string>
     <string name="store_payment_methods_header">Vaš način plaćanja</string>
     <string name="other_payment_methods">Odaberite drugi način</string>
     <string name="continue_button">Nastavi</string>

--- a/drop-in/src/main/res/values-hu-rHU/strings.xml
+++ b/drop-in/src/main/res/values-hu-rHU/strings.xml
@@ -11,6 +11,7 @@
     <string name="payment_failed">Hiba történt a fizetés elküldése során. Próbálkozzon újra.</string>
     <string name="action_failed">Fizetése feldolgozása során hiba történt. Próbálkozzon újra később.</string>
     <string name="time_out_error">A kérés időkorlátja lejárt. Próbálkozzon újra.</string>
+    <string name="unknown_error">Ismeretlen hiba történt</string>
     <string name="store_payment_methods_header">Fizetési módjai</string>
     <string name="other_payment_methods">Másik mód választása</string>
     <string name="continue_button">Folytatás</string>

--- a/drop-in/src/main/res/values-it-rIT/strings.xml
+++ b/drop-in/src/main/res/values-it-rIT/strings.xml
@@ -11,6 +11,7 @@
     <string name="payment_failed">Errore durante l\'invio del pagamento. Riprova.</string>
     <string name="action_failed">Si è verificato un errore durante l\'elaborazione del pagamento. Riprova più tardi.</string>
     <string name="time_out_error">Il tempo disponibile per la richiesta è scaduto. Riprova.</string>
+    <string name="unknown_error">Si è verificato un errore sconosciuto</string>
     <string name="store_payment_methods_header">Metodi di pagamento</string>
     <string name="other_payment_methods">Scegli altro metodo di pagamento</string>
     <string name="continue_button">Continua</string>

--- a/drop-in/src/main/res/values-ja-rJP/strings.xml
+++ b/drop-in/src/main/res/values-ja-rJP/strings.xml
@@ -11,6 +11,7 @@
     <string name="payment_failed">支払いの送信中にエラーが発生しました。再度お試し下さい。</string>
     <string name="action_failed">支払の処理中にエラーが発生しました。後でもう一度やり直してください。</string>
     <string name="time_out_error">リクエストがタイムアウトになりました。再度お試し下さい。</string>
+    <string name="unknown_error">不明なエラーが発生しました</string>
     <string name="store_payment_methods_header">選択済みのお支払い方法</string>
     <string name="other_payment_methods">その他のお支払いオプション</string>
     <string name="continue_button">続ける</string>

--- a/drop-in/src/main/res/values-ko-rKR/strings.xml
+++ b/drop-in/src/main/res/values-ko-rKR/strings.xml
@@ -11,6 +11,7 @@
     <string name="payment_failed">결제 전송 중 오류 발생. 다시 시도해 주세요.</string>
     <string name="action_failed">결제 처리 중 오류가 발생했습니다. 나중에 다시 시도해 주세요.</string>
     <string name="time_out_error">요청 시간 초과. 다시 시도해 주세요.</string>
+    <string name="unknown_error">알 수 없는 오류 발생</string>
     <string name="store_payment_methods_header">귀하의 결제 수단</string>
     <string name="other_payment_methods">다른 수단 선택</string>
     <string name="continue_button">계속</string>

--- a/drop-in/src/main/res/values-nb-rNO/strings.xml
+++ b/drop-in/src/main/res/values-nb-rNO/strings.xml
@@ -11,6 +11,7 @@
     <string name="payment_failed">Feil ved sending av betaling. Vennligst prøv igjen.</string>
     <string name="action_failed">Det oppstod en feil under behandlingen av betalingen din. Vennligst prøv igjen senere.</string>
     <string name="time_out_error">Forespørselen fikk tidsavbrudd. Vennligst prøv igjen.</string>
+    <string name="unknown_error">En ukjent feil oppstod</string>
     <string name="store_payment_methods_header">Dine betalingsmetoder</string>
     <string name="other_payment_methods">Velg annen metode</string>
     <string name="continue_button">Fortsett</string>

--- a/drop-in/src/main/res/values-nl-rNL/strings.xml
+++ b/drop-in/src/main/res/values-nl-rNL/strings.xml
@@ -11,6 +11,7 @@
     <string name="payment_failed">Fout bij het verzenden van betaling. Probeer het opnieuw.</string>
     <string name="action_failed">Er is een fout opgetreden bij het verwerken van uw betaling. Probeer het later opnieuw.</string>
     <string name="time_out_error">Verzoek is verlopen. Probeer het opnieuw.</string>
+    <string name="unknown_error">Er is een onbekende fout opgetreden</string>
     <string name="store_payment_methods_header">Opgeslagen betaalmethodes</string>
     <string name="other_payment_methods">Alle betaalmethodes</string>
     <string name="continue_button">Doorgaan</string>

--- a/drop-in/src/main/res/values-pl-rPL/strings.xml
+++ b/drop-in/src/main/res/values-pl-rPL/strings.xml
@@ -11,6 +11,7 @@
     <string name="payment_failed">Wystąpił błąd podczas wysyłania płatności. Spróbuj ponownie.</string>
     <string name="action_failed">Podczas przetwarzania płatności wystąpił błąd. Prosimy spróbować ponownie.</string>
     <string name="time_out_error">Upłynął limit czasu żądania. Spróbuj ponownie.</string>
+    <string name="unknown_error">Wystąpił nieoczekiwany błąd</string>
     <string name="store_payment_methods_header">Twoje metody płatności</string>
     <string name="other_payment_methods">Wybierz inną metodę</string>
     <string name="continue_button">Kontynuuj</string>

--- a/drop-in/src/main/res/values-pt-rBR/strings.xml
+++ b/drop-in/src/main/res/values-pt-rBR/strings.xml
@@ -11,6 +11,7 @@
     <string name="payment_failed">Erro ao enviar o pagamento. Tente novamente.</string>
     <string name="action_failed">Ocorreu um erro ao processar o seu pagamento. Tente novamente mais tarde.</string>
     <string name="time_out_error">O pedido expirou. Tente novamente.</string>
+    <string name="unknown_error">Ocorreu um erro desconhecido</string>
     <string name="store_payment_methods_header">Meus métodos de pagamento</string>
     <string name="other_payment_methods">Todos os métodos de pagamento</string>
     <string name="continue_button">Continuar</string>

--- a/drop-in/src/main/res/values-pt-rPT/strings.xml
+++ b/drop-in/src/main/res/values-pt-rPT/strings.xml
@@ -11,6 +11,7 @@
     <string name="payment_failed">Erro ao enviar pagamento. Tente novamente</string>
     <string name="action_failed">Ocorreu um erro ao processar o seu pagamento. Tente novamente mais tarde.</string>
     <string name="time_out_error">Pedido com tempo limite. Tente novamente</string>
+    <string name="unknown_error">Ocorreu um erro desconhecido</string>
     <string name="store_payment_methods_header">Os seus métodos de pagamento</string>
     <string name="other_payment_methods">Selecione outro método</string>
     <string name="continue_button">Continuar</string>

--- a/drop-in/src/main/res/values-ro-rRO/strings.xml
+++ b/drop-in/src/main/res/values-ro-rRO/strings.xml
@@ -11,6 +11,7 @@
     <string name="payment_failed">Eroare la trimiterea plății. Vă rugăm să încercați din nou.</string>
     <string name="action_failed">S-a produs o eroare la prelucrarea plății. Vă rugăm să încercați din nou mai târziu.</string>
     <string name="time_out_error">Solicitarea a expirat. Vă rugăm să încercați din nou.</string>
+    <string name="unknown_error">S-a produs o eroare necunoscută</string>
     <string name="store_payment_methods_header">Metodele dvs. de plată</string>
     <string name="other_payment_methods">Selectați o altă metodă</string>
     <string name="continue_button">Continuare</string>

--- a/drop-in/src/main/res/values-ru-rRU/strings.xml
+++ b/drop-in/src/main/res/values-ru-rRU/strings.xml
@@ -11,6 +11,7 @@
     <string name="payment_failed">Ошибка при отправке платежа. Повторите попытку.</string>
     <string name="action_failed">При обработке платежа возникла ошибка. Повторите попытку позже.</string>
     <string name="time_out_error">Время ожидания запроса истекло. Повторите попытку.</string>
+    <string name="unknown_error">Возникла неизвестная ошибка</string>
     <string name="store_payment_methods_header">Ваши способы оплаты</string>
     <string name="other_payment_methods">Выбрать другой способ</string>
     <string name="continue_button">Продолжить</string>

--- a/drop-in/src/main/res/values-sk-rSK/strings.xml
+++ b/drop-in/src/main/res/values-sk-rSK/strings.xml
@@ -11,6 +11,7 @@
     <string name="payment_failed">Pri odosielaní platby došlo k chybe. Skúste to znova.</string>
     <string name="action_failed">Pri spracúvaní vašej platby sa vyskytla chyba. Skúste to neskôr znova.</string>
     <string name="time_out_error">Časový limit pre požiadavku uplynul. Skúste to znova.</string>
+    <string name="unknown_error">Vyskytla sa neznáma chyba</string>
     <string name="store_payment_methods_header">Vaše spôsoby platby</string>
     <string name="other_payment_methods">Vyberte iný spôsob</string>
     <string name="continue_button">Pokračovať</string>

--- a/drop-in/src/main/res/values-sl-rSI/strings.xml
+++ b/drop-in/src/main/res/values-sl-rSI/strings.xml
@@ -11,6 +11,7 @@
     <string name="payment_failed">Napaka pri pošiljanju plačila. Poskusite znova.</string>
     <string name="action_failed">Pri obdelavi vašega plačila je prišlo do napake. Poskusite znova pozneje.</string>
     <string name="time_out_error">Zahteva je potekla. Poskusite znova.</string>
+    <string name="unknown_error">Prišlo je do neznane napake</string>
     <string name="store_payment_methods_header">Vaši načini plačila</string>
     <string name="other_payment_methods">Izberite drug način</string>
     <string name="continue_button">Nadaljuj</string>

--- a/drop-in/src/main/res/values-sv-rSE/strings.xml
+++ b/drop-in/src/main/res/values-sv-rSE/strings.xml
@@ -11,6 +11,7 @@
     <string name="payment_failed">Fel när betalningen skickades. Försök igen.</string>
     <string name="action_failed">Det uppstod ett fel vid behandlingen av din betalning. Försök igen senare.</string>
     <string name="time_out_error">Förfrågan tog för lång tid. Försök igen.</string>
+    <string name="unknown_error">Ett okänt fel uppstod</string>
     <string name="store_payment_methods_header">Dina sparade betalningsmetoder</string>
     <string name="other_payment_methods">Välj annan betalningsmetod</string>
     <string name="continue_button">Fortsätt</string>

--- a/drop-in/src/main/res/values-zh-rCN/strings.xml
+++ b/drop-in/src/main/res/values-zh-rCN/strings.xml
@@ -11,6 +11,7 @@
     <string name="payment_failed">付款时出错。请重试。</string>
     <string name="action_failed">处理您的付款时发生错误。请稍候重试。</string>
     <string name="time_out_error">请求超时。请重试。</string>
+    <string name="unknown_error">发生未知错误</string>
     <string name="store_payment_methods_header">您的支付方式</string>
     <string name="other_payment_methods">选择其他方式</string>
     <string name="continue_button">继续</string>

--- a/drop-in/src/main/res/values-zh-rTW/strings.xml
+++ b/drop-in/src/main/res/values-zh-rTW/strings.xml
@@ -11,6 +11,7 @@
     <string name="payment_failed">傳送付款時出錯。請再試一次。</string>
     <string name="action_failed">處理您的付款時發生錯誤。請稍後再試。</string>
     <string name="time_out_error">請求已逾時。請再試一次。</string>
+    <string name="unknown_error">發生未知錯誤</string>
     <string name="store_payment_methods_header">您的付款方式</string>
     <string name="other_payment_methods">選取其他方式</string>
     <string name="continue_button">繼續</string>

--- a/drop-in/src/main/res/values/strings.xml
+++ b/drop-in/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="payment_failed">Error sending payment. Please try again.</string>
     <string name="action_failed">There was an error while processing your payment. Please try again later.</string>
     <string name="time_out_error">Request timed out. Please try again.</string>
+    <string name="unknown_error">An unknown error occurred</string>
     <string name="store_payment_methods_header">Your payment methods</string>
     <string name="other_payment_methods">Select other method</string>
     <string name="continue_button">Continue</string>

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/model/DropInParamsMapperTest.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/model/DropInParamsMapperTest.kt
@@ -121,6 +121,7 @@ internal class DropInParamsMapperTest {
             amount = sessionsValue,
             returnUrl = null,
             shopperLocale = null,
+            showRemovePaymentMethodButton = null,
         )
 
         val params = dropInParamsMapper.mapToParams(
@@ -150,6 +151,7 @@ internal class DropInParamsMapperTest {
             amount = null,
             returnUrl = "",
             shopperLocale = sessionsValue,
+            showRemovePaymentMethodButton = null,
         )
 
         val params = dropInParamsMapper.mapToParams(

--- a/example-app/src/main/java/com/adyen/checkout/example/data/api/model/SessionRequest.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/data/api/model/SessionRequest.kt
@@ -32,5 +32,6 @@ data class SessionRequest(
     val storePaymentMethodMode: String?,
     val recurringProcessingModel: String?,
     val installmentOptions: Map<String, SessionSetupInstallmentOptions>?,
-    val showInstallmentAmount: Boolean
+    val showInstallmentAmount: Boolean,
+    val showRemovePaymentMethodButton: Boolean,
 )

--- a/example-app/src/main/java/com/adyen/checkout/example/data/storage/KeyValueStorage.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/data/storage/KeyValueStorage.kt
@@ -29,6 +29,7 @@ interface KeyValueStorage {
     fun getMerchantAccount(): String
     fun isSplitCardFundingSources(): Boolean
     fun getCardAddressMode(): CardAddressMode
+    fun isRemoveStoredPaymentMethodEnabled(): Boolean
     fun getInstantPaymentMethodType(): String
     fun getInstallmentOptionsMode(): CardInstallmentOptionsMode
     fun isInstallmentAmountShown(): Boolean
@@ -121,6 +122,12 @@ internal class DefaultKeyValueStorage(
             ),
         )
     }
+
+    override fun isRemoveStoredPaymentMethodEnabled() = sharedPreferences.getBoolean(
+        appContext = appContext,
+        stringRes = R.string.remove_stored_payment_method_key,
+        defaultStringRes = R.string.preferences_default_remove_stored_payment_method,
+    )
 
     override fun getInstantPaymentMethodType(): String {
         return sharedPreferences.getString(

--- a/example-app/src/main/java/com/adyen/checkout/example/service/ExampleSessionsDropInService.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/service/ExampleSessionsDropInService.kt
@@ -58,7 +58,7 @@ class ExampleSessionsDropInService : SessionDropInService() {
                     merchantAccount = keyValueStorage.getMerchantAccount(),
                     redirectUrl = RedirectComponent.getReturnUrl(applicationContext),
                     threeDSMode = keyValueStorage.getThreeDSMode(),
-                    shopperEmail = keyValueStorage.getShopperEmail()
+                    shopperEmail = keyValueStorage.getShopperEmail(),
                 )
 
                 Log.v(TAG, "paymentComponentJson - ${paymentComponentJson.toStringPretty()}")
@@ -81,7 +81,7 @@ class ExampleSessionsDropInService : SessionDropInService() {
                 Log.d(TAG, "onDetailsCallRequested")
 
                 val response = paymentsRepository.makeDetailsRequest(
-                    ActionComponentData.SERIALIZER.serialize(actionComponentData)
+                    ActionComponentData.SERIALIZER.serialize(actionComponentData),
                 )
 
                 val result = handleResponse(response)

--- a/example-app/src/main/java/com/adyen/checkout/example/service/RequestUtils.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/service/RequestUtils.kt
@@ -64,6 +64,7 @@ fun getSessionRequest(
     threeDSMode: ThreeDSMode,
     installmentOptions: Map<String, SessionSetupInstallmentOptions>?,
     showInstallmentAmount: Boolean = false,
+    showRemovePaymentMethodButton: Boolean = false,
     threeDSAuthenticationOnly: Boolean = false,
     shopperEmail: String? = null,
     allowedPaymentMethods: List<String>? = null,
@@ -90,6 +91,7 @@ fun getSessionRequest(
         recurringProcessingModel = recurringProcessingModel,
         installmentOptions = installmentOptions,
         showInstallmentAmount = showInstallmentAmount,
+        showRemovePaymentMethodButton = showRemovePaymentMethodButton,
     )
 }
 

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/card/SessionsCardTakenOverViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/card/SessionsCardTakenOverViewModel.kt
@@ -136,6 +136,7 @@ internal class SessionsCardTakenOverViewModel @Inject constructor(
                 allowedPaymentMethods = listOf(paymentMethodType),
                 installmentOptions = getSettingsInstallmentOptionsMode(keyValueStorage.getInstallmentOptionsMode()),
                 showInstallmentAmount = keyValueStorage.isInstallmentAmountShown(),
+                showRemovePaymentMethodButton = keyValueStorage.isRemoveStoredPaymentMethodEnabled(),
             ),
         ) ?: return null
 

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/card/SessionsCardViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/card/SessionsCardViewModel.kt
@@ -98,6 +98,7 @@ internal class SessionsCardViewModel @Inject constructor(
                 allowedPaymentMethods = listOf(paymentMethodType),
                 installmentOptions = getSettingsInstallmentOptionsMode(keyValueStorage.getInstallmentOptionsMode()),
                 showInstallmentAmount = keyValueStorage.isInstallmentAmountShown(),
+                showRemovePaymentMethodButton = keyValueStorage.isRemoveStoredPaymentMethodEnabled(),
             ),
         ) ?: return null
 

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/configuration/CheckoutConfigurationProvider.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/configuration/CheckoutConfigurationProvider.kt
@@ -56,7 +56,7 @@ internal class CheckoutConfigurationProvider @Inject constructor(
         ) {
             // Drop-in
             dropIn {
-                setEnableRemovingStoredPaymentMethods(true)
+                setEnableRemovingStoredPaymentMethods(keyValueStorage.isRemoveStoredPaymentMethodEnabled())
             }
 
             // Payment methods

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/giftcard/SessionsGiftCardViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/giftcard/SessionsGiftCardViewModel.kt
@@ -100,6 +100,8 @@ internal class SessionsGiftCardViewModel @Inject constructor(
                 shopperEmail = keyValueStorage.getShopperEmail(),
                 allowedPaymentMethods = listOf(paymentMethodType),
                 installmentOptions = getSettingsInstallmentOptionsMode(keyValueStorage.getInstallmentOptionsMode()),
+                showInstallmentAmount = keyValueStorage.isInstallmentAmountShown(),
+                showRemovePaymentMethodButton = keyValueStorage.isRemoveStoredPaymentMethodEnabled(),
             ),
         ) ?: return null
 

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/googlepay/compose/SessionsGooglePayViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/googlepay/compose/SessionsGooglePayViewModel.kt
@@ -112,6 +112,7 @@ internal class SessionsGooglePayViewModel @Inject constructor(
                 allowedPaymentMethods = listOf(paymentMethodType),
                 installmentOptions = getSettingsInstallmentOptionsMode(keyValueStorage.getInstallmentOptionsMode()),
                 showInstallmentAmount = keyValueStorage.isInstallmentAmountShown(),
+                showRemovePaymentMethodButton = keyValueStorage.isRemoveStoredPaymentMethodEnabled(),
             ),
         ) ?: return null
 

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/main/MainViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/main/MainViewModel.kt
@@ -182,6 +182,7 @@ internal class MainViewModel @Inject constructor(
                 shopperEmail = keyValueStorage.getShopperEmail(),
                 installmentOptions = getSettingsInstallmentOptionsMode(keyValueStorage.getInstallmentOptionsMode()),
                 showInstallmentAmount = keyValueStorage.isInstallmentAmountShown(),
+                showRemovePaymentMethodButton = keyValueStorage.isRemoveStoredPaymentMethodEnabled(),
             ),
         ) ?: return null
 

--- a/example-app/src/main/res/values/strings.xml
+++ b/example-app/src/main/res/values/strings.xml
@@ -58,6 +58,8 @@
     <string name="card_installment_show_amount_key">card_installment_show_amount</string>
     <string name="card_installment_show_amount_title">Show installment amount</string>
     <string name="card_address_form_title">Address mode</string>
+    <string name="remove_stored_payment_method_key">remove_stored_payment_method</string>
+    <string name="remove_stored_payment_method_title">Remove stored payment method</string>
     <string name="instant_payment_method_type_key">instant_payment_method_type</string>
     <string name="instant_payment_method_type_title">Instant Payment Method Type</string>
     <string name="use_sessions_key">use_sessions</string>
@@ -85,6 +87,7 @@
     <string name="preferences_default_address_form_mode">NONE</string>
     <string name="preferences_default_installment_options_mode">NONE</string>
     <string name="preferences_default_installment_amount_shown">false</string>
+    <string name="preferences_default_remove_stored_payment_method">true</string>
     <string name="preferences_default_instant_payment_method">wechatpaySDK</string>
     <string name="preferences_default_use_sessions">true</string>
     <string name="preferences_default_analytics_level">ALL</string>

--- a/example-app/src/main/res/xml/preferences.xml
+++ b/example-app/src/main/res/xml/preferences.xml
@@ -86,7 +86,7 @@
             app:useSimpleSummaryProvider="true" />
 
         <SwitchPreference
-            android:defaultValue="@string/preferences_default_split_card_funding_sources"
+            android:defaultValue="@string/preferences_default_installment_amount_shown"
             android:key="@string/card_installment_show_amount_key"
             android:title="@string/card_installment_show_amount_title" />
 
@@ -98,6 +98,11 @@
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/other_payment_methods_settings_title">
+
+        <SwitchPreference
+            android:defaultValue="@string/preferences_default_remove_stored_payment_method"
+            android:key="@string/remove_stored_payment_method_key"
+            android:title="@string/remove_stored_payment_method_title" />
 
         <EditTextPreference
             android:defaultValue="@string/preferences_default_instant_payment_method"

--- a/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/ui/model/GiftCardComponentParamsMapperTest.kt
+++ b/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/ui/model/GiftCardComponentParamsMapperTest.kt
@@ -9,6 +9,7 @@ import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParamsLevel
 import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParams
 import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
+import com.adyen.checkout.components.core.internal.ui.model.SessionInstallmentConfiguration
 import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.giftcard.GiftCardConfiguration
@@ -90,12 +91,8 @@ internal class GiftCardComponentParamsMapperTest {
         val testConfiguration = createCheckoutConfiguration(configurationValue)
 
         val dropInOverrideParams = dropInValue?.let { DropInOverrideParams(it, null) }
-        val sessionParams = SessionParams(
-            enableStoreDetails = null,
-            installmentConfiguration = null,
+        val sessionParams = createSessionParams(
             amount = sessionsValue,
-            returnUrl = "",
-            shopperLocale = null,
         )
 
         val params = giftCardComponentParamsMapper.mapToParams(
@@ -120,11 +117,7 @@ internal class GiftCardComponentParamsMapperTest {
     ) {
         val configuration = createCheckoutConfiguration(shopperLocale = configurationValue)
 
-        val sessionParams = SessionParams(
-            enableStoreDetails = null,
-            installmentConfiguration = null,
-            amount = null,
-            returnUrl = "",
+        val sessionParams = createSessionParams(
             shopperLocale = sessionsValue,
         )
 
@@ -154,6 +147,23 @@ internal class GiftCardComponentParamsMapperTest {
     ) {
         giftCard(configuration)
     }
+
+    @Suppress("LongParameterList")
+    private fun createSessionParams(
+        enableStoreDetails: Boolean? = null,
+        installmentConfiguration: SessionInstallmentConfiguration? = null,
+        showRemovePaymentMethodButton: Boolean? = null,
+        amount: Amount? = null,
+        returnUrl: String? = "",
+        shopperLocale: Locale? = null,
+    ) = SessionParams(
+        enableStoreDetails = enableStoreDetails,
+        installmentConfiguration = installmentConfiguration,
+        showRemovePaymentMethodButton = showRemovePaymentMethodButton,
+        amount = amount,
+        returnUrl = returnUrl,
+        shopperLocale = shopperLocale,
+    )
 
     @Suppress("LongParameterList")
     private fun getComponentParams(

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParamsMapperTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParamsMapperTest.kt
@@ -19,6 +19,7 @@ import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParamsLevel
 import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParams
 import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
+import com.adyen.checkout.components.core.internal.ui.model.SessionInstallmentConfiguration
 import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.core.exception.ComponentException
@@ -403,12 +404,8 @@ internal class GooglePayComponentParamsMapperTest {
         val configuration = createCheckoutConfiguration(configurationValue)
 
         val dropInOverrideParams = dropInValue?.let { DropInOverrideParams(it, null) }
-        val sessionParams = SessionParams(
-            enableStoreDetails = null,
-            installmentConfiguration = null,
+        val sessionParams = createSessionParams(
             amount = sessionsValue,
-            returnUrl = "",
-            shopperLocale = null,
         )
         val params = googlePayComponentParamsMapper.mapToParams(
             checkoutConfiguration = configuration,
@@ -436,11 +433,7 @@ internal class GooglePayComponentParamsMapperTest {
     ) {
         val configuration = createCheckoutConfiguration(shopperLocale = configurationValue)
 
-        val sessionParams = SessionParams(
-            enableStoreDetails = null,
-            installmentConfiguration = null,
-            amount = null,
-            returnUrl = "",
+        val sessionParams = createSessionParams(
             shopperLocale = sessionsValue,
         )
 
@@ -474,6 +467,23 @@ internal class GooglePayComponentParamsMapperTest {
             apply(configuration)
         }
     }
+
+    @Suppress("LongParameterList")
+    private fun createSessionParams(
+        enableStoreDetails: Boolean? = null,
+        installmentConfiguration: SessionInstallmentConfiguration? = null,
+        showRemovePaymentMethodButton: Boolean? = null,
+        amount: Amount? = null,
+        returnUrl: String? = "",
+        shopperLocale: Locale? = null,
+    ) = SessionParams(
+        enableStoreDetails = enableStoreDetails,
+        installmentConfiguration = installmentConfiguration,
+        showRemovePaymentMethodButton = showRemovePaymentMethodButton,
+        amount = amount,
+        returnUrl = returnUrl,
+        shopperLocale = shopperLocale,
+    )
 
     @Suppress("LongParameterList")
     private fun getGooglePayComponentParams(

--- a/issuer-list/src/test/java/com/adyen/checkout/issuerlist/internal/ui/model/IssuerListComponentParamsMapperTest.kt
+++ b/issuer-list/src/test/java/com/adyen/checkout/issuerlist/internal/ui/model/IssuerListComponentParamsMapperTest.kt
@@ -17,6 +17,7 @@ import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParamsLevel
 import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParams
 import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
+import com.adyen.checkout.components.core.internal.ui.model.SessionInstallmentConfiguration
 import com.adyen.checkout.components.core.internal.ui.model.SessionParams
 import com.adyen.checkout.core.Environment
 import com.adyen.checkout.issuerlist.IssuerListViewType
@@ -142,12 +143,8 @@ internal class IssuerListComponentParamsMapperTest {
         val configuration = createCheckoutConfiguration(configurationValue)
 
         val dropInOverrideParams = dropInValue?.let { DropInOverrideParams(it, null) }
-        val sessionParams = SessionParams(
-            enableStoreDetails = null,
-            installmentConfiguration = null,
+        val sessionParams = createSessionParams(
             amount = sessionsValue,
-            returnUrl = "",
-            shopperLocale = null,
         )
         val params = issuerListComponentParamsMapper.mapToParams(
             checkoutConfiguration = configuration,
@@ -176,11 +173,7 @@ internal class IssuerListComponentParamsMapperTest {
     ) {
         val configuration = createCheckoutConfiguration(shopperLocale = configurationValue)
 
-        val sessionParams = SessionParams(
-            enableStoreDetails = null,
-            installmentConfiguration = null,
-            amount = null,
-            returnUrl = "",
+        val sessionParams = createSessionParams(
             shopperLocale = sessionsValue,
         )
 
@@ -215,6 +208,23 @@ internal class IssuerListComponentParamsMapperTest {
             .build()
         addConfiguration(TEST_CONFIGURATION_KEY, issuerListConfiguration)
     }
+
+    @Suppress("LongParameterList")
+    private fun createSessionParams(
+        enableStoreDetails: Boolean? = null,
+        installmentConfiguration: SessionInstallmentConfiguration? = null,
+        showRemovePaymentMethodButton: Boolean? = null,
+        amount: Amount? = null,
+        returnUrl: String? = "",
+        shopperLocale: Locale? = null,
+    ) = SessionParams(
+        enableStoreDetails = enableStoreDetails,
+        installmentConfiguration = installmentConfiguration,
+        showRemovePaymentMethodButton = showRemovePaymentMethodButton,
+        amount = amount,
+        returnUrl = returnUrl,
+        shopperLocale = shopperLocale,
+    )
 
     @Suppress("LongParameterList")
     private fun getIssuerListComponentParams(

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/SessionSetupConfiguration.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/SessionSetupConfiguration.kt
@@ -19,13 +19,15 @@ import org.json.JSONObject
 data class SessionSetupConfiguration(
     val enableStoreDetails: Boolean? = null,
     val showInstallmentAmount: Boolean = false,
-    val installmentOptions: Map<String, SessionSetupInstallmentOptions?>? = null
+    val installmentOptions: Map<String, SessionSetupInstallmentOptions?>? = null,
+    val showRemovePaymentMethodButton: Boolean = false,
 ) : ModelObject() {
 
     companion object {
         private const val ENABLE_STORE_DETAILS = "enableStoreDetails"
         private const val SHOW_INSTALLMENT_AMOUNT = "showInstallmentAmount"
         private const val INSTALLMENT_OPTIONS = "installmentOptions"
+        private const val SHOW_REMOVE_PAYMENT_METHOD_BUTTON = "showRemovePaymentMethodButton"
 
         @JvmField
         val SERIALIZER: Serializer<SessionSetupConfiguration> = object : Serializer<SessionSetupConfiguration> {
@@ -36,8 +38,9 @@ data class SessionSetupConfiguration(
                         putOpt(SHOW_INSTALLMENT_AMOUNT, modelObject.showInstallmentAmount)
                         putOpt(
                             INSTALLMENT_OPTIONS,
-                            modelObject.installmentOptions?.let { JSONObject(it) }
+                            modelObject.installmentOptions?.let { JSONObject(it) },
                         )
+                        putOpt(SHOW_REMOVE_PAYMENT_METHOD_BUTTON, modelObject.showRemovePaymentMethodButton)
                     }
                 } catch (e: JSONException) {
                     throw ModelSerializationException(SessionSetupConfiguration::class.java, e)
@@ -50,7 +53,8 @@ data class SessionSetupConfiguration(
                         enableStoreDetails = jsonObject.optBoolean(ENABLE_STORE_DETAILS),
                         showInstallmentAmount = jsonObject.optBoolean(SHOW_INSTALLMENT_AMOUNT),
                         installmentOptions = jsonObject.optJSONObject(INSTALLMENT_OPTIONS)
-                            ?.jsonToMap(SessionSetupInstallmentOptions.SERIALIZER)
+                            ?.jsonToMap(SessionSetupInstallmentOptions.SERIALIZER),
+                        showRemovePaymentMethodButton = jsonObject.optBoolean(SHOW_REMOVE_PAYMENT_METHOD_BUTTON),
                     )
                 } catch (e: JSONException) {
                     throw ModelSerializationException(SessionSetupConfiguration::class.java, e)

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/SessionCallResult.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/SessionCallResult.kt
@@ -52,6 +52,11 @@ interface SessionCallResult {
         object TakenOver : CancelOrder()
     }
 
+    sealed class RemoveStoredPaymentMethod : SessionCallResult {
+        data object Successful : RemoveStoredPaymentMethod()
+        data class Error(val throwable: Throwable) : RemoveStoredPaymentMethod()
+    }
+
     sealed class UpdatePaymentMethods : SessionCallResult {
         data class Successful(
             val paymentMethods: PaymentMethodsApiResponse,

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/SessionInteractor.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/SessionInteractor.kt
@@ -266,7 +266,7 @@ class SessionInteractor(
         return if (!callWasHandled) {
             if (isFlowTakenOver) {
                 throw MethodNotImplementedException(
-                    "Sessions flow was already taken over in a previous call, $merchantMethodName should be implemented",
+                    "Sessions flow was already taken over in a previous call, $merchantMethodName should be implemented"
                 )
             } else {
                 internalCall()

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/SessionInteractor.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/SessionInteractor.kt
@@ -133,23 +133,17 @@ class SessionInteractor(
 
     private suspend fun makeCheckBalanceCallInternal(
         paymentComponentState: PaymentComponentState<*>
-    ): SessionCallResult.Balance {
-        sessionRepository.checkBalance(sessionModel, paymentComponentState)
-            .fold(
-                onSuccess = { response ->
-                    updateSessionData(response.sessionData)
-                    return if (response.balance.value <= 0) {
-                        SessionCallResult.Balance.Error(CheckoutException("Not enough balance"))
-                    } else {
-                        val balanceResult = BalanceResult(response.balance, response.transactionLimit)
-                        SessionCallResult.Balance.Successful(balanceResult)
-                    }
-                },
-                onFailure = {
-                    return SessionCallResult.Balance.Error(throwable = it)
-                },
-            )
-    }
+    ) = sessionRepository.checkBalance(sessionModel, paymentComponentState)
+        .fold(
+            onSuccess = { response ->
+                updateSessionData(response.sessionData)
+                val balanceResult = BalanceResult(response.balance, response.transactionLimit)
+                SessionCallResult.Balance.Successful(balanceResult)
+            },
+            onFailure = {
+                SessionCallResult.Balance.Error(throwable = it)
+            },
+        )
 
     suspend fun createOrder(
         merchantCall: () -> Boolean,

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/data/api/SessionRepository.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/data/api/SessionRepository.kt
@@ -23,6 +23,8 @@ import com.adyen.checkout.sessions.core.internal.data.model.SessionCancelOrderRe
 import com.adyen.checkout.sessions.core.internal.data.model.SessionCancelOrderResponse
 import com.adyen.checkout.sessions.core.internal.data.model.SessionDetailsRequest
 import com.adyen.checkout.sessions.core.internal.data.model.SessionDetailsResponse
+import com.adyen.checkout.sessions.core.internal.data.model.SessionDisableTokenRequest
+import com.adyen.checkout.sessions.core.internal.data.model.SessionDisableTokenResponse
 import com.adyen.checkout.sessions.core.internal.data.model.SessionOrderRequest
 import com.adyen.checkout.sessions.core.internal.data.model.SessionOrderResponse
 import com.adyen.checkout.sessions.core.internal.data.model.SessionPaymentsRequest
@@ -43,7 +45,7 @@ class SessionRepository(
         sessionService.setupSession(
             request = request,
             sessionId = sessionModel.id,
-            clientKey = clientKey
+            clientKey = clientKey,
         )
     }
 
@@ -55,7 +57,7 @@ class SessionRepository(
         sessionService.submitPayment(
             request = request,
             sessionId = sessionModel.id,
-            clientKey = clientKey
+            clientKey = clientKey,
         )
     }
 
@@ -66,12 +68,12 @@ class SessionRepository(
         val request = SessionDetailsRequest(
             sessionData = sessionModel.sessionData.orEmpty(),
             paymentData = actionComponentData.paymentData,
-            details = actionComponentData.details
+            details = actionComponentData.details,
         )
         sessionService.submitDetails(
             request = request,
             sessionId = sessionModel.id,
-            clientKey = clientKey
+            clientKey = clientKey,
         )
     }
 
@@ -82,12 +84,12 @@ class SessionRepository(
         val request = SessionBalanceRequest(
             sessionModel.sessionData.orEmpty(),
             paymentComponentState.data.paymentMethod,
-            paymentComponentState.data.amount
+            paymentComponentState.data.amount,
         )
         sessionService.checkBalance(
             request = request,
             sessionId = sessionModel.id,
-            clientKey = clientKey
+            clientKey = clientKey,
         )
     }
 
@@ -96,7 +98,7 @@ class SessionRepository(
         sessionService.createOrder(
             request = request,
             sessionId = sessionModel.id,
-            clientKey = clientKey
+            clientKey = clientKey,
         )
     }
 
@@ -108,7 +110,19 @@ class SessionRepository(
         sessionService.cancelOrder(
             request = request,
             sessionId = sessionModel.id,
-            clientKey = clientKey
+            clientKey = clientKey,
+        )
+    }
+
+    suspend fun disableToken(
+        sessionModel: SessionModel,
+        storedPaymentMethodId: String,
+    ): Result<SessionDisableTokenResponse> = runSuspendCatching {
+        val request = SessionDisableTokenRequest(sessionModel.sessionData.orEmpty(), storedPaymentMethodId)
+        sessionService.disableToken(
+            request = request,
+            sessionId = sessionModel.id,
+            clientKey = clientKey,
         )
     }
 }

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/data/api/SessionService.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/data/api/SessionService.kt
@@ -18,6 +18,8 @@ import com.adyen.checkout.sessions.core.internal.data.model.SessionCancelOrderRe
 import com.adyen.checkout.sessions.core.internal.data.model.SessionCancelOrderResponse
 import com.adyen.checkout.sessions.core.internal.data.model.SessionDetailsRequest
 import com.adyen.checkout.sessions.core.internal.data.model.SessionDetailsResponse
+import com.adyen.checkout.sessions.core.internal.data.model.SessionDisableTokenRequest
+import com.adyen.checkout.sessions.core.internal.data.model.SessionDisableTokenResponse
 import com.adyen.checkout.sessions.core.internal.data.model.SessionOrderRequest
 import com.adyen.checkout.sessions.core.internal.data.model.SessionOrderResponse
 import com.adyen.checkout.sessions.core.internal.data.model.SessionPaymentsRequest
@@ -114,6 +116,20 @@ class SessionService(
             body = request,
             requestSerializer = SessionCancelOrderRequest.SERIALIZER,
             responseSerializer = SessionCancelOrderResponse.SERIALIZER,
+        )
+    }
+
+    suspend fun disableToken(
+        request: SessionDisableTokenRequest,
+        sessionId: String,
+        clientKey: String,
+    ): SessionDisableTokenResponse = withContext(coroutineDispatcher) {
+        httpClient.post(
+            path = "v1/sessions/$sessionId/disableToken",
+            queryParameters = mapOf("clientKey" to clientKey),
+            body = request,
+            requestSerializer = SessionDisableTokenRequest.SERIALIZER,
+            responseSerializer = SessionDisableTokenResponse.SERIALIZER,
         )
     }
 }

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/data/model/SessionDisableTokenRequest.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/data/model/SessionDisableTokenRequest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 15/2/2024.
+ */
+
+package com.adyen.checkout.sessions.core.internal.data.model
+
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.core.exception.ModelSerializationException
+import com.adyen.checkout.core.internal.data.model.ModelObject
+import kotlinx.parcelize.Parcelize
+import org.json.JSONException
+import org.json.JSONObject
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Parcelize
+data class SessionDisableTokenRequest(
+    val sessionData: String,
+    val storedPaymentMethodId: String
+) : ModelObject() {
+    companion object {
+        private const val SESSION_DATA = "sessionData"
+        private const val STORED_PAYMENT_METHOD_ID = "storedPaymentMethodId"
+
+        @JvmField
+        val SERIALIZER: Serializer<SessionDisableTokenRequest> = object : Serializer<SessionDisableTokenRequest> {
+            override fun serialize(modelObject: SessionDisableTokenRequest): JSONObject {
+                val jsonObject = JSONObject()
+                try {
+                    jsonObject.putOpt(SESSION_DATA, modelObject.sessionData)
+                    jsonObject.putOpt(STORED_PAYMENT_METHOD_ID, modelObject.storedPaymentMethodId)
+                } catch (e: JSONException) {
+                    throw ModelSerializationException(SessionDisableTokenRequest::class.java, e)
+                }
+                return jsonObject
+            }
+
+            override fun deserialize(jsonObject: JSONObject): SessionDisableTokenRequest {
+                return try {
+                    SessionDisableTokenRequest(
+                        sessionData = jsonObject.optString(SESSION_DATA),
+                        storedPaymentMethodId = jsonObject.optString(STORED_PAYMENT_METHOD_ID),
+                    )
+                } catch (e: JSONException) {
+                    throw ModelSerializationException(SessionDisableTokenRequest::class.java, e)
+                }
+            }
+        }
+    }
+}

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/data/model/SessionDisableTokenResponse.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/data/model/SessionDisableTokenResponse.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 15/2/2024.
+ */
+
+package com.adyen.checkout.sessions.core.internal.data.model
+
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.core.exception.ModelSerializationException
+import com.adyen.checkout.core.internal.data.model.ModelObject
+import kotlinx.parcelize.Parcelize
+import org.json.JSONException
+import org.json.JSONObject
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Parcelize
+data class SessionDisableTokenResponse(
+    val sessionData: String,
+) : ModelObject() {
+    companion object {
+        private const val SESSION_DATA = "sessionData"
+
+        @JvmField
+        val SERIALIZER: Serializer<SessionDisableTokenResponse> = object : Serializer<SessionDisableTokenResponse> {
+            override fun serialize(modelObject: SessionDisableTokenResponse): JSONObject {
+                val jsonObject = JSONObject()
+                try {
+                    jsonObject.putOpt(SESSION_DATA, modelObject.sessionData)
+                } catch (e: JSONException) {
+                    throw ModelSerializationException(SessionDisableTokenResponse::class.java, e)
+                }
+                return jsonObject
+            }
+
+            override fun deserialize(jsonObject: JSONObject): SessionDisableTokenResponse {
+                return try {
+                    SessionDisableTokenResponse(
+                        sessionData = jsonObject.optString(SESSION_DATA),
+                    )
+                } catch (e: JSONException) {
+                    throw ModelSerializationException(SessionDisableTokenResponse::class.java, e)
+                }
+            }
+        }
+    }
+}

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/ui/model/SessionParamsFactory.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/ui/model/SessionParamsFactory.kt
@@ -45,6 +45,7 @@ object SessionParamsFactory {
                 }?.toMap(),
                 showInstallmentAmount = sessionSetupConfiguration?.showInstallmentAmount,
             ),
+            showRemovePaymentMethodButton = sessionSetupConfiguration?.showRemovePaymentMethodButton,
             amount = amount,
             returnUrl = returnUrl,
             shopperLocale = getShopperLocale(shopperLocale),

--- a/sessions-core/src/test/java/com/adyen/checkout/sessions/core/internal/SessionInteractorTest.kt
+++ b/sessions-core/src/test/java/com/adyen/checkout/sessions/core/internal/SessionInteractorTest.kt
@@ -406,32 +406,6 @@ internal class SessionInteractorTest(
             }
 
             @Test
-            fun `balance is zero then Error is returned and session data is updated`() = runTest {
-                sessionInteractor.sessionFlow.test {
-                    val mockResponse = SessionBalanceResponse(
-                        sessionData = "session_data_updated",
-                        balance = Amount("USD", 0),
-                        transactionLimit = null,
-                    )
-
-                    whenever(sessionRepository.checkBalance(any(), any())) doReturn Result.success(mockResponse)
-
-                    val result = sessionInteractor.checkBalance(TEST_COMPONENT_STATE, { false }, "")
-
-                    assertTrue(result is SessionCallResult.Balance.Error)
-                    require(result is SessionCallResult.Balance.Error)
-
-                    assertTrue(result.throwable is CheckoutException)
-                    require(result.throwable is CheckoutException)
-
-                    assertEquals("Not enough balance", result.throwable.message)
-
-                    val expectedSessionModel = TEST_SESSION_MODEL.copy(sessionData = mockResponse.sessionData)
-                    assertEquals(expectedSessionModel, expectMostRecentItem())
-                }
-            }
-
-            @Test
             fun `an error is thrown then Error is returned`() = runTest {
                 val exception = Exception("failed for testing")
 

--- a/sessions-core/src/test/java/com/adyen/checkout/sessions/core/internal/SessionInteractorTest.kt
+++ b/sessions-core/src/test/java/com/adyen/checkout/sessions/core/internal/SessionInteractorTest.kt
@@ -709,11 +709,11 @@ internal class SessionInteractorTest(
     }
 
     @Nested
-    @DisplayName("when an update payment methods call is requested and")
+    @DisplayName("when disable token call is requested and")
     inner class RemoveStoredPaymentMethodCallTest {
 
         @Test
-        fun `payment methods are fetched then Successful is returned and session data is updated`() = runTest {
+        fun `it is successful then session data is updated`() = runTest {
             sessionInteractor.sessionFlow.test {
                 val mockResponse = SessionDisableTokenResponse(sessionData = "session_data_updated")
                 whenever(sessionRepository.disableToken(any(), any())) doReturn Result.success(mockResponse)


### PR DESCRIPTION
## Description
- Now merchants do not have to override `onRemoveStoredPaymentMethod` to support removing stored payment methods for session integration.
- A new toggle has been added to the settings page of the example app to allow removing stored payment methods.
- `SessionConfiguration` object has been created to optimize `SessionParams` and keep configuration related params separate.

To be done:
- Align error messages with other platforms.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-835
