### PR TITLE
Fix setInteractionBlocked blocking PaymentInProgressView cancel button

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -30,3 +30,6 @@
   | Previous                                 | Now                                      |
   |------------------------------------------|------------------------------------------|
   | AdyenCheckout.TextAppearance.HeaderTitle | AdyenCheckout.TextAppearance.HeaderLabel |
+
+## Fixed
+- When `setInteractionBlocked(Boolean)` is called with `true`, it does not block the cancel button in `PaymentInProgressView` anymore.  

--- a/ui-core/api/ui-core.api
+++ b/ui-core/api/ui-core.api
@@ -5,7 +5,6 @@ public final class com/adyen/checkout/ui/core/AdyenComponentView : android/widge
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun attach (Lcom/adyen/checkout/ui/core/internal/ui/ViewableComponent;Landroidx/lifecycle/LifecycleOwner;)V
 	public final fun highlightValidationErrors ()V
-	public fun onInterceptTouchEvent (Landroid/view/MotionEvent;)Z
 }
 
 public final class com/adyen/checkout/ui/core/BuildConfig {

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/AdyenComponentView.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/AdyenComponentView.kt
@@ -10,7 +10,6 @@ package com.adyen.checkout.ui.core
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
-import android.view.MotionEvent
 import android.widget.LinearLayout
 import androidx.core.view.children
 import androidx.core.view.isVisible
@@ -59,12 +58,6 @@ class AdyenComponentView @JvmOverloads constructor(
         LayoutInflater.from(context),
         this,
     )
-
-    /**
-     * Indicates if user interaction is blocked.
-     */
-    @Volatile
-    private var isInteractionBlocked = false
 
     private var componentView: ComponentView? = null
 
@@ -170,8 +163,6 @@ class AdyenComponentView @JvmOverloads constructor(
     }
 
     private fun setInteractionBlocked(isInteractionBlocked: Boolean) {
-        this.isInteractionBlocked = isInteractionBlocked
-
         binding.frameLayoutButtonContainer.children.forEach { it.isEnabled = !isInteractionBlocked }
 
         if (isInteractionBlocked) {
@@ -212,10 +203,5 @@ class AdyenComponentView @JvmOverloads constructor(
      */
     fun highlightValidationErrors() {
         componentView?.highlightValidationErrors()
-    }
-
-    override fun onInterceptTouchEvent(ev: MotionEvent?): Boolean {
-        if (isInteractionBlocked) return true
-        return super.onInterceptTouchEvent(ev)
     }
 }


### PR DESCRIPTION
## Description
[//]: # (Include a short summary of your changes)
[//]: # (If this is a new feature: attach screenshots or a video if applicable)
[//]: # (If this is a bug fix: include a reproduction path)
When `setInteractionBlocked(true)` is called it used to block touch event for everything displayed in `AdyenComponentView`, including `PaymentInProgressView`. Now it only blocks the submit button when set.

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Changes are tested manually

COAND-978
