### PR TITLE
PayTo - Recover state when view gets recreated

### DIFF
--- a/payto/src/main/java/com/adyen/checkout/payto/internal/ui/DefaultPayToDelegate.kt
+++ b/payto/src/main/java/com/adyen/checkout/payto/internal/ui/DefaultPayToDelegate.kt
@@ -119,21 +119,18 @@ internal class DefaultPayToDelegate(
         updateComponentState(outputData)
     }
 
-    private fun createOutputData(): PayToOutputData {
-        val sanitizedPhoneNumber = inputData.phoneNumber.trimStart('0')
-        return PayToOutputData(
-            mode = inputData.mode,
-            payIdTypeModel = inputData.payIdTypeModel,
-            mobilePhoneNumber = "$PHONE_NUMBER_PREFIX-$sanitizedPhoneNumber",
-            emailAddress = inputData.emailAddress,
-            abnNumber = inputData.abnNumber,
-            organizationId = inputData.organizationId,
-            bsbStateBranch = inputData.bsbStateBranch,
-            bsbAccountNumber = inputData.bsbAccountNumber,
-            firstName = inputData.firstName,
-            lastName = inputData.lastName,
-        )
-    }
+    private fun createOutputData() = PayToOutputData(
+        mode = inputData.mode,
+        payIdTypeModel = inputData.payIdTypeModel,
+        mobilePhoneNumber = inputData.phoneNumber.trimStart('0'),
+        emailAddress = inputData.emailAddress,
+        abnNumber = inputData.abnNumber,
+        organizationId = inputData.organizationId,
+        bsbStateBranch = inputData.bsbStateBranch,
+        bsbAccountNumber = inputData.bsbAccountNumber,
+        firstName = inputData.firstName,
+        lastName = inputData.lastName,
+    )
 
     private fun outputDataChanged(outputData: PayToOutputData) {
         _outputDataFlow.tryEmit(outputData)
@@ -178,7 +175,7 @@ internal class DefaultPayToDelegate(
 
     private fun getShopperAccountIdentifierForPayId(outputData: PayToOutputData) =
         when (outputData.payIdTypeModel?.type) {
-            PayIdType.PHONE -> outputData.phoneNumberFieldState.value
+            PayIdType.PHONE -> "$PHONE_NUMBER_PREFIX-${outputData.phoneNumberFieldState.value}"
             PayIdType.EMAIL -> outputData.emailAddressFieldState.value
             PayIdType.ABN -> outputData.abnNumberFieldState.value
             PayIdType.ORGANIZATION_ID -> outputData.organizationIdFieldState.value

--- a/payto/src/main/java/com/adyen/checkout/payto/internal/util/PayToValidationUtils.kt
+++ b/payto/src/main/java/com/adyen/checkout/payto/internal/util/PayToValidationUtils.kt
@@ -12,7 +12,7 @@ import java.util.regex.Pattern
 
 internal object PayToValidationUtils {
 
-    private const val PHONE_NUMBER_REGEX = "^\\+[0-9]{1,3}-[1-9]{1,1}[0-9]{1,29}\$"
+    private const val PHONE_NUMBER_REGEX = "^[1-9]{1,1}[0-9]{1,29}$"
     private val PHONE_NUMBER_PATTERN = Pattern.compile(PHONE_NUMBER_REGEX)
 
     private const val ABN_NUMBER_REGEX = "^((\\d{9})|(\\d{11}))\$"

--- a/payto/src/test/java/com/adyen/checkout/payto/internal/ui/DefaultPayToDelegateTest.kt
+++ b/payto/src/test/java/com/adyen/checkout/payto/internal/ui/DefaultPayToDelegateTest.kt
@@ -324,7 +324,7 @@ internal class DefaultPayToDelegateTest(
                     createOutputData(
                         mode = PayToMode.PAY_ID,
                         payIdTypeModel = PayIdTypeModel(PayIdType.PHONE, 0),
-                        mobilePhoneNumber = "+61-9876543210",
+                        mobilePhoneNumber = "9876543210",
                         firstName = "First name",
                         lastName = "Last name",
                     ),

--- a/payto/src/test/java/com/adyen/checkout/payto/internal/util/PayToValidationUtilsTest.kt
+++ b/payto/src/test/java/com/adyen/checkout/payto/internal/util/PayToValidationUtilsTest.kt
@@ -50,18 +50,18 @@ internal class PayToValidationUtilsTest {
         @JvmStatic
         fun getPhoneNumberTestCases() = listOf(
             // phoneNumber, expectedValidationResult
-            arguments("+1-123456789", true),
-            arguments("+44-789456123", true),
-            arguments("+91-9876543210", true),
-            arguments("+33-145678912", true),
-            arguments("+49-1523456789", true),
-            arguments("+61-412345678", true),
-            arguments("+81-9076543210", true),
-            arguments("123456789", false),
+            arguments("123456789", true),
+            arguments("789456123", true),
+            arguments("9876543210", true),
+            arguments("145678912", true),
+            arguments("1523456789", true),
+            arguments("412345678", true),
+            arguments("9076543210", true),
+            arguments("+31-123456789", false),
             arguments("+1-", false),
-            arguments("+1-abc", false),
+            arguments("abc", false),
             arguments("++1-123456789", false),
-            arguments("+123-000000000000000000000000000000", false),
+            arguments("000000000000000000000000000000", false),
             arguments("+1-00000000000000000000000000000", false),
         )
 


### PR DESCRIPTION
## Description
- Do not include country code in phone number validation, since it is hardcoded and not necessary for the validation and in the view it acts as a prefix
- Recover state from outputData when view gets recreated

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-1058
