### PR TITLE
Address Lookup hide keyboard

### DIFF
--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/AddressLookupView.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/AddressLookupView.kt
@@ -25,6 +25,7 @@ import com.adyen.checkout.ui.core.internal.ui.AddressLookupDelegate
 import com.adyen.checkout.ui.core.internal.ui.ComponentView
 import com.adyen.checkout.ui.core.internal.ui.model.AddressLookupState
 import com.adyen.checkout.ui.core.internal.util.formatStringWithHyperlink
+import com.adyen.checkout.ui.core.internal.util.hideKeyboard
 import com.adyen.checkout.ui.core.internal.util.setLocalizedQueryHintFromStyle
 import com.adyen.checkout.ui.core.internal.util.setLocalizedTextFromStyle
 import com.adyen.checkout.ui.core.internal.util.showKeyboard
@@ -303,7 +304,13 @@ class AddressLookupView @JvmOverloads constructor(
     }
 
     private fun onAddressSelected(lookupAddress: LookupAddress) {
+        removeFocusFromSearch()
         addressLookupDelegate.onAddressLookupCompletion(lookupAddress)
+    }
+
+    private fun removeFocusFromSearch() {
+        binding.textInputLayoutAddressLookupQuerySearch.hideKeyboard()
+        binding.textInputLayoutAddressLookupQuerySearch.clearFocus()
     }
 
     override fun getView(): View = this

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/AddressLookupView.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/AddressLookupView.kt
@@ -143,6 +143,7 @@ class AddressLookupView @JvmOverloads constructor(
             setOnQueryTextListener(
                 object : OnQueryTextListener {
                     override fun onQueryTextSubmit(query: String): Boolean {
+                        removeFocusFromSearch()
                         return true
                     }
 

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/AddressLookupView.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/AddressLookupView.kt
@@ -173,17 +173,15 @@ class AddressLookupView @JvmOverloads constructor(
     }
 
     private fun initManualEntryFields() {
-        binding.textViewManualEntryError.setOnClickListener {
+        val listener = OnClickListener {
             addressLookupDelegate.onManualEntryModeSelected()
+            removeFocusFromSearch()
         }
+        binding.textViewManualEntryError.setOnClickListener(listener)
 
-        binding.textViewManualEntryInitial.setOnClickListener {
-            addressLookupDelegate.onManualEntryModeSelected()
-        }
+        binding.textViewManualEntryInitial.setOnClickListener(listener)
 
-        binding.buttonManualEntry.setOnClickListener {
-            addressLookupDelegate.onManualEntryModeSelected()
-        }
+        binding.buttonManualEntry.setOnClickListener(listener)
     }
 
     private fun initSubmitAddressButton() {


### PR DESCRIPTION
## Description
In Address Lookup the keyboard is now hidden when:
- an address is selected
- a search query is submitted
- the manual entry button is clicked

## Checklist <!-- Remove any line that's not applicable -->
- [x] If applicable, make sure Breaking change label is added.
- [x] Changes are tested manually

COAND-873

## Release notes

### Improved
- For Address Lookup, the keyboard is now hidden when:
  - an address is selected
  - a search query is submitted
  - the manual entry button is clicked