### PR TITLE
Add action to manage stale issues

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -1,0 +1,23 @@
+# This workflow warns and then closes issues that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Manage stale issues
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Run every day at midnight
+
+jobs:
+  close_stale_prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close stale issues
+        uses: actions/stale@v9
+        with:
+          any-of-labels: 'Needs more info'
+          stale-issue-message: 'This issue is now stale because it has been open for 14 days with no activity. Please provide the requested information or the issue will be closed automatically.'
+          close-issue-message: 'This issue is now closed because it has been stalled for 14 days with no activity.'
+          days-before-issue-stale: 14
+          days-before-issue-close: 14


### PR DESCRIPTION
## Description
The stale action allows us to automatically comment on and close inactive issues. The configuration I suggested is:
- We need to manually label issues with `Needs more info` to prevent this from running on all issues.
- After 14 days without any activity, the stale bot will comment with the first message (`stale-issue-message`).
- After another 14 days the stale bot will comment with the second message (`close-issue-message`) and then close the issue.

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
