### PR TITLE
Fix duplicate parent styling for AdyenCheckout.DropdownTextInputLayout

### DIFF
--- a/card/src/main/res/values/styles.xml
+++ b/card/src/main/res/values/styles.xml
@@ -83,7 +83,6 @@
         <item name="android:textSize">18sp</item>
     </style>
 
-    <style name="AdyenCheckout.DropdownTextInputLayout" />
 
     <style name="AdyenCheckout.DropdownTextInputLayout.Installments" parent="AdyenCheckout.DropdownTextInputLayout">
         <item name="android:hint">@string/checkout_card_installments_title</item>


### PR DESCRIPTION
## Description
This fixes an issue where the styling was incorrect and caused weird looks and behavior. In #1534 we accidentally caused this, but we didn't release it yet.

| Before | After |
|--------|--------|
| ![Screenshot_20240405_144611](https://github.com/Adyen/adyen-android/assets/17701279/3677ad2a-d671-4731-9d5b-144f9e2c995d) | ![Screenshot_20240405_144447](https://github.com/Adyen/adyen-android/assets/17701279/9c38e586-5156-4835-b631-f9aa563ad3ef) |

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-880
