### PR TITLE
Address Lookup - Display country name instead of country code

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,5 +10,8 @@
 
 ## Fixed
 - For the Address Lookup functionality:
-  -  Address data is now correctly saved to `PaymentComponentData`.
-  -  Address fields that were edited manually no longer lose their state when starting Lookup mode.  
+  - Address data is now correctly saved to `PaymentComponentData`.
+  - Address fields that were edited manually no longer lose their state when starting Lookup mode.
+
+## Changed
+- In Card Component selected lookup address field, country name is displayed now instead of country code.

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardView.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardView.kt
@@ -726,7 +726,9 @@ class CardView @JvmOverloads constructor(
     }
 
     private fun updateAddressLookupInputText(addressOutputData: AddressOutputData) {
-        binding.autoCompleteTextViewAddressLookup.setText(addressOutputData.toString())
+        binding.autoCompleteTextViewAddressLookup.setText(
+            addressOutputData.getDisplayAddress(cardDelegate.componentParams.shopperLocale)
+        )
     }
 
     private fun updateAddressHint(addressFormUIState: AddressFormUIState, isOptional: Boolean) {

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/model/AddressOutputData.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/model/AddressOutputData.kt
@@ -11,6 +11,8 @@ package com.adyen.checkout.ui.core.internal.ui.model
 import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.core.internal.ui.model.FieldState
 import com.adyen.checkout.components.core.internal.ui.model.OutputData
+import com.adyen.checkout.components.core.internal.util.CountryUtils
+import java.util.Locale
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class AddressOutputData(
@@ -34,7 +36,7 @@ data class AddressOutputData(
             city.validation.isValid() &&
             country.validation.isValid()
 
-    override fun toString(): String {
+    fun getDisplayAddress(locale: Locale): String {
         return listOf(
             street.value,
             houseNumberOrName.value,
@@ -42,7 +44,7 @@ data class AddressOutputData(
             postalCode.value,
             city.value,
             stateOrProvince.value,
-            country.value,
+            CountryUtils.getCountryName(country.value, locale),
         ).filter { it.isNotBlank() }.joinToString(" ")
     }
 }

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/AddressLookupView.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/AddressLookupView.kt
@@ -31,6 +31,7 @@ import com.adyen.checkout.ui.core.internal.util.showKeyboard
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import java.util.Locale
 
 @Suppress("TooManyFunctions")
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -50,6 +51,8 @@ class AddressLookupView @JvmOverloads constructor(
 
     private lateinit var localizedContext: Context
 
+    private lateinit var shopperLocale: Locale
+
     private lateinit var addressLookupDelegate: AddressLookupDelegate
 
     private var addressLookupOptionsAdapter: AddressLookupOptionsAdapter? = null
@@ -63,6 +66,8 @@ class AddressLookupView @JvmOverloads constructor(
     override fun initView(delegate: ComponentDelegate, coroutineScope: CoroutineScope, localizedContext: Context) {
         require(delegate is AddressLookupDelegate) { "Unsupported delegate type" }
         addressLookupDelegate = delegate
+
+        shopperLocale = delegate.componentParams.shopperLocale
 
         this.localizedContext = localizedContext
         initLocalizedStrings(localizedContext)
@@ -164,7 +169,7 @@ class AddressLookupView @JvmOverloads constructor(
     }
 
     private fun initAddressOptions() {
-        addressLookupOptionsAdapter = AddressLookupOptionsAdapter(::onAddressSelected)
+        addressLookupOptionsAdapter = AddressLookupOptionsAdapter(shopperLocale, ::onAddressSelected)
         addressLookupOptionsAdapter?.let { adapter ->
             binding.recyclerViewAddressLookupOptions.adapter = adapter
         }

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/util/AddressFormUtils.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/util/AddressFormUtils.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.ui.core.internal.util
 
 import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.core.Address
+import com.adyen.checkout.components.core.internal.util.CountryUtils
 import com.adyen.checkout.ui.core.internal.data.model.AddressItem
 import com.adyen.checkout.ui.core.internal.ui.AddressFormUIState
 import com.adyen.checkout.ui.core.internal.ui.model.AddressListItem
@@ -70,13 +71,16 @@ object AddressFormUtils {
 
                 val defaultCountryCode = getInitialCountryCode(
                     shopperLocale = shopperLocale,
-                    addressParams = addressParams
+                    addressParams = addressParams,
                 )
-                markAddressListItemSelected(mapToListItem(filteredCountryList), defaultCountryCode)
+                markAddressListItemSelected(
+                    mapToCountryListItem(filteredCountryList, shopperLocale),
+                    defaultCountryCode,
+                )
             }
 
             is AddressParams.Lookup -> {
-                mapToListItem(countryList)
+                mapToCountryListItem(countryList, shopperLocale)
             }
 
             else -> emptyList()
@@ -106,7 +110,7 @@ object AddressFormUtils {
      * @return State options.
      */
     fun initializeStateOptions(stateList: List<AddressItem>): List<AddressListItem> {
-        return markAddressListItemSelected(mapToListItem(stateList))
+        return markAddressListItemSelected(mapToStateListItem(stateList))
     }
 
     /**
@@ -136,7 +140,7 @@ object AddressFormUtils {
                 stateOrProvince = addressOutputData.stateOrProvince.value.ifEmpty { Address.ADDRESS_NULL_PLACEHOLDER },
                 houseNumberOrName = makeHouseNumberOrName(
                     addressOutputData.houseNumberOrName.value,
-                    addressOutputData.apartmentSuite.value
+                    addressOutputData.apartmentSuite.value,
                 ).ifEmpty { Address.ADDRESS_NULL_PLACEHOLDER },
                 city = addressOutputData.city.value.ifEmpty { Address.ADDRESS_NULL_PLACEHOLDER },
                 country = addressOutputData.country.value,
@@ -173,16 +177,34 @@ object AddressFormUtils {
     /**
      * Map a list of [AddressItem] to a list of [AddressListItem].
      *
-     * @param list Input list.
+     * @param list Input country list.
      *
      * @return Mapped list of [AddressListItem].
      */
-    private fun mapToListItem(list: List<AddressItem>): List<AddressListItem> {
+    private fun mapToCountryListItem(list: List<AddressItem>, shopperLocale: Locale): List<AddressListItem> {
+        return list.map {
+            AddressListItem(
+                name = it.id?.let { isoCode -> CountryUtils.getCountryName(isoCode, shopperLocale) }
+                    ?: it.name.orEmpty(),
+                code = it.id.orEmpty(),
+                selected = false,
+            )
+        }
+    }
+
+    /**
+     * Map a list of [AddressItem] to a list of [AddressListItem].
+     *
+     * @param list Input states list.
+     *
+     * @return Mapped list of [AddressListItem].
+     */
+    private fun mapToStateListItem(list: List<AddressItem>): List<AddressListItem> {
         return list.map {
             AddressListItem(
                 name = it.name.orEmpty(),
                 code = it.id.orEmpty(),
-                selected = false
+                selected = false,
             )
         }
     }

--- a/ui-core/src/test/java/com/adyen/checkout/ui/core/internal/ui/model/AddressOutputDataTest.kt
+++ b/ui-core/src/test/java/com/adyen/checkout/ui/core/internal/ui/model/AddressOutputDataTest.kt
@@ -12,24 +12,25 @@ import com.adyen.checkout.components.core.internal.ui.model.FieldState
 import com.adyen.checkout.components.core.internal.ui.model.Validation
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import java.util.Locale
 
 class AddressOutputDataTest {
     @Test
     fun addressOutputDataToString() {
         val addressOutputData = AddressOutputData(
-            postalCode = FieldState("postalCode", Validation.Valid),
-            houseNumberOrName = FieldState("houseNumberOrName", Validation.Valid),
-            apartmentSuite = FieldState("apartmentSuite", Validation.Valid),
-            street = FieldState("street", Validation.Valid),
-            city = FieldState("city", Validation.Valid),
-            stateOrProvince = FieldState("stateOrProvince", Validation.Valid),
-            country = FieldState("country", Validation.Valid),
+            postalCode = FieldState("1234AB", Validation.Valid),
+            houseNumberOrName = FieldState("1", Validation.Valid),
+            apartmentSuite = FieldState("A", Validation.Valid),
+            street = FieldState("Straat", Validation.Valid),
+            city = FieldState("Amsterdam", Validation.Valid),
+            stateOrProvince = FieldState("Noord-Holland", Validation.Valid),
+            country = FieldState("NL", Validation.Valid),
             isOptional = false,
             countryOptions = emptyList(),
             stateOptions = emptyList(),
         )
 
-        val expected = "street houseNumberOrName apartmentSuite postalCode city stateOrProvince country"
-        assertEquals(expected, addressOutputData.toString())
+        val expected = "Straat 1 A 1234AB Amsterdam Noord-Holland Netherlands"
+        assertEquals(expected, addressOutputData.getDisplayAddress(Locale.ENGLISH))
     }
 }

--- a/ui-core/src/test/java/com/adyen/checkout/ui/core/internal/util/AddressFormUtilsTest.kt
+++ b/ui-core/src/test/java/com/adyen/checkout/ui/core/internal/util/AddressFormUtilsTest.kt
@@ -211,17 +211,17 @@ internal class AddressFormUtilsTest {
         )
         val expected = listOf(
             AddressListItem(
-                name = "Canada",
+                name = "Kanada",
                 code = "CA",
                 selected = false,
             ),
             AddressListItem(
-                name = "United States",
+                name = "Vereinigte Staaten",
                 code = "US",
                 selected = false,
             ),
             AddressListItem(
-                name = "United Kingdom",
+                name = "Vereinigtes Königreich",
                 code = "GB",
                 selected = false,
             ),


### PR DESCRIPTION
## Description
[//]: # (Include a short summary of your changes)
[//]: # (If this is a new feature: attach screenshots or a video if applicable)
[//]: # (If this is a bug fix: include a reproduction path)
Display country name instead of country code in `CardView` address lookup selected address field.

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-1039
