### PR TITLE
Address Lookup fix infinite loading

### DIFF
--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/AddressLookupDelegate.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/AddressLookupDelegate.kt
@@ -13,10 +13,8 @@ import com.adyen.checkout.components.core.AddressLookupCallback
 import com.adyen.checkout.components.core.AddressLookupResult
 import com.adyen.checkout.components.core.LookupAddress
 import com.adyen.checkout.components.core.internal.ui.model.AddressInputModel
-import com.adyen.checkout.ui.core.internal.ui.model.AddressLookupEvent
 import com.adyen.checkout.ui.core.internal.ui.model.AddressLookupState
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -25,7 +23,6 @@ interface AddressLookupDelegate {
     val addressDelegate: AddressDelegate
 
     val addressLookupStateFlow: Flow<AddressLookupState>
-    val addressLookupEventChannel: Channel<AddressLookupEvent>
     val addressLookupSubmitFlow: Flow<AddressInputModel>
     val addressLookupErrorPopupFlow: Flow<String?>
 

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/DefaultAddressLookupDelegate.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/DefaultAddressLookupDelegate.kt
@@ -61,7 +61,7 @@ class DefaultAddressLookupDelegate(
     private val currentAddressLookupState
         get() = mutableAddressLookupStateFlow.value
 
-    override val addressLookupEventChannel = bufferedChannel<AddressLookupEvent>()
+    private val addressLookupEventChannel = bufferedChannel<AddressLookupEvent>()
     private val addressLookupEventFlow: Flow<AddressLookupEvent> = addressLookupEventChannel.receiveAsFlow()
 
     override val addressOutputData: AddressOutputData


### PR DESCRIPTION
## Description
Reproduction path:
1. Open card component
2. Open address lookup
3. Search "a"
4. Navigate back
5. Open address lookup again
6. Search "a" again
7. Infinite loading...

IMPORTANT: it turns out this was just a example app issue as we fully delegate the address lookup features to the merchant. 

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-1062
