### PR TITLE
Fix address lookup formatting

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardView.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardView.kt
@@ -726,7 +726,7 @@ class CardView @JvmOverloads constructor(
     }
 
     private fun updateAddressLookupInputText(addressOutputData: AddressOutputData) {
-        binding.autoCompleteTextViewAddressLookup.setText(addressOutputData.toString())
+        binding.autoCompleteTextViewAddressLookup.setText(addressOutputData.formatted())
     }
 
     private fun updateAddressHint(addressFormUIState: AddressFormUIState, isOptional: Boolean) {

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/model/AddressOutputData.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/model/AddressOutputData.kt
@@ -25,6 +25,7 @@ data class AddressOutputData(
     val countryOptions: List<AddressListItem>,
     val stateOptions: List<AddressListItem>
 ) : OutputData {
+
     override val isValid: Boolean
         get() = postalCode.validation.isValid() &&
             street.validation.isValid() &&
@@ -34,15 +35,26 @@ data class AddressOutputData(
             city.validation.isValid() &&
             country.validation.isValid()
 
-    override fun toString(): String {
-        return listOf(
+    fun formatted(): String {
+        val line1 = arrayOf(
             street.value,
             houseNumberOrName.value,
             apartmentSuite.value,
+        )
+            .filter { it.isNotBlank() }
+            .joinToString(" ")
+
+        val line2 = arrayOf(
             postalCode.value,
             city.value,
             stateOrProvince.value,
             country.value,
-        ).filter { it.isNotBlank() }.joinToString(" ")
+        )
+            .filter { it.isNotBlank() }
+            .joinToString(", ")
+
+        return arrayOf(line1, line2)
+            .filter { it.isNotBlank() }
+            .joinToString("\n")
     }
 }

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/AddressLookupOptionsAdapter.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/AddressLookupOptionsAdapter.kt
@@ -62,27 +62,29 @@ data class LookupOption(
     val lookupAddress: LookupAddress,
     val isLoading: Boolean = false
 ) {
-    override fun toString(): String {
-        return listOf(
-            lookupAddress.address.street,
-            lookupAddress.address.houseNumberOrName,
-            lookupAddress.address.apartmentSuite,
-            lookupAddress.address.postalCode,
-            lookupAddress.address.city,
-            lookupAddress.address.stateOrProvince,
-            lookupAddress.address.country,
-        ).filter { !it.isNullOrBlank() }.joinToString(" ")
+
+    val title: String = formatTitle()
+
+    private fun formatTitle(): String = with(lookupAddress.address) {
+        arrayOf(
+            street,
+            houseNumberOrName,
+            apartmentSuite.orEmpty(),
+        )
+            .filter { it.isNotBlank() }
+            .joinToString(" ")
     }
 
-    val title
-        get() = lookupAddress.address.street.ifBlank {
-            toString()
-        }
+    val subtitle = formatSubtitle()
 
-    val subtitle
-        get() = if (lookupAddress.address.street.isBlank()) {
-            ""
-        } else {
-            toString()
-        }
+    private fun formatSubtitle() = with(lookupAddress.address) {
+        arrayOf(
+            postalCode,
+            city,
+            stateOrProvince,
+            country,
+        )
+            .filter { it.isNotBlank() }
+            .joinToString(", ")
+    }
 }

--- a/ui-core/src/test/java/com/adyen/checkout/ui/core/internal/ui/model/AddressOutputDataTest.kt
+++ b/ui-core/src/test/java/com/adyen/checkout/ui/core/internal/ui/model/AddressOutputDataTest.kt
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test
 internal class AddressOutputDataTest {
 
     @Test
-    fun addressOutputDataFormatted() {
+    fun `AddressOutputData is formatted, then a certain template is used`() {
         val addressOutputData = AddressOutputData(
             postalCode = FieldState("postalCode", Validation.Valid),
             houseNumberOrName = FieldState("houseNumberOrName", Validation.Valid),

--- a/ui-core/src/test/java/com/adyen/checkout/ui/core/internal/ui/model/AddressOutputDataTest.kt
+++ b/ui-core/src/test/java/com/adyen/checkout/ui/core/internal/ui/model/AddressOutputDataTest.kt
@@ -13,9 +13,10 @@ import com.adyen.checkout.components.core.internal.ui.model.Validation
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
-class AddressOutputDataTest {
+internal class AddressOutputDataTest {
+
     @Test
-    fun addressOutputDataToString() {
+    fun addressOutputDataFormatted() {
         val addressOutputData = AddressOutputData(
             postalCode = FieldState("postalCode", Validation.Valid),
             houseNumberOrName = FieldState("houseNumberOrName", Validation.Valid),
@@ -29,7 +30,7 @@ class AddressOutputDataTest {
             stateOptions = emptyList(),
         )
 
-        val expected = "street houseNumberOrName apartmentSuite postalCode city stateOrProvince country"
-        assertEquals(expected, addressOutputData.toString())
+        val expected = "street houseNumberOrName apartmentSuite\npostalCode, city, stateOrProvince, country"
+        assertEquals(expected, addressOutputData.formatted())
     }
 }

--- a/ui-core/src/test/java/com/adyen/checkout/ui/core/internal/ui/view/LookupOptionTest.kt
+++ b/ui-core/src/test/java/com/adyen/checkout/ui/core/internal/ui/view/LookupOptionTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 18/2/2025.
+ */
+
+package com.adyen.checkout.ui.core.internal.ui.view
+
+import com.adyen.checkout.components.core.AddressData
+import com.adyen.checkout.components.core.LookupAddress
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class LookupOptionTest {
+
+    @Test
+    fun `when creating LookupOption, then title and subtitle are formatted`() {
+        val option = LookupOption(createLookupAddress())
+
+        assertEquals("street houseNumberOrName apartmentSuite", option.title)
+        assertEquals("postalCode, city, stateOrProvince, country", option.subtitle)
+    }
+
+    private fun createLookupAddress() = LookupAddress(
+        id = "id",
+        address = AddressData(
+            postalCode = "postalCode",
+            street = "street",
+            stateOrProvince = "stateOrProvince",
+            houseNumberOrName = "houseNumberOrName",
+            apartmentSuite = "apartmentSuite",
+            city = "city",
+            country = "country",
+        ),
+    )
+}


### PR DESCRIPTION
## Description
In both the card view and search results of address lookup the addresses are now nicely formatted in two lines.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-1069

## Release notes

### Changed
- For address lookup, addresses are now formatted onto two lines