### PR TITLE
Restrict CardNumberValidator.MAXIMUM_CARD_NUMBER_LENGTH to library group

### DIFF
--- a/checkout-core/api/checkout-core.api
+++ b/checkout-core/api/checkout-core.api
@@ -291,7 +291,6 @@ public final class com/adyen/checkout/core/ui/validation/CardNumberValidationRes
 
 public final class com/adyen/checkout/core/ui/validation/CardNumberValidator {
 	public static final field INSTANCE Lcom/adyen/checkout/core/ui/validation/CardNumberValidator;
-	public static final field MAXIMUM_CARD_NUMBER_LENGTH I
 	public final fun validateCardNumber (Ljava/lang/String;Z)Lcom/adyen/checkout/core/ui/validation/CardNumberValidationResult;
 }
 

--- a/checkout-core/src/main/java/com/adyen/checkout/core/ui/validation/CardNumberValidator.kt
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/ui/validation/CardNumberValidator.kt
@@ -8,6 +8,7 @@
 
 package com.adyen.checkout.core.ui.validation
 
+import androidx.annotation.RestrictTo
 import com.adyen.checkout.core.internal.util.StringUtil
 
 object CardNumberValidator {
@@ -18,6 +19,8 @@ object CardNumberValidator {
 
     // Card Number
     private const val MINIMUM_CARD_NUMBER_LENGTH = 12
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     const val MAXIMUM_CARD_NUMBER_LENGTH = 19
 
     /**


### PR DESCRIPTION
## Description
[//]: # (Include a short summary of your changes)
[//]: # (If this is a new feature: attach screenshots or a video if applicable)
[//]: # (If this is a bug fix: include a reproduction path)
Restrict public field `CardNumberValidator.MAXIMUM_CARD_NUMBER_LENGTH` to library group.

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-985
