### PR TITLE
Automatically update verification metadata when AGP is updated

### DIFF
--- a/.github/workflows/update_verification_metadata.yml
+++ b/.github/workflows/update_verification_metadata.yml
@@ -1,17 +1,21 @@
 name: Update verification metadata
 
 on:
+  push:
+    branches:
+      - 'renovate/android.gradle.plugin'
   workflow_dispatch:
 
 jobs:
   update-verification-metadata:
     name: Update verification metadata
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.commits[0].message, '[skip update-verification-metadata]') }}
 
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          token: ${{ secrets.ADYEN_AUTOMATION_BOT_ACCESS_TOKEN }}
 
       - name: Set up JDK
         uses: actions/setup-java@v4
@@ -32,8 +36,10 @@ jobs:
 
       - name: Commit
         run: |
-          git config --global user.name "${{ github.actor }}"
-          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "${{ secrets.ADYEN_AUTOMATION_BOT_USER }}"
+          git config user.email "${{ secrets.ADYEN_AUTOMATION_BOT_NO_REPLY_EMAIL }}"
           git add .
-          git diff-index --quiet HEAD || git commit -am 'Update verification metadata'
+          git diff-index --quiet HEAD || git commit -m "Update verification metadata
+          
+          [skip update-verification-metadata]"
           git push


### PR DESCRIPTION
## Description

Added a new trigger to the `Update verification metadata` job to run automatically when code is pushed to a branch named `renovate/android.gradle.plugin` (this is the name of the branch that Renovate creates when updating AGP).
- For now AGP is the only dependency where we need to run this command. If we encounter similar issues in other dependencies we should add there branch names as well. Adding this step as part of any dependency update is overkill and will waste resources since the job can takes +40 minutes to complete and it will produce no code changes except with AGP.
- The trigger is set to `push` instead of `pull_request` because we should only run this job when new code is pushed.
- The `AdyenAutomationBot` will make a commit when the job is done, however this commit would trigger another job run since it is considered a `push`. To avoid this issue check the `[skip update-verification-metadata]` line in the commit message and the job's `if` condition. However, the only downside of this is that the first job will trigger a second job run which will be skipped right away through this `if` condition.
- The reason the `AdyenAutomationBot` is used instead of the github actions bot is that commits made from the github actions bot do not trigger any jobs [by design](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow). Which means that PRs will not be mergeable since their last commit will be unchecked. 

Used a test branch to verify the job:
- Manually created a branch named `renovate/android.gradle.plugin` and pushed a [commit](https://github.com/Adyen/adyen-android/commit/c80d0d34d536ca3a06049d7c54d49891a365733c)  that bumps the AGP version.
- This commit triggers an [Update verification metadata job run](https://github.com/Adyen/adyen-android/actions/runs/12354889144) which is turn updates the metadata and pushed [this commit](https://github.com/Adyen/adyen-android/commit/0613683fed2598ee0ca333b479e37318920c7de0).
- The second push triggers another [Update verification metadata job run](https://github.com/Adyen/adyen-android/actions/runs/12355679284), this one however is skipped because the commit had `[skip update-verification-metadata]` in its body.

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Changes are tested manually