### PR TITLE
Release - Add release notes jobs to the release workflow

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,8 +1,10 @@
 name: Publish Release
 
-# Every time we trigger the workflow on a branch.
+# Every time a release/** branch is created
 on:
-  workflow_dispatch:
+  create:
+    branches:
+      - 'releases/**'
 
 jobs:
   check:

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,10 +1,10 @@
 name: Publish Release
 
-# Every time a release/** branch is created
+# Every time a push happens to the release/** branch. We use this trigger since create event does not support filtering
 on:
-  create:
+  push:
     branches:
-      - 'releases/**'
+      - 'release/**'
 
 jobs:
   check:

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -19,9 +19,22 @@ jobs:
     with:
       version-name: ${{ needs.generate_version_name.outputs.version-name }}
   create_github_release:
-    name: Create GitHub Release
+    name: Create GitHub release
     uses: ./.github/workflows/create_github_release.yml
     secrets: inherit
     needs: [generate_version_name, publish_to_maven_central]
+    with:
+      version-name: ${{ needs.generate_version_name.outputs.version-name }}
+  generate_release_notes:
+    name: Generate release notes
+    uses: ./.github/workflows/generate_release_notes.yml
+    secrets: inherit
+    needs: [generate_version_name, create_github_release]
+    with:
+      version-name: ${{ needs.generate_version_name.outputs.version-name }}
+  create_release_notes_pr:
+    name: Create release notes pr
+    uses: ./.github/workflows/create_release_notes_pr.yml
+    needs: [generate_version_name, generate_release_notes]
     with:
       version-name: ${{ needs.generate_version_name.outputs.version-name }}


### PR DESCRIPTION
## Description
- Added generating release notes and creating release notes pr steps to the release workflow
- Used `push` trigger to start the release workflow. `create` trigger does not support branch filtering and since we will add a rule to not allow pushes on release notes, this should function similarly.

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Changes are tested manually

COAND-1016
