### PR TITLE
Release - Add action to verify new dependencies

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -28,3 +28,6 @@ jobs:
     name: Validate public API
     uses: ./.github/workflows/validate_public_api.yml
     secrets: inherit
+  verify_dependencies:
+    name: Validate dependencies
+    uses: ./.github/workflows/validate_dependencies.yml

--- a/.github/workflows/validate_dependencies.yml
+++ b/.github/workflows/validate_dependencies.yml
@@ -1,0 +1,20 @@
+name: Validate dependencies
+
+on:
+  workflow_call:
+
+jobs:
+  validate_dependencies_for_release_notes:
+    runs-on: ubuntu-latest
+    name: Validate newly added dependencies for release notes
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate dependencies for release notes
+        run: |
+          chmod +x scripts/validate_dependencies_for_release_notes.py
+          pip install toml
+          python scripts/validate_dependencies_for_release_notes.py

--- a/scripts/validate_dependencies_for_release_notes.py
+++ b/scripts/validate_dependencies_for_release_notes.py
@@ -12,7 +12,6 @@ def fetch_changed_dependencies() -> dict:
         ['git', 'merge-base', 'origin/main', 'HEAD']
     ).decode(sys.stdout.encoding).strip()
 
-
     # Fetch the version of the file before the PR changes
     old_toml_file = subprocess.check_output(
         ['git', 'show', base_commit + ':' + toml_file_path]

--- a/scripts/validate_dependencies_for_release_notes.py
+++ b/scripts/validate_dependencies_for_release_notes.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+
+import subprocess
+import sys
+import toml
+
+def fetch_changed_dependencies() -> dict:
+    toml_file_path = 'gradle/libs.versions.toml'
+
+    # Fetch the base commit of the PR using the merge base
+    base_commit = subprocess.check_output(
+        ['git', 'merge-base', 'origin/main', 'HEAD']
+    ).decode(sys.stdout.encoding).strip()
+
+
+    # Fetch the version of the file before the PR changes
+    old_toml_file = subprocess.check_output(
+        ['git', 'show', base_commit + ':' + toml_file_path]
+    ).decode(sys.stdout.encoding).strip()
+    old_versions = toml.loads(old_toml_file)
+
+    # Load the current version of the file after the PR changes
+    with open(toml_file_path) as file:
+        new_versions = toml.load(file)
+
+    # Combine libraries and plugins for both old and new versions
+    old_dependencies = {**old_versions['libraries'], **old_versions['plugins']}
+    new_dependencies = {**new_versions['libraries'], **new_versions['plugins']}
+
+    # Identify newly added dependencies
+    added_dependencies = {}
+
+    for dependency_name, dependency_data in new_dependencies.items():
+        # Check if the dependency is not in the old dependencies
+        if dependency_name not in old_dependencies:
+            # Add the new dependency to the dictionary
+            added_dependencies[dependency_name] = dependency_data
+
+    return added_dependencies
+
+def validate_new_dependencies(added_dependencies):
+    with open('.github/release_notes_dependency_list.toml') as file:
+        dependency_list = toml.load(file)
+
+    for value in added_dependencies.values():
+        # Determine the identifier for matching
+        if 'group' in value and 'name' in value:
+            id = value['group'] + ':' + value['name']
+        elif 'module' in value:
+            id = value['module']
+        else:
+            id = value['id']
+
+        # Check against included and excluded lists
+        if id not in dependency_list['excluded'] and id not in dependency_list['included']:
+            raise Exception(
+                f"❌ Dependency not recognized: {id}\n"
+                "Please add it to either the 'included' or 'excluded' lists in `.github/release_notes_dependency_list.toml`."
+            )
+
+def main():
+    try:
+        # Check for changed dependencies in the PR
+        added_dependencies = fetch_changed_dependencies()
+
+        if added_dependencies:
+            validate_new_dependencies(added_dependencies)
+            print("✅ All new dependencies are properly listed.")
+        else:
+            print("✅ No new dependencies added in this PR.")
+
+    except Exception as e:
+        print(f"❌ Error: {e}")
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Description
Added a new action to run as part of `check_pr` workflow and fail if there are newly added dependencies which are not part of `included` or `excluded` lists for release notes.

Here are workflow runs:
- [New dependency has been added, which causes the action to fail](https://github.com/Adyen/adyen-testcards-android/actions/runs/12636449335/job/35208539572?pr=55) ❌
- [Action run on a PR where no dependencies have been changed](https://github.com/Adyen/adyen-testcards-android/actions/runs/12636429874/job/35208475346?pr=55) ✅
- [Action run on a PR where new dependency has been added](https://github.com/Adyen/adyen-testcards-android/actions/runs/12636662709/job/35209229890?pr=56) ✅

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Changes are tested manually

COAND-1055
