### PR TITLE
Include the 3DS2 module in Google Pay by default

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -81,3 +81,4 @@ CheckoutConfiguration(
 - With the sessions flow, when starting drop-in (with `DropIn.startPayment`) or creating a component (with `YourComponent.PROVIDER.get`), the configuration parameter is now optional.
 - When `CheckoutSessionProvider.createSession` to create a `CheckoutSession`, you can pass the `environment` and `clientKey` instead of the whole configuration.
 - In drop-in all actions will start in expanded mode
+- When using the Google Pay component, it is no longer necessary to manually import the `3ds2` module to handle transactions that require a native 3DS2 challenge. 

--- a/googlepay/build.gradle
+++ b/googlepay/build.gradle
@@ -36,6 +36,7 @@ android {
 
 dependencies {
     // Checkout
+    api project(':3ds2')
     api project(':action-core')
     api project(':components-core')
     api project(':sessions-core')


### PR DESCRIPTION
## Description
Currently to handle a native 3DS2 challenge with the standalone Google Pay component you need to import both the Google Pay and 3DS2 module:
```groovy
implementation "com.adyen.checkout:googlepay:VERSION"
implementation "com.adyen.checkout:3ds2:VERSION"
```

However 3D Secure is a very common flow with Google Pay (3DS must be done for all FPANs as discussed with [Dominik](https://github.com/dmengelt)).
Therefore we should include 3DS2 inside the Google Pay component by default (this is already the case for Cards).

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-682
