### PR TITLE
Throw exception if onAddressLookupQueryChanged is not implemented

### DIFF
--- a/drop-in/src/main/java/com/adyen/checkout/dropin/BaseDropInServiceContract.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/BaseDropInServiceContract.kt
@@ -128,7 +128,9 @@ interface BaseDropInServiceContract {
      *
      * @param query Query inputted by shopper.
      */
-    fun onAddressLookupQueryChanged(query: String) = Unit
+    fun onAddressLookupQueryChanged(query: String) {
+        throw MethodNotImplementedException("Method onAddressLookupQueryChanged is not implemented")
+    }
 
     /**
      * Set a callback that will be called when shopper chooses an address option that requires complete details to be


### PR DESCRIPTION
Throw `MethodNotImplementedException` if `onAddressLookupQueryChanged(query: String)` is not implemented in drop-in.

## Description
[//]: # (Include a short summary of your changes)
[//]: # (If this is a new feature: attach screenshots or a video if applicable)
[//]: # (If this is a bug fix: include a reproduction path)

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-730