### PR TITLE
Release - Move release scripts to the release notes branch

### DIFF
--- a/.github/workflows/cleanup_release.yml
+++ b/.github/workflows/cleanup_release.yml
@@ -1,0 +1,28 @@
+name: Finalize Release
+
+# Every time the workflow is triggered
+on:
+  workflow_call:
+    inputs:
+      version-name:
+        required: true
+        type: string
+
+jobs:
+  remove_release_branch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Remove release branch
+        env:
+          VERSION_NAME: ${{ inputs.version-name }}
+        run: |
+          RELEASE_BRANCH_NAME="release/$VERSION_NAME"
+          
+          if git ls-remote --exit-code --heads origin "$RELEASE_BRANCH_NAME"; then
+            git push origin --delete "$RELEASE_BRANCH_NAME"
+          else
+            echo "Warning: Branch $RELEASE_BRANCH_NAME does not exist."
+          fi

--- a/.github/workflows/fetch_version_name_from_release_notes.yml
+++ b/.github/workflows/fetch_version_name_from_release_notes.yml
@@ -1,0 +1,26 @@
+name: Fetch version name from release notes
+
+on:
+  workflow_call:
+    outputs:
+      version-name:
+        description: "The version name of the release associated to latest release notes"
+        value: ${{ jobs.fetch_version_name.outputs.version-name }}
+
+jobs:
+  fetch_version_name:
+    name: Fetch Version Name
+    runs-on: ubuntu-latest
+    outputs:
+      version-name: ${{ steps.fetch_version_name.outputs.version-name }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fetch version name from latest release notes
+        id: fetch_version_name
+        run: |
+          chmod +x scripts/fetch_release_notes_version_name.sh
+          commit_message="${{ github.event.head_commit.message }}"
+          VERSION_NAME=$(./scripts/fetch_release_notes_version_name.sh "${commit_message// /}")
+          echo -e "version-name=$VERSION_NAME" >> $GITHUB_OUTPUT
+          echo -e $VERSION_NAME

--- a/.github/workflows/finalize_release.yml
+++ b/.github/workflows/finalize_release.yml
@@ -1,0 +1,32 @@
+name: Finalize release
+
+on:
+  push:
+    branches:
+      - 'release-notes'
+
+jobs:
+  fetch_version_name:
+    name: Fetch version name
+    uses: ./.github/workflows/fetch_version_name_from_release_notes.yml
+  update_release_notes:
+    name: Update release notes
+    uses: ./.github/workflows/update_release_notes.yml
+    secrets: inherit
+    needs: fetch_version_name
+    with:
+      version-name: ${{ needs.fetch_version_name.outputs.version-name }}
+  publish_github_release:
+    name: Publish Github release
+    uses: ./.github/workflows/publish_github_release.yml
+    secrets: inherit
+    needs: [fetch_version_name, update_release_notes]
+    with:
+      version-name: ${{ needs.fetch_version_name.outputs.version-name }}
+  cleanup_release:
+    name: Clean up release
+    uses: ./.github/workflows/cleanup_release.yml
+    secrets: inherit
+    needs: [fetch_version_name, publish_github_release]
+    with:
+      version-name: ${{ needs.fetch_version_name.outputs.version-name }}

--- a/.github/workflows/publish_github_release.yml
+++ b/.github/workflows/publish_github_release.yml
@@ -1,0 +1,31 @@
+name: Finalize Release
+
+# Every time the workflow is triggered
+on:
+  workflow_call:
+    inputs:
+      version-name:
+        required: true
+        type: string
+
+jobs:
+  publish_draft_release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Publish Github release and the tag
+      - name: Publish Github release
+        uses: ncipollo/release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION_NAME: ${{ inputs.version-name }}
+        with:
+          token: ${{ env.GITHUB_TOKEN }}
+          tag: ${{ env.VERSION_NAME }}
+          allowUpdates: true
+          updateOnlyUnreleased: true
+          omitNameDuringUpdate: true
+          omitBodyDuringUpdate: true
+          draft: false

--- a/.github/workflows/update_release_notes.yml
+++ b/.github/workflows/update_release_notes.yml
@@ -1,0 +1,59 @@
+name: Update release notes
+
+# Every time the workflow is triggered
+on:
+  workflow_call:
+    inputs:
+      version-name:
+        required: true
+        type: string
+
+jobs:
+  fetch_updated_release_notes_file:
+    name: Fetch Updated Release Notes File
+    runs-on: ubuntu-latest
+    outputs:
+      updated-release-notes-filepath: ${{ steps.fetch_updated_release_notes_file.outputs.updated-release-notes-filepath }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch filepath for updated release notes file
+        id: fetch_updated_release_notes_file
+        env:
+          PROJECT_ROOT: ${{ github.workspace }}
+          VERSION_NAME: ${{ inputs.version-name }}
+        run: |
+          chmod +x scripts/fetch_updated_release_notes_file.sh
+          UPDATED_RELEASE_NOTES_FILEPATH=$(./scripts/fetch_updated_release_notes_file.sh $PROJECT_ROOT $VERSION_NAME)
+          echo -e "updated-release-notes-filepath=$UPDATED_RELEASE_NOTES_FILEPATH" >> $GITHUB_OUTPUT
+          echo -e $UPDATED_RELEASE_NOTES_FILEPATH
+
+  update_release_notes:
+    name: Update Release Notes
+    runs-on: ubuntu-latest
+    needs: fetch_updated_release_notes_file
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Print updated release notes
+        run: |
+          cat ${{ needs.fetch_updated_release_notes_file.outputs.updated-release-notes-filepath }}
+
+      # Update Github release with the updated release notes
+      - name: Update Github release notes
+        id: update_github_release_notes
+        uses: ncipollo/release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION_NAME: ${{ inputs.version-name }}
+          BODY_FILE : ${{ needs.fetch_updated_release_notes_file.outputs.updated-release-notes-filepath }}
+        with:
+          token: ${{ env.GITHUB_TOKEN }}
+          tag: ${{ env.VERSION_NAME }}
+          allowUpdates: true
+          updateOnlyUnreleased: true
+          omitNameDuringUpdate: true
+          draft: true
+          bodyFile: ${{ env.BODY_FILE }}

--- a/scripts/fetch_release_notes_version_name.sh
+++ b/scripts/fetch_release_notes_version_name.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Copyright (c) 2024 Adyen N.V.
+#
+# This file is open source and available under the MIT license. See the LICENSE file for more info.
+#
+# Created by ozgur on 10/12/2024.
+#
+function fetch_release_notes_version_name() {
+    if [ "$#" -ne 1 ]; then
+        echo "Usage: $0 <merge_commit_message>" >&2
+        exit 1
+    fi
+    commit_message=$1
+
+    # Extract the branch name
+    release_notes_branch_name=$(echo "$commit_message" | grep -oE 'release-notes.*')
+
+    # Check if "release-notes" was found
+    if [[ -z "$release_notes_branch_name" ]]; then
+        echo "No part starting with 'release-notes' found in the string." >&2
+        exit 1
+    fi
+
+    # Regex for version (starts with a version number like 1.2.3.md)
+    version_name_regex="[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}(-(alpha|beta|rc)[0-9]{2})?"
+
+    # Extract the version name from the "release-notes" part
+    version_name=$(echo "$release_notes_branch_name" | grep -oE "$version_name_regex")
+
+    # Check if version name was found
+    if [[ -z "$version_name" ]]; then
+        echo "Version cannot be extracted." >&2
+        exit 1
+    fi
+
+    echo "$version_name"
+}
+
+fetch_release_notes_version_name "$1"

--- a/scripts/fetch_updated_release_notes_file.sh
+++ b/scripts/fetch_updated_release_notes_file.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Copyright (c) 2024 Adyen N.V.
+#
+# This file is open source and available under the MIT license. See the LICENSE file for more info.
+#
+# Created by ozgur on 10/12/2024.
+#
+function fetch_updated_release_notes_file() {
+    if [ "$#" -ne 2 ]; then
+        echo "Error: Not enough arguments. Usage: $0 <project_root_directory> <version_name>" >&2
+        exit 1
+    fi
+
+    directory=$1
+    version_name=$2
+    notes_file_name="${version_name}.md"
+
+    # Search for matching files using the find command
+    file=$(ls -R "$directory" 2>/dev/null | grep -x "$notes_file_name")
+    if [[ -z "$file" ]]; then
+          echo "Release notes file is not found. Make sure release notes file with name ${notes_file_name} exists in the project root directory." >&2
+          exit 1
+    fi
+    if [[ "${directory: -1}" == "/" ]]; then
+        full_path="${directory}${file}"
+    else
+        full_path="${directory}/${file}"
+    fi
+    echo "$full_path"
+}
+
+fetch_updated_release_notes_file $1 $2


### PR DESCRIPTION
## Description
- After merging the release notes PR, a single `finalize_release` workflow will be run.
- All related jobs have been separated into different files to keep the main workflow clean
- All release notes related files have been moved to the `release-notes` branch, since they need access to the files.

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Changes are tested manually

COAND-1054
