### PR TITLE
Add bottom margin to card brand selection section

### DIFF
--- a/card/src/main/res/layout/card_view.xml
+++ b/card/src/main/res/layout/card_view.xml
@@ -165,6 +165,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/standard_half_margin"
+        android:layout_marginBottom="@dimen/standard_margin"
         android:descendantFocusability="beforeDescendants"
         android:focusable="false"
         android:focusableInTouchMode="false"


### PR DESCRIPTION
## Description
[//]: # (Include a short summary of your changes)
[//]: # (If this is a new feature: attach screenshots or a video if applicable)
[//]: # (If this is a bug fix: include a reproduction path)
Fix having no margin below brand selection section in CardView.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COSDK-493

## Release notes
[//]: # (Use the headers listed below to organize your release notes. Each section should begin with ### followed by a valid label)
[//]: # (Allowed labels: `Breaking changes`, `New`, `Fixed`, `Improved`, `Changed`, `Removed`, `Deprecated`)
[//]: # (Content will be grouped under a specific label until the next header #, ##, or ### is found)
[//]: # (### New)
[//]: # (List any new features or enhancements)
[//]: # (e.g. - Added functionality for user authentication)
[//]: # (### Fixed)
[//]: # (List fixes here)
[//]: # (e.g. - Fixed issue with incorrect data rendering)

### Improved
- Small UI improvements for co-badged cards brand selection.

