### PR TITLE
Release - Add trigger finalize release workflow

### DIFF
--- a/.github/workflows/fetch_version_name_from_release_notes.yml
+++ b/.github/workflows/fetch_version_name_from_release_notes.yml
@@ -1,0 +1,26 @@
+name: Fetch version name from release notes
+
+on:
+  workflow_call:
+    outputs:
+      version-name:
+        description: "The version name of the release associated to latest release notes"
+        value: ${{ jobs.fetch_version_name.outputs.version-name }}
+
+jobs:
+  fetch_version_name:
+    name: Fetch Version Name
+    runs-on: ubuntu-latest
+    outputs:
+      version-name: ${{ steps.fetch_version_name.outputs.version-name }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fetch version name from latest release notes
+        id: fetch_version_name
+        run: |
+          chmod +x scripts/fetch_release_notes_version_name.sh
+          commit_message="${{ github.event.head_commit.message }}"
+          VERSION_NAME=$(./scripts/fetch_release_notes_version_name.sh "${commit_message// /}")
+          echo -e "version-name=$VERSION_NAME" >> $GITHUB_OUTPUT
+          echo -e $VERSION_NAME

--- a/.github/workflows/trigger_finalize_release.yml
+++ b/.github/workflows/trigger_finalize_release.yml
@@ -1,0 +1,32 @@
+name: Trigger Finalize Release
+
+on:
+  push:
+    branches:
+      - 'release-notes'
+
+jobs:
+  fetch_version_name:
+    name: Fetch version name
+    uses: ./.github/workflows/fetch_version_name_from_release_notes.yml
+
+  trigger_finalize_release:
+    name: Trigger Finalize Release on Release Branch
+    runs-on: ubuntu-latest
+    needs: fetch_version_name
+    env:
+      VERSION_NAME: ${{ needs.fetch_version_name.outputs.version-name }}
+
+    steps:
+      - name: Checkout to Release and Trigger Finalize Release
+        run: |
+          curl -X POST \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/${{ github.repository }}/actions/workflows/finalize_release.yml/dispatches \
+          -d '{
+            "ref":"release/${{ env.VERSION_NAME }}",
+            "inputs": {
+              "version-name": "${{ env.VERSION_NAME }}"
+            }
+          }'

--- a/scripts/fetch_release_notes_version_name.sh
+++ b/scripts/fetch_release_notes_version_name.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Copyright (c) 2024 Adyen N.V.
+#
+# This file is open source and available under the MIT license. See the LICENSE file for more info.
+#
+# Created by ozgur on 10/12/2024.
+#
+function fetch_release_notes_version_name() {
+    if [ "$#" -ne 1 ]; then
+        echo "Usage: $0 <merge_commit_message>" >&2
+        exit 1
+    fi
+    commit_message=$1
+
+    # Extract the branch name
+    release_notes_branch_name=$(echo "$commit_message" | grep -oE 'release-notes.*')
+
+    # Check if "release-notes" was found
+    if [[ -z "$release_notes_branch_name" ]]; then
+        echo "No part starting with 'release-notes' found in the string." >&2
+        exit 1
+    fi
+
+    # Regex for version (starts with a version number like 1.2.3.md)
+    version_name_regex="[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}(-(alpha|beta|rc)[0-9]{2})?"
+
+    # Extract the version name from the "release-notes" part
+    version_name=$(echo "$release_notes_branch_name" | grep -oE "$version_name_regex")
+
+    # Check if version name was found
+    if [[ -z "$version_name" ]]; then
+        echo "Version cannot be extracted." >&2
+        exit 1
+    fi
+
+    echo "$version_name"
+}
+
+fetch_release_notes_version_name "$1"

--- a/scripts/fetch_updated_release_notes_file.sh
+++ b/scripts/fetch_updated_release_notes_file.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Copyright (c) 2024 Adyen N.V.
+#
+# This file is open source and available under the MIT license. See the LICENSE file for more info.
+#
+# Created by ozgur on 10/12/2024.
+#
+function fetch_updated_release_notes_file() {
+    if [ "$#" -ne 2 ]; then
+        echo "Error: Not enough arguments. Usage: $0 <project_root_directory> <version_name>" >&2
+        exit 1
+    fi
+
+    directory=$1
+    version_name=$2
+    notes_file_name="${version_name}.md"
+
+    # Search for matching files using the find command
+    file=$(ls -R "$directory" 2>/dev/null | grep -x "$notes_file_name")
+    if [[ -z "$file" ]]; then
+          echo "Release notes file is not found. Make sure release notes file with name ${notes_file_name} exists in the project root directory." >&2
+          exit 1
+    fi
+    if [[ "${directory: -1}" == "/" ]]; then
+        full_path="${directory}${file}"
+    else
+        full_path="${directory}/${file}"
+    fi
+    echo "$full_path"
+}
+
+fetch_updated_release_notes_file $1 $2


### PR DESCRIPTION
## Description
[//]: # (Include a short summary of your changes)
[//]: # (If this is a new feature: attach screenshots or a video if applicable)
[//]: # (If this is a bug fix: include a reproduction path)
Whenever there's a push (i.e. update release notes PR merge) to `release-notes` branch, `trigger_finalize_release.yml` workflow triggers `finalize_release.yml` on `release/<VERSION_NAME>` branch. 
We will keep fetching the version name and fetching the updated release notes file bash scripts on this branch, since they are needed to be placed on the same branch as the release notes files.
Although `fetch_updated_release_notes_file.sh` is on this branch, it will be run from `release/<VERSION_NAME>` branch since we will be managing the whole `finalize_release` workflow there.

## Checklist <!-- Remove any line that's not applicable -->
- [x] PR is labelled <!-- Breaking change, Feature, Fix, Dependencies or Chore -->
- [x] Changes are tested manually

COAND-1034
