### PR TITLE
Fix action handling concurrency issue

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -62,6 +62,7 @@ CheckoutConfiguration(
 
 ## Fixed
 - When building `minifyEnabled` and without the `kotlin-parcelize` plugin in your project the build should no longer crash.
+- When handling actions you should no longer get `IllegalArgumentException: Unsupported delegate type`.
 
 ## Deprecated
 - When creating a configuration, the `Builder` constructors with a `Context` are now deprecated. You can omit the `context` parameter.

--- a/action-core/src/main/java/com/adyen/checkout/action/core/GenericActionComponent.kt
+++ b/action-core/src/main/java/com/adyen/checkout/action/core/GenericActionComponent.kt
@@ -7,12 +7,15 @@
  */
 package com.adyen.checkout.action.core
 
+import android.app.Activity
+import android.content.Intent
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.adyen.checkout.action.core.internal.ActionHandlingComponent
 import com.adyen.checkout.action.core.internal.provider.GenericActionComponentProvider
 import com.adyen.checkout.action.core.internal.ui.GenericActionDelegate
+import com.adyen.checkout.components.core.action.Action
 import com.adyen.checkout.components.core.internal.ActionComponent
 import com.adyen.checkout.components.core.internal.ActionComponentEvent
 import com.adyen.checkout.components.core.internal.ActionComponentEventHandler
@@ -30,13 +33,12 @@ import kotlinx.coroutines.flow.Flow
  */
 class GenericActionComponent internal constructor(
     private val genericActionDelegate: GenericActionDelegate,
-    private val actionHandlingComponent: ActionHandlingComponent,
     internal val actionComponentEventHandler: ActionComponentEventHandler,
 ) : ViewModel(),
     ActionComponent,
     ViewableComponent,
     IntentHandlingComponent,
-    ActionHandlingComponent by actionHandlingComponent {
+    ActionHandlingComponent {
 
     override val delegate: ActionDelegate
         get() = genericActionDelegate.delegate
@@ -54,6 +56,22 @@ class GenericActionComponent internal constructor(
 
     internal fun removeObserver() {
         genericActionDelegate.removeObserver()
+    }
+
+    override fun canHandleAction(action: Action): Boolean {
+        return PROVIDER.canHandleAction(action)
+    }
+
+    override fun handleAction(action: Action, activity: Activity) {
+        genericActionDelegate.handleAction(action, activity)
+    }
+
+    override fun handleIntent(intent: Intent) {
+        genericActionDelegate.handleIntent(intent)
+    }
+
+    override fun setOnRedirectListener(listener: () -> Unit) {
+        genericActionDelegate.setOnRedirectListener(listener)
     }
 
     override fun onCleared() {

--- a/action-core/src/main/java/com/adyen/checkout/action/core/internal/DefaultActionHandlingComponent.kt
+++ b/action-core/src/main/java/com/adyen/checkout/action/core/internal/DefaultActionHandlingComponent.kt
@@ -20,22 +20,25 @@ import com.adyen.checkout.components.core.internal.ui.PaymentComponentDelegate
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class DefaultActionHandlingComponent(
     private val genericActionDelegate: GenericActionDelegate,
-    paymentDelegate: PaymentComponentDelegate<*>?,
+    private val paymentDelegate: PaymentComponentDelegate<*>,
 ) : ActionHandlingComponent {
 
-    var activeDelegate: ComponentDelegate = paymentDelegate ?: genericActionDelegate
-        private set
+    private var isHandlingAction: Boolean = false
+
+    val activeDelegate: ComponentDelegate
+        get() = if (isHandlingAction) {
+            genericActionDelegate.delegate
+        } else {
+            paymentDelegate
+        }
 
     override fun canHandleAction(action: Action): Boolean {
         return GenericActionComponent.PROVIDER.canHandleAction(action)
     }
 
     override fun handleAction(action: Action, activity: Activity) {
-        activeDelegate = genericActionDelegate
+        isHandlingAction = true
         genericActionDelegate.handleAction(action, activity)
-        // genericActionDelegate.delegate is set when calling genericActionDelegate.handleAction, so we set the more
-        // specific delegate here as soon as we can.
-        activeDelegate = genericActionDelegate.delegate
     }
 
     override fun handleIntent(intent: Intent) {

--- a/action-core/src/main/java/com/adyen/checkout/action/core/internal/provider/GenericActionComponentProvider.kt
+++ b/action-core/src/main/java/com/adyen/checkout/action/core/internal/provider/GenericActionComponentProvider.kt
@@ -17,7 +17,6 @@ import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
 import com.adyen.checkout.action.core.GenericActionComponent
 import com.adyen.checkout.action.core.GenericActionConfiguration
-import com.adyen.checkout.action.core.internal.DefaultActionHandlingComponent
 import com.adyen.checkout.action.core.internal.ui.ActionDelegateProvider
 import com.adyen.checkout.action.core.internal.ui.DefaultGenericActionDelegate
 import com.adyen.checkout.action.core.internal.ui.GenericActionDelegate
@@ -63,7 +62,6 @@ constructor(
             val genericActionDelegate = getDelegate(checkoutConfiguration, savedStateHandle, application)
             GenericActionComponent(
                 genericActionDelegate = genericActionDelegate,
-                actionHandlingComponent = DefaultActionHandlingComponent(genericActionDelegate, null),
                 actionComponentEventHandler = DefaultActionComponentEventHandler(callback),
             )
         }

--- a/action-core/src/test/java/com/adyen/checkout/action/core/GenericActionComponentTest.kt
+++ b/action-core/src/test/java/com/adyen/checkout/action/core/GenericActionComponentTest.kt
@@ -8,11 +8,13 @@
 
 package com.adyen.checkout.action.core
 
+import android.app.Activity
+import android.content.Intent
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.viewModelScope
 import app.cash.turbine.test
-import com.adyen.checkout.action.core.internal.DefaultActionHandlingComponent
 import com.adyen.checkout.action.core.internal.ui.GenericActionDelegate
+import com.adyen.checkout.components.core.action.AwaitAction
 import com.adyen.checkout.components.core.internal.ActionComponentEvent
 import com.adyen.checkout.components.core.internal.ActionComponentEventHandler
 import com.adyen.checkout.components.core.internal.ui.ActionDelegate
@@ -37,7 +39,6 @@ import org.mockito.kotlin.whenever
 internal class GenericActionComponentTest(
     @Mock private val actionDelegate: ActionDelegate,
     @Mock private val genericActionDelegate: GenericActionDelegate,
-    @Mock private val actionHandlingComponent: DefaultActionHandlingComponent,
     @Mock private val actionComponentEventHandler: ActionComponentEventHandler,
 ) {
 
@@ -47,7 +48,7 @@ internal class GenericActionComponentTest(
     fun before() {
         whenever(genericActionDelegate.delegate) doReturn actionDelegate
         whenever(genericActionDelegate.viewFlow) doReturn MutableStateFlow(TestComponentViewType.VIEW_TYPE_1)
-        component = GenericActionComponent(genericActionDelegate, actionHandlingComponent, actionComponentEventHandler)
+        component = GenericActionComponent(genericActionDelegate, actionComponentEventHandler)
     }
 
     @Test
@@ -96,7 +97,7 @@ internal class GenericActionComponentTest(
     fun `when delegate view flow emits a value then component view flow should match that value`() = runTest {
         val delegateViewFlow = MutableStateFlow(TestComponentViewType.VIEW_TYPE_1)
         whenever(genericActionDelegate.viewFlow) doReturn delegateViewFlow
-        component = GenericActionComponent(genericActionDelegate, actionHandlingComponent, actionComponentEventHandler)
+        component = GenericActionComponent(genericActionDelegate, actionComponentEventHandler)
 
         component.viewFlow.test {
             assertEquals(TestComponentViewType.VIEW_TYPE_1, awaitItem())
@@ -106,5 +107,33 @@ internal class GenericActionComponentTest(
 
             expectNoEvents()
         }
+    }
+
+    @Test
+    fun `when handleAction is called then handleAction in delegate is called`() {
+        val action = AwaitAction()
+        val activity = Activity()
+
+        component.handleAction(action, activity)
+
+        verify(genericActionDelegate).handleAction(action, activity)
+    }
+
+    @Test
+    fun `when handleIntent is called then handleIntent in delegate is called`() {
+        val intent = Intent()
+
+        component.handleIntent(intent)
+
+        verify(genericActionDelegate).handleIntent(intent)
+    }
+
+    @Test
+    fun `when setOnRedirectListener is called then setOnRedirectListener in delegate is called`() {
+        val listener = { }
+
+        component.setOnRedirectListener(listener)
+
+        verify(genericActionDelegate).setOnRedirectListener(listener)
     }
 }

--- a/action-core/src/test/java/com/adyen/checkout/action/core/internal/DefaultActionHandlingComponentTest.kt
+++ b/action-core/src/test/java/com/adyen/checkout/action/core/internal/DefaultActionHandlingComponentTest.kt
@@ -1,0 +1,81 @@
+package com.adyen.checkout.action.core.internal
+
+import android.app.Activity
+import android.content.Intent
+import com.adyen.checkout.action.core.internal.ui.GenericActionDelegate
+import com.adyen.checkout.components.core.action.AwaitAction
+import com.adyen.checkout.components.core.internal.ui.ActionDelegate
+import com.adyen.checkout.components.core.internal.ui.PaymentComponentDelegate
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+internal class DefaultActionHandlingComponentTest(
+    @Mock private val genericActionDelegate: GenericActionDelegate,
+    @Mock private val paymentDelegate: PaymentComponentDelegate<*>,
+) {
+
+    private lateinit var actionHandlingComponent: DefaultActionHandlingComponent
+
+    @BeforeEach
+    fun setup() {
+        actionHandlingComponent = DefaultActionHandlingComponent(
+            genericActionDelegate = genericActionDelegate,
+            paymentDelegate = paymentDelegate,
+        )
+    }
+
+    @Test
+    fun `when getting active delegate before handling an action, then the payment delegate should be returned`() {
+        val activeDelegate = actionHandlingComponent.activeDelegate
+
+        assertEquals(paymentDelegate, activeDelegate)
+    }
+
+    @Test
+    fun `when getting active delegate after handling an action, then the generic action delegate should be returned`() {
+        val mockActionDelegate = mock<ActionDelegate>()
+        whenever(genericActionDelegate.delegate) doReturn mockActionDelegate
+        actionHandlingComponent.handleAction(AwaitAction(), Activity())
+
+        val activeDelegate = actionHandlingComponent.activeDelegate
+
+        assertEquals(mockActionDelegate, activeDelegate)
+    }
+
+    @Test
+    fun `when handleAction is called then handleAction in delegate is called`() {
+        val action = AwaitAction()
+        val activity = Activity()
+
+        actionHandlingComponent.handleAction(action, activity)
+
+        verify(genericActionDelegate).handleAction(action, activity)
+    }
+
+    @Test
+    fun `when handleIntent is called then handleIntent in delegate is called`() {
+        val intent = Intent()
+
+        actionHandlingComponent.handleIntent(intent)
+
+        verify(genericActionDelegate).handleIntent(intent)
+    }
+
+    @Test
+    fun `when setOnRedirectListener is called then setOnRedirectListener in delegate is called`() {
+        val listener = { }
+
+        actionHandlingComponent.setOnRedirectListener(listener)
+
+        verify(genericActionDelegate).setOnRedirectListener(listener)
+    }
+}


### PR DESCRIPTION
## Description
Fixes an issue with getting the active delegate while handling an action.

Steps to reproduce:
- Integrate Blik in an compose app
- Make a Blik payment
- It will crash while trying to handle the await action

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually
- [x] Link to related issues: fixes #1498 
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-864
