### PR TITLE
Format response body accordingly for logging

### DIFF
--- a/checkout-core/src/main/java/com/adyen/checkout/core/internal/data/api/HttpClientExt.kt
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/internal/data/api/HttpClientExt.kt
@@ -100,6 +100,12 @@ private fun Any.logResponse(response: AdyenApiResponse) {
     response.headers.forEach { (key, value) ->
         adyenLog(AdyenLogLevel.VERBOSE) { "$key: $value" }
     }
-    adyenLog(AdyenLogLevel.VERBOSE) { response.body.toJSONObject().toStringPretty() }
+    adyenLog(AdyenLogLevel.VERBOSE) { response.body.tryToFormatJson() }
     adyenLog(AdyenLogLevel.VERBOSE) { "response - END" }
+}
+
+private fun String.tryToFormatJson(): String = when {
+    startsWith("{") -> JSONObject(this).toStringPretty()
+    startsWith("[") -> JSONArray(this).toStringPretty()
+    else -> this
 }


### PR DESCRIPTION
## Description
This fixes an issue where the log would crash if the response body couldn't be transformed into a JSONObject.

NOTE: the improved logging was not released yet, so there are no release notes needed.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-1077