### PR TITLE
Correctly check nullability when reading from JSON objects

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,6 +29,9 @@
   |--------------------------------------------------------------------------------------------------------|-------------------------------|
   | [Adyen 3DS2](https://github.com/Adyen/adyen-3ds2-android/releases/tag/2.2.20)                          | **2.2.20**                    |
 
+## Fixed
+- JSON deserialization no longer returns the coerced `"null"` string when parsing JSON objects with explicit null values.
+
 ## Deprecated
 - The style for payment method list headers has been changed.
   | Previous                                 | Now                                      |

--- a/checkout-core/src/main/java/com/adyen/checkout/core/internal/data/model/JsonUtils.kt
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/internal/data/model/JsonUtils.kt
@@ -20,22 +20,27 @@ private const val PARSING_ERROR = "PARSING_ERROR"
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun JSONObject.getStringOrNull(key: String): String? {
-    return if (has(key)) getString(key) else null
+    return if (!isNull(key)) getString(key) else null
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun JSONObject.getBooleanOrNull(key: String): Boolean? {
-    return if (has(key)) getBoolean(key) else null
+    return if (!isNull(key)) getBoolean(key) else null
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun JSONObject.getIntOrNull(key: String): Int? {
-    return if (has(key)) getInt(key) else null
+    return if (!isNull(key)) getInt(key) else null
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun JSONObject.getLongOrNull(key: String): Long? {
-    return if (has(key)) getLong(key) else null
+    return if (!isNull(key)) getLong(key) else null
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun JSONObject.getDoubleOrNull(key: String): Double? {
+    return if (!isNull(key)) getDouble(key) else null
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -93,7 +98,7 @@ inline fun <reified T : ModelObject> JSONObject.jsonToMap(
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun JSONObject.getMapOrNull(key: String): Map<String, String>? {
-    return if (has(key)) getJSONObject(key).toMap() else null
+    return if (!isNull(key)) getJSONObject(key).toMap() else null
 }
 
 private fun JSONObject.toMap(): Map<String, String> {

--- a/checkout-core/src/test/java/com/adyen/checkout/core/internal/data/model/JsonUtilsTest.kt
+++ b/checkout-core/src/test/java/com/adyen/checkout/core/internal/data/model/JsonUtilsTest.kt
@@ -7,9 +7,8 @@
  */
 package com.adyen.checkout.core.internal.data.model
 
-import org.json.JSONArray
+import org.json.JSONObject
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -17,27 +16,193 @@ import org.junit.jupiter.api.Test
 internal class JsonUtilsTest {
 
     @Test
-    fun parseOptStringList_Pass_ParseStringArray() {
-        val jsonArray = JSONArray()
-        val testString = "Test"
-        jsonArray.put(testString)
-        val stringList = JsonUtils.parseOptStringList(jsonArray)
-        assertNotNull(stringList)
-        val first = stringList!![0]
-        assertEquals(testString, first)
+    fun `when calling getStringOrNull with a non null string then result should be that string`() {
+        val jsonObject = JSONObject(
+            """
+            { "key": "value" }
+            """.trimIndent(),
+        )
+        val result = jsonObject.getStringOrNull("key")
+        assertEquals("value", result)
     }
 
     @Test
-    fun parseOptStringList_Pass_ParseEmptyArray() {
-        val jsonArray = JSONArray()
-        val stringList = JsonUtils.parseOptStringList(jsonArray)
-        assertNotNull(stringList)
-        assertTrue(stringList!!.isEmpty())
+    fun `when calling getStringOrNull with a null string then result should be null`() {
+        val jsonObject = JSONObject(
+            """
+            { "key": null }
+            """.trimIndent(),
+        )
+        val result = jsonObject.getStringOrNull("key")
+        assertNull(result)
     }
 
     @Test
-    fun parseOptStringList_Pass_ParseNull() {
-        val stringList = JsonUtils.parseOptStringList(null)
-        assertNull(stringList)
+    fun `when calling getStringOrNull with a non existent string then result should be null`() {
+        val jsonObject = JSONObject()
+        val result = jsonObject.getStringOrNull("key")
+        assertNull(result)
+    }
+
+    @Test
+    fun `when calling getIntOrNull with a non null integer then result should be that integer`() {
+        val jsonObject = JSONObject(
+            """
+            { "key": 1 }
+            """.trimIndent(),
+        )
+        val result = jsonObject.getIntOrNull("key")
+        assertEquals(1, result)
+    }
+
+    @Test
+    fun `when calling getIntOrNull with a null integer then result should be null`() {
+        val jsonObject = JSONObject(
+            """
+            { "key": null }
+            """.trimIndent(),
+        )
+        val result = jsonObject.getIntOrNull("key")
+        assertNull(result)
+    }
+
+    @Test
+    fun `when calling getIntOrNull with a non existent integer then result should be null`() {
+        val jsonObject = JSONObject()
+        val result = jsonObject.getIntOrNull("key")
+        assertNull(result)
+    }
+
+    @Test
+    fun `when calling getBooleanOrNull with a non null boolean then result should be that boolean`() {
+        val jsonObject = JSONObject(
+            """
+            { "key": true }
+            """.trimIndent(),
+        )
+        val result = jsonObject.getBooleanOrNull("key")
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun `when calling getBooleanOrNull with a null boolean then result should be null`() {
+        val jsonObject = JSONObject(
+            """
+            { "key": null }
+            """.trimIndent(),
+        )
+        val result = jsonObject.getBooleanOrNull("key")
+        assertNull(result)
+    }
+
+    @Test
+    fun `when calling getBooleanOrNull with a non existent boolean then result should be null`() {
+        val jsonObject = JSONObject()
+        val result = jsonObject.getBooleanOrNull("key")
+        assertNull(result)
+    }
+
+    @Test
+    fun `when calling getLongOrNull with a non null long then result should be that long`() {
+        val jsonObject = JSONObject(
+            """
+            { "key": 92233720368547758 }
+            """.trimIndent(),
+        )
+        val result = jsonObject.getLongOrNull("key")
+        assertEquals(92233720368547758L, result)
+    }
+
+    @Test
+    fun `when calling getLongOrNull with a null long then result should be null`() {
+        val jsonObject = JSONObject(
+            """
+            { "key": null }
+            """.trimIndent(),
+        )
+        val result = jsonObject.getLongOrNull("key")
+        assertNull(result)
+    }
+
+    @Test
+    fun `when calling getLongOrNull with a non existent long then result should be null`() {
+        val jsonObject = JSONObject()
+        val result = jsonObject.getLongOrNull("key")
+        assertNull(result)
+    }
+
+    @Test
+    fun `when calling getDoubleOrNull with a non null double then result should be that double`() {
+        val jsonObject = JSONObject(
+            """
+            { "key": 13.37 }
+            """.trimIndent(),
+        )
+        val result = jsonObject.getDoubleOrNull("key")
+        assertEquals(13.37, result)
+    }
+
+    @Test
+    fun `when calling getDoubleOrNull with a null double then result should be null`() {
+        val jsonObject = JSONObject(
+            """
+            { "key": null }
+            """.trimIndent(),
+        )
+        val result = jsonObject.getDoubleOrNull("key")
+        assertNull(result)
+    }
+
+    @Test
+    fun `when calling getDoubleOrNull with a non existent double then result should be null`() {
+        val jsonObject = JSONObject()
+        val result = jsonObject.getDoubleOrNull("key")
+        assertNull(result)
+    }
+
+    @Test
+    fun `when calling parseOptStringList with a non empty JSON array then result should be matching string list`() {
+        val jsonObject = JSONObject(
+            """
+            {
+                "array":["value1", "value2", "value3"]
+            }
+            """.trimIndent(),
+        )
+        val result = JsonUtils.parseOptStringList(jsonObject.optJSONArray("array"))
+        assertEquals(listOf("value1", "value2", "value3"), result)
+    }
+
+    @Test
+    fun `when calling parseOptStringList with an empty JSON array then result should be a empty list`() {
+        val jsonObject = JSONObject(
+            """
+            {
+                "array":[]
+            }
+            """.trimIndent(),
+        )
+        val result = JsonUtils.parseOptStringList(jsonObject.optJSONArray("array"))
+        assertTrue(result != null && result.isEmpty())
+    }
+
+    @Test
+    fun `when calling parseOptStringList with a null JSON array then result should be null`() {
+        val jsonObject = JSONObject(
+            """
+            {
+                "array": null
+            }
+            """.trimIndent(),
+        )
+        val result = JsonUtils.parseOptStringList(jsonObject.optJSONArray("array"))
+        assertNull(result)
+    }
+
+    @Test
+    fun `when calling parseOptStringList with a non existent JSON array then result should be null`() {
+        val jsonObject = JSONObject()
+        val result = JsonUtils.parseOptStringList(jsonObject.optJSONArray("array"))
+        assertNull(result)
     }
 }


### PR DESCRIPTION
## Description
Replace `JSONObject.has` with `!JSONObject.isNull` when reading JSON values to ensure correct handling of null values.

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Changes are tested manually
- [x] Related issues are linked

COAND-994