### PR TITLE
Fix initial log level

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,7 @@
 
 ## Fixed
 - Fixed various memory leaks.
+- Drop-in no longer overrides the log level in case of debug builds.
 
 ## Changed
 - Flags are replaced by ISO codes in the phone number inputs (affected payment methods: MB Way, Pay Easy, Convenience Stores Japan, Online Banking Japan and Seven-Eleven).

--- a/checkout-core/src/main/java/com/adyen/checkout/core/AdyenLogger.kt
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/AdyenLogger.kt
@@ -9,6 +9,7 @@
 package com.adyen.checkout.core
 
 import android.util.Log
+import androidx.annotation.RestrictTo
 import com.adyen.checkout.core.internal.util.LogcatLogger
 import com.adyen.checkout.core.internal.util.Logger
 
@@ -35,6 +36,8 @@ interface AdyenLogger {
         internal var logger: AdyenLogger = LogcatLogger()
             private set
 
+        private var didSetLogLevelManually = false
+
         /**
          * Sets the minimum level to be logged.
          */
@@ -55,13 +58,14 @@ interface AdyenLogger {
                 Log.ERROR -> AdyenLogLevel.ERROR
                 else -> AdyenLogLevel.NONE
             }
-            logger.setLogLevel(mappedLevel)
+            setLogLevel(mappedLevel)
         }
 
         /**
          * Sets the minimum level to be logged.
          */
         fun setLogLevel(level: AdyenLogLevel) {
+            didSetLogLevelManually = true
             logger.setLogLevel(level)
         }
 
@@ -77,6 +81,14 @@ interface AdyenLogger {
          */
         fun resetLogger() {
             this.logger = LogcatLogger()
+            didSetLogLevelManually = false
+        }
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        fun setInitialLogLevel(level: AdyenLogLevel) {
+            if (!didSetLogLevelManually) {
+                logger.setLogLevel(level)
+            }
         }
     }
 }

--- a/checkout-core/src/test/java/com/adyen/checkout/core/internal/util/AdyenLoggerTest.kt
+++ b/checkout-core/src/test/java/com/adyen/checkout/core/internal/util/AdyenLoggerTest.kt
@@ -27,6 +27,7 @@ internal class AdyenLoggerTest {
 
     @BeforeEach
     fun setup() {
+        AdyenLogger.resetLogger()
         logger = TestLogger()
     }
 
@@ -75,6 +76,25 @@ internal class AdyenLoggerTest {
         adyenLog(AdyenLogLevel.VERBOSE) { "test" }
 
         logger.assertLogNotCalled()
+    }
+
+    @Test
+    fun `when log level is set manually, then setting the initial level has no effect`() {
+        AdyenLogger.setLogger(logger)
+        AdyenLogger.setLogLevel(AdyenLogLevel.ASSERT)
+
+        AdyenLogger.setInitialLogLevel(AdyenLogLevel.ERROR)
+
+        logger.assertLogLevel(AdyenLogLevel.ASSERT)
+    }
+
+    @Test
+    fun `when log level is not set manually, then setting the initial level has effect`() {
+        AdyenLogger.setLogger(logger)
+
+        AdyenLogger.setInitialLogLevel(AdyenLogLevel.ERROR)
+
+        logger.assertLogLevel(AdyenLogLevel.ERROR)
     }
 
     @Suppress("DEPRECATION")

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropIn.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropIn.kt
@@ -256,6 +256,6 @@ object DropIn {
         } else {
             AdyenLogLevel.NONE
         }
-        AdyenLogger.setLogLevel(logLevel)
+        AdyenLogger.setInitialLogLevel(logLevel)
     }
 }


### PR DESCRIPTION
## Description
This fixes a bug where drop-in would override the log level that a merchant has already set before.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-889
