### PR TITLE
Add lint rule to check if `android:text` is used directly

### DIFF
--- a/drop-in/src/main/res/layout/fragment_generic_action_component.xml
+++ b/drop-in/src/main/res/layout/fragment_generic_action_component.xml
@@ -34,10 +34,8 @@
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/button_finish"
-                style="@style/AdyenCheckout.Button.Colored"
+                style="@style/AdyenCheckout.DropIn.GenericAction.Button"
                 android:layout_width="match_parent"
-                android:layout_marginBottom="@dimen/standard_margin"
-                android:text="@string/checkout_voucher_finish"
                 android:visibility="gone"
                 tools:visibility="visible" />
 

--- a/drop-in/src/main/res/layout/fragment_gift_card_payment_confirmation.xml
+++ b/drop-in/src/main/res/layout/fragment_gift_card_payment_confirmation.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) 2021 Adyen N.V.
   ~
   ~ This file is open source and available under the MIT license. See the LICENSE file for more info.
@@ -7,12 +6,12 @@
   ~ Created by josephj on 1/10/2021.
   -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:paddingBottom="@dimen/standard_half_margin"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:paddingBottom="@dimen/standard_half_margin">
 
     <com.adyen.checkout.dropin.internal.ui.DropInBottomSheetToolbar
         android:id="@+id/bottom_sheet_toolbar"
@@ -23,19 +22,19 @@
         android:id="@+id/recyclerView_giftCards"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1"
-        android:clipToPadding="false"
         android:layout_marginTop="@dimen/standard_half_margin"
         android:layout_marginBottom="@dimen/standard_half_margin"
+        android:layout_weight="1"
+        android:clipToPadding="false"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         tools:itemCount="2"
-        tools:listitem="@layout/payment_methods_list_item"/>
+        tools:listitem="@layout/payment_methods_list_item" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/payButton"
         style="@style/AdyenCheckout.Button.Colored"
         android:layout_width="match_parent"
-        tools:text="Pay €13,37"/>
+        tools:text="Pay €13,37" />
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/textView_remainingBalance"
@@ -55,8 +54,8 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/change_payment_method_button"
+        style="@style/AdyenCheckout.DropIn.ChangePaymentMethodButton"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        style="@style/AdyenCheckout.Button.Secondary"
-        android:text="@string/change_payment_method" />
+        android:layout_height="wrap_content" />
+
 </LinearLayout>

--- a/drop-in/src/main/res/layout/fragment_stored_payment_method.xml
+++ b/drop-in/src/main/res/layout/fragment_stored_payment_method.xml
@@ -33,9 +33,8 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/payButton"
-        style="@style/AdyenCheckout.Button.Colored"
-        android:layout_width="match_parent"
-        android:text="@string/continue_button" />
+        style="@style/AdyenCheckout.DropIn.ContinueButton"
+        android:layout_width="match_parent" />
 
     <androidx.core.widget.ContentLoadingProgressBar
         android:id="@+id/progressBar"
@@ -47,8 +46,7 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/change_payment_method_button"
-        style="@style/AdyenCheckout.Button.Secondary"
+        style="@style/AdyenCheckout.DropIn.ChangePaymentMethodButton"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/change_payment_method" />
+        android:layout_height="wrap_content" />
 </LinearLayout>

--- a/drop-in/src/main/res/values/styles.xml
+++ b/drop-in/src/main/res/values/styles.xml
@@ -11,8 +11,7 @@
     <!-- Override 3DS2 Theme to match Checkout theme -->
     <style name="ThreeDS2Theme" parent="AdyenCheckout" tools:ignore="PrivateResource" />
 
-    <style name="AdyenCheckout.BottomSheetToolbar">
-    </style>
+    <style name="AdyenCheckout.BottomSheetToolbar"></style>
 
     <style name="AdyenCheckout.Toolbar" />
 
@@ -89,6 +88,23 @@
         <item name="android:textColor">?attr/colorPrimary</item>
         <item name="android:textIsSelectable">false</item>
         <item name="android:textSize">12sp</item>
+    </style>
+
+    <style name="AdyenCheckout.DropIn" />
+
+    <style name="AdyenCheckout.DropIn.GenericAction" />
+
+    <style name="AdyenCheckout.DropIn.GenericAction.Button" parent="AdyenCheckout.Button.Colored">
+        <item name="android:layout_marginBottom">@dimen/standard_margin</item>
+        <item name="android:text">@string/checkout_voucher_finish</item>
+    </style>
+
+    <style name="AdyenCheckout.DropIn.ContinueButton" parent="AdyenCheckout.Button.Colored">
+        <item name="android:text">@string/continue_button</item>
+    </style>
+
+    <style name="AdyenCheckout.DropIn.ChangePaymentMethodButton" parent="AdyenCheckout.Button.Secondary">
+        <item name="android:text">@string/change_payment_method</item>
     </style>
 
 </resources>

--- a/lint/src/main/java/com/adyen/checkout/lint/LintIssueRegistry.kt
+++ b/lint/src/main/java/com/adyen/checkout/lint/LintIssueRegistry.kt
@@ -20,5 +20,6 @@ internal class LintIssueRegistry : IssueRegistry() {
     override val issues: List<Issue> = listOf(
         NOT_ADYEN_LOG_ISSUE,
         OBJECT_IN_PUBLIC_SEALED_CLASS_ISSUE,
+        TEXT_IN_LAYOUT_XML_ISSUE,
     )
 }

--- a/lint/src/main/java/com/adyen/checkout/lint/TextInLayoutXml.kt
+++ b/lint/src/main/java/com/adyen/checkout/lint/TextInLayoutXml.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 14/8/2024.
+ */
+
+package com.adyen.checkout.lint
+
+import com.android.SdkConstants
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.LayoutDetector
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.XmlContext
+import org.w3c.dom.Attr
+
+internal val TEXT_IN_LAYOUT_XML_ISSUE = Issue.create(
+    id = "TextInLayoutXml",
+    briefDescription = "android:text should not be used directly",
+    explanation = """
+        Text should be defined in a style, so that merchants can easily override it.
+    """.trimIndent().replace(Regex("(\n*)\n"), "$1"),
+    implementation = Implementation(TextInLayoutXmlDetector::class.java, Scope.ALL_RESOURCES_SCOPE),
+    category = Category.MESSAGES,
+    priority = 5,
+    severity = Severity.ERROR,
+    androidSpecific = true,
+)
+
+internal class TextInLayoutXmlDetector : LayoutDetector() {
+
+    override fun getApplicableAttributes(): Collection<String> = listOf(
+        SdkConstants.ATTR_TEXT,
+    )
+
+    override fun visitAttribute(context: XmlContext, attribute: Attr) {
+        if (isTools(attribute)) return
+
+        context.report(
+            TEXT_IN_LAYOUT_XML_ISSUE,
+            attribute,
+            context.getLocation(attribute),
+            "Text should be defined in a style",
+        )
+    }
+
+    private fun isTools(attribute: Attr): Boolean {
+        return attribute.namespaceURI == SdkConstants.TOOLS_URI
+    }
+}

--- a/lint/src/main/java/com/adyen/checkout/lint/TextInLayoutXml.kt
+++ b/lint/src/main/java/com/adyen/checkout/lint/TextInLayoutXml.kt
@@ -20,7 +20,7 @@ import org.w3c.dom.Attr
 
 internal val TEXT_IN_LAYOUT_XML_ISSUE = Issue.create(
     id = "TextInLayoutXml",
-    briefDescription = "android:text should not be used directly",
+    briefDescription = "Text should not be set directly",
     explanation = """
         Text should be defined in a style, so that merchants can easily override it.
     """.trimIndent().replace(Regex("(\n*)\n"), "$1"),
@@ -35,6 +35,7 @@ internal class TextInLayoutXmlDetector : LayoutDetector() {
 
     override fun getApplicableAttributes(): Collection<String> = listOf(
         SdkConstants.ATTR_TEXT,
+        SdkConstants.ATTR_HINT,
     )
 
     override fun visitAttribute(context: XmlContext, attribute: Attr) {

--- a/lint/src/test/java/com/adyen/checkout/lint/TextInLayoutXmlTest.kt
+++ b/lint/src/test/java/com/adyen/checkout/lint/TextInLayoutXmlTest.kt
@@ -1,0 +1,108 @@
+package com.adyen.checkout.lint
+
+import com.android.tools.lint.checks.infrastructure.LintDetectorTest.xml
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import org.junit.Test
+
+internal class TextInLayoutXmlTest {
+
+    @Test
+    fun whenAndroidTextIsUsedDirectly_thenIssueIsDetected() {
+        lint()
+            .files(
+                xml(
+                    "/res/layout/some_view.xml",
+                    """
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <LinearLayout
+                        xmlns:android="http://schemas.android.com/apk/res/android"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical">
+                        
+                        <TextView
+                            android:id="@+id/test"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:text="test" />
+                    
+                    </LinearLayout>
+                    """.trimIndent(),
+                ),
+            )
+            .issues(TEXT_IN_LAYOUT_XML_ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expect(
+                """
+                res/layout/some_view.xml:12: Error: Text should be defined in a style [TextInLayoutXml]
+                        android:text="test" />
+                        ~~~~~~~~~~~~~~~~~~~
+                1 errors, 0 warnings
+                """,
+            )
+    }
+
+    @Test
+    fun whenAndroidTextIsNotUsed_thenIssueIsNotDetected() {
+        lint()
+            .files(
+                xml(
+                    "/res/layout/some_view.xml",
+                    """
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <LinearLayout
+                        xmlns:android="http://schemas.android.com/apk/res/android"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical">
+                        
+                        <TextView
+                            android:id="@+id/test"
+                            style="@styles/some_style"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:textSize="14sp" />
+                    
+                    </LinearLayout>
+                    """.trimIndent(),
+                ),
+            )
+            .issues(TEXT_IN_LAYOUT_XML_ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenAndroidTextIsUsedInTools_thenIssueIsNotDetected() {
+        lint()
+            .files(
+                xml(
+                    "/res/layout/some_view.xml",
+                    """
+                    <?xml version="1.0" encoding="utf-8"?>
+                    <LinearLayout
+                        xmlns:android="http://schemas.android.com/apk/res/android"
+                        xmlns:tools="http://schemas.android.com/tools"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical">
+                        
+                        <TextView
+                            android:id="@+id/test"
+                            style="@styles/some_style"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            tools:text="test" />
+                    
+                    </LinearLayout>
+                    """.trimIndent(),
+                ),
+            )
+            .issues(TEXT_IN_LAYOUT_XML_ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
+}

--- a/lint/src/test/java/com/adyen/checkout/lint/TextInLayoutXmlTest.kt
+++ b/lint/src/test/java/com/adyen/checkout/lint/TextInLayoutXmlTest.kt
@@ -25,6 +25,17 @@ internal class TextInLayoutXmlTest {
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:text="test" />
+                            
+                        <com.google.android.material.textfield.TextInputLayout
+                            android:id="@+id/textInputLayout"
+                            style="@style/AdyenCheckout.TextInputLayout"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content">
+                            
+                            <com.adyen.checkout.ui.core.internal.ui.view.AdyenTextInputEditText
+                                android:id="@+id/editText"
+                                android:hint="hint" />
+                        </com.google.android.material.textfield.TextInputLayout>
                     
                     </LinearLayout>
                     """.trimIndent(),
@@ -38,7 +49,10 @@ internal class TextInLayoutXmlTest {
                 res/layout/some_view.xml:12: Error: Text should be defined in a style [TextInLayoutXml]
                         android:text="test" />
                         ~~~~~~~~~~~~~~~~~~~
-                1 errors, 0 warnings
+                res/layout/some_view.xml:22: Error: Text should be defined in a style [TextInLayoutXml]
+                            android:hint="hint" />
+                            ~~~~~~~~~~~~~~~~~~~
+                2 errors, 0 warnings
                 """,
             )
     }

--- a/ui-core/src/main/res/layout/address_lookup_view.xml
+++ b/ui-core/src/main/res/layout/address_lookup_view.xml
@@ -30,43 +30,30 @@
 
     <TextView
         android:id="@+id/textView_error"
-        style="@style/AdyenCheckout.TextAppearance.Secondary"
+        style="@style/AdyenCheckout.AddressLookup.Empty.Title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginBottom="@dimen/standard_half_margin"
-        android:gravity="center"
-        android:text="@string/checkout_address_lookup_empty"
         android:visibility="gone" />
 
     <TextView
         android:id="@+id/textView_manualEntryError"
+        style="@style/AdyenCheckout.AddressLookup.Empty.Description"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:gravity="center"
-        android:text="@string/checkout_address_lookup_empty_description"
         android:visibility="gone" />
 
     <TextView
         android:id="@+id/textView_initialDisclaimer"
-        style="@style/AdyenCheckout.TextAppearance.Secondary"
+        style="@style/AdyenCheckout.AddressLookup.InitialDisclaimer.Title"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginBottom="@dimen/standard_half_margin"
-        android:gravity="center"
-        android:text="@string/checkout_address_lookup_initial" />
+        android:layout_height="wrap_content" />
 
     <TextView
         android:id="@+id/textView_manualEntryInitial"
+        style="@style/AdyenCheckout.AddressLookup.InitialDisclaimer.Description"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:gravity="center"
-        android:text="@string/checkout_address_lookup_initial_description"
         android:visibility="gone" />
-
 
     <com.adyen.checkout.ui.core.internal.ui.view.AddressFormInput
         android:id="@+id/addressFormInput"

--- a/ui-core/src/main/res/values/styles.xml
+++ b/ui-core/src/main/res/values/styles.xml
@@ -365,27 +365,29 @@
         <item name="android:text">@string/checkout_address_lookup_submit</item>
     </style>
 
-    <style name="AdyenCheckout.AddressLookup.InitialDisclaimer.Title" parent="AdyenCheckout.TextAppearance">
-        <item name="android:textColor">?attr/colorOnSurface</item>
-        <item name="android:textSize">12sp</item>
+    <style name="AdyenCheckout.AddressLookup.InitialDisclaimer.Title" parent="AdyenCheckout.TextAppearance.Secondary">
+        <item name="android:layout_gravity">center_horizontal</item>
+        <item name="android:layout_marginBottom">@dimen/standard_half_margin</item>
+        <item name="android:gravity">center</item>
         <item name="android:text">@string/checkout_address_lookup_initial</item>
     </style>
 
-    <style name="AdyenCheckout.AddressLookup.InitialDisclaimer.Description" parent="AdyenCheckout.TextAppearance">
-        <item name="android:textColor">?attr/colorOnSurface</item>
-        <item name="android:textSize">12sp</item>
+    <style name="AdyenCheckout.AddressLookup.InitialDisclaimer.Description" parent="AdyenCheckout.TextAppearance.Secondary">
+        <item name="android:layout_gravity">center_horizontal</item>
+        <item name="android:gravity">center</item>
         <item name="android:text">@string/checkout_address_lookup_initial_description</item>
     </style>
 
-    <style name="AdyenCheckout.AddressLookup.Empty.Title" parent="AdyenCheckout.TextAppearance">
-        <item name="android:textColor">?attr/colorOnSurface</item>
-        <item name="android:textSize">12sp</item>
+    <style name="AdyenCheckout.AddressLookup.Empty.Title" parent="AdyenCheckout.TextAppearance.Secondary">
+        <item name="android:layout_gravity">center_horizontal</item>
+        <item name="android:layout_marginBottom">@dimen/standard_half_margin</item>
+        <item name="android:gravity">center</item>
         <item name="android:text">@string/checkout_address_lookup_empty</item>
     </style>
 
-    <style name="AdyenCheckout.AddressLookup.Empty.Description" parent="AdyenCheckout.TextAppearance">
-        <item name="android:textColor">?attr/colorOnSurface</item>
-        <item name="android:textSize">12sp</item>
+    <style name="AdyenCheckout.AddressLookup.Empty.Description" parent="AdyenCheckout.TextAppearance.Secondary">
+        <item name="android:layout_gravity">center_horizontal</item>
+        <item name="android:gravity">center</item>
         <item name="android:text">@string/checkout_address_lookup_empty_description</item>
     </style>
 


### PR DESCRIPTION
## Description
Add lint rule to check if `android:text` is used directly and fix violations of this new rule.

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-956
