### PR TITLE
Fix address lookup view state

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegate.kt
@@ -507,6 +507,7 @@ class DefaultCardDelegate(
 
     override fun handleBackPress(): Boolean {
         return if (_viewFlow.value == CardComponentViewType.AddressLookup) {
+            addressDelegate.updateAddressInputData { reset() }
             _viewFlow.tryEmit(CardComponentViewType.DefaultCardView)
             true
         } else {

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegateTest.kt
@@ -64,6 +64,7 @@ import com.adyen.checkout.test.TestDispatcherExtension
 import com.adyen.checkout.test.extensions.test
 import com.adyen.checkout.ui.core.internal.data.api.AddressRepository
 import com.adyen.checkout.ui.core.internal.data.api.TestAddressRepository
+import com.adyen.checkout.ui.core.internal.ui.AddressDelegate
 import com.adyen.checkout.ui.core.internal.ui.AddressFormUIState
 import com.adyen.checkout.ui.core.internal.ui.AddressLookupDelegate
 import com.adyen.checkout.ui.core.internal.ui.SubmitHandler
@@ -1231,6 +1232,7 @@ internal class DefaultCardDelegateTest(
     @Test
     fun `when view type is AddressLookup and handleBackPress() is called DefaultCardView should be emitted`() =
         runTest {
+            whenever(addressLookupDelegate.addressDelegate) doReturn mock()
             delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
             delegate.startAddressLookup()
             assertTrue(delegate.handleBackPress())
@@ -1238,6 +1240,19 @@ internal class DefaultCardDelegateTest(
                 assertEquals(CardComponentViewType.DefaultCardView, awaitItem())
                 expectNoEvents()
             }
+        }
+
+    @Test
+    fun `when view type is AddressLookup and handleBackPress() is called, then address form data should be reset`() =
+        runTest {
+            val addressDelegate = mock<AddressDelegate>()
+            whenever(addressLookupDelegate.addressDelegate) doReturn addressDelegate
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+            delegate.startAddressLookup()
+
+            delegate.handleBackPress()
+
+            verify(addressDelegate).updateAddressInputData(any())
         }
 
     @Test

--- a/example-app/src/main/assets/lookup_options.json
+++ b/example-app/src/main/assets/lookup_options.json
@@ -12,6 +12,17 @@
       }
     },
     {
+      "id": "5",
+      "address": {
+        "country": "NL",
+        "postalCode": "1012KK",
+        "houseNumberOrName": "49",
+        "street": "Rokin",
+        "stateOrProvince": "Noord-Holland",
+        "city": "Amsterdam"
+      }
+    },
+    {
       "id": "1",
       "address": {
         "country": "TR",

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/AddressFormInput.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/AddressFormInput.kt
@@ -24,6 +24,7 @@ import com.adyen.checkout.ui.core.internal.ui.AddressDelegate
 import com.adyen.checkout.ui.core.internal.ui.AddressSpecification
 import com.adyen.checkout.ui.core.internal.ui.SimpleTextListAdapter
 import com.adyen.checkout.ui.core.internal.ui.model.AddressListItem
+import com.adyen.checkout.ui.core.internal.ui.model.AddressOutputData
 import com.adyen.checkout.ui.core.internal.util.hideError
 import com.adyen.checkout.ui.core.internal.util.setLocalizedHintFromStyle
 import com.adyen.checkout.ui.core.internal.util.setLocalizedTextFromStyle
@@ -220,6 +221,8 @@ class AddressFormInput @JvmOverloads constructor(
             currentSpec = selectedSpecification
             autoCompleteTextViewCountry?.setText(selectedCountry?.name)
             populateFormFields(selectedSpecification)
+        } else {
+            updateInputFields(delegate.addressOutputData)
         }
     }
 
@@ -248,6 +251,7 @@ class AddressFormInput @JvmOverloads constructor(
         val hadFocus = hasFocus()
         formContainer?.removeAllViews()
         LayoutInflater.from(context).inflate(layoutResId, formContainer, true)
+        updateInputFields(delegate.addressOutputData)
         initForm(specification)
         if (hadFocus) requestFocus()
     }
@@ -314,7 +318,7 @@ class AddressFormInput @JvmOverloads constructor(
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 setAutofillHints(HintConstants.AUTOFILL_HINT_POSTAL_ADDRESS_STREET_ADDRESS)
             }
-            setText(delegate.addressOutputData.street.value)
+
             setOnChangeListener {
                 delegate.updateAddressInputData { street = it.toString() }
                 textInputLayoutStreet?.hideError()
@@ -333,7 +337,7 @@ class AddressFormInput @JvmOverloads constructor(
     private fun initHouseNumberInput(styleResId: Int?) {
         styleResId?.let { textInputLayoutHouseNumber?.setLocalizedHintFromStyle(it, localizedContext) }
         editTextHouseNumber?.apply {
-            setText(delegate.addressOutputData.houseNumberOrName.value)
+
             setOnChangeListener {
                 delegate.updateAddressInputData { houseNumberOrName = it.toString() }
                 textInputLayoutHouseNumber?.hideError()
@@ -355,7 +359,7 @@ class AddressFormInput @JvmOverloads constructor(
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 setAutofillHints(HintConstants.AUTOFILL_HINT_POSTAL_ADDRESS_APT_NUMBER)
             }
-            setText(delegate.addressOutputData.apartmentSuite.value)
+
             setOnChangeListener {
                 delegate.updateAddressInputData { apartmentSuite = it.toString() }
             }
@@ -376,7 +380,7 @@ class AddressFormInput @JvmOverloads constructor(
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 setAutofillHints(HintConstants.AUTOFILL_HINT_POSTAL_CODE)
             }
-            setText(delegate.addressOutputData.postalCode.value)
+
             setOnChangeListener {
                 delegate.updateAddressInputData { postalCode = it.toString() }
                 textInputLayoutPostalCode?.hideError()
@@ -398,7 +402,7 @@ class AddressFormInput @JvmOverloads constructor(
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 setAutofillHints(HintConstants.AUTOFILL_HINT_POSTAL_ADDRESS_LOCALITY)
             }
-            setText(delegate.addressOutputData.city.value)
+
             setOnChangeListener {
                 delegate.updateAddressInputData { city = it.toString() }
                 textInputLayoutCity?.hideError()
@@ -420,7 +424,7 @@ class AddressFormInput @JvmOverloads constructor(
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 setAutofillHints(HintConstants.AUTOFILL_HINT_POSTAL_ADDRESS_REGION)
             }
-            setText(delegate.addressOutputData.stateOrProvince.value)
+
             setOnChangeListener {
                 delegate.updateAddressInputData { stateOrProvince = it.toString() }
                 textInputLayoutProvinceTerritory?.hideError()
@@ -449,6 +453,21 @@ class AddressFormInput @JvmOverloads constructor(
                 delegate.updateAddressInputData { stateOrProvince = statesAdapter.getItem(position).code }
                 textInputLayoutState?.hideError()
             }
+        }
+    }
+
+    private fun updateInputFields(outputData: AddressOutputData) {
+        editTextStreet?.setTextIfChanged(outputData.street.value)
+        editTextHouseNumber?.setTextIfChanged(outputData.houseNumberOrName.value)
+        editTextApartmentSuite?.setTextIfChanged(outputData.apartmentSuite.value)
+        editTextPostalCode?.setTextIfChanged(outputData.postalCode.value)
+        editTextCity?.setTextIfChanged(outputData.city.value)
+        editTextProvinceTerritory?.setTextIfChanged(outputData.stateOrProvince.value)
+    }
+
+    private fun TextView.setTextIfChanged(newText: String?) {
+        if (newText != text.toString()) {
+            text = newText
         }
     }
 

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/AddressFormInput.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/AddressFormInput.kt
@@ -122,7 +122,8 @@ class AddressFormInput @JvmOverloads constructor(
                 val selectedCountryCode = countryAdapter.getItem(position).code
                 if (delegate.addressOutputData.country.value != selectedCountryCode) {
                     delegate.updateAddressInputData {
-                        reset()
+                        // Only reset state/province, so filled in data is retained.
+                        stateOrProvince = ""
                         country = selectedCountryCode
                     }
                     populateFormFields(AddressSpecification.fromString(selectedCountryCode))

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/AddressFormInput.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/AddressFormInput.kt
@@ -338,7 +338,6 @@ class AddressFormInput @JvmOverloads constructor(
     private fun initHouseNumberInput(styleResId: Int?) {
         styleResId?.let { textInputLayoutHouseNumber?.setLocalizedHintFromStyle(it, localizedContext) }
         editTextHouseNumber?.apply {
-
             setOnChangeListener {
                 delegate.updateAddressInputData { houseNumberOrName = it.toString() }
                 textInputLayoutHouseNumber?.hideError()


### PR DESCRIPTION
## Description
- In address lookup selecting a consecutive address  from the same country will now update all fields to the latest selection.
- The input is now retained when changing countries

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-1064

## Release notes

### Fixed
- For address lookup, when selecting a different address it will now correctly update the form's input fields.

### Improved
- For address lookup, the input is now retained when changing countries.
