### PR TITLE
Fix Twint overriding store payment method mode

### DIFF
--- a/twint/src/main/java/com/adyen/checkout/twint/internal/ui/DefaultTwintDelegate.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/internal/ui/DefaultTwintDelegate.kt
@@ -130,7 +130,7 @@ internal class DefaultTwintDelegate(
             paymentMethod = paymentMethod,
             order = order,
             amount = componentParams.amount,
-            storePaymentMethod = shouldStorePaymentMethod(),
+            storePaymentMethod = if (componentParams.showStorePaymentField) outputData.isStorePaymentSelected else null,
         )
 
         return TwintComponentState(
@@ -146,9 +146,6 @@ internal class DefaultTwintDelegate(
             ActionHandlingMethod.PREFER_WEB -> null
         }
     }
-
-    private fun shouldStorePaymentMethod(): Boolean =
-        componentParams.showStorePaymentField && outputData.isStorePaymentSelected
 
     private fun getTrackedSubmitFlow() = submitHandler.submitFlow.onEach {
         val event = GenericEvents.submit(paymentMethod.type.orEmpty())

--- a/twint/src/test/java/com/adyen/checkout/twint/internal/ui/DefaultTwintDelegateTest.kt
+++ b/twint/src/test/java/com/adyen/checkout/twint/internal/ui/DefaultTwintDelegateTest.kt
@@ -253,6 +253,23 @@ internal class DefaultTwintDelegateTest(
 
                 assertEquals(true, componentStateFlow.latestValue.data.storePaymentMethod)
             }
+
+        @Test
+        fun `store checkbox is not shown, then we leave it up to the api`() =
+            runTest {
+                delegate = createDefaultTwintDelegate(
+                    createCheckoutConfiguration(Amount("USD", 0L)) {
+                        setShowStorePaymentField(false)
+                    },
+                )
+                val componentStateFlow = delegate.componentStateFlow.test(testScheduler)
+                delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+                delegate.updateInputData { isStorePaymentSelected = true }
+
+                delegate.onSubmit()
+
+                assertNull(componentStateFlow.latestValue.data.storePaymentMethod)
+            }
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## Description
This fixes an issue where the Twint component would override the `storePaymentMethodMode = enabled` for sessions making it impossible to store Twint.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-1067

## Release notes

### Fixed
- For Twint with sessions flow, the payment method will now be stored correctly when setting `storePaymentMethodMode` to `enabled`