### PR TITLE
Add configData field to rendered  analytics event

### DIFF
--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/internal/provider/BcmcComponentProvider.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/internal/provider/BcmcComponentProvider.kt
@@ -23,6 +23,7 @@ import com.adyen.checkout.bcmc.internal.ui.model.BcmcComponentParamsMapper
 import com.adyen.checkout.bcmc.toCheckoutConfiguration
 import com.adyen.checkout.card.internal.data.api.BinLookupService
 import com.adyen.checkout.card.internal.data.api.DefaultDetectCardTypeRepository
+import com.adyen.checkout.card.internal.ui.CardConfigDataGenerator
 import com.adyen.checkout.card.internal.ui.CardValidationMapper
 import com.adyen.checkout.card.internal.ui.DefaultCardDelegate
 import com.adyen.checkout.components.core.CheckoutConfiguration
@@ -138,6 +139,7 @@ constructor(
                     addressRepository = addressRepository,
                     shopperLocale = componentParams.shopperLocale,
                 ),
+                cardConfigDataGenerator = CardConfigDataGenerator(),
             )
 
             val genericActionDelegate =
@@ -243,6 +245,7 @@ constructor(
                     addressRepository = addressRepository,
                     shopperLocale = componentParams.shopperLocale,
                 ),
+                cardConfigDataGenerator = CardConfigDataGenerator(),
             )
 
             val genericActionDelegate =

--- a/card/src/main/java/com/adyen/checkout/card/internal/provider/CardComponentProvider.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/provider/CardComponentProvider.kt
@@ -20,6 +20,7 @@ import com.adyen.checkout.card.CardComponentState
 import com.adyen.checkout.card.CardConfiguration
 import com.adyen.checkout.card.internal.data.api.BinLookupService
 import com.adyen.checkout.card.internal.data.api.DefaultDetectCardTypeRepository
+import com.adyen.checkout.card.internal.ui.CardConfigDataGenerator
 import com.adyen.checkout.card.internal.ui.CardValidationMapper
 import com.adyen.checkout.card.internal.ui.DefaultCardDelegate
 import com.adyen.checkout.card.internal.ui.StoredCardDelegate
@@ -158,6 +159,7 @@ constructor(
                     addressRepository = DefaultAddressRepository(AddressService(httpClient)),
                     shopperLocale = componentParams.shopperLocale,
                 ),
+                cardConfigDataGenerator = CardConfigDataGenerator(),
             )
 
             val genericActionDelegate =
@@ -268,6 +270,7 @@ constructor(
                     addressRepository = DefaultAddressRepository(AddressService(httpClient)),
                     shopperLocale = componentParams.shopperLocale,
                 ),
+                cardConfigDataGenerator = CardConfigDataGenerator(),
             )
 
             val genericActionDelegate =
@@ -381,6 +384,7 @@ constructor(
                 cardEncryptor = cardEncryptor,
                 publicKeyRepository = publicKeyRepository,
                 submitHandler = SubmitHandler(savedStateHandle),
+                cardConfigDataGenerator = CardConfigDataGenerator(),
             )
 
             val genericActionDelegate =
@@ -477,6 +481,7 @@ constructor(
                 cardEncryptor = cardEncryptor,
                 publicKeyRepository = publicKeyRepository,
                 submitHandler = SubmitHandler(savedStateHandle),
+                cardConfigDataGenerator = CardConfigDataGenerator(),
             )
 
             val genericActionDelegate =

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardConfigDataGenerator.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardConfigDataGenerator.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2024 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 6/8/2024.
+ */
+
+package com.adyen.checkout.card.internal.ui
+
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.card.KCPAuthVisibility
+import com.adyen.checkout.card.SocialSecurityNumberVisibility
+import com.adyen.checkout.card.internal.ui.model.CVCVisibility
+import com.adyen.checkout.card.internal.ui.model.CardComponentParams
+import com.adyen.checkout.card.internal.ui.model.StoredCVCVisibility
+import com.adyen.checkout.ui.core.internal.ui.model.AddressParams
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class CardConfigDataGenerator {
+
+    fun generate(
+        configuration: CardComponentParams,
+        isStored: Boolean,
+    ): Map<String, String> {
+        return mapOf(
+            // TODO Check if we need to send null or empty list
+            "billingAddressAllowedCountries" to ((configuration.addressParams as? AddressParams.FullAddress)
+                ?.supportedCountryCodes?.joinToString(",") ?: ""),
+            "billingAddressMode" to getBillingAddressMode(configuration.addressParams),
+            "billingAddressRequired" to (configuration.addressParams !is AddressParams.None).toString(),
+            "brands" to configuration.supportedCardBrands.joinToString(",") { it.txVariant },
+            "enableStoreDetails" to configuration.isStorePaymentFieldVisible.toString(),
+            "hasHolderName" to configuration.isHolderNameRequired.toString(),
+            "hasInstallmentOptions" to (configuration.installmentParams != null).toString(),
+            "hideCVC" to getHideCVC(configuration, isStored),
+            "holderNameRequired" to configuration.isHolderNameRequired.toString(),
+            "showInstallmentAmounts" to (configuration.installmentParams?.showInstallmentAmount ?: false).toString(),
+            "showKCPType" to getShowKCPType(configuration.kcpAuthVisibility),
+            "showPayButton" to configuration.isSubmitButtonVisible.toString(),
+            "socialSecurityNumberMode" to getSocialSecurityNumberMode(configuration.socialSecurityNumberVisibility),
+        )
+    }
+
+    private fun getBillingAddressMode(addressParams: AddressParams): String {
+        return when (addressParams) {
+            is AddressParams.FullAddress -> "full"
+            is AddressParams.Lookup -> "lookup"
+            AddressParams.None -> "none"
+            is AddressParams.PostalCode -> "partial"
+        }
+    }
+
+    private fun getHideCVC(configuration: CardComponentParams, isStored: Boolean): String {
+        return if (isStored) {
+            when (configuration.storedCVCVisibility) {
+                StoredCVCVisibility.SHOW -> "show"
+                StoredCVCVisibility.HIDE -> "hide"
+            }
+        } else {
+            when (configuration.cvcVisibility) {
+                CVCVisibility.ALWAYS_SHOW -> "show"
+                CVCVisibility.ALWAYS_HIDE -> "hide"
+                CVCVisibility.HIDE_FIRST -> "auto"
+            }
+        }
+    }
+
+    private fun getShowKCPType(kcpAuthVisibility: KCPAuthVisibility): String {
+        return when (kcpAuthVisibility) {
+            KCPAuthVisibility.SHOW -> "show"
+            KCPAuthVisibility.HIDE -> "hide"
+        }
+    }
+
+    private fun getSocialSecurityNumberMode(socialSecurityNumberVisibility: SocialSecurityNumberVisibility): String {
+        return when (socialSecurityNumberVisibility) {
+            SocialSecurityNumberVisibility.SHOW -> "show"
+            SocialSecurityNumberVisibility.HIDE -> "hide"
+        }
+    }
+}

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardConfigDataGenerator.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardConfigDataGenerator.kt
@@ -23,23 +23,29 @@ class CardConfigDataGenerator {
         configuration: CardComponentParams,
         isStored: Boolean,
     ): Map<String, String> {
-        return mapOf(
-            // TODO Check if we need to send null or empty list
-            "billingAddressAllowedCountries" to ((configuration.addressParams as? AddressParams.FullAddress)
-                ?.supportedCountryCodes?.joinToString(",") ?: ""),
-            "billingAddressMode" to getBillingAddressMode(configuration.addressParams),
-            "billingAddressRequired" to (configuration.addressParams !is AddressParams.None).toString(),
-            "brands" to configuration.supportedCardBrands.joinToString(",") { it.txVariant },
-            "enableStoreDetails" to configuration.isStorePaymentFieldVisible.toString(),
-            "hasHolderName" to configuration.isHolderNameRequired.toString(),
-            "hasInstallmentOptions" to (configuration.installmentParams != null).toString(),
-            "hideCVC" to getHideCVC(configuration, isStored),
-            "holderNameRequired" to configuration.isHolderNameRequired.toString(),
-            "showInstallmentAmounts" to (configuration.installmentParams?.showInstallmentAmount ?: false).toString(),
-            "showKCPType" to getShowKCPType(configuration.kcpAuthVisibility),
-            "showPayButton" to configuration.isSubmitButtonVisible.toString(),
-            "socialSecurityNumberMode" to getSocialSecurityNumberMode(configuration.socialSecurityNumberVisibility),
-        )
+        return buildMap {
+            if (configuration.addressParams is AddressParams.FullAddress) {
+                val countryList = configuration.addressParams.supportedCountryCodes.joinToString(",")
+                put("billingAddressAllowedCountries", countryList)
+            }
+
+            put("billingAddressMode", getBillingAddressMode(configuration.addressParams))
+            put("billingAddressRequired", (configuration.addressParams !is AddressParams.None).toString())
+            put("brands", configuration.supportedCardBrands.joinToString(",") { it.txVariant })
+            put("enableStoreDetails", configuration.isStorePaymentFieldVisible.toString())
+            put("hasHolderName", configuration.isHolderNameRequired.toString())
+            put("hasInstallmentOptions", (configuration.installmentParams != null).toString())
+            put("hideCVC", getHideCVC(configuration, isStored))
+            put("holderNameRequired", configuration.isHolderNameRequired.toString())
+
+            if (configuration.installmentParams != null) {
+                put("showInstallmentAmounts", configuration.installmentParams.showInstallmentAmount.toString())
+            }
+
+            put("showKCPType", getShowKCPType(configuration.kcpAuthVisibility))
+            put("showPayButton", configuration.isSubmitButtonVisible.toString())
+            put("socialSecurityNumberMode", getSocialSecurityNumberMode(configuration.socialSecurityNumberVisibility))
+        }
     }
 
     private fun getBillingAddressMode(addressParams: AddressParams): String {

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegate.kt
@@ -105,7 +105,8 @@ class DefaultCardDelegate(
     private val cardEncryptor: BaseCardEncryptor,
     private val genericEncryptor: BaseGenericEncryptor,
     private val submitHandler: SubmitHandler<CardComponentState>,
-    private val addressLookupDelegate: AddressLookupDelegate
+    private val addressLookupDelegate: AddressLookupDelegate,
+    private val cardConfigDataGenerator: CardConfigDataGenerator,
 ) : CardDelegate, AddressLookupDelegate by addressLookupDelegate {
 
     private val inputData: CardInputData = CardInputData()
@@ -176,7 +177,10 @@ class DefaultCardDelegate(
         adyenLog(AdyenLogLevel.VERBOSE) { "initializeAnalytics" }
         analyticsManager.initialize(this, coroutineScope)
 
-        val event = GenericEvents.rendered(paymentMethod.type.orEmpty())
+        val event = GenericEvents.rendered(
+            component = paymentMethod.type.orEmpty(),
+            configData = cardConfigDataGenerator.generate(configuration = componentParams, isStored = false),
+        )
         analyticsManager.trackEvent(event)
     }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/StoredCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/StoredCardDelegate.kt
@@ -77,6 +77,7 @@ internal class StoredCardDelegate(
     private val cardEncryptor: BaseCardEncryptor,
     private val publicKeyRepository: PublicKeyRepository,
     private val submitHandler: SubmitHandler<CardComponentState>,
+    private val cardConfigDataGenerator: CardConfigDataGenerator,
 ) : CardDelegate {
 
     private val noCvcBrands: Set<CardBrand> = hashSetOf(CardBrand(cardType = CardType.BCMC))
@@ -159,6 +160,7 @@ internal class StoredCardDelegate(
         val event = GenericEvents.rendered(
             component = storedPaymentMethod.type.orEmpty(),
             isStoredPaymentMethod = true,
+            configData = cardConfigDataGenerator.generate(configuration = componentParams, isStored = true)
         )
         analyticsManager.trackEvent(event)
     }

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/CardConfigDataGeneratorTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/CardConfigDataGeneratorTest.kt
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2024 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 19/8/2024.
+ */
+
+package com.adyen.checkout.card.internal.ui
+
+import com.adyen.checkout.card.CardBrand
+import com.adyen.checkout.card.KCPAuthVisibility
+import com.adyen.checkout.card.SocialSecurityNumberVisibility
+import com.adyen.checkout.card.internal.ui.model.AddressFieldPolicyParams
+import com.adyen.checkout.card.internal.ui.model.CVCVisibility
+import com.adyen.checkout.card.internal.ui.model.CardComponentParams
+import com.adyen.checkout.card.internal.ui.model.InstallmentParams
+import com.adyen.checkout.card.internal.ui.model.StoredCVCVisibility
+import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
+import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParamsLevel
+import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParams
+import com.adyen.checkout.core.Environment
+import com.adyen.checkout.ui.core.internal.ui.model.AddressParams
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.Locale
+
+internal class CardConfigDataGeneratorTest {
+
+    private lateinit var cardConfigDataGenerator: CardConfigDataGenerator
+
+    @BeforeEach
+    fun beforeEach() {
+        cardConfigDataGenerator = CardConfigDataGenerator()
+    }
+
+    @ParameterizedTest
+    @MethodSource("testSource")
+    fun `when mapping, then expect`(
+        configuration: CardComponentParams,
+        isStored: Boolean,
+        expected: Map<String, String>
+    ) {
+        val result = cardConfigDataGenerator.generate(configuration, isStored)
+
+        assertEquals(expected, result)
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun testSource() = listOf(
+            arguments(
+                createCardComponentParams(
+                    isSubmitButtonVisible = true,
+                    isHolderNameRequired = true,
+                    supportedCardBrands = listOf(CardBrand("mc"), CardBrand("visa")),
+                    isStorePaymentFieldVisible = true,
+                    socialSecurityNumberVisibility = SocialSecurityNumberVisibility.SHOW,
+                    kcpAuthVisibility = KCPAuthVisibility.SHOW,
+                    installmentParams = InstallmentParams(shopperLocale = Locale.US, showInstallmentAmount = true),
+                    addressParams = AddressParams.FullAddress(
+                        supportedCountryCodes = listOf("US", "CA"),
+                        addressFieldPolicy = AddressFieldPolicyParams.Required,
+                    ),
+                    cvcVisibility = CVCVisibility.ALWAYS_SHOW,
+                    storedCVCVisibility = StoredCVCVisibility.HIDE,
+                ),
+                false,
+                mapOf(
+                    "billingAddressAllowedCountries" to "US,CA",
+                    "billingAddressMode" to "full",
+                    "billingAddressRequired" to "true",
+                    "brands" to "mc,visa",
+                    "enableStoreDetails" to "true",
+                    "hasHolderName" to "true",
+                    "hasInstallmentOptions" to "true",
+                    "hideCVC" to "show",
+                    "holderNameRequired" to "true",
+                    "showInstallmentAmounts" to "true",
+                    "showKCPType" to "show",
+                    "showPayButton" to "true",
+                    "socialSecurityNumberMode" to "show",
+                ),
+            ),
+            arguments(
+                createCardComponentParams(
+                    isSubmitButtonVisible = false,
+                    isHolderNameRequired = false,
+                    supportedCardBrands = emptyList(),
+                    isStorePaymentFieldVisible = false,
+                    socialSecurityNumberVisibility = SocialSecurityNumberVisibility.HIDE,
+                    kcpAuthVisibility = KCPAuthVisibility.HIDE,
+                    installmentParams = InstallmentParams(shopperLocale = Locale.US, showInstallmentAmount = false),
+                    addressParams = AddressParams.PostalCode(addressFieldPolicy = AddressFieldPolicyParams.Required),
+                    cvcVisibility = CVCVisibility.HIDE_FIRST,
+                    storedCVCVisibility = StoredCVCVisibility.SHOW,
+                ),
+                false,
+                mapOf(
+                    "billingAddressMode" to "partial",
+                    "billingAddressRequired" to "true",
+                    "brands" to "",
+                    "enableStoreDetails" to "false",
+                    "hasHolderName" to "false",
+                    "hasInstallmentOptions" to "true",
+                    "hideCVC" to "auto",
+                    "holderNameRequired" to "false",
+                    "showInstallmentAmounts" to "false",
+                    "showKCPType" to "hide",
+                    "showPayButton" to "false",
+                    "socialSecurityNumberMode" to "hide",
+                ),
+            ),
+            arguments(
+                createCardComponentParams(
+                    isSubmitButtonVisible = false,
+                    isHolderNameRequired = false,
+                    supportedCardBrands = emptyList(),
+                    isStorePaymentFieldVisible = false,
+                    socialSecurityNumberVisibility = SocialSecurityNumberVisibility.HIDE,
+                    kcpAuthVisibility = KCPAuthVisibility.HIDE,
+                    installmentParams = null,
+                    addressParams = AddressParams.Lookup(),
+                    cvcVisibility = CVCVisibility.ALWAYS_HIDE,
+                    storedCVCVisibility = StoredCVCVisibility.SHOW,
+                ),
+                false,
+                mapOf(
+                    "billingAddressMode" to "lookup",
+                    "billingAddressRequired" to "true",
+                    "brands" to "",
+                    "enableStoreDetails" to "false",
+                    "hasHolderName" to "false",
+                    "hasInstallmentOptions" to "false",
+                    "hideCVC" to "hide",
+                    "holderNameRequired" to "false",
+                    "showKCPType" to "hide",
+                    "showPayButton" to "false",
+                    "socialSecurityNumberMode" to "hide",
+                ),
+            ),
+            arguments(
+                createCardComponentParams(
+                    isSubmitButtonVisible = false,
+                    isHolderNameRequired = false,
+                    supportedCardBrands = emptyList(),
+                    isStorePaymentFieldVisible = false,
+                    socialSecurityNumberVisibility = SocialSecurityNumberVisibility.HIDE,
+                    kcpAuthVisibility = KCPAuthVisibility.HIDE,
+                    installmentParams = null,
+                    addressParams = AddressParams.None,
+                    cvcVisibility = CVCVisibility.ALWAYS_HIDE,
+                    storedCVCVisibility = StoredCVCVisibility.SHOW,
+                ),
+                false,
+                mapOf(
+                    "billingAddressMode" to "none",
+                    "billingAddressRequired" to "false",
+                    "brands" to "",
+                    "enableStoreDetails" to "false",
+                    "hasHolderName" to "false",
+                    "hasInstallmentOptions" to "false",
+                    "hideCVC" to "hide",
+                    "holderNameRequired" to "false",
+                    "showKCPType" to "hide",
+                    "showPayButton" to "false",
+                    "socialSecurityNumberMode" to "hide",
+                ),
+            ),
+            arguments(
+                createCardComponentParams(
+                    isSubmitButtonVisible = false,
+                    isHolderNameRequired = false,
+                    supportedCardBrands = emptyList(),
+                    isStorePaymentFieldVisible = false,
+                    socialSecurityNumberVisibility = SocialSecurityNumberVisibility.HIDE,
+                    kcpAuthVisibility = KCPAuthVisibility.HIDE,
+                    installmentParams = null,
+                    addressParams = AddressParams.None,
+                    cvcVisibility = CVCVisibility.ALWAYS_HIDE,
+                    storedCVCVisibility = StoredCVCVisibility.SHOW,
+                ),
+                true,
+                mapOf(
+                    "billingAddressMode" to "none",
+                    "billingAddressRequired" to "false",
+                    "brands" to "",
+                    "enableStoreDetails" to "false",
+                    "hasHolderName" to "false",
+                    "hasInstallmentOptions" to "false",
+                    "hideCVC" to "show",
+                    "holderNameRequired" to "false",
+                    "showKCPType" to "hide",
+                    "showPayButton" to "false",
+                    "socialSecurityNumberMode" to "hide",
+                ),
+            ),
+            arguments(
+                createCardComponentParams(
+                    isSubmitButtonVisible = false,
+                    isHolderNameRequired = false,
+                    supportedCardBrands = emptyList(),
+                    isStorePaymentFieldVisible = false,
+                    socialSecurityNumberVisibility = SocialSecurityNumberVisibility.HIDE,
+                    kcpAuthVisibility = KCPAuthVisibility.HIDE,
+                    installmentParams = null,
+                    addressParams = AddressParams.None,
+                    cvcVisibility = CVCVisibility.ALWAYS_SHOW,
+                    storedCVCVisibility = StoredCVCVisibility.HIDE,
+                ),
+                true,
+                mapOf(
+                    "billingAddressMode" to "none",
+                    "billingAddressRequired" to "false",
+                    "brands" to "",
+                    "enableStoreDetails" to "false",
+                    "hasHolderName" to "false",
+                    "hasInstallmentOptions" to "false",
+                    "hideCVC" to "hide",
+                    "holderNameRequired" to "false",
+                    "showKCPType" to "hide",
+                    "showPayButton" to "false",
+                    "socialSecurityNumberMode" to "hide",
+                ),
+            ),
+        )
+
+        @Suppress("LongParameterList")
+        private fun createCardComponentParams(
+            isSubmitButtonVisible: Boolean,
+            isHolderNameRequired: Boolean,
+            supportedCardBrands: List<CardBrand>,
+            isStorePaymentFieldVisible: Boolean,
+            socialSecurityNumberVisibility: SocialSecurityNumberVisibility,
+            kcpAuthVisibility: KCPAuthVisibility,
+            installmentParams: InstallmentParams?,
+            addressParams: AddressParams,
+            cvcVisibility: CVCVisibility,
+            storedCVCVisibility: StoredCVCVisibility,
+        ) = CardComponentParams(
+            commonComponentParams = CommonComponentParams(
+                shopperLocale = Locale.US,
+                environment = Environment.TEST,
+                clientKey = "clientKey",
+                analyticsParams = AnalyticsParams(AnalyticsParamsLevel.ALL, ""),
+                isCreatedByDropIn = false,
+                amount = null,
+            ),
+            isSubmitButtonVisible = isSubmitButtonVisible,
+            isHolderNameRequired = isHolderNameRequired,
+            supportedCardBrands = supportedCardBrands,
+            shopperReference = "shopperReference",
+            isStorePaymentFieldVisible = isStorePaymentFieldVisible,
+            socialSecurityNumberVisibility = socialSecurityNumberVisibility,
+            kcpAuthVisibility = kcpAuthVisibility,
+            installmentParams = installmentParams,
+            addressParams = addressParams,
+            cvcVisibility = cvcVisibility,
+            storedCVCVisibility = storedCVCVisibility,
+        )
+    }
+}

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegateTest.kt
@@ -92,6 +92,8 @@ import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.Locale
@@ -101,6 +103,7 @@ import java.util.Locale
 internal class DefaultCardDelegateTest(
     @Mock private val submitHandler: SubmitHandler<CardComponentState>,
     @Mock private val addressLookupDelegate: AddressLookupDelegate,
+    @Mock private val cardConfigDataGenerator: CardConfigDataGenerator,
 ) {
 
     private lateinit var cardEncryptor: TestCardEncryptor
@@ -121,6 +124,7 @@ internal class DefaultCardDelegateTest(
         analyticsManager = TestAnalyticsManager()
 
         whenever(addressLookupDelegate.addressLookupSubmitFlow).thenReturn(MutableStateFlow(AddressInputModel()))
+        whenever(cardConfigDataGenerator.generate(any(), any())) doReturn emptyMap()
 
         delegate = createCardDelegate()
     }
@@ -1047,7 +1051,10 @@ internal class DefaultCardDelegateTest(
         fun `when delegate is initialized, then render event is tracked`() {
             delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
 
-            val expectedEvent = GenericEvents.rendered(PaymentMethodTypes.SCHEME)
+            val expectedEvent = GenericEvents.rendered(
+                component = PaymentMethodTypes.SCHEME,
+                configData = emptyMap(),
+            )
             analyticsManager.assertLastEventEquals(expectedEvent)
         }
 
@@ -1266,6 +1273,7 @@ internal class DefaultCardDelegateTest(
             analyticsManager = analyticsManager,
             submitHandler = submitHandler,
             addressLookupDelegate = addressLookupDelegate,
+            cardConfigDataGenerator = cardConfigDataGenerator,
         )
     }
 

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/StoredCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/StoredCardDelegateTest.kt
@@ -72,13 +72,17 @@ import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.util.Locale
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(MockitoExtension::class, TestDispatcherExtension::class)
 internal class StoredCardDelegateTest(
-    @Mock private val submitHandler: SubmitHandler<CardComponentState>
+    @Mock private val submitHandler: SubmitHandler<CardComponentState>,
+    @Mock private val cardConfigDataGenerator: CardConfigDataGenerator,
 ) {
 
     private lateinit var cardEncryptor: TestCardEncryptor
@@ -92,6 +96,8 @@ internal class StoredCardDelegateTest(
         publicKeyRepository = TestPublicKeyRepository()
         analyticsManager = TestAnalyticsManager()
         delegate = createCardDelegate()
+
+        whenever(cardConfigDataGenerator.generate(any(), any())) doReturn emptyMap()
     }
 
     @Test
@@ -435,7 +441,11 @@ internal class StoredCardDelegateTest(
         fun `when delegate is initialized, then render event is tracked`() {
             delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
 
-            val expectedEvent = GenericEvents.rendered(PaymentMethodTypes.SCHEME, isStoredPaymentMethod = true)
+            val expectedEvent = GenericEvents.rendered(
+                component = PaymentMethodTypes.SCHEME,
+                isStoredPaymentMethod = true,
+                configData = emptyMap(),
+            )
             analyticsManager.assertLastEventEquals(expectedEvent)
         }
 
@@ -500,6 +510,7 @@ internal class StoredCardDelegateTest(
             analyticsManager = analyticsManager,
             submitHandler = submitHandler,
             order = order,
+            cardConfigDataGenerator = cardConfigDataGenerator,
         )
     }
 

--- a/checkout-core/src/main/java/com/adyen/checkout/core/internal/data/model/JsonUtils.kt
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/internal/data/model/JsonUtils.kt
@@ -5,6 +5,8 @@
  *
  * Created by caiof on 17/12/2020.
  */
+@file:Suppress("TooManyFunctions")
+
 package com.adyen.checkout.core.internal.data.model
 
 import androidx.annotation.RestrictTo
@@ -98,7 +100,7 @@ private fun JSONObject.toMap(): Map<String, String> {
     val map = mutableMapOf<String, String>()
 
     val iterator = keys()
-    while(iterator.hasNext()) {
+    while (iterator.hasNext()) {
         val key = iterator.next()
         val value = this[key]
 

--- a/checkout-core/src/main/java/com/adyen/checkout/core/internal/data/model/JsonUtils.kt
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/internal/data/model/JsonUtils.kt
@@ -90,6 +90,27 @@ inline fun <reified T : ModelObject> JSONObject.jsonToMap(
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun JSONObject.getMapOrNull(key: String): Map<String, String>? {
+    return if (has(key)) getJSONObject(key).toMap() else null
+}
+
+private fun JSONObject.toMap(): Map<String, String> {
+    val map = mutableMapOf<String, String>()
+
+    val iterator = keys()
+    while(iterator.hasNext()) {
+        val key = iterator.next()
+        val value = this[key]
+
+        if (value is String) {
+            map[key] = value
+        }
+    }
+
+    return map
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 object JsonUtils {
 
     /**

--- a/components-core/api/components-core.api
+++ b/components-core/api/components-core.api
@@ -1654,11 +1654,12 @@ public abstract interface class com/adyen/checkout/components/core/internal/Paym
 }
 
 public final class com/adyen/checkout/components/core/internal/analytics/AnalyticsEvent$Info : com/adyen/checkout/components/core/internal/analytics/AnalyticsEvent {
-	public fun <init> (Ljava/lang/String;JZLjava/lang/String;Lcom/adyen/checkout/components/core/internal/analytics/AnalyticsEvent$Info$Type;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;JZLjava/lang/String;Lcom/adyen/checkout/components/core/internal/analytics/AnalyticsEvent$Info$Type;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;JZLjava/lang/String;Lcom/adyen/checkout/components/core/internal/analytics/AnalyticsEvent$Info$Type;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;JZLjava/lang/String;Lcom/adyen/checkout/components/core/internal/analytics/AnalyticsEvent$Info$Type;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Ljava/lang/String;
 	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/util/Map;
 	public final fun component2 ()J
 	public final fun component3 ()Z
 	public final fun component4 ()Ljava/lang/String;
@@ -1667,11 +1668,12 @@ public final class com/adyen/checkout/components/core/internal/analytics/Analyti
 	public final fun component7 ()Ljava/lang/Boolean;
 	public final fun component8 ()Ljava/lang/String;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;JZLjava/lang/String;Lcom/adyen/checkout/components/core/internal/analytics/AnalyticsEvent$Info$Type;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/internal/analytics/AnalyticsEvent$Info;
-	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/internal/analytics/AnalyticsEvent$Info;Ljava/lang/String;JZLjava/lang/String;Lcom/adyen/checkout/components/core/internal/analytics/AnalyticsEvent$Info$Type;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/internal/analytics/AnalyticsEvent$Info;
+	public final fun copy (Ljava/lang/String;JZLjava/lang/String;Lcom/adyen/checkout/components/core/internal/analytics/AnalyticsEvent$Info$Type;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lcom/adyen/checkout/components/core/internal/analytics/AnalyticsEvent$Info;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/internal/analytics/AnalyticsEvent$Info;Ljava/lang/String;JZLjava/lang/String;Lcom/adyen/checkout/components/core/internal/analytics/AnalyticsEvent$Info$Type;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/internal/analytics/AnalyticsEvent$Info;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBrand ()Ljava/lang/String;
 	public fun getComponent ()Ljava/lang/String;
+	public final fun getConfigData ()Ljava/util/Map;
 	public fun getId ()Ljava/lang/String;
 	public final fun getIssuer ()Ljava/lang/String;
 	public fun getShouldForceSend ()Z

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/analytics/AnalyticsEvent.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/analytics/AnalyticsEvent.kt
@@ -32,6 +32,7 @@ sealed interface AnalyticsEvent {
         val issuer: String? = null,
         val validationErrorCode: String? = null,
         val validationErrorMessage: String? = null,
+        val configData: Map<String, String>? = null,
     ) : AnalyticsEvent {
         enum class Type(val value: String) {
             DISPLAYED("displayed"),

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/analytics/GenericEvents.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/analytics/GenericEvents.kt
@@ -20,11 +20,13 @@ object GenericEvents {
         component: String,
         isStoredPaymentMethod: Boolean? = null,
         brand: String? = null,
+        configData: Map<String, String>? = null,
     ) = AnalyticsEvent.Info(
         component = component,
         type = AnalyticsEvent.Info.Type.RENDERED,
         isStoredPaymentMethod = isStoredPaymentMethod,
         brand = brand,
+        configData = configData,
     )
 
     fun displayed(

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/analytics/data/remote/AnalyticsTrackRequestProvider.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/analytics/data/remote/AnalyticsTrackRequestProvider.kt
@@ -39,6 +39,7 @@ internal class AnalyticsTrackRequestProvider {
         issuer = issuer,
         validationErrorCode = validationErrorCode,
         validationErrorMessage = validationErrorMessage,
+        configData = configData,
     )
 
     private fun AnalyticsEvent.Log.mapToTrackEvent() = AnalyticsTrackLog(

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/model/AnalyticsTrackInfo.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/model/AnalyticsTrackInfo.kt
@@ -12,6 +12,7 @@ import com.adyen.checkout.core.exception.ModelSerializationException
 import com.adyen.checkout.core.internal.data.model.ModelObject
 import com.adyen.checkout.core.internal.data.model.getBooleanOrNull
 import com.adyen.checkout.core.internal.data.model.getLongOrNull
+import com.adyen.checkout.core.internal.data.model.getMapOrNull
 import com.adyen.checkout.core.internal.data.model.getStringOrNull
 import kotlinx.parcelize.Parcelize
 import org.json.JSONException
@@ -29,6 +30,7 @@ internal data class AnalyticsTrackInfo(
     val issuer: String?,
     val validationErrorCode: String?,
     val validationErrorMessage: String?,
+    val configData: Map<String, String>?,
 ) : ModelObject() {
 
     companion object {
@@ -42,6 +44,7 @@ internal data class AnalyticsTrackInfo(
         private const val ISSUER = "issuer"
         private const val VALIDATION_ERROR_CODE = "validationErrorCode"
         private const val VALIDATION_ERROR_MESSAGE = "validationErrorMessage"
+        private const val CONFIG_DATA = "configData"
 
         @JvmField
         val SERIALIZER: Serializer<AnalyticsTrackInfo> = object : Serializer<AnalyticsTrackInfo> {
@@ -58,6 +61,7 @@ internal data class AnalyticsTrackInfo(
                         putOpt(ISSUER, modelObject.issuer)
                         putOpt(VALIDATION_ERROR_CODE, modelObject.validationErrorCode)
                         putOpt(VALIDATION_ERROR_MESSAGE, modelObject.validationErrorMessage)
+                        putOpt(CONFIG_DATA, modelObject.configData?.let { JSONObject(it) })
                     }
                 } catch (e: JSONException) {
                     throw ModelSerializationException(AnalyticsTrackInfo::class.java, e)
@@ -78,6 +82,7 @@ internal data class AnalyticsTrackInfo(
                             issuer = getStringOrNull(ISSUER),
                             validationErrorCode = getStringOrNull(VALIDATION_ERROR_CODE),
                             validationErrorMessage = getStringOrNull(VALIDATION_ERROR_MESSAGE),
+                            configData = getMapOrNull(CONFIG_DATA),
                         )
                     }
                 } catch (e: JSONException) {

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/analytics/data/remote/AnalyticsTrackRequestProviderTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/analytics/data/remote/AnalyticsTrackRequestProviderTest.kt
@@ -33,6 +33,7 @@ internal class AnalyticsTrackRequestProviderTest {
                 issuer = "issuer",
                 validationErrorCode = "418",
                 validationErrorMessage = "I'm a teapot",
+                configData = mapOf("test" to "yes"),
             ),
         )
         val logList = listOf(
@@ -64,6 +65,7 @@ internal class AnalyticsTrackRequestProviderTest {
                     issuer = "issuer",
                     validationErrorCode = "418",
                     validationErrorMessage = "I'm a teapot",
+                    configData = mapOf("test" to "yes"),
                 ),
             ),
             logs = listOf(

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/model/AnalyticsTrackInfoTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/model/AnalyticsTrackInfoTest.kt
@@ -21,6 +21,7 @@ internal class AnalyticsTrackInfoTest {
             issuer = "ing",
             validationErrorCode = "418",
             validationErrorMessage = "I'm a teapot",
+            mapOf("test" to "something"),
         )
 
         val actual = AnalyticsTrackInfo.SERIALIZER.serialize(request)
@@ -36,6 +37,11 @@ internal class AnalyticsTrackInfoTest {
             .put("issuer", "ing")
             .put("validationErrorCode", "418")
             .put("validationErrorMessage", "I'm a teapot")
+            .put(
+                "configData",
+                JSONObject()
+                    .put("test", "something"),
+            )
 
         assertEquals(expected.toString(), actual.toString())
     }
@@ -53,6 +59,11 @@ internal class AnalyticsTrackInfoTest {
             .put("issuer", "ing")
             .put("validationErrorCode", "418")
             .put("validationErrorMessage", "I'm a teapot")
+            .put(
+                "configData",
+                JSONObject()
+                    .put("test", "something"),
+            )
 
         val actual = AnalyticsTrackInfo.SERIALIZER.deserialize(response)
 
@@ -67,6 +78,7 @@ internal class AnalyticsTrackInfoTest {
             issuer = "ing",
             validationErrorCode = "418",
             validationErrorMessage = "I'm a teapot",
+            mapOf("test" to "something"),
         )
 
         assertEquals(expected, actual)

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/model/AnalyticsTrackRequestTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/model/AnalyticsTrackRequestTest.kt
@@ -21,6 +21,7 @@ internal class AnalyticsTrackRequestTest {
                 issuer = null,
                 validationErrorCode = null,
                 validationErrorMessage = null,
+                configData = null,
             ),
         )
         val logs = listOf(
@@ -67,6 +68,7 @@ internal class AnalyticsTrackRequestTest {
                 issuer = null,
                 validationErrorCode = null,
                 validationErrorMessage = null,
+                configData = null,
             ),
         )
         val logs = listOf(


### PR DESCRIPTION
## Description
Added `configData` to the rendered analytics event. This field contains the merchant configuration for the specific component. Currently, the field is only used by the card component.

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-967
