### PR TITLE
Release - New GitHub workflow for releasing

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -73,5 +73,5 @@ jobs:
           tag_name: ${{ env.PROJECT_VERSION }}
           release_name: ${{ env.PROJECT_VERSION }}
           body_path: ${{ github.workspace }}/RELEASE_NOTES.md
-          draft: false
+          draft: true
           prerelease: false

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -11,8 +11,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: main
 
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Publish to Maven Central
         run: ./gradlew publishReleasePublicationToSonatypeRepository --max-workers 1 --stacktrace
         env:
-          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          OSSRH_USERNAME: ${{ secrets.OSSRH_TOKEN_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_TOKEN_PASSWORD }}
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_SECRET_KEY_RING_FILE: ${{ secrets.SIGNING_SECRET_KEY_RING_FILE }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,13 +1,11 @@
 name: Publish Release
 
-# Every time we merge to main branch we publish a release.
+# Every time we trigger the workflow on a branch.
 on:
-  push:
-    branches: [ main ]
   workflow_dispatch:
 
 jobs:
-  
+
   publish-release:
     runs-on: ubuntu-latest
 
@@ -32,8 +30,6 @@ jobs:
 
       - name: Gradle check
         run: ./gradlew check
-
-      # TODO: add more tests or rely on check_release workflow?
 
       # Base64 decodes and pipes the GPG key content into the secret file
       - name: Prepare environment

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -67,7 +67,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          commitish: main
           tag_name: ${{ env.PROJECT_VERSION }}
           release_name: ${{ env.PROJECT_VERSION }}
           body_path: ${{ github.workspace }}/RELEASE_NOTES.md

--- a/.github/workflows/publish_release_old.yml
+++ b/.github/workflows/publish_release_old.yml
@@ -1,0 +1,81 @@
+name: Publish Release - Old
+
+# Every time we merge to main branch we publish a release.
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+
+  publish-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 17
+
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-read-only: true
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Gradle check
+        run: ./gradlew check
+
+      # TODO: add more tests or rely on check_release workflow?
+
+      # Base64 decodes and pipes the GPG key content into the secret file
+      - name: Prepare environment
+        env:
+          GPG_KEY_CONTENTS: ${{ secrets.GPG_KEY_CONTENTS }}
+          SIGNING_SECRET_KEY_RING_FILE: ${{ secrets.SIGNING_SECRET_KEY_RING_FILE }}
+        run: |
+          git fetch --unshallow
+          sudo bash -c "echo '$GPG_KEY_CONTENTS' | base64 -d > '$SIGNING_SECRET_KEY_RING_FILE'"
+
+      # Packages and publishes to Maven Central
+      - name: Publish to Maven Central
+        run: ./gradlew publishReleasePublicationToSonatypeRepository --max-workers 1 --stacktrace
+        env:
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          SIGNING_SECRET_KEY_RING_FILE: ${{ secrets.SIGNING_SECRET_KEY_RING_FILE }}
+          SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
+
+      # Get the version name from a script and save to environment variable.
+      - name: Set PROJECT_VERSION
+        run: |
+          echo "▸ Set run permission."
+          chmod +x scripts/version_name.sh
+          echo "▸ Getting version name"
+          PROJECT_VERSION=$(./scripts/version_name.sh)
+          echo "▸ Variable PROJECT_VERSION set to: ${PROJECT_VERSION}"
+          echo "▸ Adding PROJECT_VERSION variable with: $PROJECT_VERSION"
+          echo "PROJECT_VERSION=$PROJECT_VERSION" >> $GITHUB_ENV
+          echo "▸ DONE"
+
+      # Create the Release TAG and notes.
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          commitish: main
+          tag_name: ${{ env.PROJECT_VERSION }}
+          release_name: ${{ env.PROJECT_VERSION }}
+          body_path: ${{ github.workspace }}/RELEASE_NOTES.md
+          draft: false
+          prerelease: false


### PR DESCRIPTION
## Description
- Allow running the job on a specified branch instead of main
- Use new Github secrets for publishing the app on maven central
- Make the Github release draft

## Things to do in the future
- Add a step to verify if the branch name starts with e.g. `release/`
- Separate each step into a different job

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Changes are tested manually

COAND-1013
