### PR TITLE
Fix wrong `RestrictTo` annotations

### DIFF
--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/Component.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/Component.kt
@@ -13,7 +13,6 @@ import com.adyen.checkout.components.core.internal.ui.ComponentDelegate
 /**
  * A [Component] is a class that helps to retrieve or format data related to a part of the Checkout API payment.
  */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface Component {
     /**
      * The delegate from this component.

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/model/DropInResultContractParams.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/model/DropInResultContractParams.kt
@@ -8,13 +8,11 @@
 
 package com.adyen.checkout.dropin.internal.ui.model
 
-import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.core.CheckoutConfiguration
 import com.adyen.checkout.components.core.PaymentMethodsApiResponse
 import com.adyen.checkout.dropin.DropInService
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-data class DropInResultContractParams(
+data class DropInResultContractParams internal constructor(
     val checkoutConfiguration: CheckoutConfiguration,
     val paymentMethodsApiResponse: PaymentMethodsApiResponse,
     val serviceClass: Class<out DropInService>,

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/model/SessionDropInResultContractParams.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/model/SessionDropInResultContractParams.kt
@@ -8,13 +8,11 @@
 
 package com.adyen.checkout.dropin.internal.ui.model
 
-import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.core.CheckoutConfiguration
 import com.adyen.checkout.dropin.SessionDropInService
 import com.adyen.checkout.sessions.core.CheckoutSession
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-data class SessionDropInResultContractParams(
+data class SessionDropInResultContractParams internal constructor(
     val checkoutConfiguration: CheckoutConfiguration,
     val checkoutSession: CheckoutSession,
     val serviceClass: Class<out SessionDropInService>,


### PR DESCRIPTION
## Description
Remove RestrictTo annotations from classes that can be publicly accessible:
- `DropInResultContractParams` and `SessionDropInResultContractParams` are needed if you need to explicitly specify the type of `dropInLauncher`.
- `Component` is needed if you want to use components generically.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-867
