### PR TITLE
Fix expiry date autofill hint

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardView.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardView.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.card.internal.ui.view
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
+import android.os.Build
 import android.text.Editable
 import android.text.InputType
 import android.util.AttributeSet
@@ -86,6 +87,10 @@ class CardView @JvmOverloads constructor(
         orientation = VERTICAL
         val padding = resources.getDimension(UICoreR.dimen.standard_margin).toInt()
         setPadding(padding, padding, padding, 0)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            binding.editTextExpiryDate.setAutofillHints(AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_DATE)
+        }
     }
 
     override fun onAttachedToWindow() {

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/ExpiryDateInput.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/ExpiryDateInput.kt
@@ -8,7 +8,6 @@
 package com.adyen.checkout.ui.core.internal.ui.view
 
 import android.content.Context
-import android.os.Build
 import android.text.Editable
 import android.util.AttributeSet
 import androidx.annotation.RestrictTo
@@ -39,9 +38,6 @@ constructor(
         enforceMaxInputLength(MAX_LENGTH)
         // Make sure DateFormat only accepts the correct formatting.
         dateFormat.isLenient = false
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            setAutofillHints(AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_DATE)
-        }
     }
 
     public override fun afterTextChanged(editable: Editable) {


### PR DESCRIPTION
## Description
Move expiry date autofill hint to CardView. Now it should only autofill for credit cards and not for French meal vouchers.

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Changes are tested manually