### PR TITLE
Display validation error on CardView when no address has been selected

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@
 ## Fixed
 - Fixed various memory leaks.
 - Drop-in no longer overrides the log level in case of debug builds.
+- Address Lookup not displaying validation error on Card Component when no address has been selected.
 
 ## Changed
 - Flags are replaced by ISO codes in the phone number inputs (affected payment methods: MB Way, Pay Easy, Convenience Stores Japan, Online Banking Japan and Seven-Eleven).

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardView.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardView.kt
@@ -277,6 +277,11 @@ class CardView @JvmOverloads constructor(
             if (binding.addressFormInput.isVisible && !it.addressState.isValid) {
                 binding.addressFormInput.highlightValidationErrors(isErrorFocused)
             }
+            if (binding.textInputLayoutAddressLookup.isVisible && !it.addressState.isValid) {
+                binding.textInputLayoutAddressLookup.showError(
+                    localizedContext.getString(R.string.checkout_address_lookup_validation_empty)
+                )
+            }
         }
     }
 

--- a/card/src/main/res/values/styles.xml
+++ b/card/src/main/res/values/styles.xml
@@ -103,7 +103,6 @@
     <style name="AdyenCheckout.Card.AddressLookup.DropdownTextInputEditText" parent="AdyenCheckout.DropdownTextInputEditText">
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_width">match_parent</item>
-        <item name="android:layout_marginBottom">@dimen/standard_margin</item>
         <item name="android:minHeight">@dimen/input_height</item>
         <item name="android:hint">@string/checkout_address_lookup_hint</item>
         <item name="drawableTint">?attr/colorOnSurface</item>

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/model/AddressOutputData.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/model/AddressOutputData.kt
@@ -42,7 +42,7 @@ data class AddressOutputData(
             postalCode.value,
             city.value,
             stateOrProvince.value,
-            country.value
+            country.value,
         ).filter { it.isNotBlank() }.joinToString(" ")
     }
 }

--- a/ui-core/src/main/res/template/values/strings.xml.tt
+++ b/ui-core/src/main/res/template/values/strings.xml.tt
@@ -54,6 +54,7 @@
     <string name="checkout_address_lookup_empty_description">%%address.lookup.search.empty.subtitle.noResults%%</string>
     <string name="checkout_address_lookup_enter_manually">%%address.enterManually%%</string>
     <string name="checkout_address_lookup_submit">%%address.lookup.submit%%</string>
+    <string name="checkout_address_lookup_validation_empty">%%address.lookup.item.validationFailureMessage.empty%%</string>
 
     <!-- Untranslatable strings -->
     <string name="checkout_country_name_format" translatable="false">%1$s (%2$s)</string>

--- a/ui-core/src/main/res/values-ar/strings.xml
+++ b/ui-core/src/main/res/values-ar/strings.xml
@@ -54,5 +54,6 @@
     <string name="checkout_address_lookup_empty_description">لم يتطابق \'%s\' مع أي شيء، حاول مرة أخرى أو استخدم #إدخال العنوان يدويًا#</string>
     <string name="checkout_address_lookup_enter_manually">أدخل العنوان يدويًا</string>
     <string name="checkout_address_lookup_submit">استخدم هذا العنوان</string>
+    <string name="checkout_address_lookup_validation_empty">العنوان مطلوب</string>
 
 </resources>

--- a/ui-core/src/main/res/values-cs-rCZ/strings.xml
+++ b/ui-core/src/main/res/values-cs-rCZ/strings.xml
@@ -54,5 +54,6 @@
     <string name="checkout_address_lookup_empty_description">„%s“ se s ničím neshoduje, zkuste to znovu nebo použijte #ruční zadání adresy#</string>
     <string name="checkout_address_lookup_enter_manually">Zadejte adresu ručně</string>
     <string name="checkout_address_lookup_submit">Použijte tuto adresu</string>
+    <string name="checkout_address_lookup_validation_empty">Požadovaná adresa</string>
 
 </resources>

--- a/ui-core/src/main/res/values-da-rDK/strings.xml
+++ b/ui-core/src/main/res/values-da-rDK/strings.xml
@@ -54,5 +54,6 @@
     <string name="checkout_address_lookup_empty_description">Fandt ikke noget match for \'%s\'. Prøv igen eller #indtast adresse manuelt#.</string>
     <string name="checkout_address_lookup_enter_manually">Indtast adresse manuelt</string>
     <string name="checkout_address_lookup_submit">Brug denne adresse</string>
+    <string name="checkout_address_lookup_validation_empty">Adresse er påkrævet</string>
 
 </resources>

--- a/ui-core/src/main/res/values-de-rDE/strings.xml
+++ b/ui-core/src/main/res/values-de-rDE/strings.xml
@@ -54,5 +54,6 @@
     <string name="checkout_address_lookup_empty_description">\'%s\' stimmt nicht mit irgendetwas überein, versuchen Sie es erneut oder verwenden Sie #manual address entry#</string>
     <string name="checkout_address_lookup_enter_manually">Geben Sie die Adresse manuell ein</string>
     <string name="checkout_address_lookup_submit">Diese Adresse verwenden</string>
+    <string name="checkout_address_lookup_validation_empty">Adresse erforderlich</string>
 
 </resources>

--- a/ui-core/src/main/res/values-el-rGR/strings.xml
+++ b/ui-core/src/main/res/values-el-rGR/strings.xml
@@ -54,5 +54,6 @@
     <string name="checkout_address_lookup_empty_description">Το \'%s\' δεν ταιριάζει με τίποτα. Προσπαθήστε ξανά ή χρησιμοποιήστε #μη αυτόματη εισαγωγή διεύθυνσης#</string>
     <string name="checkout_address_lookup_enter_manually">Εισαγάγετε τη διεύθυνση μη αυτόματα</string>
     <string name="checkout_address_lookup_submit">Χρησιμοποιήστε αυτήν τη διεύθυνση</string>
+    <string name="checkout_address_lookup_validation_empty">Απαιτείται διεύθυνση</string>
 
 </resources>

--- a/ui-core/src/main/res/values-es-rES/strings.xml
+++ b/ui-core/src/main/res/values-es-rES/strings.xml
@@ -54,5 +54,6 @@
     <string name="checkout_address_lookup_empty_description">"%s" no ha coincidido con nada, inténtelo de nuevo o #introduzca su dirección manualmente#</string>
     <string name="checkout_address_lookup_enter_manually">Introduzca la dirección manualmente</string>
     <string name="checkout_address_lookup_submit">Usar esta dirección</string>
+    <string name="checkout_address_lookup_validation_empty">Se necesita la dirección</string>
 
 </resources>

--- a/ui-core/src/main/res/values-fi-rFI/strings.xml
+++ b/ui-core/src/main/res/values-fi-rFI/strings.xml
@@ -54,5 +54,6 @@
     <string name="checkout_address_lookup_empty_description">\'%s\' ei tuottanut tuloksia. Yritä uudelleen tai käytä #manuaalista osoitteen syöttöä#</string>
     <string name="checkout_address_lookup_enter_manually">Syötä osoite manuaalisesti</string>
     <string name="checkout_address_lookup_submit">Käytä tätä osoitetta</string>
+    <string name="checkout_address_lookup_validation_empty">Osoite vaaditaan</string>
 
 </resources>

--- a/ui-core/src/main/res/values-fr-rFR/strings.xml
+++ b/ui-core/src/main/res/values-fr-rFR/strings.xml
@@ -54,5 +54,6 @@
     <string name="checkout_address_lookup_empty_description">Aucune correspondance pour \'%s\', réessayez ou #saisissez votre adresse manuellement#</string>
     <string name="checkout_address_lookup_enter_manually">Saisissez l\'adresse manuellement</string>
     <string name="checkout_address_lookup_submit">Utiliser cette adresse</string>
+    <string name="checkout_address_lookup_validation_empty">Adresse requise</string>
 
 </resources>

--- a/ui-core/src/main/res/values-hr-rHR/strings.xml
+++ b/ui-core/src/main/res/values-hr-rHR/strings.xml
@@ -54,5 +54,6 @@
     <string name="checkout_address_lookup_empty_description">\'%s\' nije se podudarao s ničime, pokušajte ponovno ili upotrijebite #ručni unos adrese#</string>
     <string name="checkout_address_lookup_enter_manually">Ručno unesite adresu</string>
     <string name="checkout_address_lookup_submit">Koristi ovu adresu</string>
+    <string name="checkout_address_lookup_validation_empty">Potrebna je adresa</string>
 
 </resources>

--- a/ui-core/src/main/res/values-hu-rHU/strings.xml
+++ b/ui-core/src/main/res/values-hu-rHU/strings.xml
@@ -54,5 +54,6 @@
     <string name="checkout_address_lookup_empty_description">A keresett „%s„ kifejezésre nincs találat, próbálkozzon újra, vagy #írja be manuálisan a címet#</string>
     <string name="checkout_address_lookup_enter_manually">Manuálisan írjon be egy címet</string>
     <string name="checkout_address_lookup_submit">Használja ezt a címet</string>
+    <string name="checkout_address_lookup_validation_empty">A cím megadása kötelező</string>
 
 </resources>

--- a/ui-core/src/main/res/values-it-rIT/strings.xml
+++ b/ui-core/src/main/res/values-it-rIT/strings.xml
@@ -54,5 +54,6 @@
     <string name="checkout_address_lookup_empty_description">%s non corrisponde a nulla, riprova o usa #inserimento indirizzo manuale#</string>
     <string name="checkout_address_lookup_enter_manually">Inserisci l\'indirizzo manualmente</string>
     <string name="checkout_address_lookup_submit">Usa questo indirizzo</string>
+    <string name="checkout_address_lookup_validation_empty">Indirizzo richiesto</string>
 
 </resources>

--- a/ui-core/src/main/res/values-ja-rJP/strings.xml
+++ b/ui-core/src/main/res/values-ja-rJP/strings.xml
@@ -54,5 +54,6 @@
     <string name="checkout_address_lookup_empty_description">「%s」との一致はありませんでした。もう一度試すか、#手動でアドレスを入力#してください</string>
     <string name="checkout_address_lookup_enter_manually">住所を手動で入力してください</string>
     <string name="checkout_address_lookup_submit">この住所を使用する</string>
+    <string name="checkout_address_lookup_validation_empty">住所が必要です</string>
 
 </resources>

--- a/ui-core/src/main/res/values-ko-rKR/strings.xml
+++ b/ui-core/src/main/res/values-ko-rKR/strings.xml
@@ -54,5 +54,6 @@
     <string name="checkout_address_lookup_empty_description">\'%s\'와(과) 일치하는 항목이 없습니다. 다시 시도하거나 #수동 주소 입력#을 사용하세요.</string>
     <string name="checkout_address_lookup_enter_manually">수동으로 주소 입력</string>
     <string name="checkout_address_lookup_submit">이 주소 사용</string>
+    <string name="checkout_address_lookup_validation_empty">주소 필수</string>
 
 </resources>

--- a/ui-core/src/main/res/values-nb-rNO/strings.xml
+++ b/ui-core/src/main/res/values-nb-rNO/strings.xml
@@ -54,5 +54,6 @@
     <string name="checkout_address_lookup_empty_description">Fikk ingen treff på «%s». Prøv igjen eller #skriv inn adressen manuelt#</string>
     <string name="checkout_address_lookup_enter_manually">Skriv inn adressen manuelt</string>
     <string name="checkout_address_lookup_submit">Bruk denne adressen</string>
+    <string name="checkout_address_lookup_validation_empty">Adresse er nødvendig</string>
 
 </resources>

--- a/ui-core/src/main/res/values-nl-rNL/strings.xml
+++ b/ui-core/src/main/res/values-nl-rNL/strings.xml
@@ -54,5 +54,6 @@
     <string name="checkout_address_lookup_empty_description">Geen resulaten gevonden voor \'%s\', probeer het opnieuw of gebruik #adres handmatig invoeren#</string>
     <string name="checkout_address_lookup_enter_manually">Voer het adres handmatig in</string>
     <string name="checkout_address_lookup_submit">Dit adres gebruiken</string>
+    <string name="checkout_address_lookup_validation_empty">Adres verplicht</string>
 
 </resources>

--- a/ui-core/src/main/res/values-pl-rPL/strings.xml
+++ b/ui-core/src/main/res/values-pl-rPL/strings.xml
@@ -54,5 +54,6 @@
     <string name="checkout_address_lookup_empty_description">Nie znaleziono żadnych dopasowań dla \'%s\', spróbuj ponownie lub #wprowadź adres ręcznie#</string>
     <string name="checkout_address_lookup_enter_manually">Wprowadź adres ręcznie</string>
     <string name="checkout_address_lookup_submit">Użyj tego adresu</string>
+    <string name="checkout_address_lookup_validation_empty">Wymagane jest podanie adresu</string>
 
 </resources>

--- a/ui-core/src/main/res/values-pt-rBR/strings.xml
+++ b/ui-core/src/main/res/values-pt-rBR/strings.xml
@@ -54,5 +54,6 @@
     <string name="checkout_address_lookup_empty_description">A pesquisa de \'%s\' não obteve resultados. Tente novamente ou use #inserir endereço manualmente#</string>
     <string name="checkout_address_lookup_enter_manually">Inserir endereço manualmente</string>
     <string name="checkout_address_lookup_submit">Usar este endereço</string>
+    <string name="checkout_address_lookup_validation_empty">O endereço é obrigatório</string>
 
 </resources>

--- a/ui-core/src/main/res/values-pt-rPT/strings.xml
+++ b/ui-core/src/main/res/values-pt-rPT/strings.xml
@@ -54,5 +54,6 @@
     <string name="checkout_address_lookup_empty_description">\'%s\' não devolveu resultados, tente novamente ou use #inserção manual do endereço#</string>
     <string name="checkout_address_lookup_enter_manually">Introduza o endereço manualmente</string>
     <string name="checkout_address_lookup_submit">Utilize este endereço</string>
+    <string name="checkout_address_lookup_validation_empty">Endereço necessário</string>
 
 </resources>

--- a/ui-core/src/main/res/values-ro-rRO/strings.xml
+++ b/ui-core/src/main/res/values-ro-rRO/strings.xml
@@ -54,5 +54,6 @@
     <string name="checkout_address_lookup_empty_description">\'%s\' nu s-a potrivit cu nimic, încercați din nou sau folosiți #completarea manuală a adresei#</string>
     <string name="checkout_address_lookup_enter_manually">Introduceți adresa manual</string>
     <string name="checkout_address_lookup_submit">Folosiți această adresă</string>
+    <string name="checkout_address_lookup_validation_empty">Adresa este necesară</string>
 
 </resources>

--- a/ui-core/src/main/res/values-ru-rRU/strings.xml
+++ b/ui-core/src/main/res/values-ru-rRU/strings.xml
@@ -54,5 +54,6 @@
     <string name="checkout_address_lookup_empty_description">Не найдено соответствий «%s». Повторите попытку или используйте #ручной ввод адреса#</string>
     <string name="checkout_address_lookup_enter_manually">Ввести адрес вручную</string>
     <string name="checkout_address_lookup_submit">Используйте этот адрес</string>
+    <string name="checkout_address_lookup_validation_empty">Требуется адрес</string>
 
 </resources>

--- a/ui-core/src/main/res/values-sk-rSK/strings.xml
+++ b/ui-core/src/main/res/values-sk-rSK/strings.xml
@@ -54,5 +54,6 @@
     <string name="checkout_address_lookup_empty_description">\'%s\' sa s ničím nezhoduje, skúste to znova alebo použite #ručné zadanie adresy#</string>
     <string name="checkout_address_lookup_enter_manually">Manuálne zadajte adresu</string>
     <string name="checkout_address_lookup_submit">Použite túto adresu</string>
+    <string name="checkout_address_lookup_validation_empty">Adresa sa požaduje</string>
 
 </resources>

--- a/ui-core/src/main/res/values-sl-rSI/strings.xml
+++ b/ui-core/src/main/res/values-sl-rSI/strings.xml
@@ -54,5 +54,6 @@
     <string name="checkout_address_lookup_empty_description">»%s« se ni ujemalo z ničemer, poskusite znova ali uporabite #ročni vnos naslova#</string>
     <string name="checkout_address_lookup_enter_manually">Naslov vnesite ročno</string>
     <string name="checkout_address_lookup_submit">Uporabite ta naslov</string>
+    <string name="checkout_address_lookup_validation_empty">Naslov je obvezen</string>
 
 </resources>

--- a/ui-core/src/main/res/values-sv-rSE/strings.xml
+++ b/ui-core/src/main/res/values-sv-rSE/strings.xml
@@ -54,5 +54,6 @@
     <string name="checkout_address_lookup_empty_description">Det finns inga matchningar för ”%s”. Försök igen eller använd #manuell adressinmatning#</string>
     <string name="checkout_address_lookup_enter_manually">Ange adress manuellt</string>
     <string name="checkout_address_lookup_submit">Använd denna adress</string>
+    <string name="checkout_address_lookup_validation_empty">Adress krävs</string>
 
 </resources>

--- a/ui-core/src/main/res/values-zh-rCN/strings.xml
+++ b/ui-core/src/main/res/values-zh-rCN/strings.xml
@@ -54,5 +54,6 @@
     <string name="checkout_address_lookup_empty_description">“%s”无匹配内容，请重试或者使用#手动地址条目#</string>
     <string name="checkout_address_lookup_enter_manually">手动输入地址</string>
     <string name="checkout_address_lookup_submit">使用此地址</string>
+    <string name="checkout_address_lookup_validation_empty">地址为必填项</string>
 
 </resources>

--- a/ui-core/src/main/res/values-zh-rTW/strings.xml
+++ b/ui-core/src/main/res/values-zh-rTW/strings.xml
@@ -54,5 +54,6 @@
     <string name="checkout_address_lookup_empty_description">「%s」不符合任何搜尋內容，請再試一次或#手動輸入地址#</string>
     <string name="checkout_address_lookup_enter_manually">手動輸入地址</string>
     <string name="checkout_address_lookup_submit">使用此地址</string>
+    <string name="checkout_address_lookup_validation_empty">必須填寫地址</string>
 
 </resources>

--- a/ui-core/src/main/res/values/strings.xml
+++ b/ui-core/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
     <string name="checkout_address_lookup_empty_description">\'%s\' did not match with anything, try again or use #manual address entry#</string>
     <string name="checkout_address_lookup_enter_manually">Enter address manually</string>
     <string name="checkout_address_lookup_submit">Use this address</string>
+    <string name="checkout_address_lookup_validation_empty">Address required</string>
 
     <!-- Untranslatable strings -->
     <string name="checkout_country_name_format" translatable="false">%1$s (%2$s)</string>


### PR DESCRIPTION
## Description
[//]: # (Include a short summary of your changes)
[//]: # (If this is a new feature: attach screenshots or a video if applicable)
[//]: # (If this is a bug fix: include a reproduction path)
Fixed Address Lookup view in CardView not displaying validation error.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
- [x] Add relevant labels to PR  <!-- Breaking change, Feature, Fix or Dependencies. If none of these labels are applicable (for example refactor tasks or release PRs) do not use any labels -->

COAND-588

