### PR TITLE
Dependency changes workflow fixes

### DIFF
--- a/.github/workflows/check_dependency_changes.yml
+++ b/.github/workflows/check_dependency_changes.yml
@@ -4,30 +4,52 @@ on:
   workflow_call:
 
 jobs:
+  get_base_dependency_list:
+    name: Fetch dependency list in BASE
+    uses: ./.github/workflows/get_dependency_list.yml
+    with:
+      ref: ${{ github.event.pull_request.base.sha }}
+      artifact-name: "DEPENDENCY_LIST_BASE"
+
+  get_head_dependency_list:
+    name: Fetch dependency list in HEAD
+    uses: ./.github/workflows/get_dependency_list.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+      artifact-name: "DEPENDENCY_LIST_HEAD"
+
   check_dependency_changes:
     runs-on: ubuntu-latest
     name: Check dependency changes
+    needs: [ get_head_dependency_list, get_base_dependency_list ]
 
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          sparse-checkout: |
+            scripts/check_dependency_changes.py
+          sparse-checkout-cone-mode: false
 
-      - name: Setup gradle
-        uses: gradle/actions/setup-gradle@v4
-
-      - uses: actions/setup-python@v5
+      - name: Download base dependency list artifact
+        uses: actions/download-artifact@v4
         with:
-          python-version: '3.13'
+          name: "DEPENDENCY_LIST_BASE"
+
+      - name: Download head dependency list artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: "DEPENDENCY_LIST_HEAD"
 
       - name: Compare dependencies between base and head
         id: compare_deps
         env:
-          BASE_REF: ${{ github.base_ref }}
-          HEAD_REF: ${{ github.head_ref }}
+          DEPENDENCY_LIST_BASE: "DEPENDENCY_LIST_BASE"
+          DEPENDENCY_LIST_HEAD: "DEPENDENCY_LIST_HEAD"
         run: |
+          base_deps="$(cat ${DEPENDENCY_LIST_BASE})"
+          head_deps="$(cat ${DEPENDENCY_LIST_HEAD})"
           chmod +x scripts/check_dependency_changes.py
-          python scripts/check_dependency_changes.py dependency_changes.md
+          FIRST_DEPENDENCY_LIST=$(echo "$base_deps") SECOND_DEPENDENCY_LIST=$(echo "$head_deps") python scripts/check_dependency_changes.py dependency_changes.md
           if [ -s dependency_changes.md ]; then
             echo "Found dependency changes in this PR"
             echo "has_changes=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/get_dependency_list.yml
+++ b/.github/workflows/get_dependency_list.yml
@@ -1,0 +1,38 @@
+name: Get dependency list
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+      artifact-name:
+        required: true
+        type: string
+
+jobs:
+  get_dependency_list:
+    runs-on: ubuntu-latest
+    name: Fetch dependency list
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref:  ${{ inputs.ref }}
+
+      - name: Setup gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Fetch dependency list
+        env:
+          ARTIFACT_NAME: ${{ inputs.artifact-name }}
+        run: |
+          DEPENDENCY_LIST_FILE_NAME=$(echo "${ARTIFACT_NAME}")
+          ./gradlew dependencyList -q --no-configuration-cache -PoutputFileName=$DEPENDENCY_LIST_FILE_NAME
+
+      - name: Upload dependency list artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: "${{ inputs.artifact-name }}"
+          path: "${{ inputs.artifact-name }}"
+          overwrite: true

--- a/config/gradle/dependencyList.gradle
+++ b/config/gradle/dependencyList.gradle
@@ -6,6 +6,7 @@
  * Created by josephj on 18/2/2025.
  */
 
+// sample call from command line: ./gradlew dependencyList --no-configuration-cache -PoutputFileName=deps.txt -PincludeModules=true
 tasks.register('dependencyList') {
     doLast {
         def includeModules = false
@@ -26,18 +27,29 @@ tasks.register('dependencyList') {
                     }
             }.flatten()
 
+        def outputFileName = "dependency_list.txt"
+        if (project.hasProperty("outputFileName")) {
+            outputFileName = project.property("outputFileName")
+        }
+
+        def file = new File(outputFileName)
+        def fileWriter = file.newWriter()
+
         if (!includeModules) {
             groupedDependencies
                 .collect { it.dependency }
                 .unique()
                 .toSorted()
-                .each { println it }
+                .each { fileWriter.writeLine(it) }
         } else {
             groupedDependencies
                 .groupBy { it.dependency }
                 .collect { [dependency: it.key, modules: it.value.collect { it.module }.unique()] }
                 .sort { it.dependency }
-                .each { println "${it.dependency} - used by: ${it.modules}" }
+                .each { fileWriter.writeLine("${it.dependency} - used by: ${it.modules}") }
         }
+
+        fileWriter.flush()
+        fileWriter.close()
     }
 }

--- a/scripts/check_dependency_changes.py
+++ b/scripts/check_dependency_changes.py
@@ -6,26 +6,15 @@ import sys
 import difflib
 
 # You can test this script locally with this command:
-# BASE_REF="BASE_REFERENCE" HEAD_REF="HEAD_REFERENCE" python ./scripts/check_dependency_changes.py test_output.txt
+# FIRST_DEPENDENCY_LIST="FIRST_DEPENDENCY_LIST" SECOND_DEPENDENCY_LIST="SECOND_DEPENDENCY_LIST" python ./scripts/check_dependency_changes.py test_output.txt
 
-def compare_dependency_list(base_ref: str, head_ref: str):
-    base_dependency_list = get_dependency_list(base_ref)
-    head_dependency_list = get_dependency_list(head_ref)
-
-    dependency_diff = diff_strings(base_dependency_list, head_dependency_list)
+def compare_dependency_list(first_deps, second_deps):
+    dependency_diff = diff_strings(first_deps, second_deps)
     output = generate_github_comment(dependency_diff)
 
     with open(sys.argv[1], 'w+') as f:
         f.write(output)
     if os.getenv('GITHUB_STEP_SUMMARY'): os.environ[os.getenv('GITHUB_STEP_SUMMARY')] = output
-
-def get_dependency_list(git_ref: str) -> str:
-    subprocess.Popen(["git", "checkout", "-f", git_ref])
-    # This is needed to avoid having the "downloading" wrapper progress text printed inside the output of the task
-    subprocess.Popen(["./gradlew", "wrapper", "-q"])
-    return subprocess.check_output(["./gradlew", "dependencyList", "-q", "--no-configuration-cache"]
-        ).decode(sys.stdout.encoding
-        ).strip()
 
 def diff_strings(first: str, second: str) -> str:
     diff = difflib.unified_diff(first.splitlines(keepends=True), second.splitlines(keepends=True))
@@ -46,17 +35,17 @@ To check the affected modules run the `dependencyList` gradle task with `include
 def main():
     red = '\033[31m'
 
-    base_ref = os.getenv('BASE_REF')
-    if base_ref is None:
-        print(red + 'BASE_REF is not provided. Please provide it in env list. Exiting...')
+    first_deps = os.getenv('FIRST_DEPENDENCY_LIST')
+    if first_deps is None:
+        print(red + 'FIRST_DEPENDENCY_LIST is not provided. Please provide it in env list. Exiting...')
         sys.exit(1)
 
-    head_ref = os.getenv('HEAD_REF')
-    if head_ref is None:
-        print(red + 'HEAD_REF is not provided. Please provide it in env list. Exiting...')
+    second_deps = os.getenv('SECOND_DEPENDENCY_LIST')
+    if second_deps is None:
+        print(red + 'SECOND_DEPENDENCY_LIST is not provided. Please provide it in env list. Exiting...')
         sys.exit(1)
 
-    compare_dependency_list(base_ref, head_ref)
+    compare_dependency_list(first_deps, second_deps)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Description
- Write output to file instead of console: this solves the issue of gradle printing certain messages to the console that cannot be turned off (like downloading the wrapper).
- Add separate job to fetch dependency list: this allows fetching both base and head deps lists in parallel.

The Check dependency changes job in this PR will fail because the base PR (main) does not have the necessary changes yet,. This [test PR](https://github.com/Adyen/adyen-android/pull/2040) shows the new workflow completing successfully,.  

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually