### PR TITLE
Gemini - Exclude files for Gemini access - v6

### DIFF
--- a/.aiexclude
+++ b/.aiexclude
@@ -1,0 +1,21 @@
+# generated files
+build/
+release/
+
+# Local configuration file (sdk path, etc)
+local.properties
+
+# Windows thumbnail db
+.DS_Store
+
+# IDEA/Android Studio project files, because
+# the project can be imported from settings.gradle
+*.iml
+.idea/*
+!.idea/copyright
+
+# Gradle cache
+.gradle
+
+# Android Studio captures folder
+captures/

--- a/.aiexclude
+++ b/.aiexclude
@@ -19,3 +19,6 @@ local.properties
 
 # Android Studio captures folder
 captures/
+
+# Kotlin Compiler Generated Files
+.kotlin/

--- a/.aiexclude
+++ b/.aiexclude
@@ -5,7 +5,7 @@ release/
 # Local configuration file (sdk path, etc)
 local.properties
 
-# Windows thumbnail db
+# macOS folder settings
 .DS_Store
 
 # IDEA/Android Studio project files, because

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ release/
 # Local configuration file (sdk path, etc)
 local.properties
 
-# Windows thumbnail db
+# macOS folder settings
 .DS_Store
 
 # IDEA/Android Studio project files, because

--- a/example-app/.aiexclude
+++ b/example-app/.aiexclude
@@ -1,0 +1,1 @@
+local.gradle


### PR DESCRIPTION
## Description
Followed [this doc](https://developer.android.com/studio/preview/gemini/aiexclude) to exclude sensitive and unnecessary files for Gemini access.

The content is the same as in `.gitignore` files.

COSDK-486