### PR TITLE
Reduce release age to 14 days

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,7 @@
     },
     {
       "matchPackagePatterns" : ["*"],
-      "minimumReleaseAge" : "30 days",
+      "minimumReleaseAge" : "14 days",
       "schedule" : ["on the first day of the month"]
     }
   ],


### PR DESCRIPTION
## Description
Changed the release age for renovate to 14 days

## Checklist <!-- Remove any line that's not applicable -->
- [x] Link to related issues
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-897
