### PR TITLE
Improve network logging

### DIFF
--- a/checkout-core/src/main/java/com/adyen/checkout/core/internal/data/api/AdyenApiResponse.kt
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/internal/data/api/AdyenApiResponse.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 21/2/2025.
+ */
+
+package com.adyen.checkout.core.internal.data.api
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class AdyenApiResponse(
+    val path: String,
+    val statusCode: Int,
+    val headers: Map<String, String>,
+    val body: String,
+)

--- a/checkout-core/src/main/java/com/adyen/checkout/core/internal/data/api/HttpClient.kt
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/internal/data/api/HttpClient.kt
@@ -17,12 +17,12 @@ interface HttpClient {
         path: String,
         queryParameters: Map<String, String> = emptyMap(),
         headers: Map<String, String> = emptyMap()
-    ): ByteArray
+    ): AdyenApiResponse
 
     suspend fun post(
         path: String,
         jsonBody: String,
         queryParameters: Map<String, String> = emptyMap(),
         headers: Map<String, String> = emptyMap()
-    ): ByteArray
+    ): AdyenApiResponse
 }

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsServiceTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsServiceTest.kt
@@ -1,6 +1,7 @@
 package com.adyen.checkout.components.core.internal.data.api
 
 import com.adyen.checkout.components.core.internal.data.model.AnalyticsTrackRequest
+import com.adyen.checkout.core.internal.data.api.AdyenApiResponse
 import com.adyen.checkout.core.internal.data.api.HttpClient
 import com.adyen.checkout.core.internal.data.model.EmptyResponse
 import com.adyen.checkout.test.LoggingExtension
@@ -37,11 +38,11 @@ internal class AnalyticsServiceTest(
             platform = "android",
             info = emptyList(),
             logs = emptyList(),
-            errors = emptyList()
+            errors = emptyList(),
         )
         val checkoutAttemptId = "testtest"
         whenever(httpClient.post(eq("v3/analytics/$checkoutAttemptId"), any(), any(), any()))
-            .doReturn(ByteArray(0))
+            .doReturn(AdyenApiResponse("", 0, emptyMap(), ""))
 
         val response = analyticsService.sendEvents(request, checkoutAttemptId, TEST_CLIENT_KEY)
 


### PR DESCRIPTION
## Description
Responses of internal networking will now be logged like below. This will help us to debug backend related things quicker.
```
2025-02-21 14:50:09.844 15327-15401 CO.OkHttpClient         com.adyen.checkout.example           V  response - 200 .../some/path
2025-02-21 14:50:09.844 15327-15401 CO.OkHttpClient         com.adyen.checkout.example           V  header: value
2025-02-21 14:50:09.844 15327-15401 CO.OkHttpClient         com.adyen.checkout.example           V  another: one
2025-02-21 14:50:09.844 15327-15401 CO.OkHttpClient         com.adyen.checkout.example           V  {"json": "body"}
2025-02-21 14:50:09.844 15327-15401 CO.OkHttpClient         com.adyen.checkout.example           V  response - END
```

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually