### PR TITLE
Text field input composable

### DIFF
--- a/ui/api/ui.api
+++ b/ui/api/ui.api
@@ -6,6 +6,12 @@ public final class com/adyen/checkout/test/BuildConfig {
 	public fun <init> ()V
 }
 
+public final class com/adyen/checkout/ui/internal/ComposableSingletons$AdyenTextFieldKt {
+	public static final field INSTANCE Lcom/adyen/checkout/ui/internal/ComposableSingletons$AdyenTextFieldKt;
+	public fun <init> ()V
+	public final fun getLambda-1$ui_release ()Lkotlin/jvm/functions/Function2;
+}
+
 public final class com/adyen/checkout/ui/internal/ComposableSingletons$ButtonsKt {
 	public static final field INSTANCE Lcom/adyen/checkout/ui/internal/ComposableSingletons$ButtonsKt;
 	public fun <init> ()V

--- a/ui/api/ui.api
+++ b/ui/api/ui.api
@@ -218,18 +218,17 @@ public final class com/adyen/checkout/ui/theme/AdyenSwitchStyle {
 
 public final class com/adyen/checkout/ui/theme/AdyenTextFieldStyle {
 	public static final field $stable I
-	public synthetic fun <init> (Lcom/adyen/checkout/ui/theme/AdyenTextFieldStyle$Type;Lcom/adyen/checkout/ui/theme/AdyenColor;Lcom/adyen/checkout/ui/theme/AdyenColor;Lcom/adyen/checkout/ui/theme/AdyenColor;Lcom/adyen/checkout/ui/theme/AdyenColor;Ljava/lang/Integer;Lcom/adyen/checkout/ui/theme/AdyenColor;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Lcom/adyen/checkout/ui/theme/AdyenTextFieldStyle$Type;Lcom/adyen/checkout/ui/theme/AdyenColor;Lcom/adyen/checkout/ui/theme/AdyenColor;Lcom/adyen/checkout/ui/theme/AdyenColor;Lcom/adyen/checkout/ui/theme/AdyenColor;Ljava/lang/Integer;Lcom/adyen/checkout/ui/theme/AdyenColor;Ljava/lang/Integer;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/adyen/checkout/ui/theme/AdyenTextFieldStyle$Type;
+	public synthetic fun <init> (Lcom/adyen/checkout/ui/theme/AdyenColor;Lcom/adyen/checkout/ui/theme/AdyenColor;Lcom/adyen/checkout/ui/theme/AdyenColor;Lcom/adyen/checkout/ui/theme/AdyenColor;Ljava/lang/Integer;Lcom/adyen/checkout/ui/theme/AdyenColor;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/adyen/checkout/ui/theme/AdyenColor;Lcom/adyen/checkout/ui/theme/AdyenColor;Lcom/adyen/checkout/ui/theme/AdyenColor;Lcom/adyen/checkout/ui/theme/AdyenColor;Ljava/lang/Integer;Lcom/adyen/checkout/ui/theme/AdyenColor;Ljava/lang/Integer;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-DgHkB_c ()Lcom/adyen/checkout/ui/theme/AdyenColor;
 	public final fun component2-DgHkB_c ()Lcom/adyen/checkout/ui/theme/AdyenColor;
 	public final fun component3-DgHkB_c ()Lcom/adyen/checkout/ui/theme/AdyenColor;
 	public final fun component4-DgHkB_c ()Lcom/adyen/checkout/ui/theme/AdyenColor;
-	public final fun component5-DgHkB_c ()Lcom/adyen/checkout/ui/theme/AdyenColor;
-	public final fun component6 ()Ljava/lang/Integer;
-	public final fun component7-DgHkB_c ()Lcom/adyen/checkout/ui/theme/AdyenColor;
-	public final fun component8 ()Ljava/lang/Integer;
-	public final fun copy-5oWp9cY (Lcom/adyen/checkout/ui/theme/AdyenTextFieldStyle$Type;Lcom/adyen/checkout/ui/theme/AdyenColor;Lcom/adyen/checkout/ui/theme/AdyenColor;Lcom/adyen/checkout/ui/theme/AdyenColor;Lcom/adyen/checkout/ui/theme/AdyenColor;Ljava/lang/Integer;Lcom/adyen/checkout/ui/theme/AdyenColor;Ljava/lang/Integer;)Lcom/adyen/checkout/ui/theme/AdyenTextFieldStyle;
-	public static synthetic fun copy-5oWp9cY$default (Lcom/adyen/checkout/ui/theme/AdyenTextFieldStyle;Lcom/adyen/checkout/ui/theme/AdyenTextFieldStyle$Type;Lcom/adyen/checkout/ui/theme/AdyenColor;Lcom/adyen/checkout/ui/theme/AdyenColor;Lcom/adyen/checkout/ui/theme/AdyenColor;Lcom/adyen/checkout/ui/theme/AdyenColor;Ljava/lang/Integer;Lcom/adyen/checkout/ui/theme/AdyenColor;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/adyen/checkout/ui/theme/AdyenTextFieldStyle;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6-DgHkB_c ()Lcom/adyen/checkout/ui/theme/AdyenColor;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun copy-SivOpD4 (Lcom/adyen/checkout/ui/theme/AdyenColor;Lcom/adyen/checkout/ui/theme/AdyenColor;Lcom/adyen/checkout/ui/theme/AdyenColor;Lcom/adyen/checkout/ui/theme/AdyenColor;Ljava/lang/Integer;Lcom/adyen/checkout/ui/theme/AdyenColor;Ljava/lang/Integer;)Lcom/adyen/checkout/ui/theme/AdyenTextFieldStyle;
+	public static synthetic fun copy-SivOpD4$default (Lcom/adyen/checkout/ui/theme/AdyenTextFieldStyle;Lcom/adyen/checkout/ui/theme/AdyenColor;Lcom/adyen/checkout/ui/theme/AdyenColor;Lcom/adyen/checkout/ui/theme/AdyenColor;Lcom/adyen/checkout/ui/theme/AdyenColor;Ljava/lang/Integer;Lcom/adyen/checkout/ui/theme/AdyenColor;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/adyen/checkout/ui/theme/AdyenTextFieldStyle;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getActiveColor-DgHkB_c ()Lcom/adyen/checkout/ui/theme/AdyenColor;
 	public final fun getBackgroundColor-DgHkB_c ()Lcom/adyen/checkout/ui/theme/AdyenColor;
@@ -238,17 +237,8 @@ public final class com/adyen/checkout/ui/theme/AdyenTextFieldStyle {
 	public final fun getCornerRadius ()Ljava/lang/Integer;
 	public final fun getErrorColor-DgHkB_c ()Lcom/adyen/checkout/ui/theme/AdyenColor;
 	public final fun getTextColor-DgHkB_c ()Lcom/adyen/checkout/ui/theme/AdyenColor;
-	public final fun getType ()Lcom/adyen/checkout/ui/theme/AdyenTextFieldStyle$Type;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/adyen/checkout/ui/theme/AdyenTextFieldStyle$Type : java/lang/Enum {
-	public static final field OUTLINED Lcom/adyen/checkout/ui/theme/AdyenTextFieldStyle$Type;
-	public static final field UNDERLINED Lcom/adyen/checkout/ui/theme/AdyenTextFieldStyle$Type;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lcom/adyen/checkout/ui/theme/AdyenTextFieldStyle$Type;
-	public static fun values ()[Lcom/adyen/checkout/ui/theme/AdyenTextFieldStyle$Type;
 }
 
 public final class com/adyen/checkout/ui/theme/AdyenTextStyle {

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/AdyenTextField.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/AdyenTextField.kt
@@ -27,16 +27,13 @@ import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
@@ -139,46 +136,25 @@ private fun Modifier.styledBackground(
         else -> style.borderColor
     }
     val borderWidth = if (isFocused || isError) style.borderWidth + 1 else style.borderWidth
-    return when (style.type) {
-        AdyenTextFieldStyle.Type.OUTLINED -> {
-            this
-                .background(style.backgroundColor, RoundedCornerShape(style.cornerRadius.dp))
-                .border(
-                    width = borderWidth.dp,
-                    color = borderColor,
-                    shape = RoundedCornerShape(style.cornerRadius.dp),
-                )
-        }
-
-        AdyenTextFieldStyle.Type.UNDERLINED -> {
-            this
-                .background(style.backgroundColor, RoundedCornerShape(style.cornerRadius.dp))
-                .clip(RoundedCornerShape(style.cornerRadius.dp))
-                .drawBehind {
-                    val strokeWidth = borderWidth * density
-                    val y = size.height - strokeWidth
-
-                    drawLine(
-                        borderColor,
-                        Offset(0f, y),
-                        Offset(size.width, y),
-                        strokeWidth,
-                    )
-                }
-        }
-    }
+    return this
+        .background(style.backgroundColor, RoundedCornerShape(style.cornerRadius.dp))
+        .border(
+            width = borderWidth.dp,
+            color = borderColor,
+            shape = RoundedCornerShape(style.cornerRadius.dp),
+        )
 }
 
 @Preview
 @Composable
 private fun AdyenTextFieldPreview(
-    @PreviewParameter(StylingPreviewParameterProvider::class) styling: Theme,
+    @PreviewParameter(StylingPreviewParameterProvider::class) theme: Theme,
 ) {
-    AdyenCheckoutTheme(styling) {
+    AdyenCheckoutTheme(theme) {
         Column(
             verticalArrangement = Arrangement.spacedBy(16.dp),
             modifier = Modifier
-                .background(styling.colors.background.toCompose())
+                .background(theme.colors.background.toCompose())
                 .padding(16.dp),
         ) {
             AdyenTextField(
@@ -210,7 +186,7 @@ private fun AdyenTextFieldPreview(
                 supportingText = "Description",
                 modifier = Modifier.focusRequester(focusRequester),
             )
-            SideEffect {
+            LaunchedEffect(Unit) {
                 focusRequester.requestFocus()
             }
 
@@ -230,17 +206,9 @@ private class StylingPreviewParameterProvider : PreviewParameterProvider<Theme> 
     private val themeProvider = ThemePreviewParameterProvider()
 
     private val styles = sequenceOf(
+        AdyenTextFieldStyle(),
         AdyenTextFieldStyle(
-            type = AdyenTextFieldStyle.Type.OUTLINED,
-        ),
-        AdyenTextFieldStyle(
-            type = AdyenTextFieldStyle.Type.OUTLINED,
             backgroundColor = AdyenColor(0x00FFFFFF),
-        ),
-        AdyenTextFieldStyle(
-            type = AdyenTextFieldStyle.Type.UNDERLINED,
-            backgroundColor = AdyenColor(0x00FFFFFF),
-            cornerRadius = 0,
         ),
     )
 

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/AdyenTextField.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/AdyenTextField.kt
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2025 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 23/4/2025.
+ */
+
+package com.adyen.checkout.ui.internal
+
+import androidx.annotation.RestrictTo
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.selection.LocalTextSelectionColors
+import androidx.compose.foundation.text.selection.TextSelectionColors
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.adyen.checkout.test.R
+import com.adyen.checkout.ui.theme.AdyenColor
+import com.adyen.checkout.ui.theme.AdyenElements
+import com.adyen.checkout.ui.theme.AdyenTextFieldStyle
+import com.adyen.checkout.ui.theme.AdyenCheckoutTheme as Theme
+
+@Suppress("LongParameterList")
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Composable
+fun AdyenTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    modifier: Modifier = Modifier,
+    supportingText: String? = null,
+    isError: Boolean = false,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    trailingIcon: @Composable (() -> Unit)? = null,
+) {
+    val style = AdyenTextFieldDefaults.textFieldStyle(AdyenCheckoutTheme.elements.textField)
+    val innerTextStyle = AdyenCheckoutTheme.textStyles.body
+    BasicTextField(
+        value = value,
+        onValueChange = onValueChange,
+        textStyle = TextStyle(
+            color = style.textColor,
+            fontSize = innerTextStyle.size.sp,
+            fontWeight = FontWeight(innerTextStyle.weight),
+            lineHeight = innerTextStyle.lineHeight.sp,
+        ),
+        singleLine = true,
+        cursorBrush = SolidColor(style.activeColor),
+        keyboardOptions = keyboardOptions,
+        interactionSource = interactionSource,
+        modifier = modifier,
+        decorationBox = { innerTextField ->
+            val isFocused = interactionSource.collectIsFocusedAsState().value
+
+            Column(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                val labelColor = if (isFocused) style.activeColor else style.textColor
+                Label(
+                    text = label,
+                    color = labelColor,
+                )
+                Row(
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .styledBackground(style, isFocused, isError)
+                        .fillMaxWidth()
+                        .heightIn(48.dp)
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                ) {
+                    val selectionColor = style.activeColor
+                    val customTextSelectionColors = TextSelectionColors(
+                        handleColor = selectionColor,
+                        backgroundColor = selectionColor.copy(alpha = 0.4f),
+                    )
+
+                    CompositionLocalProvider(LocalTextSelectionColors provides customTextSelectionColors) {
+                        innerTextField()
+                    }
+
+                    trailingIcon?.invoke()
+                }
+                supportingText?.let {
+                    val supportingTextColor = if (isError) style.errorColor else AdyenCheckoutTheme.colors.textSecondary
+                    Caption(
+                        text = supportingText,
+                        color = supportingTextColor,
+                    )
+                }
+            }
+        },
+    )
+}
+
+@Stable
+private fun Modifier.styledBackground(
+    style: InternalTextFieldStyle,
+    isFocused: Boolean,
+    isError: Boolean,
+): Modifier {
+    val borderColor = when {
+        isError -> style.errorColor
+        isFocused -> style.textColor
+        else -> style.borderColor
+    }
+    val borderWidth = if (isFocused || isError) style.borderWidth + 1 else style.borderWidth
+    return when (style.type) {
+        AdyenTextFieldStyle.Type.OUTLINED -> {
+            this
+                .background(style.backgroundColor, RoundedCornerShape(style.cornerRadius.dp))
+                .border(
+                    width = borderWidth.dp,
+                    color = borderColor,
+                    shape = RoundedCornerShape(style.cornerRadius.dp),
+                )
+        }
+
+        AdyenTextFieldStyle.Type.UNDERLINED -> {
+            this
+                .background(style.backgroundColor, RoundedCornerShape(style.cornerRadius.dp))
+                .clip(RoundedCornerShape(style.cornerRadius.dp))
+                .drawBehind {
+                    val strokeWidth = borderWidth * density
+                    val y = size.height - strokeWidth
+
+                    drawLine(
+                        borderColor,
+                        Offset(0f, y),
+                        Offset(size.width, y),
+                        strokeWidth,
+                    )
+                }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun AdyenTextFieldPreview(
+    @PreviewParameter(StylingPreviewParameterProvider::class) styling: Theme,
+) {
+    AdyenCheckoutTheme(styling) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier
+                .background(styling.colors.background.toCompose())
+                .padding(16.dp),
+        ) {
+            AdyenTextField(
+                value = "",
+                onValueChange = {},
+                label = "Label",
+                supportingText = "Description",
+            )
+
+            AdyenTextField(
+                value = "Value",
+                onValueChange = {},
+                label = "Label",
+                supportingText = "Description",
+                trailingIcon = {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(R.drawable.ic_checkmark),
+                        contentDescription = null,
+                        tint = AdyenCheckoutTheme.colors.text,
+                    )
+                },
+            )
+
+            val focusRequester = remember { FocusRequester() }
+            AdyenTextField(
+                value = "Value",
+                onValueChange = {},
+                label = "Label",
+                supportingText = "Description",
+                modifier = Modifier.focusRequester(focusRequester),
+            )
+            SideEffect {
+                focusRequester.requestFocus()
+            }
+
+            AdyenTextField(
+                value = "Value",
+                onValueChange = {},
+                label = "Label",
+                supportingText = "Description",
+                isError = true,
+            )
+        }
+    }
+}
+
+private class StylingPreviewParameterProvider : PreviewParameterProvider<Theme> {
+
+    private val themeProvider = ThemePreviewParameterProvider()
+
+    private val styles = sequenceOf(
+        AdyenTextFieldStyle(
+            type = AdyenTextFieldStyle.Type.OUTLINED,
+        ),
+        AdyenTextFieldStyle(
+            type = AdyenTextFieldStyle.Type.OUTLINED,
+            backgroundColor = AdyenColor(0x00FFFFFF),
+        ),
+        AdyenTextFieldStyle(
+            type = AdyenTextFieldStyle.Type.UNDERLINED,
+            backgroundColor = AdyenColor(0x00FFFFFF),
+            cornerRadius = 0,
+        ),
+    )
+
+    override val values = styles.flatMap { style ->
+        themeProvider.values.map { theme ->
+            theme.copy(
+                elements = AdyenElements.default(
+                    textField = style,
+                ),
+            )
+        }
+    }
+}

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/AdyenTextField.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/AdyenTextField.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -92,7 +93,7 @@ fun AdyenTextField(
                     color = labelColor,
                 )
                 Row(
-                    horizontalArrangement = Arrangement.SpaceBetween,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier
                         .styledBackground(style, isFocused, isError)
@@ -107,7 +108,9 @@ fun AdyenTextField(
                     )
 
                     CompositionLocalProvider(LocalTextSelectionColors provides customTextSelectionColors) {
-                        innerTextField()
+                        Box(Modifier.weight(1f)) {
+                            innerTextField()
+                        }
                     }
 
                     trailingIcon?.invoke()
@@ -207,6 +210,7 @@ private class StylingPreviewParameterProvider : PreviewParameterProvider<Theme> 
 
     private val styles = sequenceOf(
         AdyenTextFieldStyle(),
+        // Transparent background to get an outlined look
         AdyenTextFieldStyle(
             backgroundColor = AdyenColor(0x00FFFFFF),
         ),

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/AdyenTextFieldDefaults.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/AdyenTextFieldDefaults.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 23/4/2025.
+ */
+
+package com.adyen.checkout.ui.internal
+
+import androidx.compose.runtime.Composable
+import com.adyen.checkout.ui.theme.AdyenTextFieldStyle
+
+internal object AdyenTextFieldDefaults {
+
+    @Composable
+    fun textFieldStyle(style: AdyenTextFieldStyle): InternalTextFieldStyle {
+        val colors = AdyenCheckoutTheme.colors
+        return InternalTextFieldStyle(
+            type = style.type,
+            backgroundColor = style.backgroundColor?.toCompose() ?: colors.container,
+            textColor = style.textColor?.toCompose() ?: colors.text,
+            activeColor = style.activeColor?.toCompose() ?: colors.action,
+            errorColor = style.errorColor?.toCompose() ?: colors.destructive,
+            cornerRadius = style.cornerRadius ?: AdyenCheckoutTheme.elements.cornerRadius,
+            borderColor = style.borderColor?.toCompose() ?: colors.container,
+            borderWidth = style.borderWidth ?: 1,
+        )
+    }
+}

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/AdyenTextFieldDefaults.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/AdyenTextFieldDefaults.kt
@@ -17,7 +17,6 @@ internal object AdyenTextFieldDefaults {
     fun textFieldStyle(style: AdyenTextFieldStyle): InternalTextFieldStyle {
         val colors = AdyenCheckoutTheme.colors
         return InternalTextFieldStyle(
-            type = style.type,
             backgroundColor = style.backgroundColor?.toCompose() ?: colors.container,
             textColor = style.textColor?.toCompose() ?: colors.text,
             activeColor = style.activeColor?.toCompose() ?: colors.action,

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/InternalTextFieldStyle.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/InternalTextFieldStyle.kt
@@ -10,11 +10,9 @@ package com.adyen.checkout.ui.internal
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
-import com.adyen.checkout.ui.theme.AdyenTextFieldStyle
 
 @Immutable
 internal data class InternalTextFieldStyle(
-    val type: AdyenTextFieldStyle.Type,
     val backgroundColor: Color,
     val textColor: Color,
     val activeColor: Color,

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/InternalTextFieldStyle.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/InternalTextFieldStyle.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 23/4/2025.
+ */
+
+package com.adyen.checkout.ui.internal
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Color
+import com.adyen.checkout.ui.theme.AdyenTextFieldStyle
+
+@Immutable
+internal data class InternalTextFieldStyle(
+    val type: AdyenTextFieldStyle.Type,
+    val backgroundColor: Color,
+    val textColor: Color,
+    val activeColor: Color,
+    val errorColor: Color,
+    val cornerRadius: Int,
+    val borderColor: Color,
+    val borderWidth: Int,
+)

--- a/ui/src/main/java/com/adyen/checkout/ui/theme/AdyenTextFieldStyle.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/theme/AdyenTextFieldStyle.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.Immutable
 // TODO - Add KDocs
 @Immutable
 data class AdyenTextFieldStyle(
-    val type: Type = Type.OUTLINED,
     val backgroundColor: AdyenColor? = null,
     val textColor: AdyenColor? = null,
     val activeColor: AdyenColor? = null,
@@ -21,10 +20,4 @@ data class AdyenTextFieldStyle(
     val cornerRadius: Int? = null,
     val borderColor: AdyenColor? = null,
     val borderWidth: Int? = null,
-) {
-
-    enum class Type {
-        OUTLINED,
-        UNDERLINED,
-    }
-}
+)

--- a/ui/src/main/res/drawable/ic_checkmark.xml
+++ b/ui/src/main/res/drawable/ic_checkmark.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M15.061,4L14,2.939L6,10.939L2,6.939L0.939,8L6,13.061L15.061,4Z"
+      android:fillColor="#00112C"/>
+</vector>


### PR DESCRIPTION
## Description
Add `AdyenTextField` composable. The checkmark drawable was added for preview purposes, but we will need it later as well. 

In the preview below the third field in every column is supposed to have a focussed state. Unfortunately, only the first preview can have a focussed state and it won't display for other previews.

![image](https://github.com/user-attachments/assets/e0b3a82e-3820-48cd-a5fb-2dce427ca000)

COAND-1084