### PR TITLE
Move loading state to GooglePayView

### DIFF
--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/DefaultGooglePayDelegate.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/DefaultGooglePayDelegate.kt
@@ -135,19 +135,22 @@ internal class DefaultGooglePayDelegate(
 
     private fun updateOutputData(
         isButtonVisible: Boolean = this.outputData.isButtonVisible,
+        isLoading: Boolean = this.outputData.isLoading,
         paymentData: PaymentData? = this.outputData.paymentData,
     ) {
-        val newOutputData = createOutputData(isButtonVisible, paymentData)
+        val newOutputData = createOutputData(isButtonVisible, isLoading, paymentData)
         _outputDataFlow.tryEmit(newOutputData)
         updateComponentState(newOutputData)
     }
 
     private fun createOutputData(
         isButtonVisible: Boolean = componentParams.isSubmitButtonVisible,
+        isLoading: Boolean = !isButtonVisible,
         paymentData: PaymentData? = null,
     ): GooglePayOutputData {
         return GooglePayOutputData(
             isButtonVisible = isButtonVisible,
+            isLoading = isLoading,
             paymentData = paymentData,
         )
     }
@@ -204,7 +207,7 @@ internal class DefaultGooglePayDelegate(
     override fun onSubmit() {
         adyenLog(AdyenLogLevel.DEBUG) { "onSubmit" }
 
-        _viewFlow.tryEmit(PaymentInProgressViewType)
+        updateOutputData(isButtonVisible = false, isLoading = true)
 
         val paymentDataRequest = GooglePayUtils.createPaymentDataRequest(componentParams)
         val paymentDataTask = paymentsClient.loadPaymentData(paymentDataRequest)

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/GooglePayViewProvider.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/GooglePayViewProvider.kt
@@ -16,7 +16,6 @@ import com.adyen.checkout.ui.core.internal.ui.ComponentView
 import com.adyen.checkout.ui.core.internal.ui.ComponentViewType
 import com.adyen.checkout.ui.core.internal.ui.ViewProvider
 import com.adyen.checkout.ui.core.internal.ui.view.PayButton
-import com.adyen.checkout.ui.core.internal.ui.view.ProcessingPaymentView
 
 internal class GooglePayViewProvider : ViewProvider {
 
@@ -25,7 +24,6 @@ internal class GooglePayViewProvider : ViewProvider {
         context: Context,
     ): ComponentView = when (viewType) {
         GooglePayComponentViewType -> GooglePayView(context)
-        PaymentInProgressViewType -> ProcessingPaymentView(context)
         else -> throw IllegalArgumentException("Unsupported view type")
     }
 
@@ -34,7 +32,6 @@ internal class GooglePayViewProvider : ViewProvider {
         layoutInflater: LayoutInflater
     ): ComponentView = when (viewType) {
         GooglePayComponentViewType -> GooglePayView(layoutInflater)
-        PaymentInProgressViewType -> ProcessingPaymentView(layoutInflater.context)
         else -> throw IllegalArgumentException("Unsupported view type")
     }
 }
@@ -49,9 +46,4 @@ internal object GooglePayComponentViewType : ButtonComponentViewType {
     override val viewProvider: ViewProvider get() = GooglePayViewProvider()
 
     override val buttonTextResId: Int = ButtonComponentViewType.DEFAULT_BUTTON_TEXT_RES_ID
-}
-
-internal object PaymentInProgressViewType : ComponentViewType {
-
-    override val viewProvider: ViewProvider get() = GooglePayViewProvider()
 }

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayOutputData.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayOutputData.kt
@@ -12,5 +12,6 @@ import com.google.android.gms.wallet.PaymentData
 
 internal data class GooglePayOutputData(
     val isButtonVisible: Boolean,
+    val isLoading: Boolean,
     val paymentData: PaymentData?,
 )

--- a/googlepay/src/main/res/layout/view_google_pay.xml
+++ b/googlepay/src/main/res/layout/view_google_pay.xml
@@ -20,4 +20,12 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
+    <!-- ProcessingPaymentView has a RestrictTo annotation, but is actually available -->
+    <!--suppress AndroidUnresolvableTag -->
+    <com.adyen.checkout.ui.core.internal.ui.view.ProcessingPaymentView
+        android:id="@+id/processingPaymentView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone" />
+
 </merge>

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/DefaultGooglePayDelegateTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/DefaultGooglePayDelegateTest.kt
@@ -158,6 +158,18 @@ internal class DefaultGooglePayDelegateTest(
         assertEquals(task, payEventFlow.latestValue)
     }
 
+    @Test
+    fun `when onSubmit is called, then button is hidden and loading state is shown`() = runTest {
+        val outputDataFlow = delegate.outputDataFlow.test(testScheduler)
+        delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+
+        delegate.onSubmit()
+
+        val latestOutputData = outputDataFlow.latestValue
+        assertFalse(latestOutputData.isButtonVisible)
+        assertTrue(latestOutputData.isLoading)
+    }
+
     @ParameterizedTest
     @MethodSource("amountSource")
     fun `when input data is valid then amount is propagated in component state if set`(
@@ -353,8 +365,9 @@ internal class DefaultGooglePayDelegateTest(
 
     private fun createOutputData(
         isButtonVisible: Boolean = false,
+        isLoading: Boolean = !isButtonVisible,
         paymentData: PaymentData? = null,
-    ) = GooglePayOutputData(isButtonVisible, paymentData)
+    ) = GooglePayOutputData(isButtonVisible, isLoading, paymentData)
 
     companion object {
         private val TEST_ORDER = OrderRequest("PSP", "ORDER_DATA")

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/ProcessingPaymentView.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/ProcessingPaymentView.kt
@@ -23,7 +23,9 @@ import com.adyen.checkout.ui.core.internal.util.setLocalizedTextFromStyle
 import kotlinx.coroutines.CoroutineScope
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class ProcessingPaymentView @JvmOverloads constructor(
+class ProcessingPaymentView
+@JvmOverloads
+constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0,


### PR DESCRIPTION
## Description
Previously, the GooglePayView was replaced with ProcessingPaymentView. This causes the Activity Result API to fail and not deliver the result in case the view got recreated on configuration change. By keeping the GooglePayView in view it will be able to successfully restore it's state and deliver the activity result. Making the loading state part of the GooglePayView is essential to fix this problem.

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Code is unit tested

COAND-941
