### PR TITLE
Display pay button in components if created by drop in

### DIFF
--- a/ach/src/main/java/com/adyen/checkout/ach/internal/ui/model/ACHDirectDebitComponentParamsMapper.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/internal/ui/model/ACHDirectDebitComponentParamsMapper.kt
@@ -39,6 +39,7 @@ internal class ACHDirectDebitComponentParamsMapper(
         return mapToParams(
             commonComponentParamsMapperData.commonComponentParams,
             commonComponentParamsMapperData.sessionParams,
+            dropInOverrideParams,
             achDirectDebitConfiguration,
         )
     }
@@ -46,11 +47,13 @@ internal class ACHDirectDebitComponentParamsMapper(
     private fun mapToParams(
         commonComponentParams: CommonComponentParams,
         sessionParams: SessionParams?,
+        dropInOverrideParams: DropInOverrideParams?,
         achDirectDebitConfiguration: ACHDirectDebitConfiguration?,
     ): ACHDirectDebitComponentParams {
         return ACHDirectDebitComponentParams(
             commonComponentParams = commonComponentParams,
-            isSubmitButtonVisible = achDirectDebitConfiguration?.isSubmitButtonVisible ?: true,
+            isSubmitButtonVisible = dropInOverrideParams?.isSubmitButtonVisible
+                ?: achDirectDebitConfiguration?.isSubmitButtonVisible ?: true,
             addressParams = achDirectDebitConfiguration?.addressConfiguration?.mapToAddressParam()
                 ?: AddressParams.FullAddress(
                     supportedCountryCodes = DEFAULT_SUPPORTED_COUNTRY_LIST,

--- a/ach/src/test/java/com/adyen/checkout/ach/internal/ui/model/ACHDirectDebitComponentParamsMapperTest.kt
+++ b/ach/src/test/java/com/adyen/checkout/ach/internal/ui/model/ACHDirectDebitComponentParamsMapperTest.kt
@@ -100,6 +100,27 @@ internal class ACHDirectDebitComponentParamsMapperTest {
     }
 
     @Test
+    fun `when setSubmitButtonVisible is set to false in ach configuration and drop-in override params are set then card component params should have isSubmitButtonVisible true`() {
+        val configuration = CheckoutConfiguration(
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+        ) {
+            achDirectDebit {
+                setSubmitButtonVisible(false)
+            }
+        }
+        val dropInOverrideParams = DropInOverrideParams(Amount("EUR", 123L), null)
+        val params = achDirectDebitComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = dropInOverrideParams,
+            componentSessionParams = null,
+        )
+
+        assertEquals(true, params.isSubmitButtonVisible)
+    }
+
+    @Test
     fun `when a address is selected as FullAddress, addressParams should return FullAddress`() {
         val addressConfiguration =
             ACHDirectDebitAddressConfiguration.FullAddress(supportedCountryCodes = SUPPORTED_COUNTRY_LIST)

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/internal/ui/model/BcmcComponentParamsMapper.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/internal/ui/model/BcmcComponentParamsMapper.kt
@@ -47,6 +47,7 @@ internal class BcmcComponentParamsMapper(
         return mapToParams(
             commonComponentParamsMapperData.commonComponentParams,
             commonComponentParamsMapperData.sessionParams,
+            dropInOverrideParams,
             bcmcConfiguration,
             paymentMethod,
         )
@@ -55,12 +56,14 @@ internal class BcmcComponentParamsMapper(
     private fun mapToParams(
         commonComponentParams: CommonComponentParams,
         sessionParams: SessionParams?,
+        dropInOverrideParams: DropInOverrideParams?,
         bcmcConfiguration: BcmcConfiguration?,
         paymentMethod: PaymentMethod,
     ): CardComponentParams {
         return CardComponentParams(
             commonComponentParams = commonComponentParams,
-            isSubmitButtonVisible = bcmcConfiguration?.isSubmitButtonVisible ?: true,
+            isSubmitButtonVisible = dropInOverrideParams?.isSubmitButtonVisible
+                ?: bcmcConfiguration?.isSubmitButtonVisible ?: true,
             isHolderNameRequired = bcmcConfiguration?.isHolderNameRequired ?: false,
             shopperReference = bcmcConfiguration?.shopperReference,
             isStorePaymentFieldVisible = getStorePaymentFieldVisible(sessionParams, bcmcConfiguration),

--- a/bcmc/src/test/java/com/adyen/checkout/bcmc/internal/ui/model/BcmcComponentParamsMapperTest.kt
+++ b/bcmc/src/test/java/com/adyen/checkout/bcmc/internal/ui/model/BcmcComponentParamsMapperTest.kt
@@ -119,6 +119,29 @@ internal class BcmcComponentParamsMapperTest {
         assertEquals(expected, params)
     }
 
+    @Test
+    fun `when setSubmitButtonVisible is set to false in bcmc configuration and drop-in override params are set then card component params should have isSubmitButtonVisible true`() {
+        val configuration = CheckoutConfiguration(
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+        ) {
+            bcmc {
+                setSubmitButtonVisible(false)
+            }
+        }
+
+        val dropInOverrideParams = DropInOverrideParams(Amount("CAD", 123L), null)
+        val params = bcmcComponentParamsMapper.mapToParams(
+            configuration,
+            DEVICE_LOCALE,
+            dropInOverrideParams,
+            null,
+            PaymentMethod(),
+        )
+
+        assertEquals(true, params.isSubmitButtonVisible)
+    }
+
     @ParameterizedTest
     @MethodSource("enableStoreDetailsSource")
     @Suppress("MaxLineLength")

--- a/boleto/src/main/java/com/adyen/checkout/boleto/internal/ui/model/BoletoComponentParamsMapper.kt
+++ b/boleto/src/main/java/com/adyen/checkout/boleto/internal/ui/model/BoletoComponentParamsMapper.kt
@@ -37,7 +37,8 @@ internal class BoletoComponentParamsMapper(
 
         return BoletoComponentParams(
             commonComponentParams = commonComponentParams,
-            isSubmitButtonVisible = boletoConfiguration?.isSubmitButtonVisible ?: true,
+            isSubmitButtonVisible = dropInOverrideParams?.isSubmitButtonVisible
+                ?: boletoConfiguration?.isSubmitButtonVisible ?: true,
             addressParams = AddressParams.FullAddress(
                 defaultCountryCode = BRAZIL_COUNTRY_CODE,
                 supportedCountryCodes = DEFAULT_SUPPORTED_COUNTRY_LIST,

--- a/boleto/src/test/java/com/adyen/checkout/boleto/internal/ui/model/BoletoComponentParamsMapperTest.kt
+++ b/boleto/src/test/java/com/adyen/checkout/boleto/internal/ui/model/BoletoComponentParamsMapperTest.kt
@@ -102,6 +102,26 @@ internal class BoletoComponentParamsMapperTest {
     }
 
     @Test
+    fun `when setSubmitButtonVisible is set to false in boleto configuration and drop-in override params are set then card component params should have isSubmitButtonVisible true`() {
+        val configuration = CheckoutConfiguration(
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+        ) {
+            boleto {
+                setSubmitButtonVisible(false)
+            }
+        }
+
+        val dropInOverrideParams = DropInOverrideParams(Amount("EUR", 20L), null)
+        val params = mapParams(
+            configuration = configuration,
+            dropInOverrideParams = dropInOverrideParams,
+        )
+
+        assertEquals(true, params.isSubmitButtonVisible)
+    }
+
+    @Test
     fun `when send email is set, them params should match`() {
         val configuration = createCheckoutConfiguration {
             setEmailVisibility(true)

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapper.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapper.kt
@@ -83,6 +83,7 @@ internal class CardComponentParamsMapper(
         return mapToParams(
             commonComponentParamsMapperData.commonComponentParams,
             commonComponentParamsMapperData.sessionParams,
+            dropInOverrideParams,
             cardConfiguration,
             paymentMethod,
         )
@@ -91,13 +92,15 @@ internal class CardComponentParamsMapper(
     private fun mapToParams(
         commonComponentParams: CommonComponentParams,
         sessionParams: SessionParams?,
+        dropInOverrideParams: DropInOverrideParams?,
         cardConfiguration: CardConfiguration?,
         paymentMethod: PaymentMethod?,
     ): CardComponentParams {
         return CardComponentParams(
             commonComponentParams = commonComponentParams,
             isHolderNameRequired = cardConfiguration?.isHolderNameRequired ?: false,
-            isSubmitButtonVisible = cardConfiguration?.isSubmitButtonVisible ?: true,
+            isSubmitButtonVisible = dropInOverrideParams?.isSubmitButtonVisible
+                ?: cardConfiguration?.isSubmitButtonVisible ?: true,
             supportedCardBrands = getSupportedCardBrands(cardConfiguration, paymentMethod),
             shopperReference = cardConfiguration?.shopperReference,
             isStorePaymentFieldVisible = getStorePaymentFieldVisible(sessionParams, cardConfiguration),

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapperTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapperTest.kt
@@ -174,6 +174,28 @@ internal class CardComponentParamsMapperTest {
     }
 
     @Test
+    fun `when setSubmitButtonVisible is set to false in card configuration and drop-in override params are set then card component params should have isSubmitButtonVisible true`() {
+        val configuration = CheckoutConfiguration(
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+        ) {
+            card {
+                setSubmitButtonVisible(false)
+            }
+        }
+        val dropInOverrideParams = DropInOverrideParams(Amount("EUR", 123L), null)
+        val params = cardComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = dropInOverrideParams,
+            componentSessionParams = null,
+            paymentMethod = PaymentMethod(),
+        )
+
+        assertEquals(true, params.isSubmitButtonVisible)
+    }
+
+    @Test
     fun `when supported card types are set in the card configuration then they should be used in the params`() {
         val configuration = createCheckoutConfiguration {
             setSupportedCardTypes(CardType.MAESTRO, CardType.BCMC)

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/model/CashAppPayComponentParamsMapper.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/model/CashAppPayComponentParamsMapper.kt
@@ -57,6 +57,7 @@ internal class CashAppPayComponentParamsMapper(
         val params = mapToParamsInternal(
             commonComponentParams = commonComponentParamsMapperData.commonComponentParams,
             sessionParams = commonComponentParamsMapperData.sessionParams,
+            dropInOverrideParams = dropInOverrideParams,
             cashAppPayConfiguration = cashAppPayConfiguration,
             clientId = clientId,
             scopeId = scopeId,
@@ -93,6 +94,7 @@ internal class CashAppPayComponentParamsMapper(
         return mapToParamsInternal(
             commonComponentParams = commonComponentParamsMapperData.commonComponentParams,
             sessionParams = commonComponentParamsMapperData.sessionParams,
+            dropInOverrideParams = dropInOverrideParams,
             cashAppPayConfiguration = cashAppPayConfiguration,
             clientId = null,
             scopeId = null,
@@ -104,6 +106,7 @@ internal class CashAppPayComponentParamsMapper(
     private fun mapToParamsInternal(
         commonComponentParams: CommonComponentParams,
         sessionParams: SessionParams?,
+        dropInOverrideParams: DropInOverrideParams?,
         cashAppPayConfiguration: CashAppPayConfiguration?,
         clientId: String?,
         scopeId: String?,
@@ -111,7 +114,8 @@ internal class CashAppPayComponentParamsMapper(
     ): CashAppPayComponentParams {
         return CashAppPayComponentParams(
             commonComponentParams = commonComponentParams,
-            isSubmitButtonVisible = cashAppPayConfiguration?.isSubmitButtonVisible ?: true,
+            isSubmitButtonVisible = dropInOverrideParams?.isSubmitButtonVisible
+                ?: cashAppPayConfiguration?.isSubmitButtonVisible ?: true,
             cashAppPayEnvironment = getCashAppPayEnvironment(
                 commonComponentParams.environment,
                 cashAppPayConfiguration,

--- a/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/model/CashAppPayComponentParamsMapperTest.kt
+++ b/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/model/CashAppPayComponentParamsMapperTest.kt
@@ -146,6 +146,39 @@ internal class CashAppPayComponentParamsMapperTest {
         assertEquals(expected, params)
     }
 
+    @Test
+    fun `when setSubmitButtonVisible is set to false in cash app configuration and drop-in override params are set then card component params should have isSubmitButtonVisible true`() {
+        val configuration = CheckoutConfiguration(
+            shopperLocale = Locale.GERMAN,
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+            amount = Amount(
+                currency = "CAD",
+                value = 1235_00L,
+            ),
+            analyticsConfiguration = AnalyticsConfiguration(AnalyticsLevel.NONE),
+        ) {
+            cashAppPay {
+                setReturnUrl(TEST_RETURN_URL)
+                setAmount(Amount("USD", 1L))
+                setAnalyticsConfiguration(AnalyticsConfiguration(AnalyticsLevel.ALL))
+                setSubmitButtonVisible(false)
+            }
+        }
+
+        val dropInOverrideParams = DropInOverrideParams(Amount("EUR", 123L), null)
+        val params = cashAppPayComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = dropInOverrideParams,
+            componentSessionParams = null,
+            paymentMethod = getDefaultPaymentMethod(),
+            context = Application(),
+        )
+
+        assertEquals(true, params.isSubmitButtonVisible)
+    }
+
     @ParameterizedTest
     @MethodSource("enableStoreDetailsSource")
     fun `showStorePaymentField should match value set in sessions if it exists, otherwise should match configuration`(

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/ButtonComponentParamsMapper.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/ButtonComponentParamsMapper.kt
@@ -24,9 +24,11 @@ class ButtonComponentParamsMapper(
             dropInOverrideParams,
             componentSessionParams,
         )
+        val commonComponentParams = commonComponentParamsMapperData.commonComponentParams
         return ButtonComponentParams(
-            commonComponentParams = commonComponentParamsMapperData.commonComponentParams,
-            isSubmitButtonVisible = (componentConfiguration as? ButtonConfiguration)?.isSubmitButtonVisible ?: true,
+            commonComponentParams = commonComponentParams,
+            isSubmitButtonVisible = dropInOverrideParams?.isSubmitButtonVisible
+                ?: (componentConfiguration as? ButtonConfiguration)?.isSubmitButtonVisible ?: true,
         )
     }
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/DropInOverrideParams.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/DropInOverrideParams.kt
@@ -15,4 +15,5 @@ import com.adyen.checkout.components.core.Amount
 data class DropInOverrideParams(
     val amount: Amount?,
     val sessionParams: SessionParams?,
+    val isSubmitButtonVisible: Boolean = true
 )

--- a/components-core/src/test/java/com/adyen/checkout/components/core/ButtonTestConfiguration.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/ButtonTestConfiguration.kt
@@ -27,7 +27,7 @@ class ButtonTestConfiguration private constructor(
 
         private var isSubmitButtonVisible: Boolean? = null
 
-        override fun setSubmitButtonVisible(isSubmitButtonVisible: Boolean): ButtonConfigurationBuilder {
+        override fun setSubmitButtonVisible(isSubmitButtonVisible: Boolean): Builder {
             this.isSubmitButtonVisible = isSubmitButtonVisible
             return this
         }

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/ui/model/ButtonComponentParamsMapperTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/ui/model/ButtonComponentParamsMapperTest.kt
@@ -78,6 +78,30 @@ internal class ButtonComponentParamsMapperTest {
         assertEquals(expected, params)
     }
 
+    @Test
+    fun `when setSubmitButtonVisible is set to false in button component configuration and drop-in override params are set then card component params should have isSubmitButtonVisible true`() {
+        val configuration = CheckoutConfiguration(
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+        ) {
+            val testConfiguration = ButtonTestConfiguration.Builder(Locale.CANADA, Environment.TEST, TEST_CLIENT_KEY_1)
+                .setSubmitButtonVisible(false)
+                .build()
+            addConfiguration(TEST_CONFIGURATION_KEY, testConfiguration)
+        }
+
+        val dropInOverrideParams = DropInOverrideParams(Amount("USD", 123L), null)
+        val params = buttonComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = dropInOverrideParams,
+            componentSessionParams = null,
+            componentConfiguration = configuration.getConfiguration(TEST_CONFIGURATION_KEY),
+        )
+
+        assertEquals(true, params.isSubmitButtonVisible)
+    }
+
     @ParameterizedTest
     @MethodSource("amountSource")
     fun `amount should match value set in sessions then drop in then component configuration`(

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/ui/model/GiftCardComponentParamsMapper.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/ui/model/GiftCardComponentParamsMapper.kt
@@ -33,10 +33,10 @@ internal class GiftCardComponentParamsMapper(
         )
         val commonComponentParams = commonComponentParamsMapperData.commonComponentParams
         val giftCardConfiguration = checkoutConfiguration.getGiftCardConfiguration()
-
         return GiftCardComponentParams(
             commonComponentParams = commonComponentParams,
-            isSubmitButtonVisible = giftCardConfiguration?.isSubmitButtonVisible ?: true,
+            isSubmitButtonVisible = dropInOverrideParams?.isSubmitButtonVisible
+                ?: giftCardConfiguration?.isSubmitButtonVisible ?: true,
             isPinRequired = giftCardConfiguration?.isPinRequired ?: true,
         )
     }

--- a/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/ui/model/GiftCardComponentParamsMapperTest.kt
+++ b/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/ui/model/GiftCardComponentParamsMapperTest.kt
@@ -80,6 +80,23 @@ internal class GiftCardComponentParamsMapperTest {
         assertEquals(expected, params)
     }
 
+    @Test
+    fun `when setSubmitButtonVisible is set to false in gift card configuration and drop-in override params are set then card component params should have isSubmitButtonVisible true`() {
+        val configuration = CheckoutConfiguration(
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+        ) {
+            giftCard {
+                setSubmitButtonVisible(false)
+            }
+        }
+
+        val dropInOverrideParams = DropInOverrideParams(Amount("CAD", 123L), null)
+        val params = giftCardComponentParamsMapper.mapToParams(configuration, DEVICE_LOCALE, dropInOverrideParams, null)
+
+        assertEquals(true, params.isSubmitButtonVisible)
+    }
+
     @ParameterizedTest
     @MethodSource("amountSource")
     fun `amount should match value set in sessions then drop in then component configuration`(

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/ui/model/IssuerListComponentParamsMapper.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/ui/model/IssuerListComponentParamsMapper.kt
@@ -37,9 +37,11 @@ class IssuerListComponentParamsMapper(
             dropInOverrideParams,
             componentSessionParams,
         )
+        val commonComponentParams = commonComponentParamsMapperData.commonComponentParams
         return IssuerListComponentParams(
-            commonComponentParams = commonComponentParamsMapperData.commonComponentParams,
-            isSubmitButtonVisible = componentConfiguration?.isSubmitButtonVisible ?: true,
+            commonComponentParams = commonComponentParams,
+            isSubmitButtonVisible = dropInOverrideParams?.isSubmitButtonVisible
+                ?: componentConfiguration?.isSubmitButtonVisible ?: true,
             viewType = componentConfiguration?.viewType ?: IssuerListViewType.RECYCLER_VIEW,
             hideIssuerLogos = componentConfiguration?.hideIssuerLogos ?: hideIssuerLogosDefaultValue,
         )

--- a/issuer-list/src/test/java/com/adyen/checkout/issuerlist/internal/ui/model/IssuerListComponentParamsMapperTest.kt
+++ b/issuer-list/src/test/java/com/adyen/checkout/issuerlist/internal/ui/model/IssuerListComponentParamsMapperTest.kt
@@ -132,6 +132,31 @@ internal class IssuerListComponentParamsMapperTest {
         assertEquals(expected, params)
     }
 
+    @Test
+    fun `when setSubmitButtonVisible is set to false in issuers list configuration and drop-in override params are set then card component params should have isSubmitButtonVisible true`() {
+        val configuration = CheckoutConfiguration(
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+        ) {
+            val issuerListConfiguration = TestIssuerListConfiguration.Builder(shopperLocale, environment, clientKey)
+                .setSubmitButtonVisible(false)
+                .build()
+            addConfiguration(TEST_CONFIGURATION_KEY, issuerListConfiguration)
+        }
+
+        val dropInOverrideParams = DropInOverrideParams(Amount("CAD", 123L), null)
+        val params = issuerListComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = dropInOverrideParams,
+            componentSessionParams = null,
+            componentConfiguration = configuration.getConfiguration(TEST_CONFIGURATION_KEY),
+            hideIssuerLogosDefaultValue = false,
+        )
+
+        assertEquals(true, params.isSubmitButtonVisible)
+    }
+
     @ParameterizedTest
     @MethodSource("amountSource")
     fun `amount should match value set in sessions then drop in then component configuration`(


### PR DESCRIPTION
## Description
[//]: # (Include a short summary of your changes)
[//]: # (If this is a new feature: attach screenshots or a video if applicable)
[//]: # (If this is a bug fix: include a reproduction path)
After this change, it is not allowed to hide to pay button in components when they are created by drop-in.

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-838

