### PR TITLE
Fix memroy leak in action components

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/provider/Adyen3DS2ComponentProvider.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/provider/Adyen3DS2ComponentProvider.kt
@@ -66,12 +66,14 @@ constructor(
 
             Adyen3DS2Component(
                 delegate = adyen3DS2Delegate,
-                actionComponentEventHandler = DefaultActionComponentEventHandler(callback),
+                actionComponentEventHandler = DefaultActionComponentEventHandler(),
             )
         }
         return ViewModelProvider(viewModelStoreOwner, threeDS2Factory)[key, Adyen3DS2Component::class.java]
             .also { component ->
-                component.observe(lifecycleOwner, component.actionComponentEventHandler::onActionComponentEvent)
+                component.observe(lifecycleOwner) {
+                    component.actionComponentEventHandler.onActionComponentEvent(it, callback)
+                }
             }
     }
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,4 +9,4 @@
 [//]: # ( - Configurations public constructor are deprecated, please use each Configuration's builder to make a Configuration object)
 
 ## Fixed
-- Fixed a memory leak in `DropInActivity`.
+- Fixed various memory leaks.

--- a/action-core/src/main/java/com/adyen/checkout/action/core/internal/provider/GenericActionComponentProvider.kt
+++ b/action-core/src/main/java/com/adyen/checkout/action/core/internal/provider/GenericActionComponentProvider.kt
@@ -62,12 +62,14 @@ constructor(
             val genericActionDelegate = getDelegate(checkoutConfiguration, savedStateHandle, application)
             GenericActionComponent(
                 genericActionDelegate = genericActionDelegate,
-                actionComponentEventHandler = DefaultActionComponentEventHandler(callback),
+                actionComponentEventHandler = DefaultActionComponentEventHandler(),
             )
         }
         return ViewModelProvider(viewModelStoreOwner, genericActionFactory)[key, GenericActionComponent::class.java]
             .also { component ->
-                component.observe(lifecycleOwner, component.actionComponentEventHandler::onActionComponentEvent)
+                component.observe(lifecycleOwner) {
+                    component.actionComponentEventHandler.onActionComponentEvent(it, callback)
+                }
             }
     }
 

--- a/await/src/main/java/com/adyen/checkout/await/internal/provider/AwaitComponentProvider.kt
+++ b/await/src/main/java/com/adyen/checkout/await/internal/provider/AwaitComponentProvider.kt
@@ -62,11 +62,13 @@ constructor(
             val awaitDelegate = getDelegate(checkoutConfiguration, savedStateHandle, application)
             AwaitComponent(
                 awaitDelegate,
-                DefaultActionComponentEventHandler(callback),
+                DefaultActionComponentEventHandler(),
             )
         }
         return ViewModelProvider(viewModelStoreOwner, awaitFactory)[key, AwaitComponent::class.java].also { component ->
-            component.observe(lifecycleOwner, component.actionComponentEventHandler::onActionComponentEvent)
+            component.observe(lifecycleOwner) {
+                component.actionComponentEventHandler.onActionComponentEvent(it, callback)
+            }
         }
     }
 

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ActionComponentEventHandler.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ActionComponentEventHandler.kt
@@ -9,8 +9,9 @@
 package com.adyen.checkout.components.core.internal
 
 import androidx.annotation.RestrictTo
+import com.adyen.checkout.components.core.ActionComponentCallback
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface ActionComponentEventHandler {
-    fun onActionComponentEvent(event: ActionComponentEvent)
+    fun onActionComponentEvent(event: ActionComponentEvent, actionComponentCallback: ActionComponentCallback)
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/DefaultActionComponentEventHandler.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/DefaultActionComponentEventHandler.kt
@@ -14,11 +14,9 @@ import com.adyen.checkout.core.AdyenLogLevel
 import com.adyen.checkout.core.internal.util.adyenLog
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class DefaultActionComponentEventHandler(
-    private val actionComponentCallback: ActionComponentCallback
-) : ActionComponentEventHandler {
+class DefaultActionComponentEventHandler : ActionComponentEventHandler {
 
-    override fun onActionComponentEvent(event: ActionComponentEvent) {
+    override fun onActionComponentEvent(event: ActionComponentEvent, actionComponentCallback: ActionComponentCallback) {
         adyenLog(AdyenLogLevel.VERBOSE) { "Event received $event" }
         when (event) {
             is ActionComponentEvent.ActionDetails -> actionComponentCallback.onAdditionalDetails(event.data)

--- a/qr-code/src/main/java/com/adyen/checkout/qrcode/internal/provider/QRCodeComponentProvider.kt
+++ b/qr-code/src/main/java/com/adyen/checkout/qrcode/internal/provider/QRCodeComponentProvider.kt
@@ -61,12 +61,14 @@ constructor(
             val qrCodeDelegate = getDelegate(checkoutConfiguration, savedStateHandle, application)
             QRCodeComponent(
                 delegate = qrCodeDelegate,
-                actionComponentEventHandler = DefaultActionComponentEventHandler(callback),
+                actionComponentEventHandler = DefaultActionComponentEventHandler(),
             )
         }
         return ViewModelProvider(viewModelStoreOwner, qrCodeFactory)[key, QRCodeComponent::class.java]
             .also { component ->
-                component.observe(lifecycleOwner, component.actionComponentEventHandler::onActionComponentEvent)
+                component.observe(lifecycleOwner) {
+                    component.actionComponentEventHandler.onActionComponentEvent(it, callback)
+                }
             }
     }
 

--- a/redirect/src/main/java/com/adyen/checkout/redirect/internal/provider/RedirectComponentProvider.kt
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/internal/provider/RedirectComponentProvider.kt
@@ -59,12 +59,14 @@ constructor(
             val redirectDelegate = getDelegate(checkoutConfiguration, savedStateHandle, application)
             RedirectComponent(
                 delegate = redirectDelegate,
-                actionComponentEventHandler = DefaultActionComponentEventHandler(callback),
+                actionComponentEventHandler = DefaultActionComponentEventHandler(),
             )
         }
         return ViewModelProvider(viewModelStoreOwner, redirectFactory)[key, RedirectComponent::class.java]
             .also { component ->
-                component.observe(lifecycleOwner, component.actionComponentEventHandler::onActionComponentEvent)
+                component.observe(lifecycleOwner) {
+                    component.actionComponentEventHandler.onActionComponentEvent(it, callback)
+                }
             }
     }
 

--- a/voucher/src/main/java/com/adyen/checkout/voucher/internal/provider/VoucherComponentProvider.kt
+++ b/voucher/src/main/java/com/adyen/checkout/voucher/internal/provider/VoucherComponentProvider.kt
@@ -57,12 +57,14 @@ constructor(
             val voucherDelegate = getDelegate(checkoutConfiguration, savedStateHandle, application)
             VoucherComponent(
                 delegate = voucherDelegate,
-                actionComponentEventHandler = DefaultActionComponentEventHandler(callback),
+                actionComponentEventHandler = DefaultActionComponentEventHandler(),
             )
         }
         return ViewModelProvider(viewModelStoreOwner, voucherFactory)[key, VoucherComponent::class.java]
             .also { component ->
-                component.observe(lifecycleOwner, component.actionComponentEventHandler::onActionComponentEvent)
+                component.observe(lifecycleOwner) {
+                    component.actionComponentEventHandler.onActionComponentEvent(it, callback)
+                }
             }
     }
 

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/internal/provider/WeChatPayActionComponentProvider.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/internal/provider/WeChatPayActionComponentProvider.kt
@@ -59,13 +59,15 @@ constructor(
             val weChatDelegate = getDelegate(checkoutConfiguration, savedStateHandle, application)
             WeChatPayActionComponent(
                 delegate = weChatDelegate,
-                actionComponentEventHandler = DefaultActionComponentEventHandler(callback),
+                actionComponentEventHandler = DefaultActionComponentEventHandler(),
             )
         }
 
         return ViewModelProvider(viewModelStoreOwner, weChatFactory)[key, WeChatPayActionComponent::class.java]
             .also { component ->
-                component.observe(lifecycleOwner, component.actionComponentEventHandler::onActionComponentEvent)
+                component.observe(lifecycleOwner) {
+                    component.actionComponentEventHandler.onActionComponentEvent(it, callback)
+                }
             }
     }
 


### PR DESCRIPTION
## Description
Fixed an issue where the action components leak their callbacks after screen rotation because `DefaultActionComponentEventHandler` holds on to them.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually