### PR TITLE
Fix crash caused by obfuscation of action configurations

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,7 @@
 - Fixed various memory leaks.
 - Drop-in no longer overrides the log level in case of debug builds.
 - Address Lookup not displaying validation error on Card Component when no address has been selected.
+- Actions no longer crash when your app uses obfuscation.
 
 ## Changed
 - Flags are replaced by ISO codes in the phone number inputs (affected payment methods: MB Way, Pay Easy, Convenience Stores Japan, Online Banking Japan and Seven-Eleven).

--- a/components-core/src/main/java/com/adyen/checkout/components/core/CheckoutConfiguration.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/CheckoutConfiguration.kt
@@ -108,7 +108,7 @@ class CheckoutConfiguration(
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun addActionConfiguration(configuration: Configuration) {
-        availableConfigurations[configuration::class.java.simpleName] = configuration
+        availableConfigurations[configuration::class.java.name] = configuration
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -120,7 +120,7 @@ class CheckoutConfiguration(
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun <T : Configuration> getActionConfiguration(configClass: Class<T>): T? {
         @Suppress("UNCHECKED_CAST")
-        return availableConfigurations[configClass.simpleName] as? T
+        return availableConfigurations[configClass.name] as? T
     }
 
     override fun writeToParcel(dest: Parcel, flags: Int) {


### PR DESCRIPTION
## Description
This solves a crash where configurations would get the same name when they are obfuscated.

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Code is unit tested
- [x] Changes are tested manually
- [x] Related issues are linked

COAND-902
