### PR TITLE
Display full country name in address lookup result

### DIFF
--- a/ach/src/main/java/com/adyen/checkout/ach/internal/ui/DefaultACHDirectDebitDelegate.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/internal/ui/DefaultACHDirectDebitDelegate.kt
@@ -223,6 +223,7 @@ internal class DefaultACHDirectDebitDelegate(
                 )
                 countryOptions.firstOrNull { it.selected }?.let {
                     inputData.address.country = it.code
+                    inputData.address.countryDisplayName = it.name
                     requestStateList(it.code)
                 }
                 updateOutputData(countryOptions = countryOptions)

--- a/ach/src/test/java/com/adyen/checkout/ach/internal/ui/DefaultACHDirectDebitDelegateTest.kt
+++ b/ach/src/test/java/com/adyen/checkout/ach/internal/ui/DefaultACHDirectDebitDelegateTest.kt
@@ -488,6 +488,7 @@ internal class DefaultACHDirectDebitDelegateTest(
                     city = FieldState(adddressInputModel.city, Validation.Valid),
                     country = FieldState(adddressInputModel.country, Validation.Valid),
                     isOptional = false,
+                    countryDisplayName = adddressInputModel.countryDisplayName,
                 )
 
                 val addressUIState = AddressFormUIState.FULL_ADDRESS
@@ -717,7 +718,8 @@ internal class DefaultACHDirectDebitDelegateTest(
         country: FieldState<String> = FieldState("", Validation.Valid),
         isOptional: Boolean = true,
         countryOptions: List<AddressListItem> = emptyList(),
-        stateOptions: List<AddressListItem> = emptyList()
+        stateOptions: List<AddressListItem> = emptyList(),
+        countryDisplayName: String = "",
     ): AddressOutputData {
         return AddressOutputData(
             postalCode = postalCode,
@@ -730,6 +732,7 @@ internal class DefaultACHDirectDebitDelegateTest(
             isOptional = isOptional,
             countryOptions = countryOptions,
             stateOptions = stateOptions,
+            countryDisplayName = countryDisplayName,
         )
     }
 
@@ -776,7 +779,8 @@ internal class DefaultACHDirectDebitDelegateTest(
             houseNumberOrName = "44",
             apartmentSuite = "apartment",
             city = "Istanbul",
-            country = "Turkey",
+            country = "TR",
+            countryDisplayName = "Turkey"
         )
     }
 

--- a/boleto/src/main/java/com/adyen/checkout/boleto/internal/ui/DefaultBoletoDelegate.kt
+++ b/boleto/src/main/java/com/adyen/checkout/boleto/internal/ui/DefaultBoletoDelegate.kt
@@ -132,6 +132,7 @@ internal class DefaultBoletoDelegate(
                 )
                 countryOptions.firstOrNull { it.selected }?.let {
                     inputData.address.country = it.code
+                    inputData.address.countryDisplayName = it.name
                     requestStateList(it.code)
                 }
                 updateOutputData(countryOptions = countryOptions)

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegate.kt
@@ -287,6 +287,7 @@ class DefaultCardDelegate(
                 )
                 countryOptions.firstOrNull { it.selected }?.let {
                     inputData.address.country = it.code
+                    inputData.address.countryDisplayName = it.name
                     requestStateList(it.code)
                 }
                 updateOutputData(countryOptions = countryOptions)

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegateTest.kt
@@ -613,7 +613,8 @@ internal class DefaultCardDelegateTest(
                         houseNumberOrName = "6"
                         apartmentSuite = "apt"
                         city = "Amsterdam"
-                        country = "Netherlands"
+                        country = "NL"
+                        countryDisplayName = "Netherlands"
                     }
                 }
 
@@ -625,7 +626,7 @@ internal class DefaultCardDelegateTest(
 
                 val expectedCountries = AddressFormUtils.markAddressListItemSelected(
                     list = countryOptions,
-                    code = null,
+                    code = "NL",
                 )
 
                 val expectedAddressOutputData = createAddressOutputData(
@@ -635,10 +636,11 @@ internal class DefaultCardDelegateTest(
                     houseNumberOrName = FieldState("6", Validation.Valid),
                     apartmentSuite = FieldState("apt", Validation.Valid),
                     city = FieldState("Amsterdam", Validation.Valid),
-                    country = FieldState("Netherlands", Validation.Valid),
+                    country = FieldState("NL", Validation.Valid),
                     isOptional = false,
                     countryOptions = expectedCountries,
                     stateOptions = AddressFormUtils.initializeStateOptions(TestAddressRepository.STATES),
+                    countryDisplayName = "Netherlands",
                 )
 
                 val expectedDetectedCardTypes = detectCardTypeRepository.getDetectedCardTypesLocal(supportedCardBrands)
@@ -1448,7 +1450,8 @@ internal class DefaultCardDelegateTest(
         country: FieldState<String> = FieldState("", Validation.Valid),
         isOptional: Boolean = true,
         countryOptions: List<AddressListItem> = emptyList(),
-        stateOptions: List<AddressListItem> = emptyList()
+        stateOptions: List<AddressListItem> = emptyList(),
+        countryDisplayName: String = "",
     ): AddressOutputData {
         return AddressOutputData(
             postalCode = postalCode,
@@ -1461,6 +1464,7 @@ internal class DefaultCardDelegateTest(
             isOptional = isOptional,
             countryOptions = countryOptions,
             stateOptions = stateOptions,
+            countryDisplayName = countryDisplayName,
         )
     }
 

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/AddressInputModel.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/AddressInputModel.kt
@@ -19,6 +19,7 @@ data class AddressInputModel(
     var apartmentSuite: String = "",
     var city: String = "",
     var country: String = "",
+    var countryDisplayName: String = "",
 ) {
 
     fun set(addressInputModel: AddressInputModel) {
@@ -29,6 +30,7 @@ data class AddressInputModel(
         apartmentSuite = addressInputModel.apartmentSuite
         city = addressInputModel.city
         country = addressInputModel.country
+        countryDisplayName = addressInputModel.countryDisplayName
     }
 
     /**
@@ -44,6 +46,7 @@ data class AddressInputModel(
         houseNumberOrName = ""
         apartmentSuite = ""
         city = ""
+        countryDisplayName = ""
     }
 
     /**
@@ -59,6 +62,7 @@ data class AddressInputModel(
         houseNumberOrName = ""
         apartmentSuite = ""
         city = ""
+        countryDisplayName = ""
     }
 
     val isEmpty

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/model/AddressOutputData.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/model/AddressOutputData.kt
@@ -23,7 +23,8 @@ data class AddressOutputData(
     val country: FieldState<String>,
     val isOptional: Boolean,
     val countryOptions: List<AddressListItem>,
-    val stateOptions: List<AddressListItem>
+    val stateOptions: List<AddressListItem>,
+    val countryDisplayName: String,
 ) : OutputData {
 
     override val isValid: Boolean
@@ -48,7 +49,7 @@ data class AddressOutputData(
             postalCode.value,
             city.value,
             stateOrProvince.value,
-            country.value,
+            countryDisplayName,
         )
             .filter { it.isNotBlank() }
             .joinToString(", ")

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/AddressFormInput.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/AddressFormInput.kt
@@ -119,14 +119,15 @@ class AddressFormInput @JvmOverloads constructor(
             inputType = 0
             setAdapter(countryAdapter)
             onItemClickListener = AdapterView.OnItemClickListener { _, _, position, _ ->
-                val selectedCountryCode = countryAdapter.getItem(position).code
-                if (delegate.addressOutputData.country.value != selectedCountryCode) {
+                val selectedCountry = countryAdapter.getItem(position)
+                if (delegate.addressOutputData.country.value != selectedCountry.code) {
                     delegate.updateAddressInputData {
                         // Only reset state/province, so filled in data is retained.
                         stateOrProvince = ""
-                        country = selectedCountryCode
+                        country = selectedCountry.code
+                        countryDisplayName = selectedCountry.name
                     }
-                    populateFormFields(AddressSpecification.fromString(selectedCountryCode))
+                    populateFormFields(AddressSpecification.fromString(selectedCountry.code))
                 }
                 textInputLayoutCountry?.hideError()
             }

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/util/AddressValidationUtils.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/util/AddressValidationUtils.kt
@@ -69,6 +69,7 @@ object AddressValidationUtils {
                 isOptional = isOptional,
                 countryOptions = countryOptions,
                 stateOptions = stateOptions,
+                countryDisplayName = countryDisplayName,
             )
         }
     }
@@ -92,6 +93,7 @@ object AddressValidationUtils {
                 isOptional = isOptional,
                 countryOptions = countryOptions,
                 stateOptions = stateOptions,
+                countryDisplayName = countryDisplayName,
             )
         }
     }
@@ -112,6 +114,7 @@ object AddressValidationUtils {
                 isOptional = true,
                 countryOptions = emptyList(),
                 stateOptions = emptyList(),
+                countryDisplayName = countryDisplayName,
             )
         }
     }

--- a/ui-core/src/test/java/com/adyen/checkout/ui/core/internal/ui/model/AddressOutputDataTest.kt
+++ b/ui-core/src/test/java/com/adyen/checkout/ui/core/internal/ui/model/AddressOutputDataTest.kt
@@ -28,9 +28,10 @@ internal class AddressOutputDataTest {
             isOptional = false,
             countryOptions = emptyList(),
             stateOptions = emptyList(),
+            countryDisplayName = "countryDisplayName",
         )
 
-        val expected = "street houseNumberOrName apartmentSuite\npostalCode, city, stateOrProvince, country"
+        val expected = "street houseNumberOrName apartmentSuite\npostalCode, city, stateOrProvince, countryDisplayName"
         assertEquals(expected, addressOutputData.formatted())
     }
 }

--- a/ui-core/src/test/java/com/adyen/checkout/ui/core/internal/util/AddressFormUtilsTest.kt
+++ b/ui-core/src/test/java/com/adyen/checkout/ui/core/internal/util/AddressFormUtilsTest.kt
@@ -452,6 +452,7 @@ internal class AddressFormUtilsTest {
             isOptional = false,
             countryOptions = emptyList(),
             stateOptions = emptyList(),
+            countryDisplayName = "",
         )
 
         @JvmStatic


### PR DESCRIPTION
## Description
Pass the full country name through address output, so we can display it in the card component.

<img width="324" alt="image" src="https://github.com/user-attachments/assets/b7f4bc3c-a4b8-4043-b3bd-c1f5fc0dbae7" />

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

COAND-1039

## Release notes

### Fixed
- For address lookup, the full country name will be displayed instead of the country code.
