### PR TITLE
Fix existing string resources with multiple substitutions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,7 @@
 - Localization issues in address lookup functionality.
 - Overriding some of the XML styles without specifying a parent style no longer causes a build error.
 - Not defining `?android:attr/textColor` in your own theme will no longer crash.
+- The build output should no longer contain warnings about multiple substitutions specified in non-positional format in string resources.
 
 ## Removed
 - The functions to get specific configurations from `CheckoutConfiguration` (such as `CheckoutConfiguration.getDropInConfiguration()` or `CheckoutConfiguration.getCardConfiguration()`) are no longer accessible. Pass the `CheckoutConfiguration` object as it is when starting Drop-in or Components.

--- a/card/src/main/res/values-ar/strings.xml
+++ b/card/src/main/res/values-ar/strings.xml
@@ -32,7 +32,7 @@
 
     <string name="checkout_card_installments_title">عدد الأقساط</string>
     <string name="checkout_card_installments_option_regular">%s أشهر</string>
-    <string name="checkout_card_installments_option_regular_with_price">%s × %s</string>
+    <string name="checkout_card_installments_option_regular_with_price">%1$s × %2$s</string>
     <string name="checkout_card_installments_option_one_time">الدفع مرة واحدة</string>
     <string name="checkout_card_installments_option_revolving">الدفع الدوري</string>
 

--- a/card/src/main/res/values-cs-rCZ/strings.xml
+++ b/card/src/main/res/values-cs-rCZ/strings.xml
@@ -32,7 +32,7 @@
 
     <string name="checkout_card_installments_title">Počet splátek</string>
     <string name="checkout_card_installments_option_regular">%s měsíců</string>
-    <string name="checkout_card_installments_option_regular_with_price">%s× %s</string>
+    <string name="checkout_card_installments_option_regular_with_price">%1$s× %2$s</string>
     <string name="checkout_card_installments_option_one_time">Jednorázová platba</string>
     <string name="checkout_card_installments_option_revolving">Opakující se platba</string>
 

--- a/card/src/main/res/values-da-rDK/strings.xml
+++ b/card/src/main/res/values-da-rDK/strings.xml
@@ -32,7 +32,7 @@
 
     <string name="checkout_card_installments_title">Antal rater</string>
     <string name="checkout_card_installments_option_regular">%s måneder</string>
-    <string name="checkout_card_installments_option_regular_with_price">%sx %s</string>
+    <string name="checkout_card_installments_option_regular_with_price">%1$sx %2$s</string>
     <string name="checkout_card_installments_option_one_time">Engangsbetaling</string>
     <string name="checkout_card_installments_option_revolving">Løbende betaling</string>
 

--- a/card/src/main/res/values-de-rDE/strings.xml
+++ b/card/src/main/res/values-de-rDE/strings.xml
@@ -32,7 +32,7 @@
 
     <string name="checkout_card_installments_title">Anzahl der Raten</string>
     <string name="checkout_card_installments_option_regular">%s Monate</string>
-    <string name="checkout_card_installments_option_regular_with_price">%sx %s</string>
+    <string name="checkout_card_installments_option_regular_with_price">%1$sx %2$s</string>
     <string name="checkout_card_installments_option_one_time">Einmalige Zahlung</string>
     <string name="checkout_card_installments_option_revolving">Ratenzahlung</string>
 

--- a/card/src/main/res/values-el-rGR/strings.xml
+++ b/card/src/main/res/values-el-rGR/strings.xml
@@ -32,7 +32,7 @@
 
     <string name="checkout_card_installments_title">Αριθμός δόσεων</string>
     <string name="checkout_card_installments_option_regular">%s μήνες</string>
-    <string name="checkout_card_installments_option_regular_with_price">%sx %s</string>
+    <string name="checkout_card_installments_option_regular_with_price">%1$sx %2$s</string>
     <string name="checkout_card_installments_option_one_time">Εφάπαξ πληρωμή</string>
     <string name="checkout_card_installments_option_revolving">Ανακυκλούμενη πληρωμή</string>
 

--- a/card/src/main/res/values-es-rES/strings.xml
+++ b/card/src/main/res/values-es-rES/strings.xml
@@ -32,7 +32,7 @@
 
     <string name="checkout_card_installments_title">Número de plazos</string>
     <string name="checkout_card_installments_option_regular">%s meses</string>
-    <string name="checkout_card_installments_option_regular_with_price">%sx %s</string>
+    <string name="checkout_card_installments_option_regular_with_price">%1$sx %2$s</string>
     <string name="checkout_card_installments_option_one_time">Pago único</string>
     <string name="checkout_card_installments_option_revolving">Pago rotativo</string>
 

--- a/card/src/main/res/values-fi-rFI/strings.xml
+++ b/card/src/main/res/values-fi-rFI/strings.xml
@@ -32,7 +32,7 @@
 
     <string name="checkout_card_installments_title">Asennusten määrä</string>
     <string name="checkout_card_installments_option_regular">%s kuukautta</string>
-    <string name="checkout_card_installments_option_regular_with_price">%s x%s</string>
+    <string name="checkout_card_installments_option_regular_with_price">%1$s x%2$s</string>
     <string name="checkout_card_installments_option_one_time">Kertamaksu</string>
     <string name="checkout_card_installments_option_revolving">Toistuva maksu</string>
 

--- a/card/src/main/res/values-fr-rFR/strings.xml
+++ b/card/src/main/res/values-fr-rFR/strings.xml
@@ -32,7 +32,7 @@
 
     <string name="checkout_card_installments_title">Nombre de versements</string>
     <string name="checkout_card_installments_option_regular">%s mois</string>
-    <string name="checkout_card_installments_option_regular_with_price">%sx %s</string>
+    <string name="checkout_card_installments_option_regular_with_price">%1$sx %2$s</string>
     <string name="checkout_card_installments_option_one_time">Paiement unique</string>
     <string name="checkout_card_installments_option_revolving">Paiement en plusieurs fois</string>
 

--- a/card/src/main/res/values-hr-rHR/strings.xml
+++ b/card/src/main/res/values-hr-rHR/strings.xml
@@ -32,7 +32,7 @@
 
     <string name="checkout_card_installments_title">Broj rata</string>
     <string name="checkout_card_installments_option_regular">Mjeseci: %s</string>
-    <string name="checkout_card_installments_option_regular_with_price">%s x %s</string>
+    <string name="checkout_card_installments_option_regular_with_price">%1$s x %2$s</string>
     <string name="checkout_card_installments_option_one_time">Jednokratno plaćanje</string>
     <string name="checkout_card_installments_option_revolving">Obnovljivo plaćanje</string>
 

--- a/card/src/main/res/values-hu-rHU/strings.xml
+++ b/card/src/main/res/values-hu-rHU/strings.xml
@@ -32,7 +32,7 @@
 
     <string name="checkout_card_installments_title">Részletek száma</string>
     <string name="checkout_card_installments_option_regular">%s hónap</string>
-    <string name="checkout_card_installments_option_regular_with_price">%s x %s</string>
+    <string name="checkout_card_installments_option_regular_with_price">%1$s x %2$s</string>
     <string name="checkout_card_installments_option_one_time">Egyösszegű fizetés</string>
     <string name="checkout_card_installments_option_revolving">Többösszegű fizetés</string>
 

--- a/card/src/main/res/values-it-rIT/strings.xml
+++ b/card/src/main/res/values-it-rIT/strings.xml
@@ -32,7 +32,7 @@
 
     <string name="checkout_card_installments_title">Numero di rate</string>
     <string name="checkout_card_installments_option_regular">%s mesi</string>
-    <string name="checkout_card_installments_option_regular_with_price">%s x%s</string>
+    <string name="checkout_card_installments_option_regular_with_price">%2$s x%1$s</string>
     <string name="checkout_card_installments_option_one_time">Pagamento una tantum</string>
     <string name="checkout_card_installments_option_revolving">Pagamento ricorrente</string>
 

--- a/card/src/main/res/values-ja-rJP/strings.xml
+++ b/card/src/main/res/values-ja-rJP/strings.xml
@@ -32,7 +32,7 @@
 
     <string name="checkout_card_installments_title">分割回数</string>
     <string name="checkout_card_installments_option_regular">%sか月</string>
-    <string name="checkout_card_installments_option_regular_with_price">%sx %s</string>
+    <string name="checkout_card_installments_option_regular_with_price">%1$sx %2$s</string>
     <string name="checkout_card_installments_option_one_time">一括払い</string>
     <string name="checkout_card_installments_option_revolving">リボ払い</string>
 

--- a/card/src/main/res/values-ko-rKR/strings.xml
+++ b/card/src/main/res/values-ko-rKR/strings.xml
@@ -32,7 +32,7 @@
 
     <string name="checkout_card_installments_title">할부 개월 수</string>
     <string name="checkout_card_installments_option_regular">%s개월</string>
-    <string name="checkout_card_installments_option_regular_with_price">%sx %s</string>
+    <string name="checkout_card_installments_option_regular_with_price">%1$sx %2$s</string>
     <string name="checkout_card_installments_option_one_time">일시불 결제</string>
     <string name="checkout_card_installments_option_revolving">리볼빙 결제</string>
 

--- a/card/src/main/res/values-nb-rNO/strings.xml
+++ b/card/src/main/res/values-nb-rNO/strings.xml
@@ -32,7 +32,7 @@
 
     <string name="checkout_card_installments_title">Antall avdrag</string>
     <string name="checkout_card_installments_option_regular">%s måneder</string>
-    <string name="checkout_card_installments_option_regular_with_price">%sx %s</string>
+    <string name="checkout_card_installments_option_regular_with_price">%1$sx %2$s</string>
     <string name="checkout_card_installments_option_one_time">Engangsbetaling</string>
     <string name="checkout_card_installments_option_revolving">Gjentakende betaling</string>
 

--- a/card/src/main/res/values-nl-rNL/strings.xml
+++ b/card/src/main/res/values-nl-rNL/strings.xml
@@ -32,7 +32,7 @@
 
     <string name="checkout_card_installments_title">Aantal termijnen</string>
     <string name="checkout_card_installments_option_regular">%s maanden</string>
-    <string name="checkout_card_installments_option_regular_with_price">%sx %s</string>
+    <string name="checkout_card_installments_option_regular_with_price">%1$sx %2$s</string>
     <string name="checkout_card_installments_option_one_time">Eenmalige betaling</string>
     <string name="checkout_card_installments_option_revolving">Terugkerende betaling</string>
 

--- a/card/src/main/res/values-pl-rPL/strings.xml
+++ b/card/src/main/res/values-pl-rPL/strings.xml
@@ -32,7 +32,7 @@
 
     <string name="checkout_card_installments_title">Liczba rat</string>
     <string name="checkout_card_installments_option_regular">%s miesięcy</string>
-    <string name="checkout_card_installments_option_regular_with_price">%sx %s</string>
+    <string name="checkout_card_installments_option_regular_with_price">%1$sx %2$s</string>
     <string name="checkout_card_installments_option_one_time">Płatność jednorazowa</string>
     <string name="checkout_card_installments_option_revolving">Płatność odnawialna</string>
 

--- a/card/src/main/res/values-pt-rBR/strings.xml
+++ b/card/src/main/res/values-pt-rBR/strings.xml
@@ -32,7 +32,7 @@
 
     <string name="checkout_card_installments_title">Opções de Parcelamento</string>
     <string name="checkout_card_installments_option_regular">%s meses</string>
-    <string name="checkout_card_installments_option_regular_with_price">%sx %s</string>
+    <string name="checkout_card_installments_option_regular_with_price">%1$sx %2$s</string>
     <string name="checkout_card_installments_option_one_time">Pagamento à vista</string>
     <string name="checkout_card_installments_option_revolving">Pagamento rotativo</string>
 

--- a/card/src/main/res/values-pt-rPT/strings.xml
+++ b/card/src/main/res/values-pt-rPT/strings.xml
@@ -32,7 +32,7 @@
 
     <string name="checkout_card_installments_title">Número de prestações</string>
     <string name="checkout_card_installments_option_regular">%s meses</string>
-    <string name="checkout_card_installments_option_regular_with_price">%sx %s</string>
+    <string name="checkout_card_installments_option_regular_with_price">%1$sx %2$s</string>
     <string name="checkout_card_installments_option_one_time">Pagamento único</string>
     <string name="checkout_card_installments_option_revolving">Pagamento rotativo</string>
 

--- a/card/src/main/res/values-ro-rRO/strings.xml
+++ b/card/src/main/res/values-ro-rRO/strings.xml
@@ -32,7 +32,7 @@
 
     <string name="checkout_card_installments_title">Număr de rate</string>
     <string name="checkout_card_installments_option_regular">%s luni</string>
-    <string name="checkout_card_installments_option_regular_with_price">%sx %s</string>
+    <string name="checkout_card_installments_option_regular_with_price">%1$sx %2$s</string>
     <string name="checkout_card_installments_option_one_time">Plată unică</string>
     <string name="checkout_card_installments_option_revolving">Plată recurentă</string>
 

--- a/card/src/main/res/values-ru-rRU/strings.xml
+++ b/card/src/main/res/values-ru-rRU/strings.xml
@@ -32,7 +32,7 @@
 
     <string name="checkout_card_installments_title">Количество платежей</string>
     <string name="checkout_card_installments_option_regular">%s мес.</string>
-    <string name="checkout_card_installments_option_regular_with_price">%s× %s</string>
+    <string name="checkout_card_installments_option_regular_with_price">%1$s× %2$s</string>
     <string name="checkout_card_installments_option_one_time">Одноразовый платеж</string>
     <string name="checkout_card_installments_option_revolving">Повторяющаяся оплата</string>
 

--- a/card/src/main/res/values-sk-rSK/strings.xml
+++ b/card/src/main/res/values-sk-rSK/strings.xml
@@ -32,7 +32,7 @@
 
     <string name="checkout_card_installments_title">Počet splátok</string>
     <string name="checkout_card_installments_option_regular">%s mesiace/-ov</string>
-    <string name="checkout_card_installments_option_regular_with_price">%s x %s</string>
+    <string name="checkout_card_installments_option_regular_with_price">%1$s x %2$s</string>
     <string name="checkout_card_installments_option_one_time">Jednorazová platba</string>
     <string name="checkout_card_installments_option_revolving">Revolvingová platba</string>
 

--- a/card/src/main/res/values-sl-rSI/strings.xml
+++ b/card/src/main/res/values-sl-rSI/strings.xml
@@ -32,7 +32,7 @@
 
     <string name="checkout_card_installments_title">Število obrokov</string>
     <string name="checkout_card_installments_option_regular">Št. mesecev: %s</string>
-    <string name="checkout_card_installments_option_regular_with_price">%s × %s</string>
+    <string name="checkout_card_installments_option_regular_with_price">%1$s × %2$s</string>
     <string name="checkout_card_installments_option_one_time">Enkratno plačilo</string>
     <string name="checkout_card_installments_option_revolving">Revolving plačilo</string>
 

--- a/card/src/main/res/values-sv-rSE/strings.xml
+++ b/card/src/main/res/values-sv-rSE/strings.xml
@@ -32,7 +32,7 @@
 
     <string name="checkout_card_installments_title">Antal delbetalningar</string>
     <string name="checkout_card_installments_option_regular">%s månader</string>
-    <string name="checkout_card_installments_option_regular_with_price">%s x %s</string>
+    <string name="checkout_card_installments_option_regular_with_price">%1$s x %2$s</string>
     <string name="checkout_card_installments_option_one_time">Engångsbetalning</string>
     <string name="checkout_card_installments_option_revolving">Uppdelad betalning</string>
 

--- a/card/src/main/res/values-zh-rCN/strings.xml
+++ b/card/src/main/res/values-zh-rCN/strings.xml
@@ -32,7 +32,7 @@
 
     <string name="checkout_card_installments_title">分期付款期数</string>
     <string name="checkout_card_installments_option_regular">%s 个月</string>
-    <string name="checkout_card_installments_option_regular_with_price">%sx %s</string>
+    <string name="checkout_card_installments_option_regular_with_price">%1$sx %2$s</string>
     <string name="checkout_card_installments_option_one_time">全款支付</string>
     <string name="checkout_card_installments_option_revolving">循环支付</string>
 

--- a/card/src/main/res/values-zh-rTW/strings.xml
+++ b/card/src/main/res/values-zh-rTW/strings.xml
@@ -32,7 +32,7 @@
 
     <string name="checkout_card_installments_title">分期付款的期數</string>
     <string name="checkout_card_installments_option_regular">%s 個月</string>
-    <string name="checkout_card_installments_option_regular_with_price">%sx %s</string>
+    <string name="checkout_card_installments_option_regular_with_price">%1$sx %2$s</string>
     <string name="checkout_card_installments_option_one_time">一次性付款</string>
     <string name="checkout_card_installments_option_revolving">延期付款</string>
 

--- a/card/src/main/res/values/strings.xml
+++ b/card/src/main/res/values/strings.xml
@@ -32,7 +32,7 @@
 
     <string name="checkout_card_installments_title">Number of installments</string>
     <string name="checkout_card_installments_option_regular">%s months</string>
-    <string name="checkout_card_installments_option_regular_with_price">%sx %s</string>
+    <string name="checkout_card_installments_option_regular_with_price">%1$sx %2$s</string>
     <string name="checkout_card_installments_option_one_time">One time payment</string>
     <string name="checkout_card_installments_option_revolving">Revolving payment</string>
 


### PR DESCRIPTION
## Description
Fix `checkout_card_installments_option_regular_with_price` which was causing build warnings.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
- [x] Link to related issues
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-879