### PR TITLE
Analytics - Track third party error events

### DIFF
--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/DefaultCashAppPayDelegate.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/DefaultCashAppPayDelegate.kt
@@ -34,6 +34,7 @@ import com.adyen.checkout.components.core.PaymentMethodTypes
 import com.adyen.checkout.components.core.internal.PaymentComponentEvent
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.analytics.AnalyticsManager
+import com.adyen.checkout.components.core.internal.analytics.ErrorEvent
 import com.adyen.checkout.components.core.internal.analytics.GenericEvents
 import com.adyen.checkout.components.core.internal.util.bufferedChannel
 import com.adyen.checkout.components.core.paymentmethod.CashAppPayPaymentMethod
@@ -284,6 +285,7 @@ constructor(
             }
 
             is CashAppPayState.CashAppPayExceptionState -> {
+                trackThirdPartyErrorEvent()
                 exceptionChannel.trySend(
                     ComponentException("Cash App Pay has encountered an error", newState.exception),
                 )
@@ -309,6 +311,14 @@ constructor(
             oneTimeData = oneTimeData,
             onFileData = onFileData,
         )
+    }
+
+    private fun trackThirdPartyErrorEvent() {
+        val event = GenericEvents.error(
+            component = getPaymentMethodType(),
+            event = ErrorEvent.THIRD_PARTY,
+        )
+        analyticsManager.trackEvent(event)
     }
 
     override fun isConfirmationRequired(): Boolean =

--- a/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/DefaultCashAppPayDelegateTest.kt
+++ b/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/DefaultCashAppPayDelegateTest.kt
@@ -35,6 +35,7 @@ import com.adyen.checkout.components.core.OrderRequest
 import com.adyen.checkout.components.core.PaymentComponentData
 import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
+import com.adyen.checkout.components.core.internal.analytics.ErrorEvent
 import com.adyen.checkout.components.core.internal.analytics.GenericEvents
 import com.adyen.checkout.components.core.internal.analytics.TestAnalyticsManager
 import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
@@ -530,6 +531,20 @@ internal class DefaultCashAppPayDelegateTest(
 
             val expectedEvent = GenericEvents.submit(TEST_PAYMENT_METHOD_TYPE)
             analyticsManager.assertLastEventNotEquals(expectedEvent)
+        }
+
+        @Test
+        fun `when state is exception, then an error is tracked`() = runTest {
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+            val exception = RuntimeException("Stub!")
+
+            delegate.cashAppPayStateDidChange(CashAppPayState.CashAppPayExceptionState(exception))
+
+            val expectedEvent = GenericEvents.error(
+                component = TEST_PAYMENT_METHOD_TYPE,
+                event = ErrorEvent.THIRD_PARTY
+            )
+            analyticsManager.assertLastEventEquals(expectedEvent)
         }
 
         @Test

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/DefaultGooglePayDelegateTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/DefaultGooglePayDelegateTest.kt
@@ -8,6 +8,7 @@
 
 package com.adyen.checkout.googlepay.internal.ui
 
+import android.app.Activity
 import app.cash.turbine.test
 import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.components.core.CheckoutConfiguration
@@ -15,6 +16,7 @@ import com.adyen.checkout.components.core.Configuration
 import com.adyen.checkout.components.core.OrderRequest
 import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
+import com.adyen.checkout.components.core.internal.analytics.ErrorEvent
 import com.adyen.checkout.components.core.internal.analytics.GenericEvents
 import com.adyen.checkout.components.core.internal.analytics.TestAnalyticsManager
 import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
@@ -184,6 +186,17 @@ internal class DefaultGooglePayDelegateTest {
             delegate.onCleared()
 
             analyticsManager.assertIsCleared()
+        }
+
+        @Test
+        fun `when activity result is OK and data is null, then error event is tracked`() {
+            delegate.handleActivityResult(Activity.RESULT_OK, data = null)
+
+            val expectedEvent = GenericEvents.error(
+                component = TEST_PAYMENT_METHOD_TYPE,
+                event = ErrorEvent.THIRD_PARTY,
+            )
+            analyticsManager.assertLastEventEquals(expectedEvent)
         }
     }
 

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/internal/ui/DefaultWeChatDelegate.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/internal/ui/DefaultWeChatDelegate.kt
@@ -23,6 +23,7 @@ import com.adyen.checkout.components.core.internal.PaymentDataRepository
 import com.adyen.checkout.components.core.internal.SavedStateHandleContainer
 import com.adyen.checkout.components.core.internal.SavedStateHandleProperty
 import com.adyen.checkout.components.core.internal.analytics.AnalyticsManager
+import com.adyen.checkout.components.core.internal.analytics.ErrorEvent
 import com.adyen.checkout.components.core.internal.analytics.GenericEvents
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParams
 import com.adyen.checkout.components.core.internal.util.bufferedChannel
@@ -169,6 +170,7 @@ constructor(
         val isWeChatNotInitiated = !initiateWeChatPayRedirect(sdkData, activityName)
 
         if (isWeChatNotInitiated) {
+            trackThirdPartyErrorEvent()
             emitError(ComponentException("Failed to initialize WeChat app"))
         }
     }
@@ -185,6 +187,14 @@ constructor(
             details = details,
             paymentData = paymentDataRepository.paymentData,
         )
+    }
+
+    private fun trackThirdPartyErrorEvent() {
+        val event = GenericEvents.error(
+            component = action?.paymentMethodType.orEmpty(),
+            event = ErrorEvent.THIRD_PARTY,
+        )
+        analyticsManager?.trackEvent(event)
     }
 
     override fun onError(e: CheckoutException) {

--- a/wechatpay/src/test/java/com/adyen/checkout/wechatpay/internal/ui/DefaultWeChatDelegateTest.kt
+++ b/wechatpay/src/test/java/com/adyen/checkout/wechatpay/internal/ui/DefaultWeChatDelegateTest.kt
@@ -17,6 +17,7 @@ import com.adyen.checkout.components.core.action.SdkAction
 import com.adyen.checkout.components.core.action.WeChatPaySdkData
 import com.adyen.checkout.components.core.internal.ActionObserverRepository
 import com.adyen.checkout.components.core.internal.PaymentDataRepository
+import com.adyen.checkout.components.core.internal.analytics.ErrorEvent
 import com.adyen.checkout.components.core.internal.analytics.GenericEvents
 import com.adyen.checkout.components.core.internal.analytics.TestAnalyticsManager
 import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
@@ -169,6 +170,25 @@ internal class DefaultWeChatDelegateTest(
             val expectedEvent = GenericEvents.action(
                 component = TEST_PAYMENT_METHOD_TYPE,
                 subType = TEST_ACTION_TYPE,
+            )
+            analyticsManager.assertHasEventEquals(expectedEvent)
+        }
+
+        @Test
+        fun `when handleAction is called and sending a request to WeChat fails, then an error is tracked`() {
+            whenever(iwxApi.sendReq(any())) doReturn false
+            val action = SdkAction(
+                paymentMethodType = TEST_PAYMENT_METHOD_TYPE,
+                type = TEST_ACTION_TYPE,
+                paymentData = TEST_PAYMENT_DATA,
+                sdkData = WeChatPaySdkData(),
+            )
+
+            delegate.handleAction(action, Activity())
+
+            val expectedEvent = GenericEvents.error(
+                component = TEST_PAYMENT_METHOD_TYPE,
+                event = ErrorEvent.THIRD_PARTY,
             )
             analyticsManager.assertLastEventEquals(expectedEvent)
         }


### PR DESCRIPTION
## Description
Track error events for Third party SDKs and services

There is a [separate PR](https://github.com/Adyen/adyen-android/pull/1900) to add events for the new flow of the Google Pay.

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-1009
