### PR TITLE
UPI - Improve payment methods list

### DIFF
--- a/components-core/src/main/java/com/adyen/checkout/components/core/PaymentMethodTypes.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/PaymentMethodTypes.kt
@@ -133,6 +133,9 @@ object PaymentMethodTypes {
         SEPA,
         TWINT,
         UPI,
+        UPI_INTENT,
+        UPI_COLLECT,
+        UPI_QR,
         WECHAT_PAY_SDK,
     )
 
@@ -178,8 +181,5 @@ object PaymentMethodTypes {
         WECHAT_PAY_MINI_PROGRAM,
         WECHAT_PAY_QR,
         WECHAT_PAY_WEB,
-        UPI_INTENT,
-        UPI_COLLECT,
-        UPI_QR,
     )
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModel.kt
@@ -127,7 +127,9 @@ internal class DropInViewModel(
     val addressLookupCompleteFlow: Flow<AddressLookupResult> = _addressLookupCompleteFlow.receiveAsFlow()
 
     fun getPaymentMethods(): List<PaymentMethod> {
-        return paymentMethodsApiResponse.paymentMethods.orEmpty()
+        return paymentMethodsApiResponse.paymentMethods?.filterNot { paymentMethod ->
+            IGNORED_PAYMENT_METHODS.any { it == paymentMethod.type }
+        }.orEmpty()
     }
 
     fun getStoredPaymentMethods(): List<StoredPaymentMethod> {
@@ -485,6 +487,12 @@ internal class DropInViewModel(
             PaymentMethodTypes.PROMPT_PAY,
             PaymentMethodTypes.TWINT,
             PaymentMethodTypes.WECHAT_PAY_SDK,
+        )
+
+        private val IGNORED_PAYMENT_METHODS = listOf(
+            PaymentMethodTypes.UPI_INTENT,
+            PaymentMethodTypes.UPI_COLLECT,
+            PaymentMethodTypes.UPI_QR,
         )
     }
 }


### PR DESCRIPTION
## Description
- Removed UPI payment methods from unsupported list
- Move the Drop-in payment method filtering to `DropInViewModel`
- Filtering is done in `getPaymentMethods()` method, to apply it for features like `skipListWhenSinglePaymentMethod`

I changed the initial approach of creating a `PaymentMethodManager`, since it was redundant with the current Drop-in structure. It could be a better fit after we refactor Drop-in.

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-965