### PR TITLE
Don't fallback to normal redirect flow

### DIFF
--- a/redirect/src/main/java/com/adyen/checkout/redirect/internal/data/model/NativeRedirectRequest.kt
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/internal/data/model/NativeRedirectRequest.kt
@@ -16,7 +16,7 @@ import org.json.JSONObject
 
 @Parcelize
 internal data class NativeRedirectRequest(
-    val redirectData: String,
+    val redirectData: String?,
     val returnQueryString: String,
 ) : ModelObject() {
 

--- a/redirect/src/main/java/com/adyen/checkout/redirect/internal/ui/DefaultRedirectDelegate.kt
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/internal/ui/DefaultRedirectDelegate.kt
@@ -147,7 +147,7 @@ constructor(
             val details = redirectHandler.parseRedirectResult(intent.data)
             val nativeRedirectData = paymentDataRepository.nativeRedirectData
             when {
-                nativeRedirectData != null -> {
+                action?.type == ActionTypes.NATIVE_REDIRECT -> {
                     handleNativeRedirect(nativeRedirectData, details)
                 }
 
@@ -167,7 +167,7 @@ constructor(
         )
     }
 
-    private fun handleNativeRedirect(nativeRedirectData: String, details: JSONObject) {
+    private fun handleNativeRedirect(nativeRedirectData: String?, details: JSONObject) {
         coroutineScope.launch {
             val request = NativeRedirectRequest(
                 redirectData = nativeRedirectData,


### PR DESCRIPTION
## Description
Before we used to fallback to the normal redirect flow if we would lose nativeRedirectData. Instead, we can just send null in the native redirect request and the backend will be able to recover the state to complete the flow.

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Changes are tested manually

COAND-996
