### PR TITLE
 Handle drop-in redirects in separate activity

### DIFF
--- a/drop-in/api/drop-in.api
+++ b/drop-in/api/drop-in.api
@@ -161,6 +161,10 @@ public final class com/adyen/checkout/dropin/DropInConfigurationKt {
 	public static synthetic fun dropIn$default (Lcom/adyen/checkout/components/core/CheckoutConfiguration;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/CheckoutConfiguration;
 }
 
+public final class com/adyen/checkout/dropin/DropInRedirectHandlingActivity : androidx/appcompat/app/AppCompatActivity {
+	public fun <init> ()V
+}
+
 public abstract class com/adyen/checkout/dropin/DropInResult {
 }
 

--- a/drop-in/src/main/AndroidManifest.xml
+++ b/drop-in/src/main/AndroidManifest.xml
@@ -5,15 +5,18 @@
     <application android:supportsRtl="true">
         <activity
             android:name=".internal.ui.DropInActivity"
-            android:exported="true"
             android:launchMode="singleTask"
+            android:theme="@style/AdyenCheckout.Translucent" />
+
+        <activity
+            android:name=".DropInRedirectHandlingActivity"
+            android:exported="true"
             android:theme="@style/AdyenCheckout.Translucent">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-
 
                 <data
                     android:host="${applicationId}"

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/DropInRedirectHandlingActivity.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/DropInRedirectHandlingActivity.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 23/4/2025.
+ */
+
+package com.adyen.checkout.dropin
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.adyen.checkout.core.AdyenLogLevel
+import com.adyen.checkout.core.internal.util.adyenLog
+import com.adyen.checkout.dropin.internal.ui.DropInActivity
+
+class DropInRedirectHandlingActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        adyenLog(AdyenLogLevel.DEBUG) { "onCreate" }
+        super.onCreate(savedInstanceState)
+
+        val intent = intent
+        if (intent == null) {
+            adyenLog(AdyenLogLevel.ERROR) { "Received a null intent" }
+            return
+        }
+
+        val newIntent = Intent(this, DropInActivity::class.java).apply {
+            fillIn(intent, 0)
+        }
+        adyenLog(AdyenLogLevel.INFO) { "Forwarding intent to DropInActivity" }
+        startActivity(newIntent)
+        finish()
+    }
+}

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInActivity.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInActivity.kt
@@ -60,7 +60,6 @@ import com.adyen.checkout.dropin.internal.ui.model.GiftCardPaymentConfirmationDa
 import com.adyen.checkout.dropin.internal.util.DropInPrefs
 import com.adyen.checkout.dropin.internal.util.checkCompileOnly
 import com.adyen.checkout.giftcard.GiftCardComponentState
-import com.adyen.checkout.redirect.RedirectComponent
 import com.adyen.checkout.sessions.core.CheckoutSession
 import com.adyen.checkout.sessions.core.SessionPaymentResult
 import com.adyen.checkout.wechatpay.WeChatPayUtils
@@ -526,7 +525,7 @@ internal class DropInActivity :
             // Redirect response
             Intent.ACTION_VIEW -> {
                 val data = intent.data
-                if (data != null && data.toString().startsWith(RedirectComponent.REDIRECT_RESULT_SCHEME)) {
+                if (data != null) {
                     handleActionIntentResponse(intent)
                 } else {
                     adyenLog(AdyenLogLevel.ERROR) { "Unexpected response from ACTION_VIEW - ${intent.data}" }


### PR DESCRIPTION
## Description
Handle Drop-in redirects in a separate activity. This allows merchants to override Drop-in's intent filter.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

## Release notes
### New
- You can now override the default [returnUrl](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions#request-returnUrl) value used by Drop-in. For example, to configure Drop-in to handle this URL `https://your.website.com/adyen-drop-in` as an [App Link](https://developer.android.com/training/app-links), pass its value from your backend to the Checkout API inside `returnUrl`, and declare an intent filter in your manifest with a matching configuration:
```xml
<activity
    android:name="com.adyen.checkout.dropin.DropInRedirectHandlingActivity"
    android:exported="true"
    android:theme="@style/AdyenCheckout.Translucent">

    <intent-filter android:autoVerify="true">
        <action android:name="android.intent.action.VIEW" />
        <category android:name="android.intent.category.DEFAULT" />
        <category android:name="android.intent.category.BROWSABLE" />

        <data android:scheme="https" />
        <data android:host="your.website.com" />
        <data android:path="/adyen-drop-in" />
    </intent-filter>

</activity>
```
