### PR TITLE
Add gradle task to show dependency list

### DIFF
--- a/.github/release_notes_dependency_list.toml
+++ b/.github/release_notes_dependency_list.toml
@@ -12,7 +12,6 @@
 "androidx.lifecycle:lifecycle-runtime-ktx" = "[AndroidX Lifecycle Runtime](https://developer.android.com/jetpack/androidx/releases/lifecycle#{})"
 "androidx.lifecycle:lifecycle-viewmodel-compose" = "[AndroidX Lifecycle ViewModel Compose](https://developer.android.com/jetpack/androidx/releases/lifecycle#{})"
 "androidx.lifecycle:lifecycle-viewmodel-ktx" = "[AndroidX Lifecycle ViewModel](https://developer.android.com/jetpack/androidx/releases/lifecycle#{})"
-"androidx.preference:preference-ktx" = "[AndroidX Preference](https://developer.android.com/jetpack/androidx/releases/preference#{})"
 "androidx.recyclerview:recyclerview" = "[AndroidX RecyclerView](https://developer.android.com/jetpack/androidx/releases/recyclerview#{})"
 "app.cash.paykit:core" = "[CashApp Pay](https://github.com/cashapp/cash-app-pay-android-sdk/releases/tag/v{})"
 "ch.twint.payment.sdk:android-sdk" = "[TWINT](https://docs.adyen.com/payment-methods/twint)"

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+import com.android.build.gradle.LibraryPlugin
+import org.jetbrains.kotlin.gradle.plugin.KotlinAndroidPluginWrapper
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     alias libs.plugins.android.application apply false
     alias libs.plugins.android.library apply false
@@ -14,6 +18,7 @@ plugins {
 apply from: "config/gradle/dokkaRoot.gradle"
 apply from: "config/gradle/sonarcloud.gradle"
 apply from: "config/gradle/apiValidator.gradle"
+apply from: "config/gradle/dependencyList.gradle"
 
 ext {
     if (project.hasProperty("version-name")) {
@@ -54,19 +59,19 @@ subprojects {
         }
     }
 
-    plugins.withType(com.android.build.gradle.LibraryPlugin).configureEach {
+    plugins.withType(LibraryPlugin).configureEach {
         dependencies {
             lintChecks project(':lint')
         }
     }
 
-    plugins.withType(org.jetbrains.kotlin.gradle.plugin.KotlinAndroidPluginWrapper).configureEach {
+    plugins.withType(KotlinAndroidPluginWrapper).configureEach {
         kotlin {
             jvmToolchain(javaVersion)
         }
     }
 
-    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    tasks.withType(KotlinCompile).configureEach {
         kotlinOptions {
             freeCompilerArgs += [
                 '-opt-in=kotlin.RequiresOptIn',

--- a/config/gradle/dependencyList.gradle
+++ b/config/gradle/dependencyList.gradle
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 18/2/2025.
+ */
+
+tasks.register('dependencyList') {
+    doLast {
+        def includeModules = false
+        if (project.hasProperty("includeModules") && project.property("includeModules") == "true") {
+            includeModules = true
+        }
+
+        def groupedDependencies = subprojects
+            .findAll { subproject -> subproject.plugins.hasPlugin("maven-publish") }
+            .collect { subproject ->
+                subproject.configurations
+                    .releaseRuntimeClasspath
+                    .incoming
+                    .resolutionResult
+                    .allDependencies
+                    .collect { dependency ->
+                        [dependency: "${dependency.selected}", module: subproject.name]
+                    }
+            }.flatten()
+
+        if (!includeModules) {
+            groupedDependencies
+                .collect { it.dependency }
+                .unique()
+                .toSorted()
+                .each { println it }
+        } else {
+            groupedDependencies
+                .groupBy { it.dependency }
+                .collect { [dependency: it.key, modules: it.value.collect { it.module }.unique()] }
+                .sort { it.dependency }
+                .each { println "${it.dependency} - used by: ${it.modules}" }
+        }
+    }
+}


### PR DESCRIPTION
## Description
The `dependencyList` task lists the dependencies used directly and indirectly by the published modules of the SDK. The `includeModules` parameter includes the list of modules that use each dependency.

## Example output

Default:
```
androidx.activity:activity-compose:1.10.0
androidx.activity:activity-ktx:1.10.0
androidx.activity:activity:1.10.0
androidx.annotation:annotation-experimental:1.4.0
androidx.annotation:annotation-experimental:1.4.1
androidx.annotation:annotation-jvm:1.9.1
androidx.annotation:annotation:1.9.1
androidx.appcompat:appcompat-resources:1.7.0
androidx.appcompat:appcompat:1.7.0
androidx.arch.core:core-common:2.2.0
androidx.arch.core:core-runtime:2.2.0
androidx.autofill:autofill:1.3.0-beta01
androidx.browser:browser:1.8.0
androidx.cardview:cardview:1.0.0
...
```

With `includeModules=true`
```
androidx.activity:activity-compose:1.10.0 - used by: [drop-in-compose]
androidx.activity:activity-ktx:1.10.0 - used by: [3ds2, ach, action, action-core, await, bacs, bcmc, blik, boleto, card, cashapppay, components-compose, components-core, convenience-stores-jp, dotpay, drop-in, drop-in-compose, econtext, entercash, eps, giftcard, googlepay, ideal, instant, issuer-list, mbway, meal-voucher-fr, molpay, online-banking-core, online-banking-cz, online-banking-jp, online-banking-pl, online-banking-sk, openbanking, paybybank, paybybank-us, payeasy, qr-code, redirect, sepa, sessions-core, seven-eleven, twint, twint-action, ui-core, upi, voucher, wechatpay]
androidx.activity:activity:1.10.0 - used by: [3ds2, ach, action, action-core, await, bacs, bcmc, blik, boleto, card, cashapppay, components-compose, components-core, convenience-stores-jp, dotpay, drop-in, drop-in-compose, econtext, entercash, eps, giftcard, googlepay, ideal, instant, issuer-list, mbway, meal-voucher-fr, molpay, online-banking-core, online-banking-cz, online-banking-jp, online-banking-pl, online-banking-sk, openbanking, paybybank, paybybank-us, payeasy, qr-code, redirect, sepa, sessions-core, seven-eleven, twint, twint-action, ui-core, upi, voucher, wechatpay]
androidx.annotation:annotation-experimental:1.4.0 - used by: [3ds2, ach, action, action-core, await, bacs, bcmc, blik, boleto, card, cashapppay, components-core, convenience-stores-jp, dotpay, drop-in, econtext, entercash, eps, giftcard, googlepay, ideal, instant, issuer-list, mbway, meal-voucher-fr, molpay, online-banking-core, online-banking-cz, online-banking-jp, online-banking-pl, online-banking-sk, openbanking, paybybank, paybybank-us, payeasy, qr-code, redirect, sepa, sessions-core, seven-eleven, twint, twint-action, ui-core, upi, voucher, wechatpay]
androidx.annotation:annotation-experimental:1.4.1 - used by: [components-compose, drop-in-compose]
androidx.annotation:annotation-jvm:1.9.1 - used by: [3ds2, ach, action, action-core, await, bacs, bcmc, blik, boleto, card, cashapppay, checkout-core, components-compose, components-core, convenience-stores-jp, cse, dotpay, drop-in, drop-in-compose, econtext, entercash, eps, giftcard, googlepay, ideal, instant, issuer-list, mbway, meal-voucher-fr, molpay, online-banking-core, online-banking-cz, online-banking-jp, online-banking-pl, online-banking-sk, openbanking, paybybank, paybybank-us, payeasy, qr-code, redirect, sepa, sessions-core, seven-eleven, twint, twint-action, ui-core, upi, voucher, wechatpay]
androidx.annotation:annotation:1.9.1 - used by: [3ds2, ach, action, action-core, await, bacs, bcmc, blik, boleto, card, cashapppay, checkout-core, components-compose, components-core, convenience-stores-jp, cse, dotpay, drop-in, drop-in-compose, econtext, entercash, eps, giftcard, googlepay, ideal, instant, issuer-list, mbway, meal-voucher-fr, molpay, online-banking-core, online-banking-cz, online-banking-jp, online-banking-pl, online-banking-sk, openbanking, paybybank, paybybank-us, payeasy, qr-code, redirect, sepa, sessions-core, seven-eleven, twint, twint-action, ui-core, upi, voucher, wechatpay]
androidx.appcompat:appcompat-resources:1.7.0 - used by: [3ds2, ach, action, action-core, await, bacs, bcmc, blik, boleto, card, cashapppay, components-compose, convenience-stores-jp, dotpay, drop-in, drop-in-compose, econtext, entercash, eps, giftcard, googlepay, ideal, instant, issuer-list, mbway, meal-voucher-fr, molpay, online-banking-core, online-banking-cz, online-banking-jp, online-banking-pl, online-banking-sk, openbanking, paybybank, paybybank-us, payeasy, qr-code, redirect, sepa, seven-eleven, twint, twint-action, ui-core, upi, voucher, wechatpay]
androidx.appcompat:appcompat:1.7.0 - used by: [3ds2, ach, action, action-core, await, bacs, bcmc, blik, boleto, card, cashapppay, components-compose, convenience-stores-jp, dotpay, drop-in, drop-in-compose, econtext, entercash, eps, giftcard, googlepay, ideal, instant, issuer-list, mbway, meal-voucher-fr, molpay, online-banking-core, online-banking-cz, online-banking-jp, online-banking-pl, online-banking-sk, openbanking, paybybank, paybybank-us, payeasy, qr-code, redirect, sepa, seven-eleven, twint, twint-action, ui-core, upi, voucher, wechatpay]
androidx.arch.core:core-common:2.2.0 - used by: [3ds2, ach, action, action-core, await, bacs, bcmc, blik, boleto, card, cashapppay, components-compose, components-core, convenience-stores-jp, dotpay, drop-in, drop-in-compose, econtext, entercash, eps, giftcard, googlepay, ideal, instant, issuer-list, mbway, meal-voucher-fr, molpay, online-banking-core, online-banking-cz, online-banking-jp, online-banking-pl, online-banking-sk, openbanking, paybybank, paybybank-us, payeasy, qr-code, redirect, sepa, sessions-core, seven-eleven, twint, twint-action, ui-core, upi, voucher, wechatpay]
androidx.arch.core:core-runtime:2.2.0 - used by: [3ds2, ach, action, action-core, await, bacs, bcmc, blik, boleto, card, cashapppay, components-compose, components-core, convenience-stores-jp, dotpay, drop-in, drop-in-compose, econtext, entercash, eps, giftcard, googlepay, ideal, instant, issuer-list, mbway, meal-voucher-fr, molpay, online-banking-core, online-banking-cz, online-banking-jp, online-banking-pl, online-banking-sk, openbanking, paybybank, paybybank-us, payeasy, qr-code, redirect, sepa, sessions-core, seven-eleven, twint, twint-action, ui-core, upi, voucher, wechatpay]
androidx.autofill:autofill:1.3.0-beta01 - used by: [3ds2, ach, action, action-core, await, bacs, bcmc, blik, boleto, card, cashapppay, components-compose, convenience-stores-jp, dotpay, drop-in, drop-in-compose, econtext, entercash, eps, giftcard, googlepay, ideal, instant, issuer-list, mbway, meal-voucher-fr, molpay, online-banking-core, online-banking-cz, online-banking-jp, online-banking-pl, online-banking-sk, openbanking, paybybank, paybybank-us, payeasy, qr-code, redirect, sepa, seven-eleven, twint, twint-action, ui-core, upi, voucher, wechatpay]
androidx.browser:browser:1.8.0 - used by: [3ds2, ach, action, action-core, await, bacs, bcmc, blik, boleto, card, cashapppay, components-compose, convenience-stores-jp, dotpay, drop-in, drop-in-compose, econtext, entercash, eps, giftcard, googlepay, ideal, instant, issuer-list, mbway, meal-voucher-fr, molpay, online-banking-core, online-banking-cz, online-banking-jp, online-banking-pl, online-banking-sk, openbanking, paybybank, paybybank-us, payeasy, qr-code, redirect, sepa, seven-eleven, twint, twint-action, ui-core, upi, voucher, wechatpay]
androidx.cardview:cardview:1.0.0 - used by: [3ds2, ach, action, action-core, await, bacs, bcmc, blik, boleto, card, cashapppay, components-compose, convenience-stores-jp, dotpay, drop-in, drop-in-compose, econtext, entercash, eps, giftcard, googlepay, ideal, instant, issuer-list, mbway, meal-voucher-fr, molpay, online-banking-core, online-banking-cz, online-banking-jp, online-banking-pl, online-banking-sk, openbanking, paybybank, paybybank-us, payeasy, qr-code, redirect, sepa, seven-eleven, twint, twint-action, ui-core, upi, voucher, wechatpay]
androidx.collection:collection-jvm:1.4.2 - used by: [3ds2, ach, action, action-core, await, bacs, bcmc, blik, boleto, card, cashapppay, convenience-stores-jp, dotpay, drop-in, econtext, entercash, eps, giftcard, googlepay, ideal, instant, issuer-list, mbway, meal-voucher-fr, molpay, online-banking-core, online-banking-cz, online-banking-jp, online-banking-pl, online-banking-sk, openbanking, paybybank, paybybank-us, payeasy, qr-code, redirect, sepa, seven-eleven, twint, twint-action, ui-core, upi, voucher, wechatpay]
androidx.collection:collection-jvm:1.4.4 - used by: [components-compose, drop-in-compose]
androidx.collection:collection-ktx:1.1.0 - used by: [components-core, sessions-core]
...
```

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
