### PR TITLE
Correctly read checkout version from version catalog

### DIFF
--- a/config/gradle/buildConfig.gradle
+++ b/config/gradle/buildConfig.gradle
@@ -8,7 +8,7 @@
 
 android {
     defaultConfig {
-        buildConfigField "String", "CHECKOUT_VERSION", "\"${libs.versions.version.name}\""
+        buildConfigField "String", "CHECKOUT_VERSION", "\"${libs.versions.version.name.get()}\""
     }
 
     buildFeatures {


### PR DESCRIPTION
## Description
Fixed an issue with reading the `BuildConfig.CHECKOUT_VERSION` from the toml file.
 
## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Changes are tested manually

COAND-977
