### PR TITLE
Address lookup fixes and improvements in example app

### DIFF
--- a/example-app/src/main/java/com/adyen/checkout/example/repositories/AddressLookupCompletionResult.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/repositories/AddressLookupCompletionResult.kt
@@ -10,7 +10,7 @@ package com.adyen.checkout.example.repositories
 
 import com.adyen.checkout.components.core.LookupAddress
 
-sealed class AddressLookupCompletionState {
-    data class Error(val message: String = "Something went wrong") : AddressLookupCompletionState()
-    data class Address(val lookupAddress: LookupAddress) : AddressLookupCompletionState()
+sealed class AddressLookupCompletionResult {
+    data class Error(val message: String = "Something went wrong") : AddressLookupCompletionResult()
+    data class Address(val lookupAddress: LookupAddress) : AddressLookupCompletionResult()
 }

--- a/example-app/src/main/java/com/adyen/checkout/example/repositories/AddressLookupRepository.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/repositories/AddressLookupRepository.kt
@@ -25,9 +25,7 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
 class AddressLookupRepository @Inject constructor(
     assetManager: AssetManager
 ) {

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/card/CardActivity.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/card/CardActivity.kt
@@ -159,15 +159,10 @@ class CardActivity : AppCompatActivity(), AddressLookupCallback {
         cardComponent?.setAddressLookupResult(AddressLookupResult.Error(message))
     }
 
+    // onLookupCompletion is not implemented intentionally to allow testing this scenario
     override fun onQueryChanged(query: String) {
         Log.d(TAG, "On address lookup query changed: $query")
         cardViewModel.onAddressLookupQueryChanged(query)
-    }
-
-    override fun onLookupCompletion(lookupAddress: LookupAddress): Boolean {
-        Log.d(TAG, "on lookup completed $lookupAddress")
-        cardViewModel.onAddressLookupCompletion(lookupAddress)
-        return true
     }
 
     override fun onBackPressed() {

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/card/CardViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/card/CardViewModel.kt
@@ -102,6 +102,7 @@ internal class CardViewModel @Inject constructor(
         addressLookupRepository.onQuery(query)
     }
 
+    // intentionally not called, check comment in CardActivity
     fun onAddressLookupCompletion(lookupAddress: LookupAddress) {
         viewModelScope.launch {
             when (val lookupResult = addressLookupRepository.onAddressLookupCompleted(lookupAddress)) {

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/card/CardViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/card/CardViewModel.kt
@@ -13,7 +13,7 @@ import com.adyen.checkout.components.core.PaymentComponentData
 import com.adyen.checkout.components.core.action.Action
 import com.adyen.checkout.core.DispatcherProvider
 import com.adyen.checkout.example.data.storage.KeyValueStorage
-import com.adyen.checkout.example.repositories.AddressLookupCompletionState
+import com.adyen.checkout.example.repositories.AddressLookupCompletionResult
 import com.adyen.checkout.example.repositories.AddressLookupRepository
 import com.adyen.checkout.example.repositories.PaymentsRepository
 import com.adyen.checkout.example.service.createPaymentRequest
@@ -53,10 +53,6 @@ internal class CardViewModel @Inject constructor(
         addressLookupRepository.addressLookupOptionsFlow
             .onEach { options ->
                 _events.emit(CardEvent.AddressLookup(options))
-            }.launchIn(viewModelScope)
-        addressLookupRepository.addressLookupCompletionFlow
-            .onEach {
-                onAddressCompleted(it)
             }.launchIn(viewModelScope)
     }
 
@@ -107,21 +103,17 @@ internal class CardViewModel @Inject constructor(
     }
 
     fun onAddressLookupCompletion(lookupAddress: LookupAddress) {
-        addressLookupRepository.onAddressLookupCompleted(lookupAddress)
-    }
-
-    private fun onAddressCompleted(addressLookupCompletionState: AddressLookupCompletionState) {
         viewModelScope.launch {
-            when (addressLookupCompletionState) {
-                is AddressLookupCompletionState.Address -> _events.emit(
+            when (val lookupResult = addressLookupRepository.onAddressLookupCompleted(lookupAddress)) {
+                is AddressLookupCompletionResult.Address -> _events.emit(
                     CardEvent.AddressLookupCompleted(
-                        addressLookupCompletionState.lookupAddress,
+                        lookupResult.lookupAddress,
                     ),
                 )
 
-                is AddressLookupCompletionState.Error -> _events.emit(
+                is AddressLookupCompletionResult.Error -> _events.emit(
                     CardEvent.AddressLookupError(
-                        addressLookupCompletionState.message,
+                        lookupResult.message,
                     ),
                 )
             }


### PR DESCRIPTION
## Description
- Fix issue where selecting the same address from the lookup list options multiple times in a row only works the first time.
- Remove `onLookupCompletion` callback in `CardActivity` to allow testing this scenario.

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Changes are tested manually