### PR TITLE
Prevent flickering of ImageViews

### DIFF
--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/ImageLoadingExtensions.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/ImageLoadingExtensions.kt
@@ -52,7 +52,10 @@ fun ImageView.load(
         }
     }
 
-    setImageResource(placeholder)
+    if (drawable == null) {
+        setImageResource(placeholder)
+    }
+
     context.getLifecycleOwner()?.lifecycleScope?.launch {
         imageLoader.load(
             url,


### PR DESCRIPTION
## Description
Only set placeholder image if ImageView doesn't have an image yet. This will prevent flickering of the ImageView when loading a new image into it.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually