### PR TITLE
Remove unnecessary Google Pay Compose Button dependency

### DIFF
--- a/example-app/build.gradle
+++ b/example-app/build.gradle
@@ -98,8 +98,6 @@ dependencies {
     implementation libs.hilt
     ksp libs.hilt.compiler
 
-    implementation libs.google.pay.compose.button
-
     debugImplementation libs.leak.canary
     debugImplementation libs.compose.ui.tooling
     debugImplementation libs.compose.ui.test.manifest

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,7 +46,6 @@ adyen3ds2 = "2.2.21"
 
 # External dependencies
 cash-app-pay = "2.5.0"
-google-pay-compose-button = "1.0.0"
 okhttp = "4.12.0"
 play-services-wallet = "19.4.0"
 twint = "8.0.0"
@@ -105,7 +104,6 @@ compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-mani
 compose-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "compose-viewmodel" }
 # this unused dependency is needed so that renovate can update the compose compiler version. More info in: https://github.com/renovatebot/renovate/issues/18354
 compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "compose-compiler" }
-google-pay-compose-button = { group = "com.google.pay.button", name = "compose-pay-button", version.ref = "google-pay-compose-button" }
 google-pay-play-services-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-play-services", version.ref = "coroutines" }
 google-pay-play-services-wallet = { group = "com.google.android.gms", name = "play-services-wallet", version.ref = "play-services-wallet" }
 hilt = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }


### PR DESCRIPTION
## Description
Remove unnecessary Google Pay Compose Button dependency. It's not needed anymore after the button was moved inside the component.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually