### PR TITLE
Restrict constructors of card and bcmc components

### DIFF
--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcComponent.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcComponent.kt
@@ -20,7 +20,7 @@ import com.adyen.checkout.components.core.internal.PaymentComponent
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.BCMC] payment method.
  */
-class BcmcComponent(
+class BcmcComponent internal constructor(
     cardDelegate: CardDelegate,
     genericActionDelegate: GenericActionDelegate,
     actionHandlingComponent: DefaultActionHandlingComponent,

--- a/card/src/main/java/com/adyen/checkout/card/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardComponent.kt
@@ -40,7 +40,9 @@ import kotlinx.coroutines.flow.Flow
  * A [PaymentComponent] that supports the [PaymentMethodTypes.SCHEME] payment method.
  */
 @Suppress("TooManyFunctions")
-open class CardComponent constructor(
+open class CardComponent
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+constructor(
     private val cardDelegate: CardDelegate,
     private val genericActionDelegate: GenericActionDelegate,
     private val actionHandlingComponent: DefaultActionHandlingComponent,


### PR DESCRIPTION
## Description
The constructors of the card and bcmc components were kept public by mistake, they should not be used directly to instantiate components. Their providers should be used instead.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
