### PR TITLE
Fix InflateException

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@
 ## Fixed
 - Localization issues in address lookup functionality.
 - Overriding some of the XML styles without specifying a parent style no longer causes a build error.
+- Not defining `?android:attr/textColor` in your own theme will no longer crash.
 
 ## Removed
 - The functions to get specific configurations from `CheckoutConfiguration` (such as `CheckoutConfiguration.getDropInConfiguration()` or `CheckoutConfiguration.getCardConfiguration()`) are no longer accessible. Pass the `CheckoutConfiguration` object as it is when starting Drop-in or Components.

--- a/card/src/main/res/values/styles.xml
+++ b/card/src/main/res/values/styles.xml
@@ -89,7 +89,7 @@
     </style>
 
     <style name="AdyenCheckout.InstallmentOptionTextView" parent="AdyenCheckout.TextAppearance">
-        <item name="android:textColor">?android:attr/textColor</item>
+        <item name="android:textColor">?attr/colorOnSurface</item>
         <item name="android:textSize">16sp</item>
         <item name="android:layout_gravity">center_vertical</item>
     </style>
@@ -106,6 +106,6 @@
         <item name="android:layout_marginBottom">@dimen/standard_margin</item>
         <item name="android:minHeight">@dimen/input_height</item>
         <item name="android:hint">@string/checkout_address_lookup_hint</item>
-        <item name="drawableTint">?android:attr/textColor</item>
+        <item name="drawableTint">?attr/colorOnSurface</item>
     </style>
 </resources>

--- a/ui-core/src/main/res/values/styles.xml
+++ b/ui-core/src/main/res/values/styles.xml
@@ -339,13 +339,13 @@
     </style>
 
     <style name="AdyenCheckout.AddressLookup.Item.Header" parent="AdyenCheckout.TextAppearance">
-        <item name="android:textColor">?android:attr/textColor</item>
+        <item name="android:textColor">?attr/colorOnSurface</item>
         <item name="android:textSize">16sp</item>
         <item name="android:layout_gravity">center_vertical</item>
     </style>
 
     <style name="AdyenCheckout.AddressLookup.Item.Description" parent="AdyenCheckout.TextAppearance">
-        <item name="android:textColor">?android:attr/textColor</item>
+        <item name="android:textColor">?attr/colorOnSurface</item>
         <item name="android:textSize">12sp</item>
         <item name="android:alpha">0.38</item>
         <item name="android:layout_gravity">center_vertical</item>
@@ -358,25 +358,25 @@
     </style>
 
     <style name="AdyenCheckout.AddressLookup.InitialDisclaimer.Title" parent="AdyenCheckout.TextAppearance">
-        <item name="android:textColor">?android:attr/textColor</item>
+        <item name="android:textColor">?attr/colorOnSurface</item>
         <item name="android:textSize">12sp</item>
         <item name="android:text">@string/checkout_address_lookup_initial</item>
     </style>
 
     <style name="AdyenCheckout.AddressLookup.InitialDisclaimer.Description" parent="AdyenCheckout.TextAppearance">
-        <item name="android:textColor">?android:attr/textColor</item>
+        <item name="android:textColor">?attr/colorOnSurface</item>
         <item name="android:textSize">12sp</item>
         <item name="android:text">@string/checkout_address_lookup_initial_description</item>
     </style>
 
     <style name="AdyenCheckout.AddressLookup.Empty.Title" parent="AdyenCheckout.TextAppearance">
-        <item name="android:textColor">?android:attr/textColor</item>
+        <item name="android:textColor">?attr/colorOnSurface</item>
         <item name="android:textSize">12sp</item>
         <item name="android:text">@string/checkout_address_lookup_empty</item>
     </style>
 
     <style name="AdyenCheckout.AddressLookup.Empty.Description" parent="AdyenCheckout.TextAppearance">
-        <item name="android:textColor">?android:attr/textColor</item>
+        <item name="android:textColor">?attr/colorOnSurface</item>
         <item name="android:textSize">12sp</item>
         <item name="android:text">@string/checkout_address_lookup_empty_description</item>
     </style>


### PR DESCRIPTION
## Description
Replace `?android:attr/textColor` with `?attr/colorOnSurface`. `?android:attr/textColor` is not defined by default by any AppCompat or Material base theme. If not defined manually it will cause a crash. `?attr/colorOnSurface` is used by Material primarily for text coloring.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
- [x] Link to related issues
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-884
