### PR TITLE
Analytics - Remove tracking redirect cancelled event

### DIFF
--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/analytics/ErrorEvent.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/analytics/ErrorEvent.kt
@@ -17,7 +17,6 @@ enum class ErrorEvent(val errorType: Type, val errorCode: String) {
     // Redirect
     REDIRECT_FAILED(Type.REDIRECT, "600"),
     REDIRECT_PARSE_FAILED(Type.REDIRECT, "601"),
-    REDIRECT_CANCELLED(Type.REDIRECT, "602"),
 
     // Encryption
     ENCRYPTION(Type.INTERNAL, "610"),

--- a/redirect/src/main/java/com/adyen/checkout/redirect/internal/ui/DefaultRedirectDelegate.kt
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/internal/ui/DefaultRedirectDelegate.kt
@@ -28,7 +28,6 @@ import com.adyen.checkout.components.core.internal.analytics.GenericEvents
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParams
 import com.adyen.checkout.components.core.internal.util.bufferedChannel
 import com.adyen.checkout.core.AdyenLogLevel
-import com.adyen.checkout.core.exception.CancellationException
 import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.core.exception.HttpException
@@ -143,7 +142,7 @@ constructor(
         } catch (ex: CheckoutException) {
             val event = GenericEvents.error(
                 component = action?.paymentMethodType.orEmpty(),
-                event = ErrorEvent.REDIRECT_FAILED
+                event = ErrorEvent.REDIRECT_FAILED,
             )
             analyticsManager?.trackEvent(event)
 
@@ -167,7 +166,7 @@ constructor(
         } catch (ex: CheckoutException) {
             val event = GenericEvents.error(
                 component = action?.paymentMethodType.orEmpty(),
-                event = ErrorEvent.REDIRECT_PARSE_FAILED
+                event = ErrorEvent.REDIRECT_PARSE_FAILED,
             )
             analyticsManager?.trackEvent(event)
 
@@ -201,14 +200,6 @@ constructor(
     }
 
     override fun onError(e: CheckoutException) {
-        if (e is CancellationException) {
-            val event = GenericEvents.error(
-                component = action?.paymentMethodType.orEmpty(),
-                event = ErrorEvent.REDIRECT_CANCELLED
-            )
-            analyticsManager?.trackEvent(event)
-        }
-
         emitError(e)
     }
 

--- a/redirect/src/test/java/com/adyen/checkout/redirect/internal/ui/DefaultRedirectDelegateTest.kt
+++ b/redirect/src/test/java/com/adyen/checkout/redirect/internal/ui/DefaultRedirectDelegateTest.kt
@@ -23,7 +23,6 @@ import com.adyen.checkout.components.core.internal.analytics.TestAnalyticsManage
 import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.components.core.internal.ui.model.GenericComponentParamsMapper
 import com.adyen.checkout.core.Environment
-import com.adyen.checkout.core.exception.CancellationException
 import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.core.exception.HttpException
 import com.adyen.checkout.core.exception.ModelSerializationException
@@ -234,24 +233,6 @@ internal class DefaultRedirectDelegateTest(
             val expectedEvent = GenericEvents.error(
                 component = TEST_PAYMENT_METHOD_TYPE,
                 event = ErrorEvent.REDIRECT_PARSE_FAILED,
-            )
-            analyticsManager.assertLastEventEquals(expectedEvent)
-        }
-
-        @Test
-        fun `when redirect is cancelled with CancellationException, then an event is tracked`() = runTest {
-            val action = RedirectAction(
-                paymentMethodType = TEST_PAYMENT_METHOD_TYPE,
-                type = TEST_ACTION_TYPE,
-            )
-            delegate.handleAction(action, Activity())
-
-            val exception = CancellationException("Redirect flow cancelled.")
-            delegate.onError(exception)
-
-            val expectedEvent = GenericEvents.error(
-                component = TEST_PAYMENT_METHOD_TYPE,
-                event = ErrorEvent.REDIRECT_CANCELLED,
             )
             analyticsManager.assertLastEventEquals(expectedEvent)
         }


### PR DESCRIPTION
## Description
Do not track an error event if the user cancels the redirect flow, since it is not considered an error anymore.

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-1006
