### PR TITLE
PayTo - Swap Bank state branch with Bank account

### DIFF
--- a/payto/src/main/java/com/adyen/checkout/payto/internal/ui/DefaultPayToDelegate.kt
+++ b/payto/src/main/java/com/adyen/checkout/payto/internal/ui/DefaultPayToDelegate.kt
@@ -128,8 +128,8 @@ internal class DefaultPayToDelegate(
             emailAddress = inputData.emailAddress,
             abnNumber = inputData.abnNumber,
             organizationId = inputData.organizationId,
-            bsbAccountNumber = inputData.bsbAccountNumber,
             bsbStateBranch = inputData.bsbStateBranch,
+            bsbAccountNumber = inputData.bsbAccountNumber,
             firstName = inputData.firstName,
             lastName = inputData.lastName,
         )
@@ -186,7 +186,7 @@ internal class DefaultPayToDelegate(
         }
 
     private fun getShopperAccountIdentifierForBsb(outputData: PayToOutputData) =
-        "${outputData.bsbAccountNumber}-${outputData.bsbStateBranch}"
+        "${outputData.bsbStateBranch}-${outputData.bsbAccountNumber}"
 
     private fun componentStateChanged(componentState: PayToComponentState) {
         _componentStateFlow.tryEmit(componentState)

--- a/payto/src/main/java/com/adyen/checkout/payto/internal/ui/model/PayToInputData.kt
+++ b/payto/src/main/java/com/adyen/checkout/payto/internal/ui/model/PayToInputData.kt
@@ -17,8 +17,8 @@ internal data class PayToInputData(
     var emailAddress: String = "",
     var abnNumber: String = "",
     var organizationId: String = "",
-    var bsbAccountNumber: String = "",
     var bsbStateBranch: String = "",
+    var bsbAccountNumber: String = "",
     var firstName: String = "",
     var lastName: String = "",
 ) : InputData

--- a/payto/src/main/java/com/adyen/checkout/payto/internal/ui/model/PayToOutputData.kt
+++ b/payto/src/main/java/com/adyen/checkout/payto/internal/ui/model/PayToOutputData.kt
@@ -23,8 +23,8 @@ internal data class PayToOutputData(
     val emailAddress: String,
     val abnNumber: String,
     val organizationId: String,
-    val bsbAccountNumber: String,
     val bsbStateBranch: String,
+    val bsbAccountNumber: String,
     val firstName: String,
     val lastName: String,
 ) : OutputData {
@@ -33,8 +33,8 @@ internal data class PayToOutputData(
     val emailAddressFieldState: FieldState<String> = validateEmailAddress(emailAddress)
     val abnNumberFieldState: FieldState<String> = validateAbnNumber(abnNumber)
     val organizationIdFieldState: FieldState<String> = validateOrganizationId(organizationId)
-    val bsbAccountNumberFieldState: FieldState<String> = validateBsbAccountNumber(bsbAccountNumber)
     val bsbStateBranchFieldState: FieldState<String> = validateBsbStateBranch(bsbStateBranch)
+    val bsbAccountNumberFieldState: FieldState<String> = validateBsbAccountNumber(bsbAccountNumber)
     val firstNameFieldState: FieldState<String> = validateFirstName(firstName)
     val lastNameFieldState: FieldState<String> = validateLastName(lastName)
 
@@ -60,8 +60,8 @@ internal data class PayToOutputData(
         }
 
     private val isBsbValid: Boolean
-        get() = bsbAccountNumberFieldState.validation.isValid() &&
-            bsbStateBranchFieldState.validation.isValid()
+        get() = bsbStateBranchFieldState.validation.isValid() &&
+            bsbAccountNumberFieldState.validation.isValid()
 
     private fun validateMobileNumber(phoneNumber: String): FieldState<String> =
         if (phoneNumber.isNotBlank() && PayToValidationUtils.isPhoneNumberValid(phoneNumber)) {
@@ -103,16 +103,6 @@ internal data class PayToOutputData(
             )
         }
 
-    private fun validateBsbAccountNumber(bsbAccountNumber: String): FieldState<String> =
-        if (bsbAccountNumber.isNotBlank() && PayToValidationUtils.isBsbAccountNumberValid(bsbAccountNumber)) {
-            FieldState(bsbAccountNumber, Validation.Valid)
-        } else {
-            FieldState(
-                bsbAccountNumber,
-                Validation.Invalid(R.string.checkout_payto_bsb_account_number_invalid),
-            )
-        }
-
     private fun validateBsbStateBranch(bsbStateBranch: String): FieldState<String> =
         if (bsbStateBranch.isNotBlank() && PayToValidationUtils.isBsbStateBranchValid(bsbStateBranch)) {
             FieldState(bsbStateBranch, Validation.Valid)
@@ -120,6 +110,16 @@ internal data class PayToOutputData(
             FieldState(
                 bsbStateBranch,
                 Validation.Invalid(R.string.checkout_payto_bsb_state_branch_invalid),
+            )
+        }
+
+    private fun validateBsbAccountNumber(bsbAccountNumber: String): FieldState<String> =
+        if (bsbAccountNumber.isNotBlank() && PayToValidationUtils.isBsbAccountNumberValid(bsbAccountNumber)) {
+            FieldState(bsbAccountNumber, Validation.Valid)
+        } else {
+            FieldState(
+                bsbAccountNumber,
+                Validation.Invalid(R.string.checkout_payto_bsb_account_number_invalid),
             )
         }
 

--- a/payto/src/main/java/com/adyen/checkout/payto/internal/ui/view/PayToView.kt
+++ b/payto/src/main/java/com/adyen/checkout/payto/internal/ui/view/PayToView.kt
@@ -67,8 +67,8 @@ internal class PayToView @JvmOverloads constructor(
         initPayIdEmailAddressInput()
         initPayIdAbnNumberInput()
         initPayIdOrganizationIdInput()
-        initBsbAccountNumberInput()
         initBsbStateBranchInput()
+        initBsbAccountNumberInput()
         initFirstNameInput()
         initLastNameInput()
     }
@@ -110,12 +110,12 @@ internal class PayToView @JvmOverloads constructor(
             R.style.AdyenCheckout_PayTo_BSB_DescriptionTextView,
             localizedContext,
         )
-        binding.editTextBsbAccountNumber.setLocalizedTextFromStyle(
-            R.style.AdyenCheckout_PayTo_BSB_AccountNumberEditText,
-            localizedContext,
-        )
         binding.editTextBsbStateBranch.setLocalizedTextFromStyle(
             R.style.AdyenCheckout_PayTo_BSB_StateBranchEditText,
+            localizedContext,
+        )
+        binding.editTextBsbAccountNumber.setLocalizedTextFromStyle(
+            R.style.AdyenCheckout_PayTo_BSB_AccountNumberEditText,
             localizedContext,
         )
         binding.editTextFirstName.setLocalizedTextFromStyle(
@@ -255,21 +255,6 @@ internal class PayToView @JvmOverloads constructor(
         }
     }
 
-    private fun initBsbAccountNumberInput() {
-        binding.editTextBsbAccountNumber.setOnChangeListener {
-            delegate.updateInputData { bsbAccountNumber = binding.editTextBsbAccountNumber.rawValue }
-            binding.textInputLayoutBsbAccountNumber.hideError()
-        }
-        binding.editTextBsbAccountNumber.onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
-            val validation = delegate.outputData.bsbAccountNumberFieldState.validation
-            if (hasFocus) {
-                binding.textInputLayoutBsbAccountNumber.hideError()
-            } else if (validation is Validation.Invalid) {
-                binding.textInputLayoutBsbAccountNumber.showError(localizedContext.getString(validation.reason))
-            }
-        }
-    }
-
     private fun initBsbStateBranchInput() {
         binding.editTextBsbStateBranch.setOnChangeListener {
             delegate.updateInputData { bsbStateBranch = binding.editTextBsbStateBranch.rawValue }
@@ -281,6 +266,21 @@ internal class PayToView @JvmOverloads constructor(
                 binding.textInputLayoutBsbStateBranch.hideError()
             } else if (validation is Validation.Invalid) {
                 binding.textInputLayoutBsbStateBranch.showError(localizedContext.getString(validation.reason))
+            }
+        }
+    }
+
+    private fun initBsbAccountNumberInput() {
+        binding.editTextBsbAccountNumber.setOnChangeListener {
+            delegate.updateInputData { bsbAccountNumber = binding.editTextBsbAccountNumber.rawValue }
+            binding.textInputLayoutBsbAccountNumber.hideError()
+        }
+        binding.editTextBsbAccountNumber.onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
+            val validation = delegate.outputData.bsbAccountNumberFieldState.validation
+            if (hasFocus) {
+                binding.textInputLayoutBsbAccountNumber.hideError()
+            } else if (validation is Validation.Invalid) {
+                binding.textInputLayoutBsbAccountNumber.showError(localizedContext.getString(validation.reason))
             }
         }
     }
@@ -373,20 +373,6 @@ internal class PayToView @JvmOverloads constructor(
                 )
             }
 
-            val bsbAccountNumberValidation = it.bsbAccountNumberFieldState.validation
-            if (isBsbContentVisible() &&
-                binding.textInputLayoutBsbAccountNumber.isVisible &&
-                bsbAccountNumberValidation is Validation.Invalid
-            ) {
-                if (!isErrorFocused) {
-                    isErrorFocused = true
-                    binding.textInputLayoutBsbAccountNumber.requestFocus()
-                }
-                binding.textInputLayoutBsbAccountNumber.showError(
-                    localizedContext.getString(bsbAccountNumberValidation.reason),
-                )
-            }
-
             val bsbStateBranchValidation = it.bsbStateBranchFieldState.validation
             if (isBsbContentVisible() &&
                 binding.textInputLayoutBsbStateBranch.isVisible &&
@@ -398,6 +384,20 @@ internal class PayToView @JvmOverloads constructor(
                 }
                 binding.textInputLayoutBsbStateBranch.showError(
                     localizedContext.getString(bsbStateBranchValidation.reason),
+                )
+            }
+
+            val bsbAccountNumberValidation = it.bsbAccountNumberFieldState.validation
+            if (isBsbContentVisible() &&
+                binding.textInputLayoutBsbAccountNumber.isVisible &&
+                bsbAccountNumberValidation is Validation.Invalid
+            ) {
+                if (!isErrorFocused) {
+                    isErrorFocused = true
+                    binding.textInputLayoutBsbAccountNumber.requestFocus()
+                }
+                binding.textInputLayoutBsbAccountNumber.showError(
+                    localizedContext.getString(bsbAccountNumberValidation.reason),
                 )
             }
 

--- a/payto/src/main/java/com/adyen/checkout/payto/internal/util/PayToValidationUtils.kt
+++ b/payto/src/main/java/com/adyen/checkout/payto/internal/util/PayToValidationUtils.kt
@@ -21,11 +21,11 @@ internal object PayToValidationUtils {
     private const val ORGANIZATION_ID_REGEX = "^[!-@\\[-~][ -@\\[-~]{0,254}[!-@\\[-~]\$"
     private val ORGANIZATION_ID_PATTERN = Pattern.compile(ORGANIZATION_ID_REGEX)
 
-    private const val BSB_ACCOUNT_NUMBER_REGEX = "^\\d{6}\$"
-    private val BSB_ACCOUNT_NUMBER_PATTERN = Pattern.compile(BSB_ACCOUNT_NUMBER_REGEX)
-
-    private const val BSB_STATE_BRANCH_REGEX = "^[ -~]{1,28}\$"
+    private const val BSB_STATE_BRANCH_REGEX = "^\\d{6}\$"
     private val BSB_STATE_BRANCH_PATTERN = Pattern.compile(BSB_STATE_BRANCH_REGEX)
+
+    private const val BSB_ACCOUNT_NUMBER_REGEX = "^[ -~]{1,28}\$"
+    private val BSB_ACCOUNT_NUMBER_PATTERN = Pattern.compile(BSB_ACCOUNT_NUMBER_REGEX)
 
     fun isPhoneNumberValid(phoneNumber: String): Boolean {
         return PHONE_NUMBER_PATTERN.matcher(phoneNumber).matches()
@@ -39,11 +39,11 @@ internal object PayToValidationUtils {
         return ORGANIZATION_ID_PATTERN.matcher(organizationId).matches()
     }
 
-    fun isBsbAccountNumberValid(bsbAccountNumber: String): Boolean {
-        return BSB_ACCOUNT_NUMBER_PATTERN.matcher(bsbAccountNumber).matches()
-    }
-
     fun isBsbStateBranchValid(bsbStateBranch: String): Boolean {
         return BSB_STATE_BRANCH_PATTERN.matcher(bsbStateBranch).matches()
+    }
+
+    fun isBsbAccountNumberValid(bsbAccountNumber: String): Boolean {
+        return BSB_ACCOUNT_NUMBER_PATTERN.matcher(bsbAccountNumber).matches()
     }
 }

--- a/payto/src/main/res/layout/payto_view.xml
+++ b/payto/src/main/res/layout/payto_view.xml
@@ -160,20 +160,6 @@
             android:layout_marginBottom="@dimen/standard_margin" />
 
         <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/textInputLayout_bsb_account_number"
-            style="@style/AdyenCheckout.TextInputLayout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-
-            <com.adyen.checkout.ui.core.internal.ui.view.AdyenTextInputEditText
-                android:id="@+id/editText_bsb_account_number"
-                style="@style/AdyenCheckout.PayTo.BSB.AccountNumberEditText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/textInputLayout_bsb_state_branch"
             style="@style/AdyenCheckout.TextInputLayout"
             android:layout_width="match_parent"
@@ -182,6 +168,20 @@
             <com.adyen.checkout.ui.core.internal.ui.view.AdyenTextInputEditText
                 android:id="@+id/editText_bsb_state_branch"
                 style="@style/AdyenCheckout.PayTo.BSB.StateBranchEditText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/textInputLayout_bsb_account_number"
+            style="@style/AdyenCheckout.TextInputLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <com.adyen.checkout.ui.core.internal.ui.view.AdyenTextInputEditText
+                android:id="@+id/editText_bsb_account_number"
+                style="@style/AdyenCheckout.PayTo.BSB.AccountNumberEditText"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 

--- a/payto/src/main/res/values/styles.xml
+++ b/payto/src/main/res/values/styles.xml
@@ -77,14 +77,14 @@
         <item name="android:text">@string/checkout_payto_bsb_description</item>
     </style>
 
-    <style name="AdyenCheckout.PayTo.BSB.AccountNumberEditText" parent="AdyenCheckout.TextInputEditText">
-        <item name="android:hint">@string/checkout_payto_bsb_account_number_hint</item>
+    <style name="AdyenCheckout.PayTo.BSB.StateBranchEditText" parent="AdyenCheckout.TextInputEditText">
+        <item name="android:hint">@string/checkout_payto_bsb_state_branch_hint</item>
         <item name="android:inputType">number</item>
         <item name="android:maxLines">1</item>
     </style>
 
-    <style name="AdyenCheckout.PayTo.BSB.StateBranchEditText" parent="AdyenCheckout.TextInputEditText">
-        <item name="android:hint">@string/checkout_payto_bsb_state_branch_hint</item>
+    <style name="AdyenCheckout.PayTo.BSB.AccountNumberEditText" parent="AdyenCheckout.TextInputEditText">
+        <item name="android:hint">@string/checkout_payto_bsb_account_number_hint</item>
         <item name="android:inputType">text</item>
         <item name="android:maxLines">1</item>
     </style>

--- a/payto/src/test/java/com/adyen/checkout/payto/internal/ui/DefaultPayToDelegateTest.kt
+++ b/payto/src/test/java/com/adyen/checkout/payto/internal/ui/DefaultPayToDelegateTest.kt
@@ -193,38 +193,40 @@ internal class DefaultPayToDelegateTest(
         }
 
         @Test
-        fun `mode is PAY_ID and PayIdType is ORGANIZATION_ID and value is valid, then output should be valid`() = runTest {
-            val outputTestFlow = delegate.outputDataFlow.test(testScheduler)
+        fun `mode is PAY_ID and PayIdType is ORGANIZATION_ID and value is valid, then output should be valid`() =
+            runTest {
+                val outputTestFlow = delegate.outputDataFlow.test(testScheduler)
 
-            delegate.updateInputData {
-                mode = PayToMode.PAY_ID
-                payIdTypeModel = PayIdTypeModel(PayIdType.ORGANIZATION_ID, 0)
-                organizationId = "12345678901"
-                firstName = "First name"
-                lastName = "Last name"
+                delegate.updateInputData {
+                    mode = PayToMode.PAY_ID
+                    payIdTypeModel = PayIdTypeModel(PayIdType.ORGANIZATION_ID, 0)
+                    organizationId = "12345678901"
+                    firstName = "First name"
+                    lastName = "Last name"
+                }
+
+                assertTrue(outputTestFlow.latestValue.isValid)
+
+                outputTestFlow.cancel()
             }
-
-            assertTrue(outputTestFlow.latestValue.isValid)
-
-            outputTestFlow.cancel()
-        }
 
         @Test
-        fun `mode is PAY_ID and PayIdType is ORGANIZATION_ID and value is invalid, then output should be invalid`() = runTest {
-            val outputTestFlow = delegate.outputDataFlow.test(testScheduler)
+        fun `mode is PAY_ID and PayIdType is ORGANIZATION_ID and value is invalid, then output should be invalid`() =
+            runTest {
+                val outputTestFlow = delegate.outputDataFlow.test(testScheduler)
 
-            delegate.updateInputData {
-                mode = PayToMode.PAY_ID
-                payIdTypeModel = PayIdTypeModel(PayIdType.ORGANIZATION_ID, 0)
-                organizationId = "Invalid Org"
-                firstName = "First name"
-                lastName = "Last name"
+                delegate.updateInputData {
+                    mode = PayToMode.PAY_ID
+                    payIdTypeModel = PayIdTypeModel(PayIdType.ORGANIZATION_ID, 0)
+                    organizationId = "Invalid Org"
+                    firstName = "First name"
+                    lastName = "Last name"
+                }
+
+                assertFalse(outputTestFlow.latestValue.isValid)
+
+                outputTestFlow.cancel()
             }
-
-            assertFalse(outputTestFlow.latestValue.isValid)
-
-            outputTestFlow.cancel()
-        }
 
         @Test
         fun `mode is BSB and account number is invalid, then output should be invalid`() = runTest {
@@ -266,8 +268,8 @@ internal class DefaultPayToDelegateTest(
 
             delegate.updateInputData {
                 mode = PayToMode.BSB
-                bsbAccountNumber = "123456"
-                bsbStateBranch = "Main Branch"
+                bsbStateBranch = "123456"
+                bsbAccountNumber = "Main Branch"
                 firstName = "First name"
                 lastName = "Last name"
             }
@@ -433,8 +435,8 @@ internal class DefaultPayToDelegateTest(
                 delegate.updateComponentState(
                     createOutputData(
                         mode = PayToMode.BSB,
-                        bsbAccountNumber = "123456",
-                        bsbStateBranch = "Branch-123",
+                        bsbStateBranch = "123456",
+                        bsbAccountNumber = "Branch-123",
                         firstName = "First name",
                         lastName = "Last name",
                     ),

--- a/payto/src/test/java/com/adyen/checkout/payto/internal/util/PayToValidationUtilsTest.kt
+++ b/payto/src/test/java/com/adyen/checkout/payto/internal/util/PayToValidationUtilsTest.kt
@@ -34,15 +34,15 @@ internal class PayToValidationUtilsTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getBsbAccountNumberTestCases")
-    fun `when BSB account number is tested, then return expected result`(bsbAccountNumber: String, expected: Boolean) {
-        assertEquals(expected, PayToValidationUtils.isBsbAccountNumberValid(bsbAccountNumber))
-    }
-
-    @ParameterizedTest
     @MethodSource("getBsbStateBranchTestCases")
     fun `when BSB state branch is tested, then return expected result`(bsbStateBranch: String, expected: Boolean) {
         assertEquals(expected, PayToValidationUtils.isBsbStateBranchValid(bsbStateBranch))
+    }
+
+    @ParameterizedTest
+    @MethodSource("getBsbAccountNumberTestCases")
+    fun `when BSB account number is tested, then return expected result`(bsbAccountNumber: String, expected: Boolean) {
+        assertEquals(expected, PayToValidationUtils.isBsbAccountNumberValid(bsbAccountNumber))
     }
 
     companion object {
@@ -89,7 +89,7 @@ internal class PayToValidationUtilsTest {
         )
 
         @JvmStatic
-        fun getBsbAccountNumberTestCases() = listOf(
+        fun getBsbStateBranchTestCases() = listOf(
             // bsbAccountNumber, expectedValidationResult
             arguments("123456", true),
             arguments("987654", true),
@@ -101,15 +101,15 @@ internal class PayToValidationUtilsTest {
         )
 
         @JvmStatic
-        fun getBsbStateBranchTestCases() = listOf(
+        fun getBsbAccountNumberTestCases() = listOf(
             // bsbStateBranch, expectedValidationResult
-            arguments("Main Branch", true),
-            arguments("Branch-123", true),
+            arguments("Main Account number", true),
+            arguments("Account-123", true),
             arguments("1234", true),
-            arguments("Central Branch", true),
-            arguments("Northside Bank", true),
+            arguments("Account Number", true),
+            arguments("Northside Bank 123", true),
             arguments("", false),
-            arguments("This is a very long branch name that exceeds 28 characters", false),
+            arguments("This is a very long account number that exceeds 28 characters", false),
         )
     }
 }


### PR DESCRIPTION
## Description
This PR fixes the BSB structure. The correct structure is: `{bank state branch}-{bank account number}`:
- Regex for bank state branch `^\d{6}$`
- Regex for bank account number `[ -~]{1,28}$`

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-1058
