### PR TITLE
Move address lookup loading spinner

### DIFF
--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/AddressLookupView.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/AddressLookupView.kt
@@ -231,16 +231,7 @@ class AddressLookupView @JvmOverloads constructor(
     }
 
     private fun handleLoadingState() {
-        binding.recyclerViewAddressLookupOptions.isVisible = false
-        binding.textViewInitialDisclaimer.isVisible = false
-        binding.textViewError.isVisible = false
-        binding.textViewManualEntryError.isVisible = false
-        binding.textViewManualEntryInitial.isVisible = false
-        binding.addressFormInput.isVisible = false
         binding.progressBar.isVisible = true
-        binding.buttonManualEntry.isVisible = false
-        binding.divider.isVisible = false
-        binding.buttonSubmitAddress.isVisible = false
     }
 
     private fun handleFormState(addressLookupState: AddressLookupState.Form) {

--- a/ui-core/src/main/res/layout/address_lookup_view.xml
+++ b/ui-core/src/main/res/layout/address_lookup_view.xml
@@ -14,19 +14,26 @@
     android:orientation="vertical"
     tools:parentTag="android.widget.LinearLayout">
 
-    <SearchView
-        android:id="@+id/textInputLayout_addressLookupQuerySearch"
-        style="@style/AdyenCheckout.AddressLookup.Query"
+    <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_marginBottom="@dimen/standard_margin" />
-
-    <ProgressBar
-        android:id="@+id/progressBar"
-        style="@style/AdyenCheckout.AddressLookup.Loading"
-        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:visibility="gone" />
+        android:layout_marginBottom="@dimen/standard_margin">
+
+        <SearchView
+            android:id="@+id/textInputLayout_addressLookupQuerySearch"
+            style="@style/AdyenCheckout.AddressLookup.Query"
+            android:layout_width="match_parent" />
+
+        <ProgressBar
+            android:id="@+id/progressBar"
+            style="@style/AdyenCheckout.AddressLookup.Loading"
+            android:layout_centerVertical="true"
+            android:layout_marginStart="-80dp"
+            android:layout_toEndOf="@id/textInputLayout_addressLookupQuerySearch"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
+    </RelativeLayout>
 
     <TextView
         android:id="@+id/textView_error"

--- a/ui-core/src/main/res/values/styles.xml
+++ b/ui-core/src/main/res/values/styles.xml
@@ -356,6 +356,8 @@
 
     <style name="AdyenCheckout.AddressLookup.Loading" parent="Widget.AppCompat.ProgressBar">
         <item name="android:tint">@color/primaryColor</item>
+        <item name="android:layout_height">24dp</item>
+        <item name="android:layout_width">24dp</item>
     </style>
 
     <style name="AdyenCheckout.AddressLookup.Item.Header" parent="AdyenCheckout.TextAppearance">


### PR DESCRIPTION
## Description
Move address lookup loading spinner inside of the search view. This prevents the view from changing size while searching.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-1063

## Release notes

### Improved
- For address lookup, the loading spinner moved to the search bar to prevent "jumping" of the view.
