### PR TITLE
Fix loading state overlapping error dialog in drop-in

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,3 +10,4 @@
 
 ## Fixed
 - For the Address Lookup functionality, when the postal/zip code field is focused and the user presses back, then it no longer crashes.
+- For drop-in, in some edge-cases the loading state would be shown on top of an error dialog. This is fixed now.

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInActivity.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInActivity.kt
@@ -277,8 +277,6 @@ internal class DropInActivity :
     private fun errorDialogDismissed(reason: String, terminateDropIn: Boolean) {
         if (terminateDropIn) {
             terminateWithError(reason)
-        } else {
-            setLoading(false)
         }
     }
 
@@ -384,6 +382,7 @@ internal class DropInActivity :
     private fun handleDropInServiceResult(dropInServiceResult: BaseDropInServiceResult) {
         adyenLog(AdyenLogLevel.DEBUG) { "handleDropInServiceResult - ${dropInServiceResult::class.simpleName}" }
         dropInViewModel.isWaitingResult = false
+        setLoading(false)
         when (dropInServiceResult) {
             is DropInServiceResult -> handleDropInServiceResult(dropInServiceResult)
             is BalanceDropInServiceResult -> handleDropInServiceResult(dropInServiceResult)
@@ -457,10 +456,10 @@ internal class DropInActivity :
         dropInServiceResult.errorDialog?.let { errorDialog ->
             val errorMessage = errorDialog.message ?: getString(R.string.unknown_error)
             showError(errorDialog.title, errorMessage, reason, dropInServiceResult.dismissDropIn)
-        } ?: if (dropInServiceResult.dismissDropIn) {
-            terminateWithError(reason)
-        } else {
-            setLoading(false)
+        } ?: run {
+            if (dropInServiceResult.dismissDropIn) {
+                terminateWithError(reason)
+            }
         }
     }
 
@@ -480,7 +479,6 @@ internal class DropInActivity :
             handleAction(action)
             return
         }
-        setLoading(false)
         hideAllScreens()
         val actionFragment = ActionComponentDialogFragment.newInstance(action, dropInViewModel.checkoutConfiguration)
         actionFragment.show(supportFragmentManager, ACTION_FRAGMENT_TAG)
@@ -654,7 +652,6 @@ internal class DropInActivity :
 
     private fun handleGiftCardFullPayment(fullPayment: GiftCardBalanceResult.FullPayment) {
         adyenLog(AdyenLogLevel.DEBUG) { "handleGiftCardFullPayment" }
-        setLoading(false)
         showGiftCardPaymentConfirmationDialog(fullPayment.data)
     }
 
@@ -679,7 +676,6 @@ internal class DropInActivity :
     }
 
     private fun handleRemovePaymentMethodResult(id: String) {
-        setLoading(false)
         dropInViewModel.removeStoredPaymentMethodWithId(id)
 
         val preselectedStoredPaymentMethodFragment =

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInActivity.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInActivity.kt
@@ -627,7 +627,7 @@ internal class DropInActivity :
         val loadingDialog = getFragmentByTag(LOADING_FRAGMENT_TAG)
         if (showLoading) {
             if (loadingDialog == null && !supportFragmentManager.isDestroyed) {
-                LoadingDialogFragment.newInstance().show(supportFragmentManager, LOADING_FRAGMENT_TAG)
+                LoadingDialogFragment.newInstance().showNow(supportFragmentManager, LOADING_FRAGMENT_TAG)
             }
         } else {
             loadingDialog?.dismiss()

--- a/drop-in/src/main/res/layout/fragment_giftcard_component.xml
+++ b/drop-in/src/main/res/layout/fragment_giftcard_component.xml
@@ -31,14 +31,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="0dp"
                 android:layout_weight="1" />
-
-            <androidx.core.widget.ContentLoadingProgressBar
-                android:id="@+id/progressBar"
-                style="@style/Widget.AppCompat.ProgressBar"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:visibility="gone" />
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>
 </LinearLayout>


### PR DESCRIPTION
## Description
1. Override this in the drop in service:
```Kotlin
override fun onBalanceCheck(paymentComponentState: PaymentComponentState<*>) {
    val result = handleBalanceResponse(null)
    sendBalanceResult(result)
}
```
2. Open drop-in
3. Do a gift card payment
4. Aaaand you're now stuck on a loading state with an error dialog behind it...

The issue is fixed by using `showNow()` when showing the loading state fragment. An extra improvement is to always dismiss the loading state when we get back a result from the merchant. Before we only dismissed the loading state in some specific places.

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Changes are tested manually

COAND-984
