### PR TITLE
Emit specific exception when Google Pay is cancelled

### DIFF
--- a/checkout-core/api/checkout-core.api
+++ b/checkout-core/api/checkout-core.api
@@ -151,7 +151,7 @@ public final class com/adyen/checkout/core/exception/BadModelException : com/ady
 	public fun <init> (Ljava/lang/Class;Ljava/lang/Throwable;)V
 }
 
-public final class com/adyen/checkout/core/exception/CancellationException : com/adyen/checkout/core/exception/CheckoutException {
+public class com/adyen/checkout/core/exception/CancellationException : com/adyen/checkout/core/exception/CheckoutException {
 	public fun <init> (Ljava/lang/String;)V
 }
 

--- a/checkout-core/api/checkout-core.api
+++ b/checkout-core/api/checkout-core.api
@@ -151,7 +151,7 @@ public final class com/adyen/checkout/core/exception/BadModelException : com/ady
 	public fun <init> (Ljava/lang/Class;Ljava/lang/Throwable;)V
 }
 
-public class com/adyen/checkout/core/exception/CancellationException : com/adyen/checkout/core/exception/CheckoutException {
+public class com/adyen/checkout/core/exception/CancellationException : com/adyen/checkout/core/exception/ComponentException {
 	public fun <init> (Ljava/lang/String;)V
 }
 

--- a/checkout-core/src/main/java/com/adyen/checkout/core/exception/CancellationException.kt
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/exception/CancellationException.kt
@@ -11,4 +11,4 @@ package com.adyen.checkout.core.exception
 /**
  * This exception indicates that the payment flow was manually cancelled by the user.
  */
-open class CancellationException(errorMessage: String) : CheckoutException(errorMessage)
+open class CancellationException(errorMessage: String) : ComponentException(errorMessage)

--- a/checkout-core/src/main/java/com/adyen/checkout/core/exception/CancellationException.kt
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/exception/CancellationException.kt
@@ -11,4 +11,4 @@ package com.adyen.checkout.core.exception
 /**
  * This exception indicates that the payment flow was manually cancelled by the user.
  */
-class CancellationException(errorMessage: String) : CheckoutException(errorMessage)
+open class CancellationException(errorMessage: String) : CheckoutException(errorMessage)

--- a/googlepay/api/googlepay.api
+++ b/googlepay/api/googlepay.api
@@ -117,6 +117,10 @@ public final class com/adyen/checkout/googlepay/GooglePayButtonType : java/lang/
 	public static fun values ()[Lcom/adyen/checkout/googlepay/GooglePayButtonType;
 }
 
+public final class com/adyen/checkout/googlepay/GooglePayCancellationException : com/adyen/checkout/core/exception/CancellationException {
+	public fun <init> (Ljava/lang/String;)V
+}
+
 public final class com/adyen/checkout/googlepay/GooglePayComponent : androidx/lifecycle/ViewModel, com/adyen/checkout/action/core/internal/ActionHandlingComponent, com/adyen/checkout/components/core/internal/ActivityResultHandlingComponent, com/adyen/checkout/components/core/internal/ButtonComponent, com/adyen/checkout/components/core/internal/PaymentComponent, com/adyen/checkout/ui/core/internal/ui/ViewableComponent {
 	public static final field Companion Lcom/adyen/checkout/googlepay/GooglePayComponent$Companion;
 	public static final field PAYMENT_METHOD_TYPES Ljava/util/List;

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayCancellationException.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayCancellationException.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2025 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 11/2/2025.
+ */
+
+package com.adyen.checkout.googlepay
+
+import com.adyen.checkout.core.exception.CancellationException
+
+/**
+ * This exception indicates that the payment flow was manually cancelled by the user.
+ */
+class GooglePayCancellationException(errorMessage: String) : CancellationException(errorMessage)

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/DefaultGooglePayDelegate.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/DefaultGooglePayDelegate.kt
@@ -263,7 +263,7 @@ internal class DefaultGooglePayDelegate(
             }
 
             Activity.RESULT_CANCELED -> {
-                exceptionChannel.trySend(ComponentException("Payment canceled."))
+                exceptionChannel.trySend(GooglePayCancellationException("Payment canceled."))
             }
 
             AutoResolveHelper.RESULT_ERROR -> {

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/DefaultGooglePayDelegate.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/DefaultGooglePayDelegate.kt
@@ -28,6 +28,7 @@ import com.adyen.checkout.core.exception.ComponentException
 import com.adyen.checkout.core.internal.data.model.ModelUtils
 import com.adyen.checkout.core.internal.util.adyenLog
 import com.adyen.checkout.googlepay.GooglePayButtonParameters
+import com.adyen.checkout.googlepay.GooglePayCancellationException
 import com.adyen.checkout.googlepay.GooglePayComponentState
 import com.adyen.checkout.googlepay.GooglePayUnavailableException
 import com.adyen.checkout.googlepay.internal.data.model.GooglePayPaymentMethodModel
@@ -225,7 +226,7 @@ internal class DefaultGooglePayDelegate(
 
             CommonStatusCodes.CANCELED -> {
                 adyenLog(AdyenLogLevel.INFO) { "GooglePay payment canceled" }
-                exceptionChannel.trySend(ComponentException("GooglePay payment canceled"))
+                exceptionChannel.trySend(GooglePayCancellationException("GooglePay payment canceled"))
             }
 
             AutoResolveHelper.RESULT_ERROR -> {


### PR DESCRIPTION
## Description
Emit specific exception when Google Pay is cancelled by a user. This makes it easier for merchant to distinguish between an actual error and a cancellation.

## Checklist <!-- Remove any line that's not applicable -->
- [x] If applicable, make sure Breaking change label is added.
- [x] Code is unit tested
- [x] Changes are tested manually
- [x] Related issues are linked

COAND-1068

## Release notes

### Changed
- For Google Pay, when a user cancels the flow you will now get a `GooglePayCancellationException` in `onError`