### PR TITLE
Create Twint payment component

### DIFF
--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/provider/ComponentProvider.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/provider/ComponentProvider.kt
@@ -97,6 +97,9 @@ import com.adyen.checkout.sepa.internal.provider.SepaComponentProvider
 import com.adyen.checkout.seveneleven.SevenElevenComponent
 import com.adyen.checkout.seveneleven.SevenElevenComponentState
 import com.adyen.checkout.seveneleven.internal.provider.SevenElevenComponentProvider
+import com.adyen.checkout.twint.TwintComponent
+import com.adyen.checkout.twint.TwintComponentState
+import com.adyen.checkout.twint.internal.provider.TwintComponentProvider
 import com.adyen.checkout.upi.UPIComponent
 import com.adyen.checkout.upi.UPIComponentState
 import com.adyen.checkout.upi.internal.provider.UPIComponentProvider
@@ -407,6 +410,15 @@ internal fun getComponentFor(
                 paymentMethod = paymentMethod,
                 checkoutConfiguration = checkoutConfiguration,
                 callback = componentCallback as ComponentCallback<SevenElevenComponentState>,
+            )
+        }
+
+        checkCompileOnly { TwintComponent.PROVIDER.isPaymentMethodSupported(paymentMethod) } -> {
+            TwintComponentProvider(dropInOverrideParams, analyticsManager).get(
+                fragment = fragment,
+                paymentMethod = paymentMethod,
+                checkoutConfiguration = checkoutConfiguration,
+                callback = componentCallback as ComponentCallback<TwintComponentState>,
             )
         }
 

--- a/twint-action/src/main/java/com/adyen/checkout/twint/action/TwintActionComponent.kt
+++ b/twint-action/src/main/java/com/adyen/checkout/twint/action/TwintActionComponent.kt
@@ -24,6 +24,9 @@ import com.adyen.checkout.ui.core.internal.ui.ComponentViewType
 import com.adyen.checkout.ui.core.internal.ui.ViewableComponent
 import kotlinx.coroutines.flow.Flow
 
+/**
+ * An [ActionComponent] that is able to handle the 'twint' action.
+ */
 class TwintActionComponent internal constructor(
     override val delegate: TwintActionDelegate,
     internal val actionComponentEventHandler: ActionComponentEventHandler,

--- a/twint-action/src/main/res/layout/view_twint_action.xml
+++ b/twint-action/src/main/res/layout/view_twint_action.xml
@@ -16,7 +16,7 @@
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragmentContainer"
-        android:name="com.adyen.checkout.twint.internal.ui.TwintActionFragment"
+        android:name="com.adyen.checkout.twint.action.internal.ui.TwintActionFragment"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 

--- a/twint/api/twint.api
+++ b/twint/api/twint.api
@@ -6,3 +6,109 @@ public final class com/adyen/checkout/twint/BuildConfig {
 	public fun <init> ()V
 }
 
+public final class com/adyen/checkout/twint/TwintComponent : androidx/lifecycle/ViewModel, com/adyen/checkout/action/core/internal/ActionHandlingComponent, com/adyen/checkout/components/core/internal/ButtonComponent, com/adyen/checkout/components/core/internal/PaymentComponent, com/adyen/checkout/ui/core/internal/ui/ViewableComponent {
+	public static final field Companion Lcom/adyen/checkout/twint/TwintComponent$Companion;
+	public static final field PAYMENT_METHOD_TYPES Ljava/util/List;
+	public static final field PROVIDER Lcom/adyen/checkout/twint/internal/provider/TwintComponentProvider;
+	public fun canHandleAction (Lcom/adyen/checkout/components/core/action/Action;)Z
+	public fun getDelegate ()Lcom/adyen/checkout/components/core/internal/ui/ComponentDelegate;
+	public fun getViewFlow ()Lkotlinx/coroutines/flow/Flow;
+	public fun handleAction (Lcom/adyen/checkout/components/core/action/Action;Landroid/app/Activity;)V
+	public fun handleIntent (Landroid/content/Intent;)V
+	public fun isConfirmationRequired ()Z
+	public fun setInteractionBlocked (Z)V
+	public fun setOnRedirectListener (Lkotlin/jvm/functions/Function0;)V
+	public fun submit ()V
+}
+
+public final class com/adyen/checkout/twint/TwintComponent$Companion {
+}
+
+public final class com/adyen/checkout/twint/TwintComponentState : com/adyen/checkout/components/core/PaymentComponentState {
+	public fun <init> (Lcom/adyen/checkout/components/core/PaymentComponentData;ZZ)V
+	public final fun component1 ()Lcom/adyen/checkout/components/core/PaymentComponentData;
+	public final fun component2 ()Z
+	public final fun component3 ()Z
+	public final fun copy (Lcom/adyen/checkout/components/core/PaymentComponentData;ZZ)Lcom/adyen/checkout/twint/TwintComponentState;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/twint/TwintComponentState;Lcom/adyen/checkout/components/core/PaymentComponentData;ZZILjava/lang/Object;)Lcom/adyen/checkout/twint/TwintComponentState;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getData ()Lcom/adyen/checkout/components/core/PaymentComponentData;
+	public fun hashCode ()I
+	public fun isInputValid ()Z
+	public fun isReady ()Z
+	public fun isValid ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/adyen/checkout/twint/TwintConfiguration : com/adyen/checkout/components/core/internal/ButtonConfiguration, com/adyen/checkout/components/core/internal/Configuration {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public synthetic fun <init> (Ljava/util/Locale;Lcom/adyen/checkout/core/Environment;Ljava/lang/String;Lcom/adyen/checkout/components/core/AnalyticsConfiguration;Lcom/adyen/checkout/components/core/Amount;Ljava/lang/Boolean;Lcom/adyen/checkout/action/core/GenericActionConfiguration;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun describeContents ()I
+	public fun getAmount ()Lcom/adyen/checkout/components/core/Amount;
+	public fun getAnalyticsConfiguration ()Lcom/adyen/checkout/components/core/AnalyticsConfiguration;
+	public fun getClientKey ()Ljava/lang/String;
+	public fun getEnvironment ()Lcom/adyen/checkout/core/Environment;
+	public final fun getGenericActionConfiguration ()Lcom/adyen/checkout/action/core/GenericActionConfiguration;
+	public fun getShopperLocale ()Ljava/util/Locale;
+	public final fun getShowStorePaymentField ()Ljava/lang/Boolean;
+	public final fun getStorePaymentMethod ()Ljava/lang/Boolean;
+	public fun isSubmitButtonVisible ()Ljava/lang/Boolean;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/adyen/checkout/twint/TwintConfiguration$Builder : com/adyen/checkout/action/core/internal/ActionHandlingPaymentMethodConfigurationBuilder, com/adyen/checkout/components/core/internal/ButtonConfigurationBuilder {
+	public fun <init> (Landroid/content/Context;Lcom/adyen/checkout/core/Environment;Ljava/lang/String;)V
+	public fun <init> (Lcom/adyen/checkout/core/Environment;Ljava/lang/String;)V
+	public fun <init> (Ljava/util/Locale;Lcom/adyen/checkout/core/Environment;Ljava/lang/String;)V
+	public synthetic fun buildInternal ()Lcom/adyen/checkout/components/core/internal/Configuration;
+	public final fun setShowStorePaymentField (Z)Lcom/adyen/checkout/twint/TwintConfiguration$Builder;
+	public final fun setStorePaymentMethod (Z)Lcom/adyen/checkout/twint/TwintConfiguration$Builder;
+	public synthetic fun setSubmitButtonVisible (Z)Lcom/adyen/checkout/components/core/internal/ButtonConfigurationBuilder;
+	public fun setSubmitButtonVisible (Z)Lcom/adyen/checkout/twint/TwintConfiguration$Builder;
+}
+
+public final class com/adyen/checkout/twint/TwintConfiguration$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/adyen/checkout/twint/TwintConfiguration;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/adyen/checkout/twint/TwintConfiguration;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/adyen/checkout/twint/TwintConfigurationKt {
+	public static final fun twint (Lcom/adyen/checkout/components/core/CheckoutConfiguration;Lkotlin/jvm/functions/Function1;)Lcom/adyen/checkout/components/core/CheckoutConfiguration;
+	public static synthetic fun twint$default (Lcom/adyen/checkout/components/core/CheckoutConfiguration;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/CheckoutConfiguration;
+}
+
+public final class com/adyen/checkout/twint/internal/provider/TwintComponentProvider : com/adyen/checkout/components/core/internal/provider/PaymentComponentProvider, com/adyen/checkout/sessions/core/internal/provider/SessionPaymentComponentProvider {
+	public synthetic fun get (Landroidx/activity/ComponentActivity;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/components/core/CheckoutConfiguration;Lcom/adyen/checkout/components/core/ComponentCallback;Lcom/adyen/checkout/components/core/OrderRequest;Ljava/lang/String;)Lcom/adyen/checkout/components/core/internal/PaymentComponent;
+	public fun get (Landroidx/activity/ComponentActivity;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/components/core/CheckoutConfiguration;Lcom/adyen/checkout/components/core/ComponentCallback;Lcom/adyen/checkout/components/core/OrderRequest;Ljava/lang/String;)Lcom/adyen/checkout/twint/TwintComponent;
+	public synthetic fun get (Landroidx/activity/ComponentActivity;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/components/core/internal/Configuration;Lcom/adyen/checkout/components/core/ComponentCallback;Lcom/adyen/checkout/components/core/OrderRequest;Ljava/lang/String;)Lcom/adyen/checkout/components/core/internal/PaymentComponent;
+	public fun get (Landroidx/activity/ComponentActivity;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/twint/TwintConfiguration;Lcom/adyen/checkout/components/core/ComponentCallback;Lcom/adyen/checkout/components/core/OrderRequest;Ljava/lang/String;)Lcom/adyen/checkout/twint/TwintComponent;
+	public synthetic fun get (Landroidx/activity/ComponentActivity;Lcom/adyen/checkout/sessions/core/CheckoutSession;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/components/core/CheckoutConfiguration;Lcom/adyen/checkout/sessions/core/SessionComponentCallback;Ljava/lang/String;)Lcom/adyen/checkout/components/core/internal/PaymentComponent;
+	public fun get (Landroidx/activity/ComponentActivity;Lcom/adyen/checkout/sessions/core/CheckoutSession;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/components/core/CheckoutConfiguration;Lcom/adyen/checkout/sessions/core/SessionComponentCallback;Ljava/lang/String;)Lcom/adyen/checkout/twint/TwintComponent;
+	public synthetic fun get (Landroidx/activity/ComponentActivity;Lcom/adyen/checkout/sessions/core/CheckoutSession;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/components/core/internal/Configuration;Lcom/adyen/checkout/sessions/core/SessionComponentCallback;Ljava/lang/String;)Lcom/adyen/checkout/components/core/internal/PaymentComponent;
+	public synthetic fun get (Landroidx/activity/ComponentActivity;Lcom/adyen/checkout/sessions/core/CheckoutSession;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/sessions/core/SessionComponentCallback;Ljava/lang/String;)Lcom/adyen/checkout/components/core/internal/PaymentComponent;
+	public fun get (Landroidx/activity/ComponentActivity;Lcom/adyen/checkout/sessions/core/CheckoutSession;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/sessions/core/SessionComponentCallback;Ljava/lang/String;)Lcom/adyen/checkout/twint/TwintComponent;
+	public fun get (Landroidx/activity/ComponentActivity;Lcom/adyen/checkout/sessions/core/CheckoutSession;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/twint/TwintConfiguration;Lcom/adyen/checkout/sessions/core/SessionComponentCallback;Ljava/lang/String;)Lcom/adyen/checkout/twint/TwintComponent;
+	public synthetic fun get (Landroidx/fragment/app/Fragment;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/components/core/CheckoutConfiguration;Lcom/adyen/checkout/components/core/ComponentCallback;Lcom/adyen/checkout/components/core/OrderRequest;Ljava/lang/String;)Lcom/adyen/checkout/components/core/internal/PaymentComponent;
+	public fun get (Landroidx/fragment/app/Fragment;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/components/core/CheckoutConfiguration;Lcom/adyen/checkout/components/core/ComponentCallback;Lcom/adyen/checkout/components/core/OrderRequest;Ljava/lang/String;)Lcom/adyen/checkout/twint/TwintComponent;
+	public synthetic fun get (Landroidx/fragment/app/Fragment;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/components/core/internal/Configuration;Lcom/adyen/checkout/components/core/ComponentCallback;Lcom/adyen/checkout/components/core/OrderRequest;Ljava/lang/String;)Lcom/adyen/checkout/components/core/internal/PaymentComponent;
+	public fun get (Landroidx/fragment/app/Fragment;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/twint/TwintConfiguration;Lcom/adyen/checkout/components/core/ComponentCallback;Lcom/adyen/checkout/components/core/OrderRequest;Ljava/lang/String;)Lcom/adyen/checkout/twint/TwintComponent;
+	public synthetic fun get (Landroidx/fragment/app/Fragment;Lcom/adyen/checkout/sessions/core/CheckoutSession;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/components/core/CheckoutConfiguration;Lcom/adyen/checkout/sessions/core/SessionComponentCallback;Ljava/lang/String;)Lcom/adyen/checkout/components/core/internal/PaymentComponent;
+	public fun get (Landroidx/fragment/app/Fragment;Lcom/adyen/checkout/sessions/core/CheckoutSession;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/components/core/CheckoutConfiguration;Lcom/adyen/checkout/sessions/core/SessionComponentCallback;Ljava/lang/String;)Lcom/adyen/checkout/twint/TwintComponent;
+	public synthetic fun get (Landroidx/fragment/app/Fragment;Lcom/adyen/checkout/sessions/core/CheckoutSession;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/components/core/internal/Configuration;Lcom/adyen/checkout/sessions/core/SessionComponentCallback;Ljava/lang/String;)Lcom/adyen/checkout/components/core/internal/PaymentComponent;
+	public synthetic fun get (Landroidx/fragment/app/Fragment;Lcom/adyen/checkout/sessions/core/CheckoutSession;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/sessions/core/SessionComponentCallback;Ljava/lang/String;)Lcom/adyen/checkout/components/core/internal/PaymentComponent;
+	public fun get (Landroidx/fragment/app/Fragment;Lcom/adyen/checkout/sessions/core/CheckoutSession;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/sessions/core/SessionComponentCallback;Ljava/lang/String;)Lcom/adyen/checkout/twint/TwintComponent;
+	public fun get (Landroidx/fragment/app/Fragment;Lcom/adyen/checkout/sessions/core/CheckoutSession;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/twint/TwintConfiguration;Lcom/adyen/checkout/sessions/core/SessionComponentCallback;Ljava/lang/String;)Lcom/adyen/checkout/twint/TwintComponent;
+	public synthetic fun get (Landroidx/savedstate/SavedStateRegistryOwner;Landroidx/lifecycle/ViewModelStoreOwner;Landroidx/lifecycle/LifecycleOwner;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/components/core/CheckoutConfiguration;Landroid/app/Application;Lcom/adyen/checkout/components/core/ComponentCallback;Lcom/adyen/checkout/components/core/OrderRequest;Ljava/lang/String;)Lcom/adyen/checkout/components/core/internal/PaymentComponent;
+	public fun get (Landroidx/savedstate/SavedStateRegistryOwner;Landroidx/lifecycle/ViewModelStoreOwner;Landroidx/lifecycle/LifecycleOwner;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/components/core/CheckoutConfiguration;Landroid/app/Application;Lcom/adyen/checkout/components/core/ComponentCallback;Lcom/adyen/checkout/components/core/OrderRequest;Ljava/lang/String;)Lcom/adyen/checkout/twint/TwintComponent;
+	public synthetic fun get (Landroidx/savedstate/SavedStateRegistryOwner;Landroidx/lifecycle/ViewModelStoreOwner;Landroidx/lifecycle/LifecycleOwner;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/components/core/internal/Configuration;Landroid/app/Application;Lcom/adyen/checkout/components/core/ComponentCallback;Lcom/adyen/checkout/components/core/OrderRequest;Ljava/lang/String;)Lcom/adyen/checkout/components/core/internal/PaymentComponent;
+	public fun get (Landroidx/savedstate/SavedStateRegistryOwner;Landroidx/lifecycle/ViewModelStoreOwner;Landroidx/lifecycle/LifecycleOwner;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/twint/TwintConfiguration;Landroid/app/Application;Lcom/adyen/checkout/components/core/ComponentCallback;Lcom/adyen/checkout/components/core/OrderRequest;Ljava/lang/String;)Lcom/adyen/checkout/twint/TwintComponent;
+	public synthetic fun get (Landroidx/savedstate/SavedStateRegistryOwner;Landroidx/lifecycle/ViewModelStoreOwner;Landroidx/lifecycle/LifecycleOwner;Lcom/adyen/checkout/sessions/core/CheckoutSession;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/components/core/CheckoutConfiguration;Landroid/app/Application;Lcom/adyen/checkout/sessions/core/SessionComponentCallback;Ljava/lang/String;)Lcom/adyen/checkout/components/core/internal/PaymentComponent;
+	public fun get (Landroidx/savedstate/SavedStateRegistryOwner;Landroidx/lifecycle/ViewModelStoreOwner;Landroidx/lifecycle/LifecycleOwner;Lcom/adyen/checkout/sessions/core/CheckoutSession;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/components/core/CheckoutConfiguration;Landroid/app/Application;Lcom/adyen/checkout/sessions/core/SessionComponentCallback;Ljava/lang/String;)Lcom/adyen/checkout/twint/TwintComponent;
+	public synthetic fun get (Landroidx/savedstate/SavedStateRegistryOwner;Landroidx/lifecycle/ViewModelStoreOwner;Landroidx/lifecycle/LifecycleOwner;Lcom/adyen/checkout/sessions/core/CheckoutSession;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/components/core/internal/Configuration;Landroid/app/Application;Lcom/adyen/checkout/sessions/core/SessionComponentCallback;Ljava/lang/String;)Lcom/adyen/checkout/components/core/internal/PaymentComponent;
+	public fun get (Landroidx/savedstate/SavedStateRegistryOwner;Landroidx/lifecycle/ViewModelStoreOwner;Landroidx/lifecycle/LifecycleOwner;Lcom/adyen/checkout/sessions/core/CheckoutSession;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/twint/TwintConfiguration;Landroid/app/Application;Lcom/adyen/checkout/sessions/core/SessionComponentCallback;Ljava/lang/String;)Lcom/adyen/checkout/twint/TwintComponent;
+	public fun isPaymentMethodSupported (Lcom/adyen/checkout/components/core/PaymentMethod;)Z
+}
+

--- a/twint/build.gradle
+++ b/twint/build.gradle
@@ -39,7 +39,11 @@ android {
 
 dependencies {
     // Checkout
+    api project(':action-core')
+    api project(':components-core')
+    api project(':sessions-core')
     api project(':twint-action')
+    api project(':ui-core')
 
     //Tests
     testImplementation project(':test-core')

--- a/twint/src/main/java/com/adyen/checkout/twint/TwintComponent.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/TwintComponent.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2024 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 10/7/2024.
+ */
+
+package com.adyen.checkout.twint
+
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.adyen.checkout.action.core.internal.ActionHandlingComponent
+import com.adyen.checkout.action.core.internal.DefaultActionHandlingComponent
+import com.adyen.checkout.action.core.internal.ui.GenericActionDelegate
+import com.adyen.checkout.components.core.PaymentMethodTypes
+import com.adyen.checkout.components.core.internal.ButtonComponent
+import com.adyen.checkout.components.core.internal.ComponentEventHandler
+import com.adyen.checkout.components.core.internal.PaymentComponent
+import com.adyen.checkout.components.core.internal.PaymentComponentEvent
+import com.adyen.checkout.components.core.internal.toActionCallback
+import com.adyen.checkout.components.core.internal.ui.ComponentDelegate
+import com.adyen.checkout.core.AdyenLogLevel
+import com.adyen.checkout.core.internal.util.adyenLog
+import com.adyen.checkout.twint.internal.provider.TwintComponentProvider
+import com.adyen.checkout.twint.internal.ui.DefaultTwintDelegate
+import com.adyen.checkout.twint.internal.ui.TwintDelegate
+import com.adyen.checkout.ui.core.internal.ui.ButtonDelegate
+import com.adyen.checkout.ui.core.internal.ui.ComponentViewType
+import com.adyen.checkout.ui.core.internal.ui.ViewableComponent
+import com.adyen.checkout.ui.core.internal.util.mergeViewFlows
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * A [PaymentComponent] that supports the [PaymentMethodTypes.TWINT] payment method.
+ */
+class TwintComponent internal constructor(
+    private val twintDelegate: TwintDelegate,
+    private val genericActionDelegate: GenericActionDelegate,
+    private val actionHandlingComponent: DefaultActionHandlingComponent,
+    internal val componentEventHandler: ComponentEventHandler<TwintComponentState>,
+) : ViewModel(),
+    PaymentComponent,
+    ViewableComponent,
+    ButtonComponent,
+    ActionHandlingComponent by actionHandlingComponent {
+
+    override val delegate: ComponentDelegate get() = actionHandlingComponent.activeDelegate
+
+    override val viewFlow: Flow<ComponentViewType?> = mergeViewFlows(
+        viewModelScope,
+        twintDelegate.viewFlow,
+        genericActionDelegate.viewFlow,
+    )
+
+    init {
+        twintDelegate.initialize(viewModelScope)
+        genericActionDelegate.initialize(viewModelScope)
+        componentEventHandler.initialize(viewModelScope)
+    }
+
+    internal fun observe(
+        lifecycleOwner: LifecycleOwner,
+        callback: (PaymentComponentEvent<TwintComponentState>) -> Unit
+    ) {
+        twintDelegate.observe(lifecycleOwner, viewModelScope, callback)
+        genericActionDelegate.observe(lifecycleOwner, viewModelScope, callback.toActionCallback())
+    }
+
+    internal fun removeObserver() {
+        twintDelegate.removeObserver()
+        genericActionDelegate.removeObserver()
+    }
+
+    override fun setInteractionBlocked(isInteractionBlocked: Boolean) {
+        (delegate as? DefaultTwintDelegate)?.setInteractionBlocked(isInteractionBlocked)
+            ?: adyenLog(AdyenLogLevel.ERROR) { "Payment component is not interactable, ignoring." }
+    }
+
+    override fun isConfirmationRequired(): Boolean =
+        (twintDelegate as? ButtonDelegate)?.isConfirmationRequired() ?: false
+
+    override fun submit() {
+        (delegate as? ButtonDelegate)?.onSubmit()
+            ?: adyenLog(AdyenLogLevel.ERROR) { "Component is currently not submittable, ignoring." }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        adyenLog(AdyenLogLevel.DEBUG) { "onCleared" }
+        twintDelegate.onCleared()
+        genericActionDelegate.onCleared()
+        componentEventHandler.onCleared()
+    }
+
+    companion object {
+
+        @JvmField
+        val PROVIDER = TwintComponentProvider()
+
+        @JvmField
+        val PAYMENT_METHOD_TYPES = listOf(PaymentMethodTypes.TWINT)
+    }
+}

--- a/twint/src/main/java/com/adyen/checkout/twint/TwintComponentState.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/TwintComponentState.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2024 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 10/7/2024.
+ */
+
+package com.adyen.checkout.twint
+
+import com.adyen.checkout.components.core.PaymentComponentData
+import com.adyen.checkout.components.core.PaymentComponentState
+import com.adyen.checkout.components.core.paymentmethod.GenericPaymentMethod
+
+/**
+ * Represents the state of [TwintComponentState]
+ */
+data class TwintComponentState(
+    override val data: PaymentComponentData<GenericPaymentMethod>,
+    override val isInputValid: Boolean,
+    override val isReady: Boolean,
+) : PaymentComponentState<GenericPaymentMethod>

--- a/twint/src/main/java/com/adyen/checkout/twint/TwintConfiguration.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/TwintConfiguration.kt
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2024 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 10/7/2024.
+ */
+
+package com.adyen.checkout.twint
+
+import android.content.Context
+import com.adyen.checkout.action.core.GenericActionConfiguration
+import com.adyen.checkout.action.core.internal.ActionHandlingPaymentMethodConfigurationBuilder
+import com.adyen.checkout.components.core.Amount
+import com.adyen.checkout.components.core.AnalyticsConfiguration
+import com.adyen.checkout.components.core.CheckoutConfiguration
+import com.adyen.checkout.components.core.PaymentMethodTypes
+import com.adyen.checkout.components.core.internal.ButtonConfiguration
+import com.adyen.checkout.components.core.internal.ButtonConfigurationBuilder
+import com.adyen.checkout.components.core.internal.Configuration
+import com.adyen.checkout.components.core.internal.util.CheckoutConfigurationMarker
+import com.adyen.checkout.core.Environment
+import kotlinx.parcelize.Parcelize
+import java.util.Locale
+
+/**
+ * Configuration class for the [TwintComponent].
+ */
+@Parcelize
+class TwintConfiguration private constructor(
+    override val shopperLocale: Locale?,
+    override val environment: Environment,
+    override val clientKey: String,
+    override val analyticsConfiguration: AnalyticsConfiguration?,
+    override val amount: Amount?,
+    override val isSubmitButtonVisible: Boolean?,
+    val genericActionConfiguration: GenericActionConfiguration,
+    val showStorePaymentField: Boolean?,
+    val storePaymentMethod: Boolean?,
+) : Configuration, ButtonConfiguration {
+
+    class Builder :
+        ActionHandlingPaymentMethodConfigurationBuilder<TwintConfiguration, Builder>,
+        ButtonConfigurationBuilder {
+
+        private var isSubmitButtonVisible: Boolean? = null
+        private var showStorePaymentField: Boolean? = null
+        private var storePaymentMethod: Boolean? = null
+
+        /**
+         * Initialize a configuration builder with the required fields.
+         *
+         * The shopper locale will match the value passed to the API with the sessions flow, or the primary user locale
+         * on the device otherwise. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
+         *
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(environment: Environment, clientKey: String) : super(
+            environment,
+            clientKey,
+        )
+
+        /**
+         * Alternative constructor that uses the [context] to fetch the user locale and use it as a shopper locale.
+         *
+         * @param context A Context
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        @Deprecated("You can omit the context parameter")
+        constructor(context: Context, environment: Environment, clientKey: String) : super(
+            context,
+            environment,
+            clientKey,
+        )
+
+        /**
+         * Builder with parameters for a [TwintConfiguration].
+         *
+         * @param shopperLocale The [Locale] of the shopper.
+         * @param environment The [Environment] to be used for internal network calls from the SDK to Adyen.
+         * @param clientKey Your Client Key used for internal network calls from the SDK to Adyen.
+         */
+        constructor(shopperLocale: Locale, environment: Environment, clientKey: String) : super(
+            shopperLocale,
+            environment,
+            clientKey,
+        )
+
+        /**
+         * Set if the option to store the shopper's account for future payments should be shown as an input field.
+         *
+         * Default is true.
+         *
+         * Not applicable for the sessions flow. Check out the
+         * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set
+         * this value.
+         *
+         * @param showStorePaymentField [Boolean]
+         * @return [TwintConfiguration.Builder]
+         */
+        fun setShowStorePaymentField(showStorePaymentField: Boolean): Builder {
+            this.showStorePaymentField = showStorePaymentField
+            return this
+        }
+
+        /**
+         * Set if the shopper's account should be stored, when the store payment method switch is not presented to the
+         * shopper.
+         *
+         * Only applicable if [showStorePaymentField] is false.
+         *
+         * Default is false.
+         *
+         * @param storePaymentMethod [Boolean]
+         * @return [TwintConfiguration.Builder]
+         */
+        fun setStorePaymentMethod(storePaymentMethod: Boolean): Builder {
+            this.storePaymentMethod = storePaymentMethod
+            return this
+        }
+
+        /**
+         * Sets if submit button will be visible or not.
+         *
+         * Default is true.
+         *
+         * @param isSubmitButtonVisible If submit button should be visible or not.
+         */
+        override fun setSubmitButtonVisible(isSubmitButtonVisible: Boolean): Builder {
+            this.isSubmitButtonVisible = isSubmitButtonVisible
+            return this
+        }
+
+        override fun buildInternal() = TwintConfiguration(
+            isSubmitButtonVisible = isSubmitButtonVisible,
+            shopperLocale = shopperLocale,
+            environment = environment,
+            clientKey = clientKey,
+            analyticsConfiguration = analyticsConfiguration,
+            amount = amount,
+            genericActionConfiguration = genericActionConfigurationBuilder.build(),
+            showStorePaymentField = showStorePaymentField,
+            storePaymentMethod = storePaymentMethod,
+        )
+    }
+}
+
+fun CheckoutConfiguration.twint(
+    configuration: @CheckoutConfigurationMarker TwintConfiguration.Builder.() -> Unit = {}
+): CheckoutConfiguration {
+    val config = TwintConfiguration.Builder(environment, clientKey)
+        .apply {
+            shopperLocale?.let { setShopperLocale(it) }
+            amount?.let { setAmount(it) }
+            analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+        }
+        .apply(configuration)
+        .build()
+    addConfiguration(PaymentMethodTypes.TWINT, config)
+    return this
+}
+
+internal fun CheckoutConfiguration.getTwintConfiguration(): TwintConfiguration? {
+    return getConfiguration(PaymentMethodTypes.TWINT)
+}
+
+internal fun TwintConfiguration.toCheckoutConfiguration(): CheckoutConfiguration {
+    return CheckoutConfiguration(
+        shopperLocale = shopperLocale,
+        environment = environment,
+        clientKey = clientKey,
+        amount = amount,
+        analyticsConfiguration = analyticsConfiguration,
+    ) {
+        addConfiguration(PaymentMethodTypes.TWINT, this@toCheckoutConfiguration)
+
+        genericActionConfiguration.getAllConfigurations().forEach {
+            addActionConfiguration(it)
+        }
+    }
+}

--- a/twint/src/main/java/com/adyen/checkout/twint/TwintConfiguration.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/TwintConfiguration.kt
@@ -27,7 +27,9 @@ import java.util.Locale
  * Configuration class for the [TwintComponent].
  */
 @Parcelize
-class TwintConfiguration private constructor(
+class TwintConfiguration
+@Suppress("LongParameterList")
+private constructor(
     override val shopperLocale: Locale?,
     override val environment: Environment,
     override val clientKey: String,

--- a/twint/src/main/java/com/adyen/checkout/twint/internal/provider/TwintComponentProvider.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/internal/provider/TwintComponentProvider.kt
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2024 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 10/7/2024.
+ */
+
+package com.adyen.checkout.twint.internal.provider
+
+import android.app.Application
+import androidx.annotation.RestrictTo
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.savedstate.SavedStateRegistryOwner
+import com.adyen.checkout.action.core.internal.DefaultActionHandlingComponent
+import com.adyen.checkout.action.core.internal.provider.GenericActionComponentProvider
+import com.adyen.checkout.components.core.CheckoutConfiguration
+import com.adyen.checkout.components.core.ComponentCallback
+import com.adyen.checkout.components.core.Order
+import com.adyen.checkout.components.core.PaymentMethod
+import com.adyen.checkout.components.core.internal.ComponentEventHandler
+import com.adyen.checkout.components.core.internal.DefaultComponentEventHandler
+import com.adyen.checkout.components.core.internal.analytics.AnalyticsManager
+import com.adyen.checkout.components.core.internal.analytics.AnalyticsManagerFactory
+import com.adyen.checkout.components.core.internal.analytics.AnalyticsSource
+import com.adyen.checkout.components.core.internal.provider.PaymentComponentProvider
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
+import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
+import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
+import com.adyen.checkout.components.core.internal.util.get
+import com.adyen.checkout.components.core.internal.util.viewModelFactory
+import com.adyen.checkout.core.exception.ComponentException
+import com.adyen.checkout.core.internal.data.api.HttpClient
+import com.adyen.checkout.core.internal.data.api.HttpClientFactory
+import com.adyen.checkout.core.internal.util.LocaleProvider
+import com.adyen.checkout.sessions.core.CheckoutSession
+import com.adyen.checkout.sessions.core.SessionComponentCallback
+import com.adyen.checkout.sessions.core.internal.SessionComponentEventHandler
+import com.adyen.checkout.sessions.core.internal.SessionInteractor
+import com.adyen.checkout.sessions.core.internal.SessionSavedStateHandleContainer
+import com.adyen.checkout.sessions.core.internal.data.api.SessionRepository
+import com.adyen.checkout.sessions.core.internal.data.api.SessionService
+import com.adyen.checkout.sessions.core.internal.provider.SessionPaymentComponentProvider
+import com.adyen.checkout.sessions.core.internal.ui.model.SessionParamsFactory
+import com.adyen.checkout.twint.TwintComponent
+import com.adyen.checkout.twint.TwintComponentState
+import com.adyen.checkout.twint.TwintConfiguration
+import com.adyen.checkout.twint.internal.ui.DefaultTwintDelegate
+import com.adyen.checkout.twint.internal.ui.TwintDelegate
+import com.adyen.checkout.twint.toCheckoutConfiguration
+import com.adyen.checkout.ui.core.internal.ui.SubmitHandler
+
+class TwintComponentProvider
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+constructor(
+    private val dropInOverrideParams: DropInOverrideParams? = null,
+    private val analyticsManager: AnalyticsManager? = null,
+    private val localeProvider: LocaleProvider = LocaleProvider(),
+) :
+    PaymentComponentProvider<
+        TwintComponent,
+        TwintConfiguration,
+        TwintComponentState,
+        ComponentCallback<TwintComponentState>,
+        >,
+    SessionPaymentComponentProvider<
+        TwintComponent,
+        TwintConfiguration,
+        TwintComponentState,
+        SessionComponentCallback<TwintComponentState>,
+        > {
+
+    override fun get(
+        savedStateRegistryOwner: SavedStateRegistryOwner,
+        viewModelStoreOwner: ViewModelStoreOwner,
+        lifecycleOwner: LifecycleOwner,
+        paymentMethod: PaymentMethod,
+        checkoutConfiguration: CheckoutConfiguration,
+        application: Application,
+        componentCallback: ComponentCallback<TwintComponentState>,
+        order: Order?,
+        key: String?
+    ): TwintComponent {
+        assertSupported(paymentMethod)
+
+        val viewModelFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
+            val componentParams = CommonComponentParamsMapper().mapToParams(
+                checkoutConfiguration = checkoutConfiguration,
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = null,
+            )
+
+            val analyticsManager = analyticsManager ?: AnalyticsManagerFactory().provide(
+                componentParams = componentParams.commonComponentParams,
+                application = application,
+                source = AnalyticsSource.PaymentComponent(paymentMethod.type.orEmpty()),
+                sessionId = null,
+            )
+
+            val twintDelegate = DefaultTwintDelegate(
+                submitHandler = SubmitHandler(savedStateHandle),
+                analyticsManager = analyticsManager,
+                paymentMethod = paymentMethod,
+                order = order,
+                componentParams = componentParams.commonComponentParams,
+            )
+
+            createComponent(
+                checkoutConfiguration = checkoutConfiguration,
+                savedStateHandle = savedStateHandle,
+                application = application,
+                delegate = twintDelegate,
+                componentEventHandler = DefaultComponentEventHandler(),
+            )
+        }
+
+        return ViewModelProvider(viewModelStoreOwner, viewModelFactory)[key, TwintComponent::class.java]
+            .also { component ->
+                component.observe(lifecycleOwner) {
+                    component.componentEventHandler.onPaymentComponentEvent(it, componentCallback)
+                }
+            }
+    }
+
+    override fun get(
+        savedStateRegistryOwner: SavedStateRegistryOwner,
+        viewModelStoreOwner: ViewModelStoreOwner,
+        lifecycleOwner: LifecycleOwner,
+        paymentMethod: PaymentMethod,
+        configuration: TwintConfiguration,
+        application: Application,
+        componentCallback: ComponentCallback<TwintComponentState>,
+        order: Order?,
+        key: String?
+    ): TwintComponent {
+        return get(
+            savedStateRegistryOwner = savedStateRegistryOwner,
+            viewModelStoreOwner = viewModelStoreOwner,
+            lifecycleOwner = lifecycleOwner,
+            paymentMethod = paymentMethod,
+            checkoutConfiguration = configuration.toCheckoutConfiguration(),
+            application = application,
+            componentCallback = componentCallback,
+            order = order,
+            key = key,
+        )
+    }
+
+    override fun get(
+        savedStateRegistryOwner: SavedStateRegistryOwner,
+        viewModelStoreOwner: ViewModelStoreOwner,
+        lifecycleOwner: LifecycleOwner,
+        checkoutSession: CheckoutSession,
+        paymentMethod: PaymentMethod,
+        checkoutConfiguration: CheckoutConfiguration,
+        application: Application,
+        componentCallback: SessionComponentCallback<TwintComponentState>,
+        key: String?
+    ): TwintComponent {
+        assertSupported(paymentMethod)
+
+        val viewModelFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
+            val componentParams = CommonComponentParamsMapper().mapToParams(
+                checkoutConfiguration = checkoutConfiguration,
+                deviceLocale = localeProvider.getLocale(application),
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = SessionParamsFactory.create(checkoutSession),
+            )
+
+            val httpClient = HttpClientFactory.getHttpClient(componentParams.commonComponentParams.environment)
+
+            val analyticsManager = analyticsManager ?: AnalyticsManagerFactory().provide(
+                componentParams = componentParams.commonComponentParams,
+                application = application,
+                source = AnalyticsSource.PaymentComponent(paymentMethod.type.orEmpty()),
+                sessionId = checkoutSession.sessionSetupResponse.id,
+            )
+
+            val cashAppPayDelegate = DefaultTwintDelegate(
+                submitHandler = SubmitHandler(savedStateHandle),
+                analyticsManager = analyticsManager,
+                paymentMethod = paymentMethod,
+                order = checkoutSession.order,
+                componentParams = componentParams.commonComponentParams,
+            )
+
+            val sessionComponentEventHandler = createSessionComponentEventHandler(
+                savedStateHandle = savedStateHandle,
+                checkoutSession = checkoutSession,
+                httpClient = httpClient,
+                componentParams = componentParams.commonComponentParams,
+            )
+
+            createComponent(
+                checkoutConfiguration = checkoutConfiguration,
+                savedStateHandle = savedStateHandle,
+                application = application,
+                delegate = cashAppPayDelegate,
+                componentEventHandler = sessionComponentEventHandler,
+            )
+        }
+
+        return ViewModelProvider(viewModelStoreOwner, viewModelFactory)[key, TwintComponent::class.java]
+            .also { component ->
+                component.observe(lifecycleOwner) {
+                    component.componentEventHandler.onPaymentComponentEvent(it, componentCallback)
+                }
+            }
+    }
+
+    override fun get(
+        savedStateRegistryOwner: SavedStateRegistryOwner,
+        viewModelStoreOwner: ViewModelStoreOwner,
+        lifecycleOwner: LifecycleOwner,
+        checkoutSession: CheckoutSession,
+        paymentMethod: PaymentMethod,
+        configuration: TwintConfiguration,
+        application: Application,
+        componentCallback: SessionComponentCallback<TwintComponentState>,
+        key: String?
+    ): TwintComponent {
+        return get(
+            savedStateRegistryOwner = savedStateRegistryOwner,
+            viewModelStoreOwner = viewModelStoreOwner,
+            lifecycleOwner = lifecycleOwner,
+            checkoutSession = checkoutSession,
+            paymentMethod = paymentMethod,
+            checkoutConfiguration = configuration.toCheckoutConfiguration(),
+            application = application,
+            componentCallback = componentCallback,
+            key = key,
+        )
+    }
+
+    private fun createComponent(
+        checkoutConfiguration: CheckoutConfiguration,
+        savedStateHandle: SavedStateHandle,
+        application: Application,
+        delegate: TwintDelegate,
+        componentEventHandler: ComponentEventHandler<TwintComponentState>,
+    ): TwintComponent {
+        val genericActionDelegate = GenericActionComponentProvider(analyticsManager, dropInOverrideParams).getDelegate(
+            checkoutConfiguration = checkoutConfiguration,
+            savedStateHandle = savedStateHandle,
+            application = application,
+        )
+
+        return TwintComponent(
+            twintDelegate = delegate,
+            genericActionDelegate = genericActionDelegate,
+            actionHandlingComponent = DefaultActionHandlingComponent(genericActionDelegate, delegate),
+            componentEventHandler = componentEventHandler,
+        )
+    }
+
+    private fun createSessionComponentEventHandler(
+        savedStateHandle: SavedStateHandle,
+        checkoutSession: CheckoutSession,
+        httpClient: HttpClient,
+        componentParams: ComponentParams,
+    ): SessionComponentEventHandler<TwintComponentState> {
+        val sessionSavedStateHandleContainer = SessionSavedStateHandleContainer(
+            savedStateHandle = savedStateHandle,
+            checkoutSession = checkoutSession,
+        )
+
+        val sessionInteractor = SessionInteractor(
+            sessionRepository = SessionRepository(
+                sessionService = SessionService(httpClient),
+                clientKey = componentParams.clientKey,
+            ),
+            sessionModel = sessionSavedStateHandleContainer.getSessionModel(),
+            isFlowTakenOver = sessionSavedStateHandleContainer.isFlowTakenOver ?: false,
+        )
+
+        return SessionComponentEventHandler(
+            sessionInteractor = sessionInteractor,
+            sessionSavedStateHandleContainer = sessionSavedStateHandleContainer,
+        )
+    }
+
+    private fun assertSupported(paymentMethod: PaymentMethod) {
+        if (!isPaymentMethodSupported(paymentMethod)) {
+            throw ComponentException("Unsupported payment method ${paymentMethod.type}")
+        }
+    }
+
+    override fun isPaymentMethodSupported(paymentMethod: PaymentMethod): Boolean {
+        return TwintComponent.PAYMENT_METHOD_TYPES.contains(paymentMethod.type)
+    }
+}

--- a/twint/src/main/java/com/adyen/checkout/twint/internal/provider/TwintComponentProvider.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/internal/provider/TwintComponentProvider.kt
@@ -23,6 +23,7 @@ import com.adyen.checkout.components.core.Order
 import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.internal.ComponentEventHandler
 import com.adyen.checkout.components.core.internal.DefaultComponentEventHandler
+import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.analytics.AnalyticsManager
 import com.adyen.checkout.components.core.internal.analytics.AnalyticsManagerFactory
 import com.adyen.checkout.components.core.internal.analytics.AnalyticsSource
@@ -105,6 +106,7 @@ constructor(
             val twintDelegate = DefaultTwintDelegate(
                 submitHandler = SubmitHandler(savedStateHandle),
                 analyticsManager = analyticsManager,
+                observerRepository = PaymentObserverRepository(),
                 paymentMethod = paymentMethod,
                 order = order,
                 componentParams = componentParams,
@@ -184,6 +186,7 @@ constructor(
             val cashAppPayDelegate = DefaultTwintDelegate(
                 submitHandler = SubmitHandler(savedStateHandle),
                 analyticsManager = analyticsManager,
+                observerRepository = PaymentObserverRepository(),
                 paymentMethod = paymentMethod,
                 order = checkoutSession.order,
                 componentParams = componentParams,

--- a/twint/src/main/java/com/adyen/checkout/twint/internal/provider/TwintComponentProvider.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/internal/provider/TwintComponentProvider.kt
@@ -50,6 +50,7 @@ import com.adyen.checkout.twint.TwintComponentState
 import com.adyen.checkout.twint.TwintConfiguration
 import com.adyen.checkout.twint.internal.ui.DefaultTwintDelegate
 import com.adyen.checkout.twint.internal.ui.TwintDelegate
+import com.adyen.checkout.twint.internal.ui.model.TwintComponentParamsMapper
 import com.adyen.checkout.twint.toCheckoutConfiguration
 import com.adyen.checkout.ui.core.internal.ui.SubmitHandler
 
@@ -87,7 +88,7 @@ constructor(
         assertSupported(paymentMethod)
 
         val viewModelFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = CommonComponentParamsMapper().mapToParams(
+            val componentParams = TwintComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
                 checkoutConfiguration = checkoutConfiguration,
                 deviceLocale = localeProvider.getLocale(application),
                 dropInOverrideParams = dropInOverrideParams,
@@ -95,7 +96,7 @@ constructor(
             )
 
             val analyticsManager = analyticsManager ?: AnalyticsManagerFactory().provide(
-                componentParams = componentParams.commonComponentParams,
+                componentParams = componentParams,
                 application = application,
                 source = AnalyticsSource.PaymentComponent(paymentMethod.type.orEmpty()),
                 sessionId = null,
@@ -106,7 +107,7 @@ constructor(
                 analyticsManager = analyticsManager,
                 paymentMethod = paymentMethod,
                 order = order,
-                componentParams = componentParams.commonComponentParams,
+                componentParams = componentParams,
             )
 
             createComponent(
@@ -164,17 +165,17 @@ constructor(
         assertSupported(paymentMethod)
 
         val viewModelFactory = viewModelFactory(savedStateRegistryOwner, null) { savedStateHandle ->
-            val componentParams = CommonComponentParamsMapper().mapToParams(
+            val componentParams = TwintComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
                 checkoutConfiguration = checkoutConfiguration,
                 deviceLocale = localeProvider.getLocale(application),
                 dropInOverrideParams = dropInOverrideParams,
                 componentSessionParams = SessionParamsFactory.create(checkoutSession),
             )
 
-            val httpClient = HttpClientFactory.getHttpClient(componentParams.commonComponentParams.environment)
+            val httpClient = HttpClientFactory.getHttpClient(componentParams.environment)
 
             val analyticsManager = analyticsManager ?: AnalyticsManagerFactory().provide(
-                componentParams = componentParams.commonComponentParams,
+                componentParams = componentParams,
                 application = application,
                 source = AnalyticsSource.PaymentComponent(paymentMethod.type.orEmpty()),
                 sessionId = checkoutSession.sessionSetupResponse.id,
@@ -185,14 +186,14 @@ constructor(
                 analyticsManager = analyticsManager,
                 paymentMethod = paymentMethod,
                 order = checkoutSession.order,
-                componentParams = componentParams.commonComponentParams,
+                componentParams = componentParams,
             )
 
             val sessionComponentEventHandler = createSessionComponentEventHandler(
                 savedStateHandle = savedStateHandle,
                 checkoutSession = checkoutSession,
                 httpClient = httpClient,
-                componentParams = componentParams.commonComponentParams,
+                componentParams = componentParams,
             )
 
             createComponent(

--- a/twint/src/main/java/com/adyen/checkout/twint/internal/ui/DefaultTwintDelegate.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/internal/ui/DefaultTwintDelegate.kt
@@ -16,6 +16,8 @@ import com.adyen.checkout.components.core.internal.PaymentComponentEvent
 import com.adyen.checkout.components.core.internal.analytics.AnalyticsManager
 import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
 import com.adyen.checkout.twint.TwintComponentState
+import com.adyen.checkout.twint.internal.ui.model.TwintComponentParams
+import com.adyen.checkout.ui.core.internal.ui.ButtonComponentViewType
 import com.adyen.checkout.ui.core.internal.ui.ButtonDelegate
 import com.adyen.checkout.ui.core.internal.ui.ComponentViewType
 import com.adyen.checkout.ui.core.internal.ui.SubmitHandler
@@ -28,7 +30,7 @@ internal class DefaultTwintDelegate(
     private val analyticsManager: AnalyticsManager,
     private val paymentMethod: PaymentMethod,
     private val order: OrderRequest?,
-    override val componentParams: ComponentParams,
+    override val componentParams: TwintComponentParams,
 ) : TwintDelegate, ButtonDelegate {
 
     // TODO

--- a/twint/src/main/java/com/adyen/checkout/twint/internal/ui/DefaultTwintDelegate.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/internal/ui/DefaultTwintDelegate.kt
@@ -10,13 +10,20 @@ package com.adyen.checkout.twint.internal.ui
 
 import androidx.lifecycle.LifecycleOwner
 import com.adyen.checkout.components.core.OrderRequest
+import com.adyen.checkout.components.core.PaymentComponentData
 import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.PaymentMethodTypes
 import com.adyen.checkout.components.core.internal.PaymentComponentEvent
+import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.analytics.AnalyticsManager
-import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
+import com.adyen.checkout.components.core.internal.analytics.GenericEvents
+import com.adyen.checkout.components.core.paymentmethod.GenericPaymentMethod
+import com.adyen.checkout.core.AdyenLogLevel
+import com.adyen.checkout.core.internal.util.adyenLog
 import com.adyen.checkout.twint.TwintComponentState
 import com.adyen.checkout.twint.internal.ui.model.TwintComponentParams
+import com.adyen.checkout.twint.internal.ui.model.TwintInputData
+import com.adyen.checkout.twint.internal.ui.model.TwintOutputData
 import com.adyen.checkout.ui.core.internal.ui.ButtonComponentViewType
 import com.adyen.checkout.ui.core.internal.ui.ButtonDelegate
 import com.adyen.checkout.ui.core.internal.ui.ComponentViewType
@@ -25,13 +32,22 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 
+@Suppress("TooManyFunctions")
 internal class DefaultTwintDelegate(
     private val submitHandler: SubmitHandler<TwintComponentState>,
     private val analyticsManager: AnalyticsManager,
+    private val observerRepository: PaymentObserverRepository,
     private val paymentMethod: PaymentMethod,
     private val order: OrderRequest?,
     override val componentParams: TwintComponentParams,
 ) : TwintDelegate, ButtonDelegate {
+
+    private val inputData = TwintInputData()
+
+    private var outputData = createOutputData()
+
+    private val _componentStateFlow = MutableStateFlow(createComponentState())
+    override val componentStateFlow: Flow<TwintComponentState> = _componentStateFlow
 
     // TODO
     private val _viewFlow: MutableStateFlow<ComponentViewType?> = MutableStateFlow(null)
@@ -40,7 +56,21 @@ internal class DefaultTwintDelegate(
     override val submitFlow: Flow<TwintComponentState> = submitHandler.submitFlow
 
     override fun initialize(coroutineScope: CoroutineScope) {
+        submitHandler.initialize(coroutineScope, componentStateFlow)
 
+        initializeAnalytics(coroutineScope)
+
+        if (!isConfirmationRequired()) {
+            initiatePayment()
+        }
+    }
+
+    private fun initializeAnalytics(coroutineScope: CoroutineScope) {
+        adyenLog(AdyenLogLevel.VERBOSE) { "initializeAnalytics" }
+        analyticsManager.initialize(this, coroutineScope)
+
+        val event = GenericEvents.rendered(paymentMethod.type.orEmpty())
+        analyticsManager.trackEvent(event)
     }
 
     override fun observe(
@@ -48,31 +78,81 @@ internal class DefaultTwintDelegate(
         coroutineScope: CoroutineScope,
         callback: (PaymentComponentEvent<TwintComponentState>) -> Unit
     ) {
-
+        observerRepository.addObservers(
+            stateFlow = componentStateFlow,
+            exceptionFlow = null,
+            submitFlow = submitFlow,
+            lifecycleOwner = lifecycleOwner,
+            coroutineScope = coroutineScope,
+            callback = callback,
+        )
     }
 
     override fun removeObserver() {
+        observerRepository.removeObservers()
+    }
 
+    private fun createOutputData(): TwintOutputData {
+        return TwintOutputData(
+            isStorePaymentSelected = inputData.isStorePaymentSelected,
+        )
+    }
+
+    private fun createComponentState(
+        outputData: TwintOutputData = this.outputData
+    ): TwintComponentState {
+        val paymentMethod = GenericPaymentMethod(
+            type = paymentMethod.type,
+            checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
+            subtype = SDK_SUBTYPE,
+        )
+
+        val paymentComponentData = PaymentComponentData(
+            paymentMethod = paymentMethod,
+            order = order,
+            amount = componentParams.amount,
+            storePaymentMethod = shouldStorePaymentMethod(),
+        )
+
+        return TwintComponentState(
+            data = paymentComponentData,
+            isInputValid = outputData.isValid,
+            isReady = true,
+        )
+    }
+
+    private fun shouldStorePaymentMethod(): Boolean = when {
+        // Shopper is presented with store switch and selected it
+        componentParams.showStorePaymentField && outputData.isStorePaymentSelected -> true
+        // Shopper is not presented with store switch and configuration indicates storing the payment method
+        !componentParams.showStorePaymentField && componentParams.storePaymentMethod -> true
+        else -> false
     }
 
     override fun onSubmit() {
-
+        if (isConfirmationRequired()) {
+            initiatePayment()
+        }
     }
 
-    override fun isConfirmationRequired(): Boolean {
-        TODO("Not yet implemented")
+    private fun initiatePayment() {
+        val event = GenericEvents.submit(paymentMethod.type.orEmpty())
+        analyticsManager.trackEvent(event)
+
+        val state = _componentStateFlow.value
+        submitHandler.onSubmit(state = state)
     }
 
-    override fun shouldShowSubmitButton(): Boolean {
-        TODO("Not yet implemented")
-    }
+    override fun isConfirmationRequired(): Boolean =
+        _viewFlow.value is ButtonComponentViewType &&
+            componentParams.showStorePaymentField
 
-    override fun shouldEnableSubmitButton(): Boolean {
-        TODO("Not yet implemented")
-    }
+    override fun shouldShowSubmitButton(): Boolean = isConfirmationRequired() && componentParams.isSubmitButtonVisible
+
+    override fun shouldEnableSubmitButton(): Boolean = true
 
     internal fun setInteractionBlocked(isInteractionBlocked: Boolean) {
-        TODO("Not yet implemented")
+        submitHandler.setInteractionBlocked(isInteractionBlocked)
     }
 
     override fun getPaymentMethodType(): String =
@@ -80,5 +160,10 @@ internal class DefaultTwintDelegate(
 
     override fun onCleared() {
         removeObserver()
+        analyticsManager.clear(this)
+    }
+
+    companion object {
+        private const val SDK_SUBTYPE = "sdk"
     }
 }

--- a/twint/src/main/java/com/adyen/checkout/twint/internal/ui/DefaultTwintDelegate.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/internal/ui/DefaultTwintDelegate.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2024 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 10/7/2024.
+ */
+
+package com.adyen.checkout.twint.internal.ui
+
+import androidx.lifecycle.LifecycleOwner
+import com.adyen.checkout.components.core.OrderRequest
+import com.adyen.checkout.components.core.PaymentMethod
+import com.adyen.checkout.components.core.PaymentMethodTypes
+import com.adyen.checkout.components.core.internal.PaymentComponentEvent
+import com.adyen.checkout.components.core.internal.analytics.AnalyticsManager
+import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
+import com.adyen.checkout.twint.TwintComponentState
+import com.adyen.checkout.ui.core.internal.ui.ButtonDelegate
+import com.adyen.checkout.ui.core.internal.ui.ComponentViewType
+import com.adyen.checkout.ui.core.internal.ui.SubmitHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+internal class DefaultTwintDelegate(
+    private val submitHandler: SubmitHandler<TwintComponentState>,
+    private val analyticsManager: AnalyticsManager,
+    private val paymentMethod: PaymentMethod,
+    private val order: OrderRequest?,
+    override val componentParams: ComponentParams,
+) : TwintDelegate, ButtonDelegate {
+
+    // TODO
+    private val _viewFlow: MutableStateFlow<ComponentViewType?> = MutableStateFlow(null)
+    override val viewFlow: Flow<ComponentViewType?> = _viewFlow
+
+    override val submitFlow: Flow<TwintComponentState> = submitHandler.submitFlow
+
+    override fun initialize(coroutineScope: CoroutineScope) {
+
+    }
+
+    override fun observe(
+        lifecycleOwner: LifecycleOwner,
+        coroutineScope: CoroutineScope,
+        callback: (PaymentComponentEvent<TwintComponentState>) -> Unit
+    ) {
+
+    }
+
+    override fun removeObserver() {
+
+    }
+
+    override fun onSubmit() {
+
+    }
+
+    override fun isConfirmationRequired(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun shouldShowSubmitButton(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun shouldEnableSubmitButton(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    internal fun setInteractionBlocked(isInteractionBlocked: Boolean) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getPaymentMethodType(): String =
+        paymentMethod.type ?: PaymentMethodTypes.UNKNOWN
+
+    override fun onCleared() {
+        removeObserver()
+    }
+}

--- a/twint/src/main/java/com/adyen/checkout/twint/internal/ui/DefaultTwintDelegate.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/internal/ui/DefaultTwintDelegate.kt
@@ -49,8 +49,7 @@ internal class DefaultTwintDelegate(
     private val _componentStateFlow = MutableStateFlow(createComponentState())
     override val componentStateFlow: Flow<TwintComponentState> = _componentStateFlow
 
-    // TODO
-    private val _viewFlow: MutableStateFlow<ComponentViewType?> = MutableStateFlow(null)
+    private val _viewFlow: MutableStateFlow<ComponentViewType?> = MutableStateFlow(TwintComponentViewType)
     override val viewFlow: Flow<ComponentViewType?> = _viewFlow
 
     override val submitFlow: Flow<TwintComponentState> = submitHandler.submitFlow

--- a/twint/src/main/java/com/adyen/checkout/twint/internal/ui/TwintDelegate.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/internal/ui/TwintDelegate.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 10/7/2024.
+ */
+
+package com.adyen.checkout.twint.internal.ui
+
+import com.adyen.checkout.components.core.internal.ui.PaymentComponentDelegate
+import com.adyen.checkout.twint.TwintComponentState
+import com.adyen.checkout.ui.core.internal.ui.ViewProvidingDelegate
+
+internal interface TwintDelegate :
+    PaymentComponentDelegate<TwintComponentState>,
+    ViewProvidingDelegate {
+
+}

--- a/twint/src/main/java/com/adyen/checkout/twint/internal/ui/TwintDelegate.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/internal/ui/TwintDelegate.kt
@@ -11,9 +11,11 @@ package com.adyen.checkout.twint.internal.ui
 import com.adyen.checkout.components.core.internal.ui.PaymentComponentDelegate
 import com.adyen.checkout.twint.TwintComponentState
 import com.adyen.checkout.ui.core.internal.ui.ViewProvidingDelegate
+import kotlinx.coroutines.flow.Flow
 
 internal interface TwintDelegate :
     PaymentComponentDelegate<TwintComponentState>,
     ViewProvidingDelegate {
 
+    val componentStateFlow: Flow<TwintComponentState>
 }

--- a/twint/src/main/java/com/adyen/checkout/twint/internal/ui/TwintViewProvider.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/internal/ui/TwintViewProvider.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 10/7/2024.
+ */
+
+package com.adyen.checkout.twint.internal.ui
+
+import android.content.Context
+import com.adyen.checkout.twint.internal.ui.view.TwintView
+import com.adyen.checkout.ui.core.internal.ui.ButtonComponentViewType
+import com.adyen.checkout.ui.core.internal.ui.ComponentView
+import com.adyen.checkout.ui.core.internal.ui.ComponentViewType
+import com.adyen.checkout.ui.core.internal.ui.ViewProvider
+
+internal class TwintViewProvider : ViewProvider {
+
+    override fun getView(viewType: ComponentViewType, context: Context): ComponentView = when (viewType) {
+        TwintComponentViewType -> TwintView(context)
+        else -> throw IllegalArgumentException("Unsupported view type")
+    }
+}
+
+internal object TwintComponentViewType : ButtonComponentViewType {
+
+    override val viewProvider: ViewProvider get() = TwintViewProvider()
+
+    override val buttonTextResId: Int = ButtonComponentViewType.DEFAULT_BUTTON_TEXT_RES_ID
+}

--- a/twint/src/main/java/com/adyen/checkout/twint/internal/ui/model/TwintComponentParams.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/internal/ui/model/TwintComponentParams.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 10/7/2024.
+ */
+
+package com.adyen.checkout.twint.internal.ui.model
+
+import com.adyen.checkout.components.core.internal.ui.model.ButtonParams
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParams
+import com.adyen.checkout.components.core.internal.ui.model.ComponentParams
+
+internal data class TwintComponentParams(
+    private val commonComponentParams: CommonComponentParams,
+    override val isSubmitButtonVisible: Boolean,
+    val showStorePaymentField: Boolean,
+    val storePaymentMethod: Boolean,
+) : ComponentParams by commonComponentParams, ButtonParams

--- a/twint/src/main/java/com/adyen/checkout/twint/internal/ui/model/TwintComponentParamsMapper.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/internal/ui/model/TwintComponentParamsMapper.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 10/7/2024.
+ */
+
+package com.adyen.checkout.twint.internal.ui.model
+
+import com.adyen.checkout.components.core.CheckoutConfiguration
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParams
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
+import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
+import com.adyen.checkout.components.core.internal.ui.model.SessionParams
+import com.adyen.checkout.twint.TwintConfiguration
+import com.adyen.checkout.twint.getTwintConfiguration
+import java.util.Locale
+
+internal class TwintComponentParamsMapper(
+    private val commonComponentParamsMapper: CommonComponentParamsMapper,
+) {
+
+    fun mapToParams(
+        checkoutConfiguration: CheckoutConfiguration,
+        deviceLocale: Locale,
+        dropInOverrideParams: DropInOverrideParams?,
+        componentSessionParams: SessionParams?,
+    ): TwintComponentParams {
+        val commonComponentParamsMapperData = commonComponentParamsMapper.mapToParams(
+            checkoutConfiguration,
+            deviceLocale,
+            dropInOverrideParams,
+            componentSessionParams,
+        )
+
+        val twintConfiguration = checkoutConfiguration.getTwintConfiguration()
+
+        return mapToParamsInternal(
+            commonComponentParams = commonComponentParamsMapperData.commonComponentParams,
+            sessionParams = commonComponentParamsMapperData.sessionParams,
+            dropInOverrideParams = dropInOverrideParams,
+            twintConfiguration = twintConfiguration,
+        )
+    }
+
+    private fun mapToParamsInternal(
+        commonComponentParams: CommonComponentParams,
+        sessionParams: SessionParams?,
+        dropInOverrideParams: DropInOverrideParams?,
+        twintConfiguration: TwintConfiguration?,
+    ): TwintComponentParams {
+        return TwintComponentParams(
+            commonComponentParams = commonComponentParams,
+            isSubmitButtonVisible = dropInOverrideParams?.isSubmitButtonVisible
+                ?: twintConfiguration?.isSubmitButtonVisible ?: true,
+            showStorePaymentField = getShowStorePaymentField(sessionParams, twintConfiguration),
+            storePaymentMethod = twintConfiguration?.storePaymentMethod ?: false,
+        )
+    }
+
+    private fun getShowStorePaymentField(
+        sessionParams: SessionParams?,
+        twintConfiguration: TwintConfiguration?,
+    ): Boolean {
+        return sessionParams?.enableStoreDetails ?: twintConfiguration?.showStorePaymentField ?: true
+    }
+}

--- a/twint/src/main/java/com/adyen/checkout/twint/internal/ui/model/TwintInputData.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/internal/ui/model/TwintInputData.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 10/7/2024.
+ */
+
+package com.adyen.checkout.twint.internal.ui.model
+
+import com.adyen.checkout.components.core.internal.ui.model.InputData
+
+internal data class TwintInputData(
+    var isStorePaymentSelected: Boolean = false,
+) : InputData

--- a/twint/src/main/java/com/adyen/checkout/twint/internal/ui/model/TwintOutputData.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/internal/ui/model/TwintOutputData.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 10/7/2024.
+ */
+
+package com.adyen.checkout.twint.internal.ui.model
+
+import com.adyen.checkout.components.core.internal.ui.model.OutputData
+
+internal data class TwintOutputData(
+    val isStorePaymentSelected: Boolean,
+) : OutputData {
+
+    override val isValid: Boolean = true
+}

--- a/twint/src/main/java/com/adyen/checkout/twint/internal/ui/view/TwintView.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/internal/ui/view/TwintView.kt
@@ -23,7 +23,7 @@ internal class TwintView @JvmOverloads constructor(
 ) : LinearLayout(context, attrs, defStyleAttr), ComponentView {
 
     override fun initView(delegate: ComponentDelegate, coroutineScope: CoroutineScope, localizedContext: Context) {
-        // TODO: Initialize view
+        // TODO Initialize view
     }
 
     override fun highlightValidationErrors() = Unit

--- a/twint/src/main/java/com/adyen/checkout/twint/internal/ui/view/TwintView.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/internal/ui/view/TwintView.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 10/7/2024.
+ */
+
+package com.adyen.checkout.twint.internal.ui.view
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import android.widget.LinearLayout
+import com.adyen.checkout.components.core.internal.ui.ComponentDelegate
+import com.adyen.checkout.ui.core.internal.ui.ComponentView
+import kotlinx.coroutines.CoroutineScope
+
+internal class TwintView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+) : LinearLayout(context, attrs, defStyleAttr), ComponentView {
+
+    override fun initView(delegate: ComponentDelegate, coroutineScope: CoroutineScope, localizedContext: Context) {
+        // TODO: Initialize view
+    }
+
+    override fun highlightValidationErrors() = Unit
+
+    override fun getView(): View = this
+}

--- a/twint/src/test/java/com/adyen/checkout/twint/TwintComponentTest.kt
+++ b/twint/src/test/java/com/adyen/checkout/twint/TwintComponentTest.kt
@@ -1,32 +1,22 @@
-/*
- * Copyright (c) 2023 Adyen N.V.
- *
- * This file is open source and available under the MIT license. See the LICENSE file for more info.
- *
- * Created by oscars on 4/7/2023.
- */
-
-package com.adyen.checkout.cashapppay
+package com.adyen.checkout.twint
 
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.viewModelScope
 import com.adyen.checkout.action.core.internal.DefaultActionHandlingComponent
 import com.adyen.checkout.action.core.internal.ui.GenericActionDelegate
-import com.adyen.checkout.cashapppay.internal.ui.CashAppPayComponentViewType
-import com.adyen.checkout.cashapppay.internal.ui.CashAppPayDelegate
-import com.adyen.checkout.cashapppay.internal.ui.DefaultCashAppPayDelegate
-import com.adyen.checkout.cashapppay.internal.ui.StoredCashAppPayDelegate
 import com.adyen.checkout.components.core.internal.ComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentComponentEvent
 import com.adyen.checkout.test.LoggingExtension
 import com.adyen.checkout.test.TestDispatcherExtension
 import com.adyen.checkout.test.extensions.invokeOnCleared
 import com.adyen.checkout.test.extensions.test
+import com.adyen.checkout.twint.internal.ui.DefaultTwintDelegate
+import com.adyen.checkout.twint.internal.ui.TwintComponentViewType
+import com.adyen.checkout.twint.internal.ui.TwintDelegate
 import com.adyen.checkout.ui.core.internal.test.TestComponentViewType
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -41,22 +31,22 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 @ExtendWith(MockitoExtension::class, TestDispatcherExtension::class, LoggingExtension::class)
-internal class CashAppPayComponentTest(
-    @Mock private val cashAppPayDelegate: CashAppPayDelegate,
+internal class TwintComponentTest(
+    @Mock private val twintDelegate: TwintDelegate,
     @Mock private val genericActionDelegate: GenericActionDelegate,
     @Mock private val actionHandlingComponent: DefaultActionHandlingComponent,
-    @Mock private val componentEventHandler: ComponentEventHandler<CashAppPayComponentState>,
+    @Mock private val componentEventHandler: ComponentEventHandler<TwintComponentState>,
 ) {
 
-    private lateinit var component: CashAppPayComponent
+    private lateinit var component: TwintComponent
 
     @BeforeEach
     fun before() {
-        whenever(cashAppPayDelegate.viewFlow) doReturn MutableStateFlow(CashAppPayComponentViewType)
+        whenever(twintDelegate.viewFlow) doReturn MutableStateFlow(TwintComponentViewType)
         whenever(genericActionDelegate.viewFlow) doReturn MutableStateFlow(null)
 
-        component = CashAppPayComponent(
-            cashAppPayDelegate,
+        component = TwintComponent(
+            twintDelegate,
             genericActionDelegate,
             actionHandlingComponent,
             componentEventHandler,
@@ -64,53 +54,53 @@ internal class CashAppPayComponentTest(
     }
 
     @Test
-    fun `when component is created then delegates are initialized`() {
-        verify(cashAppPayDelegate).initialize(component.viewModelScope)
+    fun `when component is created, then delegates are initialized`() {
+        verify(twintDelegate).initialize(component.viewModelScope)
         verify(genericActionDelegate).initialize(component.viewModelScope)
         verify(componentEventHandler).initialize(component.viewModelScope)
     }
 
     @Test
-    fun `when component is cleared then delegates are cleared`() {
+    fun `when component is cleared, then delegates are cleared`() {
         component.invokeOnCleared()
 
-        verify(cashAppPayDelegate).onCleared()
+        verify(twintDelegate).onCleared()
         verify(genericActionDelegate).onCleared()
         verify(componentEventHandler).onCleared()
     }
 
     @Test
-    fun `when observe is called then observe in delegates is called`() {
+    fun `when observe is called, then observe in delegates is called`() {
         val lifecycleOwner = mock<LifecycleOwner>()
-        val callback: (PaymentComponentEvent<CashAppPayComponentState>) -> Unit = {}
+        val callback: (PaymentComponentEvent<TwintComponentState>) -> Unit = {}
 
         component.observe(lifecycleOwner, callback)
 
-        verify(cashAppPayDelegate).observe(lifecycleOwner, component.viewModelScope, callback)
+        verify(twintDelegate).observe(lifecycleOwner, component.viewModelScope, callback)
         verify(genericActionDelegate).observe(eq(lifecycleOwner), eq(component.viewModelScope), any())
     }
 
     @Test
-    fun `when removeObserver is called then removeObserver in delegates is called`() {
+    fun `when removeObserver is called, then removeObserver in delegates is called`() {
         component.removeObserver()
 
-        verify(cashAppPayDelegate).removeObserver()
+        verify(twintDelegate).removeObserver()
         verify(genericActionDelegate).removeObserver()
     }
 
     @Test
-    fun `when component is initialized then view flow should match cash app pay delegate view flow`() = runTest {
+    fun `when component is initialized, then view flow should match twint delegate view flow`() = runTest {
         val testViewFlow = component.viewFlow.test(testScheduler)
-        assertEquals(CashAppPayComponentViewType, testViewFlow.latestValue)
+        assertEquals(TwintComponentViewType, testViewFlow.latestValue)
     }
 
     @Test
-    fun `when cash app pay delegate view flow emits a value then component view flow should match that value`() =
+    fun `when cash app pay delegate view flow emits a value, then component view flow should match that value`() =
         runTest {
             val delegateViewFlow = MutableStateFlow(TestComponentViewType.VIEW_TYPE_1)
-            whenever(cashAppPayDelegate.viewFlow) doReturn delegateViewFlow
-            component = CashAppPayComponent(
-                cashAppPayDelegate,
+            whenever(twintDelegate.viewFlow) doReturn delegateViewFlow
+            component = TwintComponent(
+                twintDelegate,
                 genericActionDelegate,
                 actionHandlingComponent,
                 componentEventHandler,
@@ -126,11 +116,11 @@ internal class CashAppPayComponentTest(
         }
 
     @Test
-    fun `when action delegate view flow emits a value then component view flow should match that value`() = runTest {
+    fun `when action delegate view flow emits a value, then component view flow should match that value`() = runTest {
         val actionDelegateViewFlow = MutableStateFlow(TestComponentViewType.VIEW_TYPE_1)
         whenever(genericActionDelegate.viewFlow) doReturn actionDelegateViewFlow
-        component = CashAppPayComponent(
-            cashAppPayDelegate,
+        component = TwintComponent(
+            twintDelegate,
             genericActionDelegate,
             actionHandlingComponent,
             componentEventHandler,
@@ -139,7 +129,7 @@ internal class CashAppPayComponentTest(
         val testViewFlow = component.viewFlow.test(testScheduler)
         // this value should match the value of the main delegate and not the action delegate
         // and in practice the initial value of the action delegate view flow is always null so it should be ignored
-        assertEquals(CashAppPayComponentViewType, testViewFlow.latestValue)
+        assertEquals(TwintComponentViewType, testViewFlow.latestValue)
 
         actionDelegateViewFlow.emit(TestComponentViewType.VIEW_TYPE_2)
 
@@ -148,9 +138,9 @@ internal class CashAppPayComponentTest(
 
     @Test
     fun `when isConfirmationRequired and delegate is default, then delegate is called`() {
-        val delegate = mock<DefaultCashAppPayDelegate>()
-        whenever(delegate.viewFlow) doReturn MutableStateFlow(CashAppPayComponentViewType)
-        component = CashAppPayComponent(
+        val delegate = mock<DefaultTwintDelegate>()
+        whenever(delegate.viewFlow) doReturn MutableStateFlow(TwintComponentViewType)
+        component = TwintComponent(
             delegate,
             genericActionDelegate,
             actionHandlingComponent,
@@ -163,26 +153,10 @@ internal class CashAppPayComponentTest(
     }
 
     @Test
-    fun `when isConfirmationRequired and delegate is stored, then result is false`() {
-        val delegate = mock<StoredCashAppPayDelegate>()
-        whenever(delegate.viewFlow) doReturn MutableStateFlow(CashAppPayComponentViewType)
-        component = CashAppPayComponent(
-            delegate,
-            genericActionDelegate,
-            actionHandlingComponent,
-            componentEventHandler,
-        )
-
-        val result = component.isConfirmationRequired()
-
-        assertFalse(result)
-    }
-
-    @Test
     fun `when submit is called and active delegate is the payment delegate, then delegate onSubmit is called`() {
-        val delegate = mock<DefaultCashAppPayDelegate>()
-        whenever(delegate.viewFlow) doReturn MutableStateFlow(CashAppPayComponentViewType)
-        component = CashAppPayComponent(
+        val delegate = mock<DefaultTwintDelegate>()
+        whenever(delegate.viewFlow) doReturn MutableStateFlow(TwintComponentViewType)
+        component = TwintComponent(
             delegate,
             genericActionDelegate,
             actionHandlingComponent,
@@ -197,9 +171,9 @@ internal class CashAppPayComponentTest(
 
     @Test
     fun `when submit is called and active delegate is the action delegate, then delegate onSubmit is not called`() {
-        val delegate = mock<DefaultCashAppPayDelegate>()
-        whenever(delegate.viewFlow) doReturn MutableStateFlow(CashAppPayComponentViewType)
-        component = CashAppPayComponent(
+        val delegate = mock<DefaultTwintDelegate>()
+        whenever(delegate.viewFlow) doReturn MutableStateFlow(TwintComponentViewType)
+        component = TwintComponent(
             delegate,
             genericActionDelegate,
             actionHandlingComponent,

--- a/twint/src/test/java/com/adyen/checkout/twint/TwintConfigurationTest.kt
+++ b/twint/src/test/java/com/adyen/checkout/twint/TwintConfigurationTest.kt
@@ -1,0 +1,98 @@
+package com.adyen.checkout.twint
+
+import com.adyen.checkout.components.core.Amount
+import com.adyen.checkout.components.core.AnalyticsConfiguration
+import com.adyen.checkout.components.core.AnalyticsLevel
+import com.adyen.checkout.components.core.CheckoutConfiguration
+import com.adyen.checkout.core.Environment
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.util.Locale
+
+internal class TwintConfigurationTest {
+
+    @Test
+    fun `when creating the configuration through CheckoutConfiguration, then it should be the same as when the builder is used`() {
+        val checkoutConfiguration = CheckoutConfiguration(
+            shopperLocale = Locale.US,
+            environment = Environment.TEST,
+            clientKey = TEST_CLIENT_KEY,
+            amount = Amount("EUR", 123L),
+            analyticsConfiguration = AnalyticsConfiguration(AnalyticsLevel.ALL),
+        ) {
+            twint {
+                setShowStorePaymentField(true)
+                setStorePaymentMethod(true)
+                setSubmitButtonVisible(false)
+            }
+        }
+
+        val actual = checkoutConfiguration.getTwintConfiguration()
+
+        val expected = TwintConfiguration.Builder(
+            shopperLocale = Locale.US,
+            environment = Environment.TEST,
+            clientKey = TEST_CLIENT_KEY,
+        )
+            .setAmount(Amount("EUR", 123L))
+            .setAnalyticsConfiguration(AnalyticsConfiguration(AnalyticsLevel.ALL))
+            .setShowStorePaymentField(true)
+            .setStorePaymentMethod(true)
+            .setSubmitButtonVisible(false)
+            .build()
+
+        assertEquals(expected.shopperLocale, actual?.shopperLocale)
+        assertEquals(expected.environment, actual?.environment)
+        assertEquals(expected.clientKey, actual?.clientKey)
+        assertEquals(expected.amount, actual?.amount)
+        assertEquals(expected.analyticsConfiguration, actual?.analyticsConfiguration)
+        assertEquals(expected.showStorePaymentField, actual?.showStorePaymentField)
+        assertEquals(expected.storePaymentMethod, actual?.storePaymentMethod)
+        assertEquals(expected.isSubmitButtonVisible, actual?.isSubmitButtonVisible)
+    }
+
+    @Test
+    fun `when the configuration is mapped to CheckoutConfiguration, then CheckoutConfiguration is created correctly`() {
+        val config = TwintConfiguration.Builder(
+            shopperLocale = Locale.US,
+            environment = Environment.TEST,
+            clientKey = TEST_CLIENT_KEY,
+        )
+            .setAmount(Amount("EUR", 123L))
+            .setAnalyticsConfiguration(AnalyticsConfiguration(AnalyticsLevel.ALL))
+            .setShowStorePaymentField(true)
+            .setStorePaymentMethod(true)
+            .setSubmitButtonVisible(false)
+            .build()
+
+        val actual = config.toCheckoutConfiguration()
+
+        val expected = CheckoutConfiguration(
+            shopperLocale = Locale.US,
+            environment = Environment.TEST,
+            clientKey = TEST_CLIENT_KEY,
+            amount = Amount("EUR", 123L),
+            analyticsConfiguration = AnalyticsConfiguration(AnalyticsLevel.ALL),
+        )
+
+        assertEquals(expected.shopperLocale, actual.shopperLocale)
+        assertEquals(expected.environment, actual.environment)
+        assertEquals(expected.clientKey, actual.clientKey)
+        assertEquals(expected.amount, actual.amount)
+        assertEquals(expected.analyticsConfiguration, actual.analyticsConfiguration)
+
+        val actualTwintConfig = actual.getTwintConfiguration()
+        assertEquals(config.shopperLocale, actualTwintConfig?.shopperLocale)
+        assertEquals(config.environment, actualTwintConfig?.environment)
+        assertEquals(config.clientKey, actualTwintConfig?.clientKey)
+        assertEquals(config.amount, actualTwintConfig?.amount)
+        assertEquals(config.analyticsConfiguration, actualTwintConfig?.analyticsConfiguration)
+        assertEquals(config.showStorePaymentField, actualTwintConfig?.showStorePaymentField)
+        assertEquals(config.storePaymentMethod, actualTwintConfig?.storePaymentMethod)
+        assertEquals(config.isSubmitButtonVisible, actualTwintConfig?.isSubmitButtonVisible)
+    }
+
+    companion object {
+        private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
+    }
+}

--- a/twint/src/test/java/com/adyen/checkout/twint/internal/ui/DefaultTwintDelegateTest.kt
+++ b/twint/src/test/java/com/adyen/checkout/twint/internal/ui/DefaultTwintDelegateTest.kt
@@ -1,0 +1,261 @@
+package com.adyen.checkout.twint.internal.ui
+
+import com.adyen.checkout.components.core.Amount
+import com.adyen.checkout.components.core.CheckoutConfiguration
+import com.adyen.checkout.components.core.OrderRequest
+import com.adyen.checkout.components.core.PaymentMethod
+import com.adyen.checkout.components.core.internal.PaymentObserverRepository
+import com.adyen.checkout.components.core.internal.analytics.GenericEvents
+import com.adyen.checkout.components.core.internal.analytics.TestAnalyticsManager
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
+import com.adyen.checkout.core.Environment
+import com.adyen.checkout.test.TestDispatcherExtension
+import com.adyen.checkout.test.extensions.test
+import com.adyen.checkout.twint.TwintComponentState
+import com.adyen.checkout.twint.TwintConfiguration
+import com.adyen.checkout.twint.internal.ui.model.TwintComponentParamsMapper
+import com.adyen.checkout.twint.twint
+import com.adyen.checkout.ui.core.internal.ui.SubmitHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import java.util.Locale
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(MockitoExtension::class, TestDispatcherExtension::class)
+internal class DefaultTwintDelegateTest(
+    @Mock private val submitHandler: SubmitHandler<TwintComponentState>,
+) {
+
+    private lateinit var analyticsManager: TestAnalyticsManager
+    private lateinit var delegate: DefaultTwintDelegate
+
+    @BeforeEach
+    fun before() {
+        analyticsManager = TestAnalyticsManager()
+        delegate = createDefaultTwintDelegate()
+    }
+
+    @Nested
+    @DisplayName("when delegate is initialized")
+    inner class InitializeTest {
+
+        @Test
+        fun `no confirmation is required, then payment should be initiated`() = runTest {
+            delegate = createDefaultTwintDelegate(
+                createCheckoutConfiguration(Amount("USD", 10L)) {
+                    setShowStorePaymentField(false)
+                },
+            )
+            delegate.initialize(this)
+
+            verify(submitHandler).onSubmit(any())
+        }
+    }
+
+    @Nested
+    @DisplayName("when submit button is configured to be")
+    inner class SubmitButtonVisibilityTest {
+
+        @Test
+        fun `hidden, then it should not show`() {
+            delegate = createDefaultTwintDelegate(
+                configuration = createCheckoutConfiguration {
+                    setSubmitButtonVisible(false)
+                },
+            )
+
+            assertFalse(delegate.shouldShowSubmitButton())
+        }
+
+        @Test
+        fun `visible, then it should show`() {
+            delegate = createDefaultTwintDelegate(
+                configuration = createCheckoutConfiguration {
+                    setSubmitButtonVisible(true)
+                },
+            )
+
+            assertTrue(delegate.shouldShowSubmitButton())
+        }
+    }
+
+    @Nested
+    inner class SubmitButtonEnableTest {
+
+        @Test
+        fun `when shouldEnableSubmitButton is called, then true is returned`() {
+            assertTrue(delegate.shouldEnableSubmitButton())
+        }
+    }
+
+    @Nested
+    inner class SubmitHandlerTest {
+
+        @Test
+        fun `when delegate is initialized, then submit handler event is initialized`() = runTest {
+            val coroutineScope = CoroutineScope(UnconfinedTestDispatcher())
+            delegate.initialize(coroutineScope)
+            verify(submitHandler).initialize(coroutineScope, delegate.componentStateFlow)
+        }
+
+        @Test
+        fun `when delegate setInteractionBlocked is called, then submit handler setInteractionBlocked is called`() =
+            runTest {
+                delegate.setInteractionBlocked(true)
+                verify(submitHandler).setInteractionBlocked(true)
+            }
+    }
+
+    @Nested
+    @DisplayName("when onSubmit is called and")
+    inner class OnSubmitTest {
+
+        @Test
+        fun `the component doesn't require confirmation, then the submit handler should not be called`() = runTest {
+            delegate = createDefaultTwintDelegate(
+                createCheckoutConfiguration(Amount("USD", 0L)) {
+                    setShowStorePaymentField(false)
+                    setStorePaymentMethod(true)
+                },
+            )
+            delegate.initialize(this)
+
+            delegate.onSubmit()
+
+            // Called once on initialization, but shouldn't be called by onSubmit
+            verify(submitHandler, times(1)).onSubmit(any())
+        }
+    }
+
+    @Nested
+    inner class AnalyticsTest {
+
+        @Test
+        fun `when delegate is initialized, then analytics manager is initialized`() {
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+
+            analyticsManager.assertIsInitialized()
+        }
+
+        @Test
+        fun `when delegate is initialized, then render event is tracked`() {
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+
+            val expectedEvent = GenericEvents.rendered(TEST_PAYMENT_METHOD_TYPE)
+            analyticsManager.assertLastEventEquals(expectedEvent)
+        }
+
+        @Test
+        fun `when delegate is initialized, then submit event is not tracked`() {
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+
+            val expectedEvent = GenericEvents.submit(TEST_PAYMENT_METHOD_TYPE)
+            analyticsManager.assertLastEventNotEquals(expectedEvent)
+        }
+
+        @Test
+        fun `when delegate is initialized and confirmation is not required, then submit event is tracked`() {
+            delegate = createDefaultTwintDelegate(
+                createCheckoutConfiguration(Amount("USD", 10L)) {
+                    setShowStorePaymentField(false)
+                },
+            )
+
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+
+            val expectedEvent = GenericEvents.submit(TEST_PAYMENT_METHOD_TYPE)
+            analyticsManager.assertLastEventEquals(expectedEvent)
+        }
+
+        @Test
+        fun `when component state is valid, then payment method should contain checkoutAttemptId`() = runTest {
+            analyticsManager.setCheckoutAttemptId(TEST_CHECKOUT_ATTEMPT_ID)
+            delegate = createDefaultTwintDelegate()
+
+            val testFlow = delegate.componentStateFlow.test(testScheduler)
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+
+            assertEquals(TEST_CHECKOUT_ATTEMPT_ID, testFlow.latestValue.data.paymentMethod?.checkoutAttemptId)
+        }
+
+        @Test
+        fun `when onSubmit is called, then submit event is tracked`() {
+            delegate.onSubmit()
+
+            val expectedEvent = GenericEvents.submit(TEST_PAYMENT_METHOD_TYPE)
+            analyticsManager.assertLastEventEquals(expectedEvent)
+        }
+
+        @Test
+        fun `when onSubmit is called and confirmation is not required, then submit event is not tracked`() {
+            delegate = createDefaultTwintDelegate(
+                createCheckoutConfiguration(Amount("USD", 10L)) {
+                    setShowStorePaymentField(false)
+                },
+            )
+
+            delegate.onSubmit()
+
+            val expectedEvent = GenericEvents.submit(TEST_PAYMENT_METHOD_TYPE)
+            analyticsManager.assertLastEventNotEquals(expectedEvent)
+        }
+
+        @Test
+        fun `when delegate is cleared then analytics manager is cleared`() {
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+
+            delegate.onCleared()
+
+            analyticsManager.assertIsCleared()
+        }
+    }
+
+    private fun createDefaultTwintDelegate(
+        configuration: CheckoutConfiguration = createCheckoutConfiguration(),
+    ) = DefaultTwintDelegate(
+        submitHandler = submitHandler,
+        analyticsManager = analyticsManager,
+        observerRepository = PaymentObserverRepository(),
+        paymentMethod = PaymentMethod(type = TEST_PAYMENT_METHOD_TYPE),
+        order = TEST_ORDER,
+        componentParams = TwintComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = Locale.US,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+        ),
+    )
+
+    private fun createCheckoutConfiguration(
+        amount: Amount? = null,
+        configuration: TwintConfiguration.Builder.() -> Unit = {},
+    ) = CheckoutConfiguration(
+        shopperLocale = Locale.US,
+        environment = Environment.TEST,
+        clientKey = "test_qwertyuiopasdfghjklzxcvbnmqwerty",
+        amount = amount,
+    ) {
+        twint(configuration)
+    }
+
+    companion object {
+        private val TEST_ORDER = OrderRequest("PSP", "ORDER_DATA")
+        private const val TEST_CHECKOUT_ATTEMPT_ID = "TEST_CHECKOUT_ATTEMPT_ID"
+        private const val TEST_PAYMENT_METHOD_TYPE = "TEST_PAYMENT_METHOD_TYPE"
+    }
+}

--- a/twint/src/test/java/com/adyen/checkout/twint/internal/ui/model/TwintComponentParamsMapperTest.kt
+++ b/twint/src/test/java/com/adyen/checkout/twint/internal/ui/model/TwintComponentParamsMapperTest.kt
@@ -1,0 +1,350 @@
+package com.adyen.checkout.twint.internal.ui.model
+
+import com.adyen.checkout.components.core.Amount
+import com.adyen.checkout.components.core.AnalyticsConfiguration
+import com.adyen.checkout.components.core.AnalyticsLevel
+import com.adyen.checkout.components.core.CheckoutConfiguration
+import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
+import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParamsLevel
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParams
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
+import com.adyen.checkout.components.core.internal.ui.model.DropInOverrideParams
+import com.adyen.checkout.components.core.internal.ui.model.SessionInstallmentConfiguration
+import com.adyen.checkout.components.core.internal.ui.model.SessionParams
+import com.adyen.checkout.core.Environment
+import com.adyen.checkout.twint.TwintConfiguration
+import com.adyen.checkout.twint.twint
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.Locale
+
+internal class TwintComponentParamsMapperTest {
+
+    private val twintComponentParamsMapper = TwintComponentParamsMapper(CommonComponentParamsMapper())
+
+    @Test
+    fun `when drop-in override params are null and custom configuration fields are null then all fields should match`() {
+        val configuration = createCheckoutConfiguration()
+
+        val params = twintComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+        )
+
+        val expected = getComponentParams()
+
+        assertEquals(expected, params)
+    }
+
+    @Test
+    fun `when drop-in override params are null and custom configuration fields are set then all fields should match`() {
+        val configuration = CheckoutConfiguration(
+            shopperLocale = Locale.FRANCE,
+            environment = Environment.APSE,
+            clientKey = TEST_CLIENT_KEY_2,
+        ) {
+            twint {
+                setShowStorePaymentField(false)
+                setStorePaymentMethod(true)
+                setSubmitButtonVisible(false)
+            }
+        }
+
+        val params = twintComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+        )
+
+        val expected = getComponentParams(
+            isSubmitButtonVisible = false,
+            shopperLocale = Locale.FRANCE,
+            environment = Environment.APSE,
+            clientKey = TEST_CLIENT_KEY_2,
+            analyticsParams = AnalyticsParams(AnalyticsParamsLevel.ALL, TEST_CLIENT_KEY_2),
+            showStorePaymentField = false,
+            storePaymentMethod = true,
+        )
+
+        assertEquals(expected, params)
+    }
+
+    @Test
+    fun `when drop-in override params are set then they should override custom configuration fields`() {
+        val configuration = CheckoutConfiguration(
+            shopperLocale = Locale.GERMAN,
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+            amount = Amount(
+                currency = "CAD",
+                value = 1235_00L,
+            ),
+            analyticsConfiguration = AnalyticsConfiguration(AnalyticsLevel.NONE),
+        ) {
+            twint {
+                setAmount(Amount("USD", 1L))
+                setAnalyticsConfiguration(AnalyticsConfiguration(AnalyticsLevel.ALL))
+            }
+        }
+
+        val dropInOverrideParams = DropInOverrideParams(Amount("EUR", 123L), null)
+        val params =
+            twintComponentParamsMapper.mapToParams(
+                checkoutConfiguration = configuration,
+                deviceLocale = DEVICE_LOCALE,
+                dropInOverrideParams = dropInOverrideParams,
+                componentSessionParams = null,
+            )
+
+        val expected = getComponentParams(
+            shopperLocale = Locale.GERMAN,
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+            analyticsParams = AnalyticsParams(AnalyticsParamsLevel.NONE, TEST_CLIENT_KEY_2),
+            isCreatedByDropIn = true,
+            amount = Amount(
+                currency = "EUR",
+                value = 123L,
+            ),
+        )
+
+        assertEquals(expected, params)
+    }
+
+    @Test
+    fun `when setSubmitButtonVisible is set to false in twint configuration and drop-in override params are set then card component params should have isSubmitButtonVisible true`() {
+        val configuration = CheckoutConfiguration(
+            shopperLocale = Locale.GERMAN,
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+            amount = Amount(
+                currency = "CAD",
+                value = 1235_00L,
+            ),
+            analyticsConfiguration = AnalyticsConfiguration(AnalyticsLevel.NONE),
+        ) {
+            twint {
+                setAmount(Amount("USD", 1L))
+                setAnalyticsConfiguration(AnalyticsConfiguration(AnalyticsLevel.ALL))
+                setSubmitButtonVisible(false)
+            }
+        }
+
+        val dropInOverrideParams = DropInOverrideParams(Amount("EUR", 123L), null)
+        val params = twintComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = dropInOverrideParams,
+            componentSessionParams = null,
+        )
+
+        assertEquals(true, params.isSubmitButtonVisible)
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableStoreDetailsSource")
+    fun `showStorePaymentField should match value set in sessions if it exists, otherwise should match configuration`(
+        configurationValue: Boolean,
+        sessionsValue: Boolean?,
+        expectedValue: Boolean
+    ) {
+        val configuration = createCheckoutConfiguration {
+            setShowStorePaymentField(configurationValue)
+        }
+        val sessionParams = createSessionParams(
+            enableStoreDetails = sessionsValue,
+        )
+        val params = twintComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = null,
+            componentSessionParams = sessionParams,
+        )
+
+        val expected = getComponentParams(
+            showStorePaymentField = expectedValue,
+        )
+
+        assertEquals(expected, params)
+    }
+
+    @ParameterizedTest
+    @MethodSource("amountSource")
+    fun `amount should match value set in sessions then drop in then component configuration`(
+        configurationValue: Amount,
+        dropInValue: Amount?,
+        sessionsValue: Amount?,
+        expectedValue: Amount
+    ) {
+        val configuration = createCheckoutConfiguration(configurationValue)
+
+        val dropInOverrideParams = dropInValue?.let { DropInOverrideParams(it, null) }
+        val sessionParams = createSessionParams(
+            amount = sessionsValue,
+        )
+        val params = twintComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = dropInOverrideParams,
+            componentSessionParams = sessionParams,
+        )
+
+        val expected = getComponentParams(
+            amount = expectedValue,
+            isCreatedByDropIn = dropInOverrideParams != null,
+        )
+
+        assertEquals(expected, params)
+    }
+
+    @ParameterizedTest
+    @MethodSource("shopperLocaleSource")
+    fun `shopper locale should match value set in configuration then sessions then device locale`(
+        configurationValue: Locale?,
+        sessionsValue: Locale?,
+        deviceLocaleValue: Locale,
+        expectedValue: Locale,
+    ) {
+        val configuration = createCheckoutConfiguration(shopperLocale = configurationValue)
+
+        val sessionParams = createSessionParams(
+            shopperLocale = sessionsValue,
+        )
+
+        val params = twintComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = deviceLocaleValue,
+            dropInOverrideParams = null,
+            componentSessionParams = sessionParams,
+        )
+
+        val expected = getComponentParams(
+            shopperLocale = expectedValue,
+        )
+
+        assertEquals(expected, params)
+    }
+
+    @Test
+    fun `environment and client key should match value set in sessions`() {
+        val configuration = createCheckoutConfiguration()
+
+        val sessionParams = createSessionParams(
+            environment = Environment.INDIA,
+            clientKey = TEST_CLIENT_KEY_2,
+        )
+
+        val params = twintComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = null,
+            componentSessionParams = sessionParams,
+        )
+
+        val expected = getComponentParams(
+            environment = Environment.INDIA,
+            clientKey = TEST_CLIENT_KEY_2,
+        )
+
+        assertEquals(expected, params)
+    }
+
+    @Suppress("LongParameterList")
+    private fun getComponentParams(
+        shopperLocale: Locale = DEVICE_LOCALE,
+        environment: Environment = Environment.TEST,
+        clientKey: String = TEST_CLIENT_KEY_1,
+        analyticsParams: AnalyticsParams = AnalyticsParams(AnalyticsParamsLevel.ALL, TEST_CLIENT_KEY_1),
+        isCreatedByDropIn: Boolean = false,
+        amount: Amount? = null,
+        isSubmitButtonVisible: Boolean = true,
+        showStorePaymentField: Boolean = true,
+        storePaymentMethod: Boolean = false,
+    ) = TwintComponentParams(
+        commonComponentParams = CommonComponentParams(
+            shopperLocale = shopperLocale,
+            environment = environment,
+            clientKey = clientKey,
+            analyticsParams = analyticsParams,
+            isCreatedByDropIn = isCreatedByDropIn,
+            amount = amount,
+        ),
+        isSubmitButtonVisible = isSubmitButtonVisible,
+        showStorePaymentField = showStorePaymentField,
+        storePaymentMethod = storePaymentMethod,
+    )
+
+    private fun createCheckoutConfiguration(
+        amount: Amount? = null,
+        shopperLocale: Locale? = null,
+        configuration: TwintConfiguration.Builder.() -> Unit = {},
+    ) = CheckoutConfiguration(
+        shopperLocale = shopperLocale,
+        environment = Environment.TEST,
+        clientKey = TEST_CLIENT_KEY_1,
+        amount = amount,
+    ) {
+        twint(configuration)
+    }
+
+    @Suppress("LongParameterList")
+    private fun createSessionParams(
+        environment: Environment = Environment.TEST,
+        clientKey: String = TEST_CLIENT_KEY_1,
+        enableStoreDetails: Boolean? = null,
+        installmentConfiguration: SessionInstallmentConfiguration? = null,
+        showRemovePaymentMethodButton: Boolean? = null,
+        amount: Amount? = null,
+        returnUrl: String? = "",
+        shopperLocale: Locale? = null,
+    ) = SessionParams(
+        environment = environment,
+        clientKey = clientKey,
+        enableStoreDetails = enableStoreDetails,
+        installmentConfiguration = installmentConfiguration,
+        showRemovePaymentMethodButton = showRemovePaymentMethodButton,
+        amount = amount,
+        returnUrl = returnUrl,
+        shopperLocale = shopperLocale,
+    )
+
+    companion object {
+        private const val TEST_CLIENT_KEY_1 = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
+        private const val TEST_CLIENT_KEY_2 = "live_qwertyui34566776787zxcvbnmqwerty"
+        private val DEVICE_LOCALE = Locale("nl", "NL")
+
+        @JvmStatic
+        fun enableStoreDetailsSource() = listOf(
+            // configurationValue, sessionsValue, expectedValue
+            arguments(false, false, false),
+            arguments(false, true, true),
+            arguments(true, false, false),
+            arguments(true, true, true),
+            arguments(false, null, false),
+            arguments(true, null, true),
+        )
+
+        @JvmStatic
+        fun amountSource() = listOf(
+            // configurationValue, dropInValue, sessionsValue, expectedValue
+            arguments(Amount("EUR", 100), Amount("USD", 200), Amount("CAD", 300), Amount("CAD", 300)),
+            arguments(Amount("EUR", 100), Amount("USD", 200), null, Amount("USD", 200)),
+            arguments(Amount("EUR", 100), null, null, Amount("EUR", 100)),
+        )
+
+        @JvmStatic
+        fun shopperLocaleSource() = listOf(
+            // configurationValue, sessionsValue, deviceLocaleValue, expectedValue
+            arguments(null, null, Locale.US, Locale.US),
+            arguments(Locale.GERMAN, null, Locale.US, Locale.GERMAN),
+            arguments(null, Locale.CHINESE, Locale.US, Locale.CHINESE),
+            arguments(Locale.GERMAN, Locale.CHINESE, Locale.US, Locale.GERMAN),
+        )
+    }
+}


### PR DESCRIPTION
## Description
Create a Twint payment component.
Next step is to populate the view, so shoppers can use a switch to store their Twint.

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-927
