### PR TITLE
Fix address lookup options not showing in example app (card + sessions)

### DIFF
--- a/example-app/src/main/java/com/adyen/checkout/example/ui/card/SessionsCardUiState.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/card/SessionsCardUiState.kt
@@ -22,7 +22,7 @@ internal data class SessionsCardUiState(
     val oneTimeMessage: String? = null,
     val componentData: SessionsCardComponentData? = null,
     val action: Action? = null,
-    val addressLookupOptions: List<LookupAddress> = emptyList(),
+    val addressLookupOptions: List<LookupAddress>? = null,
     val addressLookupResult: AddressLookupResult? = null,
     val finalResult: ResultState? = null,
 )

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/card/SessionsCardViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/card/SessionsCardViewModel.kt
@@ -179,6 +179,14 @@ internal class SessionsCardViewModel @Inject constructor(
         updateUiState { it.copy(action = null) }
     }
 
+    fun addressLookupOptionsConsumed() {
+        updateUiState { it.copy(addressLookupOptions = null) }
+    }
+
+    fun addressLookupResultConsumed() {
+        updateUiState { it.copy(addressLookupResult = null) }
+    }
+
     override fun onQueryChanged(query: String) {
         addressLookupRepository.onQuery(query)
     }

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/card/compose/SessionsCardScreen.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/card/compose/SessionsCardScreen.kt
@@ -74,18 +74,22 @@ internal fun SessionsCardScreen(
             uiState = uiState,
             onOneTimeMessageConsumed = viewModel::oneTimeMessageConsumed,
             onActionConsumed = viewModel::actionConsumed,
+            onAddressLookupOptionsConsumed = viewModel::addressLookupOptionsConsumed,
+            onAddressLookupResultConsumed = viewModel::addressLookupResultConsumed,
             addressLookupCallback = viewModel as AddressLookupCallback,
             modifier = Modifier.padding(innerPadding),
         )
     }
 }
 
-@Suppress("DestructuringDeclarationWithTooManyEntries")
+@Suppress("DestructuringDeclarationWithTooManyEntries", "LongParameterList")
 @Composable
 private fun SessionsCardContent(
     uiState: SessionsCardUiState,
     onOneTimeMessageConsumed: () -> Unit,
     onActionConsumed: () -> Unit,
+    onAddressLookupOptionsConsumed: () -> Unit,
+    onAddressLookupResultConsumed: () -> Unit,
     addressLookupCallback: AddressLookupCallback,
     modifier: Modifier = Modifier,
 ) {
@@ -127,6 +131,8 @@ private fun SessionsCardContent(
                 addressLookupCallback = addressLookupCallback,
                 addressLookupOptions = addressLookupOptions,
                 addressLookupResult = addressLookupResult,
+                onAddressLookupOptionsConsumed = onAddressLookupOptionsConsumed,
+                onAddressLookupResultConsumed = onAddressLookupResultConsumed,
                 modifier = Modifier.fillMaxSize(),
             )
         }
@@ -141,8 +147,10 @@ private fun CardComponent(
     action: Action?,
     onActionConsumed: () -> Unit,
     addressLookupCallback: AddressLookupCallback,
-    addressLookupOptions: List<LookupAddress>,
+    addressLookupOptions: List<LookupAddress>?,
     addressLookupResult: AddressLookupResult?,
+    onAddressLookupOptionsConsumed: () -> Unit,
+    onAddressLookupResultConsumed: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val component = CardComponent.PROVIDER.get(
@@ -153,12 +161,14 @@ private fun CardComponent(
         componentData.hashCode().toString(),
     )
 
-    if (addressLookupOptions.isNotEmpty()) {
+    if (addressLookupOptions != null) {
         component.updateAddressLookupOptions(addressLookupOptions)
+        onAddressLookupOptionsConsumed()
     }
 
     if (addressLookupResult != null) {
         component.setAddressLookupResult(addressLookupResult)
+        onAddressLookupResultConsumed()
     }
 
     component.setAddressLookupCallback(addressLookupCallback)


### PR DESCRIPTION
## Description
Steps to reproduce:
- Open the address lookup mode in the card + sessions screen in the example app.
- Enter a query and select one of the options.
- Enter another query. The list of options does not render again anymore.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually