### PR TITLE
Propagate additionalDetails on native 3ds2 cancel flow

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Cancelled3DS2Exception.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/Cancelled3DS2Exception.kt
@@ -12,6 +12,7 @@ import com.adyen.checkout.core.exception.ComponentException
 /**
  * This exception is an indication that the 3DS2 Authentication was cancelled by the user.
  */
+@Deprecated("This exception is no longer in use")
 class Cancelled3DS2Exception(errorMessage: String) : ComponentException(errorMessage) {
     companion object {
         private const val serialVersionUID = 3858008275644429050L

--- a/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2DelegateTest.kt
+++ b/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2DelegateTest.kt
@@ -16,7 +16,6 @@ import android.content.Context
 import android.content.Intent
 import androidx.lifecycle.SavedStateHandle
 import com.adyen.checkout.adyen3ds2.Authentication3DS2Exception
-import com.adyen.checkout.adyen3ds2.Cancelled3DS2Exception
 import com.adyen.checkout.adyen3ds2.internal.analytics.ThreeDS2Events
 import com.adyen.checkout.adyen3ds2.internal.data.api.SubmitFingerprintRepository
 import com.adyen.checkout.adyen3ds2.internal.data.model.Adyen3DS2Serializer
@@ -489,8 +488,8 @@ internal class DefaultAdyen3DS2DelegateTest(
         }
 
         @Test
-        fun `cancelled, then an error is emitted`() = runTest {
-            val exceptionFlow = delegate.exceptionFlow.test(testScheduler)
+        fun `cancelled, then details are emitted`() = runTest {
+            val detailsFlow = delegate.detailsFlow.test(testScheduler)
 
             delegate.onCompletion(
                 result = ChallengeResult.Cancelled(
@@ -499,11 +498,11 @@ internal class DefaultAdyen3DS2DelegateTest(
                 ),
             )
 
-            assertTrue(exceptionFlow.latestValue is Cancelled3DS2Exception)
+            assertNotNull(detailsFlow.latestValue.details)
         }
 
         @Test
-        fun `timedout, then details are emitted`() = runTest {
+        fun `timed out, then details are emitted`() = runTest {
             val detailsFlow = delegate.detailsFlow.test(testScheduler)
 
             delegate.onCompletion(

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,8 +26,7 @@
   |                           |                     |
 
 ## Deprecated
-- `Cancelled3DS2Exception` is now deprecated. Shopper cancellations trigger the `onAdditionalDetails()` event, enabling a `/payments/details` call for transaction insights.
-- For 3DS2 native flow, `Cancelled3DS2Exception` is deprecated. Now the shopper cancellations triggers `onAdditionalDetails()` and you can make a `/payments/details` call.
+- `Cancelled3DS2Exception` is now deprecated. Shopper cancellation of the 3DS2 native flow triggers the `onAdditionalDetails()` event, enabling a `/payments/details` call for transaction insights.
 - The styles and strings for the Cash App Pay loading indicator. Use the new styles and strings instead.
   | Previous                                                  | Now                                                              |
   |-----------------------------------------------------------|------------------------------------------------------------------|

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@
 ## New
 - Launch Google Pay with `submit()` to get rid of the deprecated activity result handling.
 - For drop-in, show a toolbar on every intermediary screen, so shoppers can always easily navigate back.
+- For 3DS2 native flow, cancellations by shopper trigger `onAdditionalDetails()` now. With this change, merchants will be able to make a `/payments/details` call so that they can get more insight on the transaction. 
 
 ## Fixed
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,19 +11,23 @@
 ## New
 - Launch Google Pay with `submit()` to get rid of the deprecated activity result handling.
 - For drop-in, show a toolbar on every intermediary screen, so shoppers can always easily navigate back.
-- For 3DS2 native flow, cancellations by shopper trigger `onAdditionalDetails()` now. With this change, merchants will be able to make a `/payments/details` call so that they can get more insight on the transaction. 
 
 ## Fixed
 
 ## Improved
 
 ## Changed
+- For 3DS2 native flow, cancellations by shopper trigger `onAdditionalDetails()` event. You can make a `/payments/details` call to gain more insight into the transaction.
+  - If you already handle other 3DS2 errors by making a `/payments/details` call, then no changes are required and the specific handling for `Cancelled3DS2Exception` can be removed.
+  - If not yet implemented, you should update your systems to handle shopper cancellations using the new flow.
 - Dependency versions:
   | Name                                                                                                   | Version                       |
   |--------------------------------------------------------------------------------------------------------|-------------------------------|
   |                           |                     |
 
 ## Deprecated
+- `Cancelled3DS2Exception` is now deprecated. Shopper cancellations trigger the `onAdditionalDetails()` event, enabling a `/payments/details` call for transaction insights.
+- For 3DS2 native flow, `Cancelled3DS2Exception` is deprecated. Now the shopper cancellations triggers `onAdditionalDetails()` and you can make a `/payments/details` call.
 - The styles and strings for the Cash App Pay loading indicator. Use the new styles and strings instead.
   | Previous                                                  | Now                                                              |
   |-----------------------------------------------------------|------------------------------------------------------------------|


### PR DESCRIPTION
## Description
[//]: # (Include a short summary of your changes)
[//]: # (If this is a new feature: attach screenshots or a video if applicable)
[//]: # (If this is a bug fix: include a reproduction path)
Trigger `onAdditionalDetails()` with the payload we get from 3ds2 sdk so that merchants can make a `/details` call with it.

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-1057
