### PR TITLE
Release - Make uploading to maven central run manually

### DIFF
--- a/.github/workflows/publish_to_maven_central.yml
+++ b/.github/workflows/publish_to_maven_central.yml
@@ -1,6 +1,13 @@
 name: Publish to Maven Central
 
 on:
+  workflow_dispatch:
+    inputs:
+      version-name:
+        description: "Version name of the build"
+        required: true
+        type: string
+
   workflow_call:
     inputs:
       version-name:


### PR DESCRIPTION
## Description
Allow the workflow to upload the build to maven central to also be run manually

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Changes are tested manually

COAND-1051
