### PR TITLE
Fix skip to payment method list

### DIFF
--- a/components-core/src/main/java/com/adyen/checkout/components/core/PaymentMethodTypes.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/PaymentMethodTypes.kt
@@ -137,6 +137,12 @@ object PaymentMethodTypes {
     )
 
     // Payment methods that do not need a payment component, but only an action component
+    @Suppress("unused")
+    @Deprecated(
+        """
+        This list is no longer relevant nor maintained. To check which payment methods are supported by the 
+        InstantPayComponent use InstantPayComponent.PROVIDER.isPaymentMethodSupported.""",
+    )
     val SUPPORTED_ACTION_ONLY_PAYMENT_METHODS: List<String> = listOf(
         DUIT_NOW,
         PAY_NOW,

--- a/drop-in/build.gradle
+++ b/drop-in/build.gradle
@@ -84,6 +84,7 @@ dependencies {
 
     //Tests
     testImplementation testFixtures(project(':test-core'))
+    testImplementation testFixtures(project(':components-core'))
     testImplementation testLibraries.androidx.lifecycle
     testImplementation testLibraries.json
     testImplementation testLibraries.junit5

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModel.kt
@@ -39,12 +39,10 @@ import com.adyen.checkout.dropin.internal.ui.model.DropInOverrideParamsFactory
 import com.adyen.checkout.dropin.internal.ui.model.DropInParams
 import com.adyen.checkout.dropin.internal.ui.model.GiftCardPaymentConfirmationData
 import com.adyen.checkout.dropin.internal.ui.model.OrderModel
-import com.adyen.checkout.dropin.internal.util.checkCompileOnly
 import com.adyen.checkout.dropin.internal.util.isStoredPaymentSupported
 import com.adyen.checkout.giftcard.GiftCardComponentState
 import com.adyen.checkout.giftcard.internal.util.GiftCardBalanceStatus
 import com.adyen.checkout.giftcard.internal.util.GiftCardBalanceUtils
-import com.adyen.checkout.googlepay.GooglePayComponent
 import com.adyen.checkout.sessions.core.internal.data.model.SessionDetails
 import com.adyen.checkout.sessions.core.internal.data.model.mapToModel
 import kotlinx.coroutines.CoroutineDispatcher
@@ -157,14 +155,10 @@ internal class DropInViewModel(
         val noStored = getStoredPaymentMethods().isEmpty()
         val singlePm = getPaymentMethods().size == 1
 
-        val firstPaymentMethod = getPaymentMethods().firstOrNull()
+        val firstPaymentMethod = getPaymentMethods().firstOrNull() ?: return false
 
-        val paymentMethodHasComponent = firstPaymentMethod?.let {
-            PaymentMethodTypes.SUPPORTED_PAYMENT_METHODS.contains(it.type) &&
-                // google pay is supported, is not action only but does not have a UI component inside our code
-                !checkCompileOnly { GooglePayComponent.PROVIDER.isPaymentMethodSupported(it) } &&
-                !PaymentMethodTypes.SUPPORTED_ACTION_ONLY_PAYMENT_METHODS.contains(it.type)
-        } ?: false
+        val paymentMethodHasComponent = !SKIP_TO_SINGLE_PM_BLOCK_LIST.contains(firstPaymentMethod.type)
+            && PaymentMethodTypes.SUPPORTED_PAYMENT_METHODS.contains(firstPaymentMethod.type)
 
         return noStored && singlePm && paymentMethodHasComponent
     }
@@ -474,5 +468,22 @@ internal class DropInViewModel(
     override fun onCleared() {
         super.onCleared()
         analyticsManager.clear(this)
+    }
+
+    companion object {
+
+        // These payment methods are either action only or have no UI.
+        private val SKIP_TO_SINGLE_PM_BLOCK_LIST = listOf(
+            PaymentMethodTypes.DUIT_NOW,
+            PaymentMethodTypes.GOOGLE_PAY,
+            PaymentMethodTypes.GOOGLE_PAY_LEGACY,
+            PaymentMethodTypes.IDEAL,
+            PaymentMethodTypes.MULTIBANCO,
+            PaymentMethodTypes.PAY_NOW,
+            PaymentMethodTypes.PIX,
+            PaymentMethodTypes.PROMPT_PAY,
+            PaymentMethodTypes.TWINT,
+            PaymentMethodTypes.WECHAT_PAY_SDK,
+        )
     }
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModel.kt
@@ -149,6 +149,7 @@ internal class DropInViewModel(
         return getStoredPaymentMethods().firstOrNull { it.id == id } ?: StoredPaymentMethod()
     }
 
+    @Suppress("ReturnCount")
     fun shouldSkipToSinglePaymentMethod(): Boolean {
         if (!dropInParams.skipListWhenSinglePaymentMethod) return false
 
@@ -157,8 +158,8 @@ internal class DropInViewModel(
 
         val firstPaymentMethod = getPaymentMethods().firstOrNull() ?: return false
 
-        val paymentMethodHasComponent = !SKIP_TO_SINGLE_PM_BLOCK_LIST.contains(firstPaymentMethod.type)
-            && PaymentMethodTypes.SUPPORTED_PAYMENT_METHODS.contains(firstPaymentMethod.type)
+        val paymentMethodHasComponent = !SKIP_TO_SINGLE_PM_BLOCK_LIST.contains(firstPaymentMethod.type) &&
+            PaymentMethodTypes.SUPPORTED_PAYMENT_METHODS.contains(firstPaymentMethod.type)
 
         return noStored && singlePm && paymentMethodHasComponent
     }

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/DropInViewModelTest.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/DropInViewModelTest.kt
@@ -1,0 +1,192 @@
+package com.adyen.checkout.dropin.internal.ui
+
+import com.adyen.checkout.components.core.Amount
+import com.adyen.checkout.components.core.PaymentMethod
+import com.adyen.checkout.components.core.PaymentMethodTypes
+import com.adyen.checkout.components.core.PaymentMethodsApiResponse
+import com.adyen.checkout.components.core.StoredPaymentMethod
+import com.adyen.checkout.components.core.internal.analytics.TestAnalyticsManager
+import com.adyen.checkout.components.core.internal.data.api.OrderStatusRepository
+import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
+import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParamsLevel
+import com.adyen.checkout.core.Environment
+import com.adyen.checkout.dropin.internal.ui.model.DropInParams
+import com.adyen.checkout.test.LoggingExtension
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
+import java.util.Locale
+
+@ExtendWith(MockitoExtension::class, LoggingExtension::class)
+internal class DropInViewModelTest(
+    @Mock private val bundleHandler: DropInSavedStateHandleContainer,
+    @Mock private val orderStatusRepository: OrderStatusRepository,
+) {
+
+    private lateinit var viewModel: DropInViewModel
+
+    @BeforeEach
+    fun beforeEach() {
+        whenever(bundleHandler.checkoutConfiguration) doReturn mock()
+        whenever(bundleHandler.serviceComponentName) doReturn mock()
+    }
+
+    @ParameterizedTest
+    @MethodSource("shouldSkipToSinglePaymentMethodSource")
+    fun `when payment methods response contains, then should skip to component`(
+        skipListWhenSinglePaymentMethodConfig: Boolean,
+        paymentMethodsApiResponse: PaymentMethodsApiResponse,
+        expected: Boolean,
+    ) {
+        whenever(bundleHandler.paymentMethodsApiResponse) doReturn paymentMethodsApiResponse
+        viewModel = createDropInViewModel(createDropInParams(skipListWhenSinglePaymentMethodConfig))
+
+        val result = viewModel.shouldSkipToSinglePaymentMethod()
+
+        assertEquals(expected, result)
+    }
+
+    private fun createDropInViewModel(
+        dropInParams: DropInParams = createDropInParams(),
+    ) = DropInViewModel(
+        bundleHandler = bundleHandler,
+        orderStatusRepository = orderStatusRepository,
+        analyticsManager = TestAnalyticsManager(),
+        initialDropInParams = dropInParams,
+    )
+
+    private fun createDropInParams(
+        skipListWhenSinglePaymentMethod: Boolean = false,
+    ) = DropInParams(
+        shopperLocale = Locale.US,
+        environment = Environment.TEST,
+        clientKey = "test",
+        analyticsParams = AnalyticsParams(AnalyticsParamsLevel.ALL, "test"),
+        amount = Amount("USD", 10),
+        showPreselectedStoredPaymentMethod = true,
+        skipListWhenSinglePaymentMethod = skipListWhenSinglePaymentMethod,
+        isRemovingStoredPaymentMethodsEnabled = true,
+        additionalDataForDropInService = null,
+        overriddenPaymentMethodInformation = emptyMap(),
+    )
+
+    companion object {
+
+        @JvmStatic
+        fun shouldSkipToSinglePaymentMethodSource() = listOf(
+            // skipListWhenSinglePaymentMethodConfig, paymentMethodsApiResponse, expected
+            // Disabled in configuration
+            arguments(
+                false,
+                PaymentMethodsApiResponse(paymentMethods = listOf(PaymentMethod(PaymentMethodTypes.SCHEME))),
+                false,
+            ),
+
+            // Stored payment method available
+            arguments(
+                true,
+                PaymentMethodsApiResponse(
+                    storedPaymentMethods = listOf(StoredPaymentMethod(type = PaymentMethodTypes.SCHEME)),
+                    paymentMethods = listOf(PaymentMethod(PaymentMethodTypes.SCHEME)),
+                ),
+                false,
+            ),
+
+            // Multiple payment methods available
+            arguments(
+                true,
+                PaymentMethodsApiResponse(
+                    paymentMethods = listOf(
+                        PaymentMethod(PaymentMethodTypes.SCHEME),
+                        PaymentMethod(PaymentMethodTypes.ACH),
+                    ),
+                ),
+                false,
+            ),
+
+            // No payment methods available
+            arguments(
+                true,
+                PaymentMethodsApiResponse(paymentMethods = listOf()),
+                false,
+            ),
+
+            // No component available for payment method
+            arguments(
+                true,
+                createPayPaymentMethodsApiResponse(listOf("UNSUPPORTED PM")),
+                false,
+            ),
+
+            // Payment methods that are either action only or have no UI
+            arguments(
+                true,
+                createPayPaymentMethodsApiResponse(listOf(PaymentMethodTypes.DUIT_NOW)),
+                false,
+            ),
+            arguments(
+                true,
+                createPayPaymentMethodsApiResponse(listOf(PaymentMethodTypes.GOOGLE_PAY)),
+                false,
+            ),
+            arguments(
+                true,
+                createPayPaymentMethodsApiResponse(listOf(PaymentMethodTypes.GOOGLE_PAY_LEGACY)),
+                false,
+            ),
+            arguments(
+                true,
+                createPayPaymentMethodsApiResponse(listOf(PaymentMethodTypes.IDEAL)),
+                false,
+            ),
+            arguments(
+                true,
+                createPayPaymentMethodsApiResponse(listOf(PaymentMethodTypes.MULTIBANCO)),
+                false,
+            ),
+            arguments(
+                true,
+                createPayPaymentMethodsApiResponse(listOf(PaymentMethodTypes.PAY_NOW)),
+                false,
+            ),
+            arguments(
+                true,
+                createPayPaymentMethodsApiResponse(listOf(PaymentMethodTypes.PIX)),
+                false,
+            ),
+            arguments(
+                true,
+                createPayPaymentMethodsApiResponse(listOf(PaymentMethodTypes.PROMPT_PAY)),
+                false,
+            ),
+            arguments(
+                true,
+                createPayPaymentMethodsApiResponse(listOf(PaymentMethodTypes.TWINT)),
+                false,
+            ),
+            arguments(
+                true,
+                createPayPaymentMethodsApiResponse(listOf(PaymentMethodTypes.WECHAT_PAY_SDK)),
+                false,
+            ),
+
+            // Supported payment method
+            arguments(
+                true,
+                createPayPaymentMethodsApiResponse(listOf(PaymentMethodTypes.SCHEME)),
+                true,
+            ),
+        )
+
+        private fun createPayPaymentMethodsApiResponse(paymentMethodTypes: List<String>): PaymentMethodsApiResponse =
+            PaymentMethodsApiResponse(paymentMethods = paymentMethodTypes.map { PaymentMethod(type = it) })
+    }
+}

--- a/instant/api/instant.api
+++ b/instant/api/instant.api
@@ -32,6 +32,7 @@ public final class com/adyen/checkout/instant/InstantComponentState : com/adyen/
 
 public final class com/adyen/checkout/instant/InstantPaymentComponent : androidx/lifecycle/ViewModel, com/adyen/checkout/action/core/internal/ActionHandlingComponent, com/adyen/checkout/components/core/internal/PaymentComponent, com/adyen/checkout/ui/core/internal/ui/ViewableComponent {
 	public static final field Companion Lcom/adyen/checkout/instant/InstantPaymentComponent$Companion;
+	public static final field PAYMENT_METHOD_TYPES Ljava/util/List;
 	public static final field PROVIDER Lcom/adyen/checkout/instant/internal/provider/InstantPaymentComponentProvider;
 	public fun canHandleAction (Lcom/adyen/checkout/components/core/action/Action;)Z
 	public fun getDelegate ()Lcom/adyen/checkout/components/core/internal/ui/ComponentDelegate;

--- a/instant/api/instant.api
+++ b/instant/api/instant.api
@@ -32,7 +32,6 @@ public final class com/adyen/checkout/instant/InstantComponentState : com/adyen/
 
 public final class com/adyen/checkout/instant/InstantPaymentComponent : androidx/lifecycle/ViewModel, com/adyen/checkout/action/core/internal/ActionHandlingComponent, com/adyen/checkout/components/core/internal/PaymentComponent, com/adyen/checkout/ui/core/internal/ui/ViewableComponent {
 	public static final field Companion Lcom/adyen/checkout/instant/InstantPaymentComponent$Companion;
-	public static final field PAYMENT_METHOD_TYPES Ljava/util/List;
 	public static final field PROVIDER Lcom/adyen/checkout/instant/internal/provider/InstantPaymentComponentProvider;
 	public fun canHandleAction (Lcom/adyen/checkout/components/core/action/Action;)Z
 	public fun getDelegate ()Lcom/adyen/checkout/components/core/internal/ui/ComponentDelegate;
@@ -81,6 +80,7 @@ public final class com/adyen/checkout/instant/InstantPaymentConfigurationKt {
 }
 
 public final class com/adyen/checkout/instant/internal/provider/InstantPaymentComponentProvider : com/adyen/checkout/components/core/internal/provider/PaymentComponentProvider, com/adyen/checkout/sessions/core/internal/provider/SessionPaymentComponentProvider {
+	public static final field Companion Lcom/adyen/checkout/instant/internal/provider/InstantPaymentComponentProvider$Companion;
 	public synthetic fun get (Landroidx/activity/ComponentActivity;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/components/core/CheckoutConfiguration;Lcom/adyen/checkout/components/core/ComponentCallback;Lcom/adyen/checkout/components/core/OrderRequest;Ljava/lang/String;)Lcom/adyen/checkout/components/core/internal/PaymentComponent;
 	public fun get (Landroidx/activity/ComponentActivity;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/components/core/CheckoutConfiguration;Lcom/adyen/checkout/components/core/ComponentCallback;Lcom/adyen/checkout/components/core/OrderRequest;Ljava/lang/String;)Lcom/adyen/checkout/instant/InstantPaymentComponent;
 	public synthetic fun get (Landroidx/activity/ComponentActivity;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/components/core/internal/Configuration;Lcom/adyen/checkout/components/core/ComponentCallback;Lcom/adyen/checkout/components/core/OrderRequest;Ljava/lang/String;)Lcom/adyen/checkout/components/core/internal/PaymentComponent;
@@ -110,5 +110,8 @@ public final class com/adyen/checkout/instant/internal/provider/InstantPaymentCo
 	public synthetic fun get (Landroidx/savedstate/SavedStateRegistryOwner;Landroidx/lifecycle/ViewModelStoreOwner;Landroidx/lifecycle/LifecycleOwner;Lcom/adyen/checkout/sessions/core/CheckoutSession;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/components/core/internal/Configuration;Landroid/app/Application;Lcom/adyen/checkout/sessions/core/SessionComponentCallback;Ljava/lang/String;)Lcom/adyen/checkout/components/core/internal/PaymentComponent;
 	public fun get (Landroidx/savedstate/SavedStateRegistryOwner;Landroidx/lifecycle/ViewModelStoreOwner;Landroidx/lifecycle/LifecycleOwner;Lcom/adyen/checkout/sessions/core/CheckoutSession;Lcom/adyen/checkout/components/core/PaymentMethod;Lcom/adyen/checkout/instant/InstantPaymentConfiguration;Landroid/app/Application;Lcom/adyen/checkout/sessions/core/SessionComponentCallback;Ljava/lang/String;)Lcom/adyen/checkout/instant/InstantPaymentComponent;
 	public fun isPaymentMethodSupported (Lcom/adyen/checkout/components/core/PaymentMethod;)Z
+}
+
+public final class com/adyen/checkout/instant/internal/provider/InstantPaymentComponentProvider$Companion {
 }
 

--- a/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentComponent.kt
+++ b/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentComponent.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.adyen.checkout.action.core.internal.ActionHandlingComponent
 import com.adyen.checkout.action.core.internal.DefaultActionHandlingComponent
 import com.adyen.checkout.action.core.internal.ui.GenericActionDelegate
+import com.adyen.checkout.components.core.PaymentMethodTypes
 import com.adyen.checkout.components.core.internal.ComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentComponent
 import com.adyen.checkout.components.core.internal.PaymentComponentEvent
@@ -74,5 +75,21 @@ class InstantPaymentComponent internal constructor(
 
         @JvmField
         val PROVIDER = InstantPaymentComponentProvider()
+
+        /**
+         * These are the payment method types known to be supported by the [InstantPaymentComponent]. There are
+         * payment method types that are not listed here that are actually supported. See
+         * [InstantPaymentComponentProvider.isPaymentMethodSupported] for more details.
+         */
+        @JvmField
+        val PAYMENT_METHOD_TYPES = listOf(
+            PaymentMethodTypes.DUIT_NOW,
+            PaymentMethodTypes.PAY_NOW,
+            PaymentMethodTypes.PIX,
+            PaymentMethodTypes.PROMPT_PAY,
+            PaymentMethodTypes.TWINT,
+            PaymentMethodTypes.WECHAT_PAY_SDK,
+            PaymentMethodTypes.MULTIBANCO,
+        )
     }
 }

--- a/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentComponent.kt
+++ b/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentComponent.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.viewModelScope
 import com.adyen.checkout.action.core.internal.ActionHandlingComponent
 import com.adyen.checkout.action.core.internal.DefaultActionHandlingComponent
 import com.adyen.checkout.action.core.internal.ui.GenericActionDelegate
-import com.adyen.checkout.components.core.PaymentMethodTypes
 import com.adyen.checkout.components.core.internal.ComponentEventHandler
 import com.adyen.checkout.components.core.internal.PaymentComponent
 import com.adyen.checkout.components.core.internal.PaymentComponentEvent
@@ -75,21 +74,5 @@ class InstantPaymentComponent internal constructor(
 
         @JvmField
         val PROVIDER = InstantPaymentComponentProvider()
-
-        /**
-         * These are the payment method types known to be supported by the [InstantPaymentComponent]. There are
-         * payment method types that are not listed here that are actually supported. See
-         * [InstantPaymentComponentProvider.isPaymentMethodSupported] for more details.
-         */
-        @JvmField
-        val PAYMENT_METHOD_TYPES = listOf(
-            PaymentMethodTypes.DUIT_NOW,
-            PaymentMethodTypes.PAY_NOW,
-            PaymentMethodTypes.PIX,
-            PaymentMethodTypes.PROMPT_PAY,
-            PaymentMethodTypes.TWINT,
-            PaymentMethodTypes.WECHAT_PAY_SDK,
-            PaymentMethodTypes.MULTIBANCO,
-        )
     }
 }

--- a/instant/src/main/java/com/adyen/checkout/instant/internal/provider/InstantPaymentComponentProvider.kt
+++ b/instant/src/main/java/com/adyen/checkout/instant/internal/provider/InstantPaymentComponentProvider.kt
@@ -267,7 +267,7 @@ constructor(
     override fun isPaymentMethodSupported(paymentMethod: PaymentMethod): Boolean {
         return when {
             PaymentMethodTypes.UNSUPPORTED_PAYMENT_METHODS.contains(paymentMethod.type) -> false
-            PaymentMethodTypes.SUPPORTED_ACTION_ONLY_PAYMENT_METHODS.contains(paymentMethod.type) -> true
+            InstantPaymentComponent.PAYMENT_METHOD_TYPES.contains(paymentMethod.type) -> true
             PaymentMethodTypes.SUPPORTED_PAYMENT_METHODS.contains(paymentMethod.type) -> false
             else -> true
         }

--- a/instant/src/main/java/com/adyen/checkout/instant/internal/provider/InstantPaymentComponentProvider.kt
+++ b/instant/src/main/java/com/adyen/checkout/instant/internal/provider/InstantPaymentComponentProvider.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.instant.internal.provider
 
 import android.app.Application
 import androidx.annotation.RestrictTo
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
@@ -267,9 +268,23 @@ constructor(
     override fun isPaymentMethodSupported(paymentMethod: PaymentMethod): Boolean {
         return when {
             PaymentMethodTypes.UNSUPPORTED_PAYMENT_METHODS.contains(paymentMethod.type) -> false
-            InstantPaymentComponent.PAYMENT_METHOD_TYPES.contains(paymentMethod.type) -> true
+            EXPLICITLY_SUPPORTED_PAYMENT_METHOD_TYPES.contains(paymentMethod.type) -> true
             PaymentMethodTypes.SUPPORTED_PAYMENT_METHODS.contains(paymentMethod.type) -> false
             else -> true
         }
+    }
+
+    companion object {
+
+        @VisibleForTesting
+        internal val EXPLICITLY_SUPPORTED_PAYMENT_METHOD_TYPES = listOf(
+            PaymentMethodTypes.DUIT_NOW,
+            PaymentMethodTypes.PAY_NOW,
+            PaymentMethodTypes.PIX,
+            PaymentMethodTypes.PROMPT_PAY,
+            PaymentMethodTypes.TWINT,
+            PaymentMethodTypes.WECHAT_PAY_SDK,
+            PaymentMethodTypes.MULTIBANCO,
+        )
     }
 }

--- a/instant/src/test/java/com/adyen/checkout/instant/internal/provider/InstantPaymentComponentProviderTest.kt
+++ b/instant/src/test/java/com/adyen/checkout/instant/internal/provider/InstantPaymentComponentProviderTest.kt
@@ -2,6 +2,7 @@ package com.adyen.checkout.instant.internal.provider
 
 import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.PaymentMethodTypes
+import com.adyen.checkout.instant.InstantPaymentComponent
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
@@ -38,7 +39,7 @@ internal class InstantPaymentComponentProviderTest {
             ) +
                 // Only action only payment methods are supported
                 PaymentMethodTypes.SUPPORTED_PAYMENT_METHODS.map {
-                    val isSupported = PaymentMethodTypes.SUPPORTED_ACTION_ONLY_PAYMENT_METHODS.contains(it)
+                    val isSupported = InstantPaymentComponent.PAYMENT_METHOD_TYPES.contains(it)
                     arguments(it, isSupported)
                 } +
                 // Unsupported payment methods are not supported

--- a/instant/src/test/java/com/adyen/checkout/instant/internal/provider/InstantPaymentComponentProviderTest.kt
+++ b/instant/src/test/java/com/adyen/checkout/instant/internal/provider/InstantPaymentComponentProviderTest.kt
@@ -2,7 +2,6 @@ package com.adyen.checkout.instant.internal.provider
 
 import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.PaymentMethodTypes
-import com.adyen.checkout.instant.InstantPaymentComponent
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
@@ -39,7 +38,8 @@ internal class InstantPaymentComponentProviderTest {
             ) +
                 // Only action only payment methods are supported
                 PaymentMethodTypes.SUPPORTED_PAYMENT_METHODS.map {
-                    val isSupported = InstantPaymentComponent.PAYMENT_METHOD_TYPES.contains(it)
+                    val isSupported =
+                        InstantPaymentComponentProvider.EXPLICITLY_SUPPORTED_PAYMENT_METHOD_TYPES.contains(it)
                     arguments(it, isSupported)
                 } +
                 // Unsupported payment methods are not supported


### PR DESCRIPTION
## Description
Separated `SUPPORTED_ACTION_ONLY_PAYMENT_METHODS` into two, one for drop-in skip to logic and one for `InstantPayComponent` supported payment methods.

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-962
