### PR TITLE
Request focus on first input in drop-in

### DIFF
--- a/ach/src/main/java/com/adyen/checkout/ach/internal/ui/view/ACHDirectDebitView.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/internal/ui/view/ACHDirectDebitView.kt
@@ -39,7 +39,7 @@ internal class ACHDirectDebitView @JvmOverloads constructor(
 ) : LinearLayout(
     context,
     attrs,
-    defStyleAttr,
+    defStyleAttr
 ),
     ComponentView {
     private val binding = AchDirectDebitViewBinding.inflate(LayoutInflater.from(context), this)
@@ -61,9 +61,9 @@ internal class ACHDirectDebitView @JvmOverloads constructor(
         initLocalizedStrings(localizedContext)
         initAddressFormInput(coroutineScope)
         observeDelegate(delegate, coroutineScope)
-        initAccountHolderName()
         initBankAccountNumber()
         initAbaRoutingNumber()
+        initAccountHolderName()
 
         binding.switchStorePaymentMethod.setOnCheckedChangeListener { _, isChecked ->
             delegate.updateInputData { isStorePaymentMethodSwitchChecked = isChecked }
@@ -74,47 +74,25 @@ internal class ACHDirectDebitView @JvmOverloads constructor(
         with(binding) {
             textviewAchHeader.setLocalizedTextFromStyle(
                 R.style.AdyenCheckout_ACHDirectDebit_AchHeaderTextView,
-                localizedContext,
+                localizedContext
             )
             textInputLayoutAccountHolderName.setLocalizedHintFromStyle(
                 R.style.AdyenCheckout_ACHDirectDebit_AccountHolderNameInput,
-                localizedContext,
+                localizedContext
             )
             textInputLayoutAccountNumber.setLocalizedHintFromStyle(
                 R.style.AdyenCheckout_ACHDirectDebit_AccountNumberInput,
-                localizedContext,
+                localizedContext
             )
             textInputLayoutAbaRoutingNumber.setLocalizedHintFromStyle(
                 R.style.AdyenCheckout_ACHDirectDebit_AbaRoutingNumberInput,
-                localizedContext,
+                localizedContext
             )
             switchStorePaymentMethod.setLocalizedTextFromStyle(
                 R.style.AdyenCheckout_ACHDirectDebit_StorePaymentSwitch,
-                localizedContext,
+                localizedContext
             )
             addressFormInput.initLocalizedContext(localizedContext)
-        }
-    }
-
-    private fun initAccountHolderName() {
-        binding.editTextAccountHolderName.apply {
-            setOnChangeListener {
-                delegate.updateInputData { ownerName = this@apply.rawValue }
-                binding.textInputLayoutAccountHolderName.hideError()
-            }
-
-            setOnFocusChangeListener { _, hasFocus ->
-                val ownerNameValidation = delegate.outputData.ownerName.validation
-                if (hasFocus) {
-                    binding.textInputLayoutAccountHolderName.hideError()
-                } else if (ownerNameValidation is Validation.Invalid) {
-                    binding.textInputLayoutAccountHolderName.showError(
-                        localizedContext.getString(ownerNameValidation.reason),
-                    )
-                }
-            }
-
-            requestFocus()
         }
     }
 
@@ -131,7 +109,7 @@ internal class ACHDirectDebitView @JvmOverloads constructor(
                     textInputLayoutAccountNumber.hideError()
                 } else if (accountNumberValidation is Validation.Invalid) {
                     textInputLayoutAccountNumber.showError(
-                        localizedContext.getString(accountNumberValidation.reason),
+                        localizedContext.getString(accountNumberValidation.reason)
                     )
                 }
             }
@@ -151,7 +129,27 @@ internal class ACHDirectDebitView @JvmOverloads constructor(
                     textInputLayoutAbaRoutingNumber.hideError()
                 } else if (bankLocationIdValidation is Validation.Invalid) {
                     textInputLayoutAbaRoutingNumber.showError(
-                        localizedContext.getString(bankLocationIdValidation.reason),
+                        localizedContext.getString(bankLocationIdValidation.reason)
+                    )
+                }
+            }
+        }
+    }
+
+    private fun initAccountHolderName() {
+        with(binding) {
+            editTextAccountHolderName.setOnChangeListener {
+                delegate.updateInputData { ownerName = editTextAccountHolderName.rawValue }
+                textInputLayoutAccountHolderName.hideError()
+            }
+
+            editTextAccountHolderName.setOnFocusChangeListener { _, hasFocus ->
+                val ownerNameValidation = delegate.outputData.ownerName.validation
+                if (hasFocus) {
+                    textInputLayoutAccountHolderName.hideError()
+                } else if (ownerNameValidation is Validation.Invalid) {
+                    textInputLayoutAccountHolderName.showError(
+                        localizedContext.getString(ownerNameValidation.reason)
                     )
                 }
             }
@@ -178,7 +176,6 @@ internal class ACHDirectDebitView @JvmOverloads constructor(
             AddressFormUIState.FULL_ADDRESS -> {
                 binding.addressFormInput.isVisible = true
             }
-
             else -> {
                 binding.addressFormInput.isVisible = false
             }
@@ -197,7 +194,7 @@ internal class ACHDirectDebitView @JvmOverloads constructor(
                 isErrorFocused = true
                 binding.editTextAccountHolderName.requestFocus()
                 binding.textInputLayoutAccountHolderName.showError(
-                    localizedContext.getString(ownerNameValidation.reason),
+                    localizedContext.getString(ownerNameValidation.reason)
                 )
             }
             val accountNumberValidation = bankAccountNumber.validation
@@ -207,7 +204,7 @@ internal class ACHDirectDebitView @JvmOverloads constructor(
                     binding.textInputLayoutAccountNumber.requestFocus()
                 }
                 binding.textInputLayoutAccountNumber.showError(
-                    localizedContext.getString(accountNumberValidation.reason),
+                    localizedContext.getString(accountNumberValidation.reason)
                 )
             }
 
@@ -218,7 +215,7 @@ internal class ACHDirectDebitView @JvmOverloads constructor(
                     binding.textInputLayoutAbaRoutingNumber.requestFocus()
                 }
                 binding.textInputLayoutAbaRoutingNumber.showError(
-                    localizedContext.getString(abaRoutingNumberValidation.reason),
+                    localizedContext.getString(abaRoutingNumberValidation.reason)
                 )
             }
 

--- a/bacs/src/main/java/com/adyen/checkout/bacs/internal/ui/view/BacsDirectDebitInputView.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/internal/ui/view/BacsDirectDebitInputView.kt
@@ -173,12 +173,11 @@ internal class BacsDirectDebitInputView @JvmOverloads constructor(
     }
 
     private fun initHolderNameInput() {
-        val holderNameEditText = binding.editTextHolderName as? AdyenTextInputEditText
-        holderNameEditText?.setOnChangeListener {
+        binding.editTextHolderName.setOnChangeListener {
             bacsDelegate.updateInputData { holderName = it.toString() }
             binding.textInputLayoutHolderName.hideError()
         }
-        holderNameEditText?.onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
+        binding.editTextHolderName.onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
             val holderNameValidation = bacsDelegate.outputData.holderNameState.validation
             if (hasFocus) {
                 binding.textInputLayoutHolderName.hideError()

--- a/bacs/src/main/java/com/adyen/checkout/bacs/internal/ui/view/BacsDirectDebitInputView.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/internal/ui/view/BacsDirectDebitInputView.kt
@@ -173,22 +173,18 @@ internal class BacsDirectDebitInputView @JvmOverloads constructor(
     }
 
     private fun initHolderNameInput() {
-        binding.editTextHolderName.apply {
-            setOnChangeListener {
-                bacsDelegate.updateInputData { holderName = it.toString() }
+        val holderNameEditText = binding.editTextHolderName as? AdyenTextInputEditText
+        holderNameEditText?.setOnChangeListener {
+            bacsDelegate.updateInputData { holderName = it.toString() }
+            binding.textInputLayoutHolderName.hideError()
+        }
+        holderNameEditText?.onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
+            val holderNameValidation = bacsDelegate.outputData.holderNameState.validation
+            if (hasFocus) {
                 binding.textInputLayoutHolderName.hideError()
+            } else if (holderNameValidation is Validation.Invalid) {
+                binding.textInputLayoutHolderName.showError(localizedContext.getString(holderNameValidation.reason))
             }
-
-            onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
-                val holderNameValidation = bacsDelegate.outputData.holderNameState.validation
-                if (hasFocus) {
-                    binding.textInputLayoutHolderName.hideError()
-                } else if (holderNameValidation is Validation.Invalid) {
-                    binding.textInputLayoutHolderName.showError(localizedContext.getString(holderNameValidation.reason))
-                }
-            }
-
-            requestFocus()
         }
     }
 

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/BlikView.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/BlikView.kt
@@ -74,26 +74,22 @@ internal class BlikView @JvmOverloads constructor(
     }
 
     private fun initBlikCodeInput() {
-        binding.editTextBlikCode.apply {
-            setOnChangeListener {
-                blikDelegate.updateInputData {
-                    blikCode = binding.editTextBlikCode.rawValue
-                }
+        binding.editTextBlikCode.setOnChangeListener {
+            blikDelegate.updateInputData {
+                blikCode = binding.editTextBlikCode.rawValue
+            }
+            binding.textInputLayoutBlikCode.hideError()
+        }
+
+        binding.editTextBlikCode.onFocusChangeListener = OnFocusChangeListener { _: View?, hasFocus: Boolean ->
+            val outputData = blikDelegate.outputData
+            val blikCodeValidation = outputData.blikCodeField.validation
+            if (hasFocus) {
                 binding.textInputLayoutBlikCode.hideError()
+            } else if (!blikCodeValidation.isValid()) {
+                val errorReasonResId = (blikCodeValidation as Validation.Invalid).reason
+                binding.textInputLayoutBlikCode.showError(localizedContext.getString(errorReasonResId))
             }
-
-            onFocusChangeListener = OnFocusChangeListener { _: View?, hasFocus: Boolean ->
-                val outputData = blikDelegate.outputData
-                val blikCodeValidation = outputData.blikCodeField.validation
-                if (hasFocus) {
-                    binding.textInputLayoutBlikCode.hideError()
-                } else if (!blikCodeValidation.isValid()) {
-                    val errorReasonResId = (blikCodeValidation as Validation.Invalid).reason
-                    binding.textInputLayoutBlikCode.showError(localizedContext.getString(errorReasonResId))
-                }
-            }
-
-            requestFocus()
         }
     }
 

--- a/boleto/src/main/java/com/adyen/checkout/boleto/internal/ui/view/BoletoView.kt
+++ b/boleto/src/main/java/com/adyen/checkout/boleto/internal/ui/view/BoletoView.kt
@@ -69,48 +69,43 @@ internal class BoletoView @JvmOverloads constructor(
     private fun initLocalizedStrings(localizedContext: Context) {
         binding.textViewPersonalInformationHeader.setLocalizedTextFromStyle(
             R.style.AdyenCheckout_Boleto_PersonalDetailsHeader,
-            localizedContext,
+            localizedContext
         )
         binding.textInputLayoutFirstName.setLocalizedHintFromStyle(
             R.style.AdyenCheckout_Boleto_FirstNameInput,
-            localizedContext,
+            localizedContext
         )
         binding.textInputLayoutLastName.setLocalizedHintFromStyle(
             R.style.AdyenCheckout_Boleto_LastNameInput,
-            localizedContext,
+            localizedContext
         )
         binding.textInputLayoutSocialSecurityNumber.setLocalizedHintFromStyle(
             R.style.AdyenCheckout_Boleto_SocialNumberInput,
-            localizedContext,
+            localizedContext
         )
         binding.addressFormInput.initLocalizedContext(localizedContext)
         binding.switchSendEmailCopy.setLocalizedTextFromStyle(
             R.style.AdyenCheckout_Boleto_EmailCopySwitch,
-            localizedContext,
+            localizedContext
         )
         binding.textInputLayoutShopperEmail.setLocalizedHintFromStyle(
             R.style.AdyenCheckout_Boleto_ShopperEmailInput,
-            localizedContext,
+            localizedContext
         )
     }
 
     private fun initFirstNameInput() {
-        binding.editTextFirstName.apply {
-            setOnChangeListener { editable: Editable ->
-                boletoDelegate.updateInputData { firstName = editable.toString() }
+        binding.editTextFirstName.setOnChangeListener { editable: Editable ->
+            boletoDelegate.updateInputData { firstName = editable.toString() }
+            binding.textInputLayoutFirstName.hideError()
+        }
+        binding.editTextFirstName.onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
+            val firstNameValidation = boletoDelegate.outputData.firstNameState.validation
+            if (hasFocus) {
                 binding.textInputLayoutFirstName.hideError()
+            } else if (firstNameValidation is Validation.Invalid) {
+                binding.textInputLayoutFirstName.showError(localizedContext.getString(firstNameValidation.reason))
             }
-
-            onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
-                val firstNameValidation = boletoDelegate.outputData.firstNameState.validation
-                if (hasFocus) {
-                    binding.textInputLayoutFirstName.hideError()
-                } else if (firstNameValidation is Validation.Invalid) {
-                    binding.textInputLayoutFirstName.showError(localizedContext.getString(firstNameValidation.reason))
-                }
-            }
-
-            requestFocus()
         }
     }
 
@@ -140,7 +135,7 @@ internal class BoletoView @JvmOverloads constructor(
                 binding.textInputLayoutSocialSecurityNumber.hideError()
             } else if (socialSecurityNumberValidation is Validation.Invalid) {
                 binding.textInputLayoutSocialSecurityNumber.showError(
-                    localizedContext.getString(socialSecurityNumberValidation.reason),
+                    localizedContext.getString(socialSecurityNumberValidation.reason)
                 )
             }
         }
@@ -210,7 +205,7 @@ internal class BoletoView @JvmOverloads constructor(
                     binding.textInputLayoutSocialSecurityNumber.requestFocus()
                 }
                 binding.textInputLayoutSocialSecurityNumber.showError(
-                    localizedContext.getString(socialSecurityNumberValidation.reason),
+                    localizedContext.getString(socialSecurityNumberValidation.reason)
                 )
             }
             if (binding.addressFormInput.isVisible && !it.addressState.isValid) {
@@ -224,7 +219,7 @@ internal class BoletoView @JvmOverloads constructor(
                     binding.textInputLayoutShopperEmail.requestFocus()
                 }
                 binding.textInputLayoutShopperEmail.showError(
-                    localizedContext.getString(shopperEmailValidation.reason),
+                    localizedContext.getString(shopperEmailValidation.reason)
                 )
             }
         }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardView.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardView.kt
@@ -379,17 +379,12 @@ class CardView @JvmOverloads constructor(
     }
 
     private fun initCardNumberInput() {
-        binding.editTextCardNumber.apply {
-            setOnChangeListener {
-                setCardErrorState(true)
-                cardDelegate.updateInputData { cardNumber = this@apply.rawValue }
-            }
-
-            onFocusChangeListener = OnFocusChangeListener { _: View?, hasFocus: Boolean ->
-                setCardErrorState(hasFocus)
-            }
-
-            requestFocus()
+        binding.editTextCardNumber.setOnChangeListener {
+            setCardErrorState(true)
+            cardDelegate.updateInputData { cardNumber = binding.editTextCardNumber.rawValue }
+        }
+        binding.editTextCardNumber.onFocusChangeListener = OnFocusChangeListener { _: View?, hasFocus: Boolean ->
+            setCardErrorState(hasFocus)
         }
     }
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/BacsDirectDebitDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/BacsDirectDebitDialogFragment.kt
@@ -19,6 +19,7 @@ import com.adyen.checkout.bacs.BacsDirectDebitComponent
 import com.adyen.checkout.core.AdyenLogLevel
 import com.adyen.checkout.core.internal.util.adyenLog
 import com.adyen.checkout.dropin.databinding.FragmentBacsDirectDebitComponentBinding
+import com.adyen.checkout.ui.core.internal.util.requestFocusOnNextLayout
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.R as MaterialR
@@ -44,7 +45,7 @@ internal class BacsDirectDebitDialogFragment : BaseComponentDialogFragment() {
         binding.bacsView.attach(bacsDirectDebitComponent, viewLifecycleOwner)
 
         if (bacsDirectDebitComponent.isConfirmationRequired()) {
-            binding.bacsView.requestFocus()
+            binding.bacsView.requestFocusOnNextLayout()
         }
     }
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/CardComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/CardComponentDialogFragment.kt
@@ -19,6 +19,7 @@ import com.adyen.checkout.components.core.LookupAddress
 import com.adyen.checkout.core.AdyenLogLevel
 import com.adyen.checkout.core.internal.util.adyenLog
 import com.adyen.checkout.dropin.databinding.FragmentCardComponentBinding
+import com.adyen.checkout.ui.core.internal.util.requestFocusOnNextLayout
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
@@ -47,7 +48,7 @@ internal class CardComponentDialogFragment : BaseComponentDialogFragment(), Addr
         binding.cardView.attach(cardComponent, viewLifecycleOwner)
 
         if (cardComponent.isConfirmationRequired()) {
-            binding.cardView.requestFocus()
+            binding.cardView.requestFocusOnNextLayout()
         }
 
         dropInViewModel.addressLookupOptionsFlow

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/GenericComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/GenericComponentDialogFragment.kt
@@ -20,6 +20,7 @@ import com.adyen.checkout.core.exception.CheckoutException
 import com.adyen.checkout.core.internal.util.adyenLog
 import com.adyen.checkout.dropin.databinding.FragmentGenericComponentBinding
 import com.adyen.checkout.ui.core.internal.ui.ViewableComponent
+import com.adyen.checkout.ui.core.internal.util.requestFocusOnNextLayout
 
 internal class GenericComponentDialogFragment : BaseComponentDialogFragment() {
 
@@ -57,7 +58,7 @@ internal class GenericComponentDialogFragment : BaseComponentDialogFragment() {
             binding.componentView.attach(component, viewLifecycleOwner)
 
             if ((component as? ButtonComponent)?.isConfirmationRequired() == true) {
-                binding.componentView.requestFocus()
+                binding.componentView.requestFocusOnNextLayout()
             }
         }
     }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/GiftCardComponentDialogFragment.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/GiftCardComponentDialogFragment.kt
@@ -26,6 +26,7 @@ import com.adyen.checkout.giftcard.GiftCardComponent
 import com.adyen.checkout.giftcard.GiftCardComponentCallback
 import com.adyen.checkout.giftcard.GiftCardComponentState
 import com.adyen.checkout.ui.core.internal.ui.ViewableComponent
+import com.adyen.checkout.ui.core.internal.util.requestFocusOnNextLayout
 import com.adyen.checkout.ui.core.R as UICoreR
 
 @Suppress("TooManyFunctions")
@@ -109,7 +110,7 @@ internal class GiftCardComponentDialogFragment : DropInBottomSheetDialogFragment
         binding.giftCardView.attach(component, viewLifecycleOwner)
 
         if (giftCardComponent.isConfirmationRequired()) {
-            binding.giftCardView.requestFocus()
+            binding.giftCardView.requestFocusOnNextLayout()
         }
     }
 

--- a/econtext/src/main/java/com/adyen/checkout/econtext/internal/ui/view/EContextView.kt
+++ b/econtext/src/main/java/com/adyen/checkout/econtext/internal/ui/view/EContextView.kt
@@ -120,14 +120,13 @@ internal class EContextView @JvmOverloads constructor(
     }
 
     private fun initFirstNameInput() {
-        val firstNameEditText = binding.editTextFirstName as? AdyenTextInputEditText
-        firstNameEditText?.setOnChangeListener {
+        binding.editTextFirstName.setOnChangeListener {
             delegate.updateInputData {
                 firstName = it.toString()
             }
             binding.textInputLayoutFirstName.error = null
         }
-        firstNameEditText?.onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
+        binding.editTextFirstName.onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
             val firstNameValidation = delegate.outputData.firstNameState.validation
             if (hasFocus) {
                 binding.textInputLayoutFirstName.error = null

--- a/econtext/src/main/java/com/adyen/checkout/econtext/internal/ui/view/EContextView.kt
+++ b/econtext/src/main/java/com/adyen/checkout/econtext/internal/ui/view/EContextView.kt
@@ -120,24 +120,20 @@ internal class EContextView @JvmOverloads constructor(
     }
 
     private fun initFirstNameInput() {
-        binding.editTextFirstName.apply {
-            setOnChangeListener {
-                delegate.updateInputData {
-                    firstName = it.toString()
-                }
+        val firstNameEditText = binding.editTextFirstName as? AdyenTextInputEditText
+        firstNameEditText?.setOnChangeListener {
+            delegate.updateInputData {
+                firstName = it.toString()
+            }
+            binding.textInputLayoutFirstName.error = null
+        }
+        firstNameEditText?.onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
+            val firstNameValidation = delegate.outputData.firstNameState.validation
+            if (hasFocus) {
                 binding.textInputLayoutFirstName.error = null
+            } else if (firstNameValidation is Validation.Invalid) {
+                binding.textInputLayoutFirstName.error = localizedContext.getString(firstNameValidation.reason)
             }
-
-            onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
-                val firstNameValidation = delegate.outputData.firstNameState.validation
-                if (hasFocus) {
-                    binding.textInputLayoutFirstName.error = null
-                } else if (firstNameValidation is Validation.Invalid) {
-                    binding.textInputLayoutFirstName.error = localizedContext.getString(firstNameValidation.reason)
-                }
-            }
-
-            requestFocus()
         }
     }
 

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/ui/view/GiftCardView.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/ui/view/GiftCardView.kt
@@ -74,24 +74,18 @@ internal class GiftCardView @JvmOverloads constructor(
             localizedContext,
         )
 
-        binding.editTextGiftcardNumber.apply {
-            setOnChangeListener {
-                giftCardDelegate.updateInputData { cardNumber = binding.editTextGiftcardNumber.rawValue }
+        binding.editTextGiftcardNumber.setOnChangeListener {
+            giftCardDelegate.updateInputData { cardNumber = binding.editTextGiftcardNumber.rawValue }
+            binding.textInputLayoutGiftcardNumber.hideError()
+        }
+
+        binding.editTextGiftcardNumber.onFocusChangeListener = OnFocusChangeListener { _: View?, hasFocus: Boolean ->
+            val cardNumberValidation = giftCardDelegate.outputData.numberFieldState.validation
+            if (hasFocus) {
                 binding.textInputLayoutGiftcardNumber.hideError()
+            } else if (cardNumberValidation is Validation.Invalid) {
+                binding.textInputLayoutGiftcardNumber.showError(localizedContext.getString(cardNumberValidation.reason))
             }
-
-            onFocusChangeListener = OnFocusChangeListener { _: View?, hasFocus: Boolean ->
-                val cardNumberValidation = giftCardDelegate.outputData.numberFieldState.validation
-                if (hasFocus) {
-                    binding.textInputLayoutGiftcardNumber.hideError()
-                } else if (cardNumberValidation is Validation.Invalid) {
-                    binding.textInputLayoutGiftcardNumber.showError(
-                        localizedContext.getString(cardNumberValidation.reason),
-                    )
-                }
-            }
-
-            requestFocus()
         }
     }
 

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MbWayView.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MbWayView.kt
@@ -58,27 +58,22 @@ internal class MbWayView @JvmOverloads constructor(
     }
 
     private fun initMobileNumberInput() {
-        binding.editTextMobileNumber.apply {
-            setOnChangeListener {
-                delegate.updateInputData {
-                    localPhoneNumber = it.toString()
-                }
+        binding.editTextMobileNumber.setOnChangeListener {
+            delegate.updateInputData {
+                localPhoneNumber = it.toString()
+            }
+            binding.textInputLayoutMobileNumber.hideError()
+        }
+        binding.editTextMobileNumber.onFocusChangeListener = OnFocusChangeListener { _, hasFocus: Boolean ->
+            val outputData = delegate.outputData
+            val mobilePhoneNumberValidation = outputData.mobilePhoneNumberFieldState.validation
+            if (hasFocus) {
                 binding.textInputLayoutMobileNumber.hideError()
+            } else if (mobilePhoneNumberValidation is Validation.Invalid) {
+                binding.textInputLayoutMobileNumber.showError(
+                    localizedContext.getString(mobilePhoneNumberValidation.reason),
+                )
             }
-
-            onFocusChangeListener = OnFocusChangeListener { _, hasFocus: Boolean ->
-                val outputData = delegate.outputData
-                val mobilePhoneNumberValidation = outputData.mobilePhoneNumberFieldState.validation
-                if (hasFocus) {
-                    binding.textInputLayoutMobileNumber.hideError()
-                } else if (mobilePhoneNumberValidation is Validation.Invalid) {
-                    binding.textInputLayoutMobileNumber.showError(
-                        localizedContext.getString(mobilePhoneNumberValidation.reason),
-                    )
-                }
-            }
-
-            requestFocus()
         }
     }
 

--- a/meal-voucher-fr/src/main/java/com/adyen/checkout/mealvoucherfr/internal/ui/view/MealVoucherFRView.kt
+++ b/meal-voucher-fr/src/main/java/com/adyen/checkout/mealvoucherfr/internal/ui/view/MealVoucherFRView.kt
@@ -76,24 +76,20 @@ internal class MealVoucherFRView @JvmOverloads constructor(
             localizedContext,
         )
 
-        binding.editTextMealVoucherFRCardNumber.apply {
-            setOnChangeListener {
-                giftCardDelegate.updateInputData { cardNumber = binding.editTextMealVoucherFRCardNumber.rawValue }
+        binding.editTextMealVoucherFRCardNumber.setOnChangeListener {
+            giftCardDelegate.updateInputData { cardNumber = binding.editTextMealVoucherFRCardNumber.rawValue }
+            binding.textInputLayoutMealVoucherFRCardNumber.hideError()
+        }
+
+        binding.editTextMealVoucherFRCardNumber.onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
+            val cardNumberValidation = giftCardDelegate.outputData.numberFieldState.validation
+            if (hasFocus) {
                 binding.textInputLayoutMealVoucherFRCardNumber.hideError()
+            } else if (cardNumberValidation is Validation.Invalid) {
+                binding.textInputLayoutMealVoucherFRCardNumber.showError(
+                    localizedContext.getString(cardNumberValidation.reason),
+                )
             }
-
-            onFocusChangeListener = OnFocusChangeListener { _, hasFocus ->
-                val cardNumberValidation = giftCardDelegate.outputData.numberFieldState.validation
-                if (hasFocus) {
-                    binding.textInputLayoutMealVoucherFRCardNumber.hideError()
-                } else if (cardNumberValidation is Validation.Invalid) {
-                    binding.textInputLayoutMealVoucherFRCardNumber.showError(
-                        localizedContext.getString(cardNumberValidation.reason),
-                    )
-                }
-            }
-
-            requestFocus()
         }
     }
 

--- a/sepa/src/main/java/com/adyen/checkout/sepa/internal/ui/view/SepaView.kt
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/internal/ui/view/SepaView.kt
@@ -64,7 +64,6 @@ internal class SepaView @JvmOverloads constructor(
             sepaDelegate.updateInputData { name = binding.editTextHolderName.rawValue }
             binding.textInputLayoutHolderName.hideError()
         }
-        binding.editTextHolderName.requestFocus()
         binding.editTextIbanNumber.setOnChangeListener {
             sepaDelegate.updateInputData { iban = binding.editTextIbanNumber.rawValue }
             binding.textInputLayoutIbanNumber.hideError()

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/util/ViewExtensions.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/util/ViewExtensions.kt
@@ -1,3 +1,5 @@
+@file:Suppress("TooManyFunctions")
+
 package com.adyen.checkout.ui.core.internal.util
 
 import android.content.Context
@@ -11,6 +13,7 @@ import android.widget.SearchView
 import android.widget.TextView
 import androidx.annotation.RestrictTo
 import androidx.annotation.StyleRes
+import androidx.core.view.doOnNextLayout
 import com.google.android.material.textfield.TextInputLayout
 
 @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -104,4 +107,11 @@ fun View.hideKeyboard() {
 internal fun View.resetFocus() {
     requestFocus()
     clearFocus()
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun View.requestFocusOnNextLayout() {
+    doOnNextLayout { view ->
+        view.requestFocus()
+    }
 }


### PR DESCRIPTION
## Description
Directly requesting focus in the view, like we previously had, didn't work for all use cases (compose for example). It is better to let the merchant decide if they want to focus on the `AdyenComponentView` or their own view. In drop-in we are in control, so we can focus on the first input

NOTE: release notes are already provided by https://github.com/Adyen/adyen-android/pull/2098

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COSDK-138
