### PR TITLE
Analytics - Fix malformed locale in analytics setup request

### DIFF
--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/analytics/data/remote/DefaultAnalyticsSetupProvider.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/analytics/data/remote/DefaultAnalyticsSetupProvider.kt
@@ -30,7 +30,7 @@ internal class DefaultAnalyticsSetupProvider(
             version = AnalyticsPlatformParams.version,
             channel = AnalyticsPlatformParams.channel,
             platform = AnalyticsPlatformParams.platform,
-            locale = shopperLocale.toString(),
+            locale = shopperLocale.toLanguageTag(),
             component = getComponentQueryParameter(source),
             flavor = getFlavorQueryParameter(isCreatedByDropIn),
             deviceBrand = Build.BRAND,

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/analytics/data/remote/DefaultAnalyticsSetupProviderTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/analytics/data/remote/DefaultAnalyticsSetupProviderTest.kt
@@ -36,7 +36,7 @@ internal class DefaultAnalyticsSetupProviderTest {
             version = AnalyticsPlatformParams.version,
             channel = AnalyticsPlatformParams.channel,
             platform = AnalyticsPlatformParams.platform,
-            locale = Locale.US.toString(),
+            locale = Locale.US.toLanguageTag(),
             component = "scheme",
             flavor = "components",
             deviceBrand = Build.BRAND,


### PR DESCRIPTION
## Description
Fix malformed locale in analytics setup request. The backend only accepts language tags (`xx-YY-zzzzzz`) and not full unformatted locales (xx_YY_#zzzzzz).

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Changes are tested manually

COAND-993
