### PR TITLE
Co-badged Cards: Use getChangePayload in DiffCallback

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardBrandAdapter.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardBrandAdapter.kt
@@ -30,6 +30,14 @@ internal class CardBrandAdapter(
         val cardBrandItem = currentList[position]
         holder.bind(cardBrandItem, onItemClicked)
     }
+
+    override fun onBindViewHolder(holder: CardBrandItemViewHolder, position: Int, payloads: MutableList<Any>) {
+        if (payloads.isEmpty()) {
+            super.onBindViewHolder(holder, position, payloads)
+        } else if (payloads.firstOrNull() == true) {
+            holder.bindSelectedState(currentList[position].isSelected)
+        }
+    }
 }
 
 internal class CardBrandItemViewHolder(
@@ -47,6 +55,10 @@ internal class CardBrandItemViewHolder(
         binding.textViewCardBrandName.text = cardBrandItem.name
         binding.radioButtonCardBrand.isChecked = cardBrandItem.isSelected
     }
+
+    fun bindSelectedState(isSelected: Boolean) {
+        binding.radioButtonCardBrand.isChecked = isSelected
+    }
 }
 
 internal object CardBrandItemDiffCallback : DiffUtil.ItemCallback<CardBrandItem>() {
@@ -56,5 +68,9 @@ internal object CardBrandItemDiffCallback : DiffUtil.ItemCallback<CardBrandItem>
 
     override fun areContentsTheSame(oldItem: CardBrandItem, newItem: CardBrandItem): Boolean {
         return oldItem == newItem
+    }
+
+    override fun getChangePayload(oldItem: CardBrandItem, newItem: CardBrandItem): Any? {
+        return if (oldItem.isSelected != newItem.isSelected) true else null
     }
 }


### PR DESCRIPTION
## Description
[//]: # (Include a short summary of your changes)
[//]: # (If this is a new feature: attach screenshots or a video if applicable)
[//]: # (If this is a bug fix: include a reproduction path)
Using `getChangePayload()` enables us to only update radio button, not the whole item in `RecyclerView`. This solves flickering issue on selected state changes.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COAND-1085