### PR TITLE
Fix drop-in unable to handle 3DS2 on API v66 and below

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,7 @@
 - Drop-in no longer overrides the log level in case of debug builds.
 - Address Lookup not displaying validation error on Card Component when no address has been selected.
 - Actions no longer crash when your app uses obfuscation.
+- Drop-in no longer throws an error while handling a 3DS2 challenge on API 66 and below.
 
 ## Changed
 - Flags are replaced by ISO codes in the phone number inputs (affected payment methods: MB Way, Pay Easy, Convenience Stores Japan, Online Banking Japan and Seven-Eleven).

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/ActionComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/ActionComponentDialogFragment.kt
@@ -145,11 +145,15 @@ internal class ActionComponentDialogFragment :
             .onEach {
                 when (it) {
                     ActionComponentFragmentEvent.HANDLE_ACTION -> {
-                        actionComponent.handleAction(action, requireActivity())
+                        handleAction(action)
                     }
                 }
             }
             .launchIn(viewLifecycleOwner.lifecycleScope)
+    }
+
+    fun handleAction(action: Action) {
+        actionComponent.handleAction(action, requireActivity())
     }
 
     override fun onBackPressed(): Boolean {
@@ -215,21 +219,19 @@ internal class ActionComponentDialogFragment :
     }
 
     companion object {
-        const val ACTION = "ACTION"
-        const val CHECKOUT_CONFIGURATION = "CHECKOUT_CONFIGURATION"
+        private const val ACTION = "ACTION"
+        private const val CHECKOUT_CONFIGURATION = "CHECKOUT_CONFIGURATION"
 
         fun newInstance(
             action: Action,
             checkoutConfiguration: CheckoutConfiguration,
         ): ActionComponentDialogFragment {
-            val args = Bundle()
-            args.putParcelable(ACTION, action)
-            args.putParcelable(CHECKOUT_CONFIGURATION, checkoutConfiguration)
-
-            val componentDialogFragment = ActionComponentDialogFragment()
-            componentDialogFragment.arguments = args
-
-            return componentDialogFragment
+            return ActionComponentDialogFragment().apply {
+                arguments = Bundle().apply {
+                    putParcelable(ACTION, action)
+                    putParcelable(CHECKOUT_CONFIGURATION, checkoutConfiguration)
+                }
+            }
         }
     }
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInActivity.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInActivity.kt
@@ -482,6 +482,10 @@ internal class DropInActivity :
 
     private fun handleAction(action: Action) {
         adyenLog(AdyenLogLevel.DEBUG) { "showActionDialog" }
+        getExistingActionFragment()?.apply {
+            handleAction(action)
+            return
+        }
         setLoading(false)
         hideAllScreens()
         val actionFragment = ActionComponentDialogFragment.newInstance(action, dropInViewModel.checkoutConfiguration)
@@ -563,14 +567,16 @@ internal class DropInActivity :
     private fun isWeChatPayIntent(intent: Intent): Boolean = checkCompileOnly { WeChatPayUtils.isResultIntent(intent) }
 
     private fun handleActionIntentResponse(intent: Intent) {
-        val actionFragment = getActionFragment() ?: return
+        val actionFragment = getExistingActionFragment()
+        if (actionFragment == null) {
+            adyenLog(AdyenLogLevel.ERROR) { "ActionComponentDialogFragment is not loaded" }
+            return
+        }
         actionFragment.handleIntent(intent)
     }
 
-    private fun getActionFragment(): ActionComponentDialogFragment? {
-        val fragment = getFragmentByTag(ACTION_FRAGMENT_TAG) as? ActionComponentDialogFragment
-        if (fragment == null) adyenLog(AdyenLogLevel.ERROR) { "ActionComponentDialogFragment is not loaded" }
-        return fragment
+    private fun getExistingActionFragment(): ActionComponentDialogFragment? {
+        return getFragmentByTag(ACTION_FRAGMENT_TAG) as? ActionComponentDialogFragment
     }
 
     private fun initObservers() {


### PR DESCRIPTION
## Description
With Checkout API v66 and earlier, drop-in throws an error while trying to handle two separate 3DS2 actions returned by the API (fingerprint and challenge).

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Changes are tested manually
- [ ] Related issues are linked

COAND-906
