### PR TITLE
Fix storedPaymentMethod removal for older integrations

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -32,6 +32,7 @@ CheckoutConfiguration(
 - Actions no longer crash when your app uses obfuscation.
 - Drop-in no longer throws an error while handling a 3DS2 challenge on API 66 and below.
 - When the app process dies during action handling, then the state will now be restored and the payment can be continued.
+- Fixed ignoring `setEnableRemovingStoredPaymentMethods` flag set in Drop-in configuration for sessions.
 
 ## Changed
 - Flags are replaced by ISO codes in the phone number inputs (affected payment methods: MB Way, Pay Easy, Convenience Stores Japan, Online Banking Japan and Seven-Eleven).

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/SessionSetupConfiguration.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/SessionSetupConfiguration.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.sessions.core
 
 import com.adyen.checkout.core.exception.ModelSerializationException
 import com.adyen.checkout.core.internal.data.model.ModelObject
+import com.adyen.checkout.core.internal.data.model.getBooleanOrNull
 import com.adyen.checkout.core.internal.data.model.jsonToMap
 import kotlinx.parcelize.Parcelize
 import org.json.JSONException
@@ -20,7 +21,7 @@ data class SessionSetupConfiguration(
     val enableStoreDetails: Boolean? = null,
     val showInstallmentAmount: Boolean = false,
     val installmentOptions: Map<String, SessionSetupInstallmentOptions?>? = null,
-    val showRemovePaymentMethodButton: Boolean = false,
+    val showRemovePaymentMethodButton: Boolean? = null,
 ) : ModelObject() {
 
     companion object {
@@ -50,11 +51,11 @@ data class SessionSetupConfiguration(
             override fun deserialize(jsonObject: JSONObject): SessionSetupConfiguration {
                 return try {
                     SessionSetupConfiguration(
-                        enableStoreDetails = jsonObject.optBoolean(ENABLE_STORE_DETAILS),
+                        enableStoreDetails = jsonObject.getBooleanOrNull(ENABLE_STORE_DETAILS),
                         showInstallmentAmount = jsonObject.optBoolean(SHOW_INSTALLMENT_AMOUNT),
                         installmentOptions = jsonObject.optJSONObject(INSTALLMENT_OPTIONS)
                             ?.jsonToMap(SessionSetupInstallmentOptions.SERIALIZER),
-                        showRemovePaymentMethodButton = jsonObject.optBoolean(SHOW_REMOVE_PAYMENT_METHOD_BUTTON),
+                        showRemovePaymentMethodButton = jsonObject.getBooleanOrNull(SHOW_REMOVE_PAYMENT_METHOD_BUTTON),
                     )
                 } catch (e: JSONException) {
                     throw ModelSerializationException(SessionSetupConfiguration::class.java, e)


### PR DESCRIPTION
## Description
Fix the bug which cause storedPaymentMethod removal to not work for older integrations

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Changes are tested manually

COAND-913
