### PR TITLE
Display toolbar on all intermediary screens for drop-in

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,6 +27,7 @@
 - For UPI Intent an error message will be shown when "Continue" button is pressed without selecting
   any UPI option.
 - For drop-in, improved accessibility of back/close button in the navigation bar.
+- For drop-in, show a toolbar on every intermediary screen, so shoppers can always easily navigate back.
 
 ## Changed
 - For drop-in, headers of preselected stored payment screen and payment methods list screen are

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/GooglePayComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/GooglePayComponentDialogFragment.kt
@@ -42,6 +42,12 @@ internal class GooglePayComponentDialogFragment :
     private lateinit var paymentMethod: PaymentMethod
     private lateinit var component: GooglePayComponent
 
+    private val toolbarMode: DropInBottomSheetToolbarMode
+        get() = when {
+            dropInViewModel.shouldSkipToSinglePaymentMethod() -> DropInBottomSheetToolbarMode.CLOSE_BUTTON
+            else -> DropInBottomSheetToolbarMode.BACK_BUTTON
+        }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         adyenLog(AdyenLogLevel.DEBUG) { "onCreate" }
         super.onCreate(savedInstanceState)
@@ -60,6 +66,8 @@ internal class GooglePayComponentDialogFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         adyenLog(AdyenLogLevel.DEBUG) { "onViewCreated" }
 
+        initToolbar()
+
         loadComponent()
 
         binding.componentView.attach(component, viewLifecycleOwner)
@@ -70,6 +78,14 @@ internal class GooglePayComponentDialogFragment :
             .onEach(::handleEvent)
             .flowWithLifecycle(viewLifecycleOwner.lifecycle)
             .launchIn(viewLifecycleOwner.lifecycleScope)
+    }
+
+    private fun initToolbar() = with(binding.bottomSheetToolbar) {
+        setTitle(paymentMethod.name)
+        setOnButtonClickListener {
+            onBackPressed()
+        }
+        setMode(toolbarMode)
     }
 
     private fun loadComponent() {

--- a/drop-in/src/main/res/layout/fragment_google_pay_component.xml
+++ b/drop-in/src/main/res/layout/fragment_google_pay_component.xml
@@ -11,6 +11,11 @@
     android:layout_height="wrap_content"
     android:orientation="vertical">
 
+    <com.adyen.checkout.dropin.internal.ui.DropInBottomSheetToolbar
+        android:id="@+id/bottom_sheet_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
     <com.adyen.checkout.ui.core.AdyenComponentView
         android:id="@+id/componentView"
         android:layout_width="match_parent"


### PR DESCRIPTION
## Description
Display toolbar in drop-in Google Pay fragment (all other fragments already have a toolbar). In a follow up PR we will show a loading indicator on all these intermediary screens as well.

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Changes are tested manually

COAND-1012