### PR TITLE
Clear 3DS state after challenge is finalized

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2Delegate.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2Delegate.kt
@@ -733,6 +733,7 @@ internal class DefaultAdyen3DS2Delegate(
 
     private fun clearState() {
         action = null
+        SharedChallengeStatusHandler.reset()
     }
 
     override fun onCleared() {

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/SharedChallengeStatusHandler.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/SharedChallengeStatusHandler.kt
@@ -8,7 +8,6 @@
 
 package com.adyen.checkout.adyen3ds2.internal.ui
 
-import androidx.annotation.VisibleForTesting
 import com.adyen.threeds2.ChallengeResult
 import com.adyen.threeds2.ChallengeStatusHandler
 
@@ -32,8 +31,7 @@ internal object SharedChallengeStatusHandler : ChallengeStatusHandler {
         }
     }
 
-    @VisibleForTesting
-    internal fun reset() {
+    fun reset() {
         onCompletionListener = null
         queuedResult = null
     }

--- a/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2DelegateTest.kt
+++ b/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2DelegateTest.kt
@@ -683,7 +683,7 @@ internal class DefaultAdyen3DS2DelegateTest(
             delegate.handleAction(Threeds2FingerprintAction(token = null), Activity())
 
             val expectedEvent = ThreeDS2Events.threeDS2FingerprintError(
-                event = ErrorEvent.THREEDS2_TOKEN_MISSING
+                event = ErrorEvent.THREEDS2_TOKEN_MISSING,
             )
             analyticsManager.assertLastEventEquals(expectedEvent)
         }
@@ -959,7 +959,7 @@ internal class DefaultAdyen3DS2DelegateTest(
 
         delegate.onCompletion(ChallengeResult.Completed("test"))
 
-        assertNull(savedStateHandle[DefaultAdyen3DS2Delegate.ACTION_KEY])
+        assertStateCleared(savedStateHandle)
     }
 
     @Test
@@ -970,7 +970,12 @@ internal class DefaultAdyen3DS2DelegateTest(
 
         delegate.handleAction(Threeds2Action(paymentMethodType = "test", paymentData = "paymentData"), Activity())
 
+        assertStateCleared(savedStateHandle)
+    }
+
+    private fun assertStateCleared(savedStateHandle: SavedStateHandle) {
         assertNull(savedStateHandle[DefaultAdyen3DS2Delegate.ACTION_KEY])
+        SharedChallengeStatusHandler.onCompletionListener = null
     }
 
     private fun getAuthenticationRequestParams() = TestAuthenticationRequestParameters(


### PR DESCRIPTION
## Description
This fixes a bug where the state was kept and consecutive 3DS challenges would re-use the state of the first challenge.

## Checklist <!-- Remove any line that's not applicable -->
- [ ] If applicable, make sure Breaking change label is added.
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-1078

## Release notes
### Fixed
For 3DS2, consecutive challenges don't fail anymore if the first challenge failed.