### PR TITLE
State management changes - MBWay - Improvements

### DIFF
--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/state/DefaultDelegateStateManager.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/state/DefaultDelegateStateManager.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.flow.update
 class DefaultDelegateStateManager<S : DelegateState, FI>(
     private val factory: DelegateStateFactory<S, FI>,
     private val validationRegistry: FieldValidatorRegistry<FI>,
-    private val stateUpdaterRegistry: StateUpdaterRegistry<FI, S>,
+    private val stateUpdaterRegistry: StateUpdaterRegistry<S, FI>,
     private val transformerRegistry: FieldTransformerRegistry<FI> = DefaultTransformerRegistry(),
 ) : DelegateStateManager<S, FI> {
 
@@ -38,7 +38,7 @@ class DefaultDelegateStateManager<S : DelegateState, FI>(
 
     private fun validateNonValidatedFields() {
         factory.getFieldIds().forEach { fieldId ->
-            val fieldState = stateUpdaterRegistry.getFieldState<Any>(fieldId, _state.value)
+            val fieldState = stateUpdaterRegistry.getFieldState<Any>(_state.value, fieldId)
 
             if (fieldState.validation == null) {
                 updateField(
@@ -60,7 +60,7 @@ class DefaultDelegateStateManager<S : DelegateState, FI>(
         var isErrorFieldFocused = false
 
         factory.getFieldIds().forEach { fieldId ->
-            val fieldState = stateUpdaterRegistry.getFieldState<Any>(fieldId, _state.value)
+            val fieldState = stateUpdaterRegistry.getFieldState<Any>(_state.value, fieldId)
 
             val shouldFocus = !isErrorFieldFocused && fieldState.validation is Validation.Invalid
             if (shouldFocus) {
@@ -89,7 +89,7 @@ class DefaultDelegateStateManager<S : DelegateState, FI>(
             )
         }
 
-        val fieldState = stateUpdaterRegistry.getFieldState<T>(fieldId, _state.value)
+        val fieldState = stateUpdaterRegistry.getFieldState<T>(_state.value, fieldId)
         val updatedFieldState = fieldState.updateFieldState(
             value = value,
             validation = validation,
@@ -98,7 +98,7 @@ class DefaultDelegateStateManager<S : DelegateState, FI>(
         )
 
         _state.update {
-            stateUpdaterRegistry.updateFieldState(fieldId, _state.value, updatedFieldState)
+            stateUpdaterRegistry.updateFieldState(_state.value, fieldId, updatedFieldState)
         }
     }
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/state/DefaultDelegateStateManager.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/state/DefaultDelegateStateManager.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.flow.update
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class DefaultDelegateStateManager<S : DelegateState, FI>(
     private val factory: DelegateStateFactory<S, FI>,
-    private val validationRegistry: FieldValidatorRegistry<FI>,
+    private val validationRegistry: FieldValidatorRegistry<S, FI>,
     private val stateUpdaterRegistry: StateUpdaterRegistry<S, FI>,
     private val transformerRegistry: FieldTransformerRegistry<FI> = DefaultTransformerRegistry(),
 ) : DelegateStateManager<S, FI> {
@@ -84,6 +84,7 @@ class DefaultDelegateStateManager<S : DelegateState, FI>(
     ) {
         val validation = value?.let {
             validationRegistry.validate(
+                _state.value,
                 fieldId,
                 transformerRegistry.transform(fieldId, it),
             )

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/state/DefaultDelegateStateManager.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/state/DefaultDelegateStateManager.kt
@@ -43,39 +43,17 @@ class DefaultDelegateStateManager<S : DelegateState, FI>(
             if (fieldState.validation == null) {
                 updateField(
                     fieldId = fieldId,
-                    value = fieldState.value, // Ensure the current value is validated
+                    value = fieldState.value, // Ensure the current value is validated,
+                    hasFocus = fieldState.hasFocus,
                 )
             }
         }
     }
 
-    // A list can be added, which will show which other fields need to be validated
-    // or updated when a specific field is updated
-    override fun <T> updateField(
-        fieldId: FI,
-        value: T?,
-        hasFocus: Boolean?,
-        shouldHighlightValidationError: Boolean?,
-    ) {
-        val validation = value?.let {
-            validationRegistry.validate(
-                fieldId,
-                transformerRegistry.transform(fieldId, it),
-            )
-        }
+    override fun <T> updateFieldValue(fieldId: FI, value: T?) = updateField(fieldId, value = value)
 
-        val fieldState = stateUpdaterRegistry.getFieldState<T>(fieldId, _state.value)
-        val updatedFieldState = fieldState.updateFieldState(
-            value = value,
-            validation = validation,
-            hasFocus = hasFocus,
-            shouldHighlightValidationError = shouldHighlightValidationError,
-        )
-
-        _state.update {
-            stateUpdaterRegistry.updateFieldState(fieldId, _state.value, updatedFieldState)
-        }
-    }
+    override fun updateFieldFocus(fieldId: FI, hasFocus: Boolean) =
+        updateField<Unit>(fieldId, hasFocus = hasFocus)
 
     override fun highlightAllFieldValidationErrors() {
         // Flag to focus only the first invalid field
@@ -95,6 +73,32 @@ class DefaultDelegateStateManager<S : DelegateState, FI>(
                 hasFocus = shouldFocus,
                 shouldHighlightValidationError = true,
             )
+        }
+    }
+
+    private fun <T> updateField(
+        fieldId: FI,
+        value: T? = null,
+        hasFocus: Boolean? = null,
+        shouldHighlightValidationError: Boolean? = null,
+    ) {
+        val validation = value?.let {
+            validationRegistry.validate(
+                fieldId,
+                transformerRegistry.transform(fieldId, it),
+            )
+        }
+
+        val fieldState = stateUpdaterRegistry.getFieldState<T>(fieldId, _state.value)
+        val updatedFieldState = fieldState.updateFieldState(
+            value = value,
+            validation = validation,
+            hasFocus = hasFocus,
+            shouldHighlightValidationError = shouldHighlightValidationError,
+        )
+
+        _state.update {
+            stateUpdaterRegistry.updateFieldState(fieldId, _state.value, updatedFieldState)
         }
     }
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/state/DelegateStateManager.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/state/DelegateStateManager.kt
@@ -18,12 +18,14 @@ interface DelegateStateManager<S, FI> {
 
     val isValid: Boolean
 
-    fun <T> updateField(
+    fun <T> updateFieldValue(
         fieldId: FI,
         value: T? = null,
-        hasFocus: Boolean? = null,
-        // Default value is false, to make sure that errors are cleared when field is updated
-        shouldHighlightValidationError: Boolean? = false,
+    )
+
+    fun updateFieldFocus(
+        fieldId: FI,
+        hasFocus: Boolean,
     )
 
     fun highlightAllFieldValidationErrors()

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/state/StateUpdaterRegistry.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/state/StateUpdaterRegistry.kt
@@ -12,8 +12,8 @@ import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.core.internal.ui.model.ComponentFieldDelegateState
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-interface StateUpdaterRegistry<K, S> {
-    fun <T> getFieldState(key: K, state: S): ComponentFieldDelegateState<T>
+interface StateUpdaterRegistry<S, K> {
+    fun <T> getFieldState(state: S, key: K): ComponentFieldDelegateState<T>
 
-    fun <T> updateFieldState(key: K, state: S, fieldState: ComponentFieldDelegateState<T>): S
+    fun <T> updateFieldState(state: S, key: K, fieldState: ComponentFieldDelegateState<T>): S
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/validation/DefaultValidator.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/validation/DefaultValidator.kt
@@ -12,6 +12,6 @@ import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.core.internal.ui.model.Validation
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class DefaultValidator : FieldValidator<Any> {
-    override fun validate(input: Any) = Validation.Valid
+class DefaultValidator : FieldValidator<Any, Any> {
+    override fun validate(state: Any, input: Any) = Validation.Valid
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/validation/FieldValidator.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/validation/FieldValidator.kt
@@ -12,6 +12,6 @@ import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.core.internal.ui.model.Validation
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-interface FieldValidator<T> {
-    fun validate(input: T): Validation
+fun interface FieldValidator<S, T> {
+    fun validate(state: S, input: T): Validation
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/validation/FieldValidatorRegistry.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/validation/FieldValidatorRegistry.kt
@@ -12,6 +12,6 @@ import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.core.internal.ui.model.Validation
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-interface FieldValidatorRegistry<K> {
-    fun <T> validate(key: K, value: T): Validation
+interface FieldValidatorRegistry<S, K> {
+    fun <T> validate(state: S, key: K, value: T): Validation
 }

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/ui/model/state/DefaultDelegateStateManagerTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/ui/model/state/DefaultDelegateStateManagerTest.kt
@@ -52,23 +52,23 @@ internal class DefaultDelegateStateManagerTest {
     }
 
     @Test
-    fun `when updateField is called and value is not null, then validate is called`() {
-        stateManager.updateField(TestFieldId.FIELD_1, value = "Some value")
+    fun `when updateFieldValue is called and value is not null, then validate is called`() {
+        stateManager.updateFieldValue(TestFieldId.FIELD_1, value = "Some value")
 
         transformerRegistry.assertIsTransformed(TestFieldId.FIELD_1)
         validationRegistry.assertIsValidated(TestFieldId.FIELD_1)
     }
 
     @Test
-    fun `when updateField is called and value is null, then validate is not called`() {
-        stateManager.updateField(TestFieldId.FIELD_1, value = null)
+    fun `when updateFieldValue is called and value is null, then validate is not called`() {
+        stateManager.updateFieldValue(TestFieldId.FIELD_1, value = null)
 
         transformerRegistry.assertNotTransformed(TestFieldId.FIELD_1)
         validationRegistry.assertNotValidated(TestFieldId.FIELD_1)
     }
 
     @Test
-    fun `when updateField is called, then field state should be updated`() {
+    fun `when updateFieldValue is called, then field state should be updated`() {
         val initialFieldState = ComponentFieldDelegateState(
             value = "",
             validation = null,
@@ -77,16 +77,33 @@ internal class DefaultDelegateStateManagerTest {
         )
         stateUpdaterRegistry.updateFieldState(TestFieldId.FIELD_1, defaultDelegateState, initialFieldState)
 
-        stateManager.updateField(
+        stateManager.updateFieldValue(
             fieldId = TestFieldId.FIELD_1,
             value = "New value",
-            hasFocus = true,
-            shouldHighlightValidationError = true,
         )
 
         val updatedFieldState = stateUpdaterRegistry.getFieldState<String>(TestFieldId.FIELD_1, defaultDelegateState)
         assertEquals("New value", updatedFieldState.value)
+        assertEquals(false, updatedFieldState.hasFocus)
+    }
+
+    @Test
+    fun `when updateFieldFocus is called, then field state should be updated`() {
+        val initialFieldState = ComponentFieldDelegateState(
+            value = "",
+            validation = null,
+            hasFocus = false,
+            shouldHighlightValidationError = false,
+        )
+        stateUpdaterRegistry.updateFieldState(TestFieldId.FIELD_1, defaultDelegateState, initialFieldState)
+
+        stateManager.updateFieldFocus(
+            fieldId = TestFieldId.FIELD_1,
+            hasFocus = true,
+        )
+
+        val updatedFieldState = stateUpdaterRegistry.getFieldState<String>(TestFieldId.FIELD_1, defaultDelegateState)
+        assertEquals("", updatedFieldState.value)
         assertEquals(true, updatedFieldState.hasFocus)
-        assertEquals(true, updatedFieldState.shouldHighlightValidationError)
     }
 }

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/ui/model/state/DefaultDelegateStateManagerTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/ui/model/state/DefaultDelegateStateManagerTest.kt
@@ -44,7 +44,7 @@ internal class DefaultDelegateStateManagerTest {
     @Test
     fun `when isValid is accessed, then non-validated fields should be validated`() = runTest {
         val fieldState = ComponentFieldDelegateState(value = "test", validation = null)
-        stateUpdaterRegistry.updateFieldState(TestFieldId.FIELD_1, defaultDelegateState, fieldState)
+        stateUpdaterRegistry.updateFieldState(defaultDelegateState, TestFieldId.FIELD_1, fieldState)
 
         stateManager.isValid
 
@@ -75,14 +75,14 @@ internal class DefaultDelegateStateManagerTest {
             hasFocus = false,
             shouldHighlightValidationError = false,
         )
-        stateUpdaterRegistry.updateFieldState(TestFieldId.FIELD_1, defaultDelegateState, initialFieldState)
+        stateUpdaterRegistry.updateFieldState(defaultDelegateState, TestFieldId.FIELD_1, initialFieldState)
 
         stateManager.updateFieldValue(
             fieldId = TestFieldId.FIELD_1,
             value = "New value",
         )
 
-        val updatedFieldState = stateUpdaterRegistry.getFieldState<String>(TestFieldId.FIELD_1, defaultDelegateState)
+        val updatedFieldState = stateUpdaterRegistry.getFieldState<String>(defaultDelegateState, TestFieldId.FIELD_1)
         assertEquals("New value", updatedFieldState.value)
         assertEquals(false, updatedFieldState.hasFocus)
     }
@@ -95,14 +95,14 @@ internal class DefaultDelegateStateManagerTest {
             hasFocus = false,
             shouldHighlightValidationError = false,
         )
-        stateUpdaterRegistry.updateFieldState(TestFieldId.FIELD_1, defaultDelegateState, initialFieldState)
+        stateUpdaterRegistry.updateFieldState(defaultDelegateState, TestFieldId.FIELD_1, initialFieldState)
 
         stateManager.updateFieldFocus(
             fieldId = TestFieldId.FIELD_1,
             hasFocus = true,
         )
 
-        val updatedFieldState = stateUpdaterRegistry.getFieldState<String>(TestFieldId.FIELD_1, defaultDelegateState)
+        val updatedFieldState = stateUpdaterRegistry.getFieldState<String>(defaultDelegateState, TestFieldId.FIELD_1)
         assertEquals("", updatedFieldState.value)
         assertEquals(true, updatedFieldState.hasFocus)
     }

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/ui/model/state/TestFieldValidatorRegistry.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/ui/model/state/TestFieldValidatorRegistry.kt
@@ -13,10 +13,10 @@ import com.adyen.checkout.components.core.internal.ui.model.validation.FieldVali
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 
-internal class TestFieldValidatorRegistry : FieldValidatorRegistry<TestFieldId> {
+internal class TestFieldValidatorRegistry : FieldValidatorRegistry<TestDelegateState, TestFieldId> {
     private val validatedFields = mutableSetOf<TestFieldId>()
 
-    override fun <T> validate(key: TestFieldId, value: T): Validation {
+    override fun <T> validate(state: TestDelegateState, key: TestFieldId, value: T): Validation {
         validatedFields.add(key)
         return Validation.Valid
     }

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/ui/model/state/TestStateUpdaterRegistry.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/ui/model/state/TestStateUpdaterRegistry.kt
@@ -10,7 +10,7 @@ package com.adyen.checkout.components.core.internal.ui.model.state
 
 import com.adyen.checkout.components.core.internal.ui.model.ComponentFieldDelegateState
 
-internal class TestStateUpdaterRegistry : StateUpdaterRegistry<TestFieldId, TestDelegateState> {
+internal class TestStateUpdaterRegistry : StateUpdaterRegistry<TestDelegateState, TestFieldId> {
 
     private val fieldStates = mutableMapOf<TestFieldId, ComponentFieldDelegateState<*>>()
 
@@ -21,15 +21,15 @@ internal class TestStateUpdaterRegistry : StateUpdaterRegistry<TestFieldId, Test
     }
 
     @Suppress("UNCHECKED_CAST")
-    override fun <T> getFieldState(key: TestFieldId, state: TestDelegateState): ComponentFieldDelegateState<T> {
+    override fun <T> getFieldState(state: TestDelegateState, key: TestFieldId): ComponentFieldDelegateState<T> {
         return fieldStates[key] as ComponentFieldDelegateState<T>
     }
 
     @Suppress("UNCHECKED_CAST")
     override fun <T> updateFieldState(
-        key: TestFieldId,
         state: TestDelegateState,
-        fieldState: ComponentFieldDelegateState<T>
+        key: TestFieldId,
+        fieldState: ComponentFieldDelegateState<T>,
     ): TestDelegateState {
         fieldStates[key] = fieldState as ComponentFieldDelegateState<Any>
         return state

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/DefaultMBWayDelegate.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/DefaultMBWayDelegate.kt
@@ -123,11 +123,11 @@ internal class DefaultMBWayDelegate(
     }
 
     override fun <T> onFieldValueChanged(fieldId: MBWayFieldId, value: T) {
-        stateManager.updateField(fieldId, value = value)
+        stateManager.updateFieldValue(fieldId, value = value)
     }
 
     override fun onFieldFocusChanged(fieldId: MBWayFieldId, hasFocus: Boolean) {
-        stateManager.updateField<Unit>(fieldId, hasFocus = hasFocus)
+        stateManager.updateFieldFocus(fieldId, hasFocus = hasFocus)
     }
 
     override fun onSubmit() = if (stateManager.isValid) {

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/model/MBWayStateUpdaterRegistry.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/model/MBWayStateUpdaterRegistry.kt
@@ -13,7 +13,7 @@ import com.adyen.checkout.components.core.internal.ui.model.state.StateUpdater
 import com.adyen.checkout.components.core.internal.ui.model.state.StateUpdaterRegistry
 import com.adyen.checkout.ui.core.internal.ui.model.CountryModel
 
-internal class MBWayStateUpdaterRegistry : StateUpdaterRegistry<MBWayFieldId, MBWayDelegateState> {
+internal class MBWayStateUpdaterRegistry : StateUpdaterRegistry<MBWayDelegateState, MBWayFieldId> {
 
     private val updaters = MBWayFieldId.entries.associateWith { fieldId ->
         when (fieldId) {
@@ -24,8 +24,8 @@ internal class MBWayStateUpdaterRegistry : StateUpdaterRegistry<MBWayFieldId, MB
 
     @Suppress("UNCHECKED_CAST")
     override fun <T> getFieldState(
+        state: MBWayDelegateState,
         key: MBWayFieldId,
-        state: MBWayDelegateState
     ): ComponentFieldDelegateState<T> {
         val updater = updaters[key] as? StateUpdater<MBWayDelegateState, ComponentFieldDelegateState<T>>
             ?: throw IllegalArgumentException("Unsupported fieldId or invalid type provided")
@@ -34,9 +34,9 @@ internal class MBWayStateUpdaterRegistry : StateUpdaterRegistry<MBWayFieldId, MB
 
     @Suppress("UNCHECKED_CAST")
     override fun <T> updateFieldState(
-        key: MBWayFieldId,
         state: MBWayDelegateState,
-        fieldState: ComponentFieldDelegateState<T>
+        key: MBWayFieldId,
+        fieldState: ComponentFieldDelegateState<T>,
     ): MBWayDelegateState {
         val updater = updaters[key] as? StateUpdater<MBWayDelegateState, ComponentFieldDelegateState<T>>
             ?: throw IllegalArgumentException("Unsupported fieldId or invalid type provided")

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/model/MBWayValidatorRegistry.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/model/MBWayValidatorRegistry.kt
@@ -15,7 +15,7 @@ import com.adyen.checkout.components.core.internal.ui.model.validation.FieldVali
 import com.adyen.checkout.components.core.internal.util.ValidationUtils
 import com.adyen.checkout.mbway.R
 
-internal class MBWayValidatorRegistry : FieldValidatorRegistry<MBWayFieldId> {
+internal class MBWayValidatorRegistry : FieldValidatorRegistry<MBWayDelegateState, MBWayFieldId> {
 
     private val validators = MBWayFieldId.entries.associateWith { fieldId ->
         when (fieldId) {
@@ -25,15 +25,15 @@ internal class MBWayValidatorRegistry : FieldValidatorRegistry<MBWayFieldId> {
     }
 
     @Suppress("UNCHECKED_CAST")
-    override fun <T> validate(key: MBWayFieldId, value: T): Validation {
-        val validator = validators[key] as? FieldValidator<T>
+    override fun <T> validate(state: MBWayDelegateState, key: MBWayFieldId, value: T): Validation {
+        val validator = validators[key] as? FieldValidator<MBWayDelegateState, T>
             ?: throw IllegalArgumentException("Unsupported fieldId or invalid type provided")
-        return validator.validate(value)
+        return validator.validate(state, value)
     }
 }
 
-internal class LocalPhoneNumberValidator : FieldValidator<String> {
-    override fun validate(input: String) =
+internal class LocalPhoneNumberValidator : FieldValidator<MBWayDelegateState, String> {
+    override fun validate(state: MBWayDelegateState, input: String) =
         if (input.isNotEmpty() && ValidationUtils.isPhoneNumberValid(input)) {
             Validation.Valid
         } else {

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MbWayView.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MbWayView.kt
@@ -12,7 +12,6 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
-import android.view.View.OnFocusChangeListener
 import android.widget.LinearLayout
 import com.adyen.checkout.components.core.internal.ui.ComponentDelegate
 import com.adyen.checkout.components.core.internal.ui.model.ComponentFieldViewState
@@ -23,7 +22,7 @@ import com.adyen.checkout.mbway.internal.ui.model.MBWayViewState
 import com.adyen.checkout.ui.core.internal.ui.ComponentView
 import com.adyen.checkout.ui.core.internal.ui.CountryAdapter
 import com.adyen.checkout.ui.core.internal.ui.model.CountryModel
-import com.adyen.checkout.ui.core.internal.ui.view.AdyenTextInputEditText
+import com.adyen.checkout.ui.core.internal.ui.view.safeUpdateText
 import com.adyen.checkout.ui.core.internal.util.hideError
 import com.adyen.checkout.ui.core.internal.util.showError
 import kotlinx.coroutines.CoroutineScope
@@ -97,10 +96,11 @@ internal class MbWayView @JvmOverloads constructor(
     }
 
     private fun updateMobileNumberInput(phoneNumberFieldState: ComponentFieldViewState<String>) {
-        binding.editTextMobileNumber.setOnChangeListener(null)
-        binding.editTextMobileNumber.onFocusChangeListener = null
-
-        binding.editTextMobileNumber.updateText(phoneNumberFieldState.value)
+        binding.editTextMobileNumber.safeUpdateText(
+            delegate = delegate,
+            fieldId = MBWayFieldId.LOCAL_PHONE_NUMBER,
+            value = phoneNumberFieldState.value,
+        )
 
         if (phoneNumberFieldState.hasFocus) {
             binding.textInputLayoutMobileNumber.requestFocus()
@@ -113,18 +113,6 @@ internal class MbWayView @JvmOverloads constructor(
         } ?: run {
             binding.textInputLayoutMobileNumber.hideError()
         }
-
-        binding.editTextMobileNumber.setOnChangeListener {
-            delegate.onFieldValueChanged(MBWayFieldId.LOCAL_PHONE_NUMBER, it.toString())
-        }
-        binding.editTextMobileNumber.onFocusChangeListener = OnFocusChangeListener { _, hasFocus: Boolean ->
-            delegate.onFieldFocusChanged(MBWayFieldId.LOCAL_PHONE_NUMBER, hasFocus)
-        }
-    }
-
-    private fun AdyenTextInputEditText.updateText(newValue: String) {
-        setText(newValue)
-        setSelection(length())
     }
 
     override fun highlightValidationErrors() {

--- a/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/DefaultMBWayDelegateTest.kt
+++ b/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/DefaultMBWayDelegateTest.kt
@@ -263,11 +263,9 @@ internal class DefaultMBWayDelegateTest(
 
         delegate.onFieldValueChanged(MBWayFieldId.LOCAL_PHONE_NUMBER, value = "123456789")
 
-        verify(stateManager).updateField(
+        verify(stateManager).updateFieldValue(
             fieldId = eq(MBWayFieldId.LOCAL_PHONE_NUMBER),
             value = eq("123456789"),
-            hasFocus = eq(null),
-            shouldHighlightValidationError = eq(false),
         )
     }
 
@@ -277,11 +275,9 @@ internal class DefaultMBWayDelegateTest(
 
         delegate.onFieldFocusChanged(MBWayFieldId.LOCAL_PHONE_NUMBER, hasFocus = true)
 
-        verify(stateManager).updateField(
+        verify(stateManager).updateFieldFocus(
             fieldId = eq(MBWayFieldId.LOCAL_PHONE_NUMBER),
-            value = eq(null),
             hasFocus = eq(true),
-            shouldHighlightValidationError = eq(false),
         )
     }
 

--- a/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/model/MBWayStateUpdaterRegistryTest.kt
+++ b/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/model/MBWayStateUpdaterRegistryTest.kt
@@ -39,14 +39,14 @@ internal class MBWayStateUpdaterRegistryTest {
 
     @Test
     fun `when getFieldState is called for phone number, then correct field state should be returned`() {
-        val fieldState = stateUpdaterRegistry.getFieldState<String>(MBWayFieldId.LOCAL_PHONE_NUMBER, initialState)
+        val fieldState = stateUpdaterRegistry.getFieldState<String>(initialState, MBWayFieldId.LOCAL_PHONE_NUMBER)
 
         assertEquals(localPhoneNumberFieldState, fieldState)
     }
 
     @Test
     fun `when getFieldState is called for country code, then correct field state should be returned`() {
-        val fieldState = stateUpdaterRegistry.getFieldState<CountryModel>(MBWayFieldId.COUNTRY_CODE, initialState)
+        val fieldState = stateUpdaterRegistry.getFieldState<CountryModel>(initialState, MBWayFieldId.COUNTRY_CODE)
 
         assertEquals(countryCodeFieldState, fieldState)
     }
@@ -56,8 +56,8 @@ internal class MBWayStateUpdaterRegistryTest {
         val newPhoneNumberState = ComponentFieldDelegateState(value = "987654321")
 
         val updatedState = stateUpdaterRegistry.updateFieldState(
-            MBWayFieldId.LOCAL_PHONE_NUMBER,
             initialState,
+            MBWayFieldId.LOCAL_PHONE_NUMBER,
             newPhoneNumberState,
         )
 
@@ -69,8 +69,8 @@ internal class MBWayStateUpdaterRegistryTest {
         val newCountryCodeState = ComponentFieldDelegateState(value = countryModel.copy(callingCode = "+123"))
 
         val updatedState = stateUpdaterRegistry.updateFieldState(
-            MBWayFieldId.COUNTRY_CODE,
             initialState,
+            MBWayFieldId.COUNTRY_CODE,
             newCountryCodeState,
         )
 

--- a/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/model/MBWayValidatorRegistryTest.kt
+++ b/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/model/MBWayValidatorRegistryTest.kt
@@ -12,10 +12,13 @@ import com.adyen.checkout.components.core.internal.ui.model.Validation
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
 
 internal class MBWayValidatorRegistryTest {
 
     private lateinit var validatorRegistry: MBWayValidatorRegistry
+
+    private var state: MBWayDelegateState = mock()
 
     @BeforeEach
     fun setup() {
@@ -24,14 +27,14 @@ internal class MBWayValidatorRegistryTest {
 
     @Test
     fun `when validate is called for country code, then validation should be valid`() {
-        val result = validatorRegistry.validate(MBWayFieldId.COUNTRY_CODE, "")
+        val result = validatorRegistry.validate(state, MBWayFieldId.COUNTRY_CODE, "")
         assertTrue(result is Validation.Valid)
     }
 
     @Test
     fun `when validate is called for invalid phone number, then validation should be invalid`() {
         val invalidPhoneNumber = "invalid-phone-number"
-        val result = validatorRegistry.validate(MBWayFieldId.LOCAL_PHONE_NUMBER, invalidPhoneNumber)
+        val result = validatorRegistry.validate(state, MBWayFieldId.LOCAL_PHONE_NUMBER, invalidPhoneNumber)
 
         assertTrue(result is Validation.Invalid)
     }
@@ -39,7 +42,7 @@ internal class MBWayValidatorRegistryTest {
     @Test
     fun `when validate is called for valid phone number, then validation should be invalid`() {
         val validPhoneNumber = "123456789"
-        val result = validatorRegistry.validate(MBWayFieldId.LOCAL_PHONE_NUMBER, validPhoneNumber)
+        val result = validatorRegistry.validate(state, MBWayFieldId.LOCAL_PHONE_NUMBER, validPhoneNumber)
 
         assertTrue(result is Validation.Valid)
     }

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/AdyenTextInputEditText.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/AdyenTextInputEditText.kt
@@ -13,7 +13,10 @@ import android.text.InputFilter
 import android.text.InputFilter.LengthFilter
 import android.text.TextWatcher
 import android.util.AttributeSet
+import android.view.View.OnFocusChangeListener
 import androidx.annotation.CallSuper
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.ui.core.internal.ui.UIEventDelegate
 import com.google.android.material.R
 import com.google.android.material.textfield.TextInputEditText
 
@@ -76,5 +79,25 @@ open class AdyenTextInputEditText @JvmOverloads constructor(
 
     companion object {
         protected const val NO_MAX_LENGTH = -1
+    }
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun <FI> AdyenTextInputEditText.safeUpdateText(
+    delegate: UIEventDelegate<FI>,
+    fieldId: FI,
+    value: String,
+) {
+    setOnChangeListener(null)
+    onFocusChangeListener = null
+
+    setText(value)
+    setSelection(length())
+
+    setOnChangeListener {
+        delegate.onFieldValueChanged(fieldId, it.toString())
+    }
+    onFocusChangeListener = OnFocusChangeListener { _, hasFocus: Boolean ->
+        delegate.onFieldFocusChanged(fieldId, hasFocus)
     }
 }


### PR DESCRIPTION
## Description
- Made `updateField()` private and exposed two different functions to update the value and the focus of a field
- Aligned generics order, to keep it consistent within the implementation
- Added `safeUpdateText()` in `AdyenTextInputEditText` to make it easier to update a text without triggering an update callback.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-935
