### PR TITLE
Continuation of #1469: Draft proposal to update the Google Pay section of the sample application

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -57,7 +57,7 @@ ext {
     google_pay_compose_button_version = '0.1.3'
     okhttp_version = "4.12.0"
     play_services_coroutines_version = '1.4.1'
-    play_services_wallet_version = '19.3.0-beta01'
+    play_services_wallet_version = '19.3.0'
     wechat_pay_version = "6.8.0"
 
     // Example app


### PR DESCRIPTION
Moved all Google Pay related logic from inside the composable, to confine the lifecycle of the `lateinit var` holding the Google Pay component, and make it easier to use.