### PR TITLE
Fix downloading gradle wrapper log leaking into dependency list task output

### DIFF
--- a/scripts/check_dependency_changes.py
+++ b/scripts/check_dependency_changes.py
@@ -21,6 +21,8 @@ def compare_dependency_list(base_ref: str, head_ref: str):
 
 def get_dependency_list(git_ref: str) -> str:
     subprocess.Popen(["git", "checkout", "-f", git_ref])
+    # This is needed to avoid having the "downloading" wrapper progress text printed inside the output of the task
+    subprocess.Popen(["./gradlew", "wrapper", "-q"])
     return subprocess.check_output(["./gradlew", "dependencyList", "-q", "--no-configuration-cache"]
         ).decode(sys.stdout.encoding
         ).strip()


### PR DESCRIPTION
## Description
When running the `dependencyList` task, if the gradle wrapper needs to be downloaded, the download progress message gets printed inside the task output which causes unwanted result such as this:

![Screenshot 2025-02-20 at 17 54 21](https://github.com/user-attachments/assets/a9f64ea9-265f-4f8b-a03f-01ba6c69d1df)

To avoid this issue we now make sure the wrapper is downloaded in advance before running the task.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually