### PR TITLE
Sonatype - Migrate workflows to Sonatype Central portal

### DIFF
--- a/.github/workflows/publish_to_maven_central.yml
+++ b/.github/workflows/publish_to_maven_central.yml
@@ -59,6 +59,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
       # Moved the repository from OSSRH to Central Portal
       - name: Move repository to Central Portal
         env:
@@ -66,47 +70,7 @@ jobs:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_CENTRAL_PORTAL_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_CENTRAL_PORTAL_PASSWORD }}
           PUBLISHING_TYPE: "user_managed"
-        run: |
-          # Constructing the URL with the namespace and publishing_type query parameter
-          API_URL="https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/$NAMESPACE?publishing_type=$PUBLISHING_TYPE"
-          
-          # Create a temporary file to store the response body
-          RESPONSE_BODY_FILE=$(mktemp)
-  
-          # Making API call
-          HTTP_STATUS_CODE=$(curl -s -w "%{http_code}" \
-          -X POST \
-          -u "$SONATYPE_USERNAME:$SONATYPE_PASSWORD" \
-          -H "Accept: application/json" \
-          -o "$RESPONSE_BODY_FILE" \
-          "$API_URL")
-
-          # Capture curl's own exit code (e.g., for network errors before HTTP status is determined)
-          CURL_EXIT_CODE=$?
-
-          echo "-------------------- RESPONSE START --------------------"
-          cat "$RESPONSE_BODY_FILE"
-          echo
-          echo "-------------------- RESPONSE END ----------------------"
-
-          # Clean up the temporary file
-          rm -f "$RESPONSE_BODY_FILE"
-  
-          echo "HTTP Status Code: $HTTP_STATUS_CODE"
-          echo "Curl Exit Code: $CURL_EXIT_CODE"
-          
-          # Check if curl itself failed (e.g., network error, couldn't connect)
-          # These errors typically result in a non-zero CURL_EXIT_CODE and often a 000 HTTP_STATUS_CODE
-          if [ "$CURL_EXIT_CODE" -ne 0 ]; then
-          echo "Error: curl command failed with exit code $CURL_EXIT_CODE (e.g., network issue, host not found)."
-          exit "$CURL_EXIT_CODE"
-          fi
-          
-          # Check if the HTTP status code indicates an error (400 or above)
-          if [ "$HTTP_STATUS_CODE" -ge 400 ]; then
-          echo "Error: Server responded with HTTP status $HTTP_STATUS_CODE."
-          exit 1 # Fail the GitHub Action step
-          fi
-        
-          # If we reach here, the request was successful
-          echo "Request finished successfully (HTTP Status: $HTTP_STATUS_CODE)."
+        run:  |
+          chmod +x scripts/move_ossrh_repository_to_central_portal.py
+          pip install requests toml
+          python scripts/move_ossrh_repository_to_central_portal.py

--- a/.github/workflows/publish_to_maven_central.yml
+++ b/.github/workflows/publish_to_maven_central.yml
@@ -42,11 +42,71 @@ jobs:
       # Packages and publishes to Maven Central
       - name: Publish to Maven Central
         env:
-          OSSRH_USERNAME: ${{ secrets.OSSRH_TOKEN_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_TOKEN_PASSWORD }}
+          SONATYPE_CENTRAL_PORTAL_USERNAME: ${{ secrets.SONATYPE_CENTRAL_PORTAL_USERNAME }}
+          SONATYPE_CENTRAL_PORTAL_PASSWORD: ${{ secrets.SONATYPE_CENTRAL_PORTAL_PASSWORD }}
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_SECRET_KEY_RING_FILE: ${{ secrets.SIGNING_SECRET_KEY_RING_FILE }}
           SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
           VERSION_NAME: ${{ inputs.version-name }}
         run: ./gradlew publishReleasePublicationToSonatypeRepository --max-workers 1 --stacktrace -Pversion-name=$VERSION_NAME
+
+  # This step should be removed when gradle plugin supports uploading to Central Portal
+  move_repository_to_central_portal:
+    needs: publish_to_maven_central
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Moved the repository from OSSRH to Central Portal
+      - name: Move repository to Central Portal
+        env:
+          NAMESPACE: "com.adyen"
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_CENTRAL_PORTAL_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_CENTRAL_PORTAL_PASSWORD }}
+          PUBLISHING_TYPE: "user_managed"
+        run: |
+          # Constructing the URL with the namespace and publishing_type query parameter
+          API_URL="https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/$NAMESPACE?publishing_type=$PUBLISHING_TYPE"
+          
+          # Create a temporary file to store the response body
+          RESPONSE_BODY_FILE=$(mktemp)
+  
+          # Making API call
+          HTTP_STATUS_CODE=$(curl -s -w "%{http_code}" \
+          -X POST \
+          -u "$SONATYPE_USERNAME:$SONATYPE_PASSWORD" \
+          -H "Accept: application/json" \
+          -o "$RESPONSE_BODY_FILE" \
+          "$API_URL")
+
+          # Capture curl's own exit code (e.g., for network errors before HTTP status is determined)
+          CURL_EXIT_CODE=$?
+
+          echo "-------------------- RESPONSE START --------------------"
+          cat "$RESPONSE_BODY_FILE"
+          echo
+          echo "-------------------- RESPONSE END ----------------------"
+
+          # Clean up the temporary file
+          rm -f "$RESPONSE_BODY_FILE"
+  
+          echo "HTTP Status Code: $HTTP_STATUS_CODE"
+          echo "Curl Exit Code: $CURL_EXIT_CODE"
+          
+          # Check if curl itself failed (e.g., network error, couldn't connect)
+          # These errors typically result in a non-zero CURL_EXIT_CODE and often a 000 HTTP_STATUS_CODE
+          if [ "$CURL_EXIT_CODE" -ne 0 ]; then
+          echo "Error: curl command failed with exit code $CURL_EXIT_CODE (e.g., network issue, host not found)."
+          exit "$CURL_EXIT_CODE"
+          fi
+          
+          # Check if the HTTP status code indicates an error (400 or above)
+          if [ "$HTTP_STATUS_CODE" -ge 400 ]; then
+          echo "Error: Server responded with HTTP status $HTTP_STATUS_CODE."
+          exit 1 # Fail the GitHub Action step
+          fi
+        
+          # If we reach here, the request was successful
+          echo "Request finished successfully (HTTP Status: $HTTP_STATUS_CODE)."

--- a/.github/workflows/publish_to_maven_central.yml
+++ b/.github/workflows/publish_to_maven_central.yml
@@ -87,7 +87,6 @@ jobs:
       # Moved the repository from OSSRH to Central Portal
       - name: Move repository to Central Portal
         env:
-          NAMESPACE: "com.adyen"
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_CENTRAL_PORTAL_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_CENTRAL_PORTAL_PASSWORD }}
           PUBLISHING_TYPE: "user_managed"

--- a/.github/workflows/publish_to_maven_central.yml
+++ b/.github/workflows/publish_to_maven_central.yml
@@ -28,8 +28,8 @@ jobs:
 
       - name: Drop all open OSSRH repositories
         env:
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_CENTRAL_PORTAL_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_CENTRAL_PORTAL_PASSWORD }}
+          SONATYPE_CENTRAL_PORTAL_USERNAME: ${{ secrets.SONATYPE_CENTRAL_PORTAL_USERNAME }}
+          SONATYPE_CENTRAL_PORTAL_PASSWORD: ${{ secrets.SONATYPE_CENTRAL_PORTAL_PASSWORD }}
         run: |
           chmod +x scripts/drop_all_open_ossrh_repositories.py
           pip install requests toml
@@ -89,8 +89,8 @@ jobs:
       # Moved the repository from OSSRH to Central Portal
       - name: Move repository to Central Portal
         env:
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_CENTRAL_PORTAL_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_CENTRAL_PORTAL_PASSWORD }}
+          SONATYPE_CENTRAL_PORTAL_USERNAME: ${{ secrets.SONATYPE_CENTRAL_PORTAL_USERNAME }}
+          SONATYPE_CENTRAL_PORTAL_PASSWORD: ${{ secrets.SONATYPE_CENTRAL_PORTAL_PASSWORD }}
           PUBLISHING_TYPE: "user_managed"
         run: |
           chmod +x scripts/move_ossrh_repository_to_central_portal.py

--- a/.github/workflows/publish_to_maven_central.yml
+++ b/.github/workflows/publish_to_maven_central.yml
@@ -15,7 +15,28 @@ on:
         type: string
 
 jobs:
+  # This step should be removed when gradle plugin supports uploading to Central Portal
+  drop_all_open_ossrh_repositories:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Drop all open OSSRH repositories
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_CENTRAL_PORTAL_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_CENTRAL_PORTAL_PASSWORD }}
+        run: |
+          chmod +x scripts/drop_all_open_ossrh_repositories.py
+          pip install requests toml
+          python scripts/drop_all_open_ossrh_repositories.py
+
   publish_to_maven_central:
+    needs: drop_all_open_ossrh_repositories
     runs-on: ubuntu-latest
 
     steps:
@@ -70,7 +91,7 @@ jobs:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_CENTRAL_PORTAL_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_CENTRAL_PORTAL_PASSWORD }}
           PUBLISHING_TYPE: "user_managed"
-        run:  |
+        run: |
           chmod +x scripts/move_ossrh_repository_to_central_portal.py
           pip install requests toml
           python scripts/move_ossrh_repository_to_central_portal.py

--- a/.github/workflows/publish_to_maven_central.yml
+++ b/.github/workflows/publish_to_maven_central.yml
@@ -37,7 +37,9 @@ jobs:
 
   publish_to_maven_central:
     needs: drop_all_open_ossrh_repositories
-    runs-on: ubuntu-latest
+    runs-on:
+      group: larger-runners
+      labels: ubuntu-latest-8-cores
 
     steps:
       - uses: actions/checkout@v4

--- a/config/gradle/release.gradle
+++ b/config/gradle/release.gradle
@@ -15,8 +15,8 @@ apply from: "${rootDir}/config/gradle/artifacts.gradle"
 ext["signing.keyId"] = ''
 ext["signing.password"] = ''
 ext["signing.secretKeyRingFile"] = ''
-ext["ossrhUsername"] = ''
-ext["ossrhPassword"] = ''
+ext["sonatypeCentralPortalUsername"] = ''
+ext["sonatypeCentralPortalPassword"] = ''
 ext["sonatypeStagingProfileId"] = ''
 
 File secretPropsFile = project.rootProject.file('local.properties')
@@ -30,8 +30,8 @@ if (secretPropsFile.exists()) {
     ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
     ext["signing.password"] = System.getenv('SIGNING_PASSWORD')
     ext["signing.secretKeyRingFile"] = System.getenv('SIGNING_SECRET_KEY_RING_FILE')
-    ext["ossrhUsername"] = System.getenv('OSSRH_USERNAME')
-    ext["ossrhPassword"] = System.getenv('OSSRH_PASSWORD')
+    ext["sonatypeCentralPortalUsername"] = System.getenv('SONATYPE_CENTRAL_PORTAL_USERNAME')
+    ext["sonatypeCentralPortalPassword"] = System.getenv('SONATYPE_CENTRAL_PORTAL_PASSWORD')
     ext["sonatypeStagingProfileId"] = System.getenv('SONATYPE_STAGING_PROFILE_ID')
 }
 
@@ -139,10 +139,10 @@ project.afterEvaluate {
         repositories {
             maven {
                 name = "sonatype"
-                url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                url = "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"
                 credentials {
-                    username ossrhUsername
-                    password ossrhPassword
+                    username sonatypeCentralPortalUsername
+                    password sonatypeCentralPortalPassword
                 }
             }
         }

--- a/scripts/drop_all_open_ossrh_repositories.py
+++ b/scripts/drop_all_open_ossrh_repositories.py
@@ -32,7 +32,7 @@ def _make_api_request(method, url, auth, params=None, headers=None, expected_suc
 
     print(f"Making {method} request to: {url} with params: {params if params else 'None'}")
     try:
-        response = requests.request(method, url, auth=auth, params=params, headers=headers, timeout=TIMEOUT_SECONDS)
+        response = requests.request(method=method, url=url, auth=auth, params=params, headers=headers, timeout=TIMEOUT_SECONDS)
 
         print(f"Response Status: {response.status_code}")
         # Optionally print response text for debugging, can be verbose

--- a/scripts/drop_all_open_ossrh_repositories.py
+++ b/scripts/drop_all_open_ossrh_repositories.py
@@ -12,11 +12,11 @@ TIMEOUT_SECONDS = 60
 def _get_auth_credentials():
     # Retrieves Sonatype username and password from environment variables.
     # Exits with an error if they are not set.
-    username = os.environ.get("SONATYPE_USERNAME")
-    password = os.environ.get("SONATYPE_PASSWORD")
+    username = os.environ.get("SONATYPE_CENTRAL_PORTAL_USERNAME")
+    password = os.environ.get("SONATYPE_CENTRAL_PORTAL_PASSWORD")
 
     if not username or not password:
-        print("Error: SONATYPE_USERNAME and SONATYPE_PASSWORD environment variables must be set.")
+        print("Error: SONATYPE_CENTRAL_PORTAL_USERNAME and SONATYPE_CENTRAL_PORTAL_PASSWORD environment variables must be set.")
         sys.exit(1)
     return username, password
 

--- a/scripts/drop_all_open_ossrh_repositories.py
+++ b/scripts/drop_all_open_ossrh_repositories.py
@@ -1,0 +1,133 @@
+import os
+import sys
+import requests
+import urllib.parse
+
+# --- Configuration ---
+SONATYPE_API_BASE_URL = "https://ossrh-staging-api.central.sonatype.com/manual"
+SEARCH_REPOSITORIES_URL = f"{SONATYPE_API_BASE_URL}/search/repositories"
+DROP_REPOSITORY_BASE_URL = f"{SONATYPE_API_BASE_URL}/drop/repository" # Key will be appended
+TIMEOUT_SECONDS = 60
+
+def _get_auth_credentials():
+    # Retrieves Sonatype username and password from environment variables.
+    # Exits with an error if they are not set.
+    username = os.environ.get("SONATYPE_USERNAME")
+    password = os.environ.get("SONATYPE_PASSWORD")
+
+    if not username or not password:
+        print("Error: SONATYPE_USERNAME and SONATYPE_PASSWORD environment variables must be set.")
+        sys.exit(1)
+    return username, password
+
+def _make_api_request(method, url, auth, params=None, headers=None, expected_success_codes=None):
+    # Makes an HTTP request and handles common errors.
+    # Returns the response object on success, None on failure or request exception.
+    if headers is None:
+        headers = {}
+    headers.setdefault("Accept", "application/json") # Default Accept header
+
+    if expected_success_codes is None:
+        expected_success_codes = [200]
+
+    print(f"Making {method} request to: {url} with params: {params if params else 'None'}")
+    try:
+        response = requests.request(method, url, auth=auth, params=params, headers=headers, timeout=TIMEOUT_SECONDS)
+
+        print(f"Response Status: {response.status_code}")
+        # Optionally print response text for debugging, can be verbose
+        # print(f"Response Text: {response.text[:500]}...") # Print first 500 chars
+
+        if response.status_code in expected_success_codes:
+            return response
+        else:
+            print(f"Error: API request to {url} failed with status {response.status_code}.")
+            print(f"Response: {response.text}")
+            return None
+
+    except requests.exceptions.RequestException as e:
+        print(f"Error: Request to {url} failed due to an exception: {e}")
+        return None
+
+def _list_open_repositories(auth):
+    # Fetches a list of 'open' repository keys.
+    # Returns a list of keys, or None if the request fails.
+    params = {"state": "open", "ip": "any"}
+    response = _make_api_request("GET", SEARCH_REPOSITORIES_URL, auth, params=params)
+
+    if response:
+        try:
+            data = response.json()
+            # Ensure 'repositories' key exists and is a list before extracting keys
+            repositories_data = data.get("repositories", [])
+            if not isinstance(repositories_data, list):
+                print(f"Error: Expected 'repositories' to be a list, but got: {type(repositories_data)}")
+                return None
+
+            repo_keys = [repo.get("key") for repo in repositories_data if repo.get("key")]
+            print(f"Found {len(repo_keys)} open repositories.")
+            return repo_keys
+        except ValueError: # Includes JSONDecodeError
+            print(f"Error: Could not decode JSON response from {SEARCH_REPOSITORIES_URL}")
+            print(f"Response text: {response.text}")
+            return None
+    return None
+
+def _drop_repository(auth, repo_key):
+    # Drops a single repository by its key.
+    # Returns True if successful or repository already gone (404), False otherwise.
+    if not repo_key:
+        print("Error: Cannot drop repository with an empty key.")
+        return False
+
+    # The key can contain slashes which need to be URL encoded for the path segment
+    encoded_repo_key = urllib.parse.quote(repo_key, safe='')
+    drop_url = f"{DROP_REPOSITORY_BASE_URL}/{encoded_repo_key}"
+
+    # Successful drop could be 200, 202, 204. 404 means it's already gone (which is success for us).
+    success_codes = [200, 202, 204, 404]
+    response = _make_api_request("DELETE", drop_url, auth, expected_success_codes=success_codes)
+
+    if response:
+        if response.status_code == 404:
+            print(f"Repository {repo_key} not found (or already dropped). Considered success.")
+        else:
+            print(f"Successfully dropped repository {repo_key} (or ensured it was dropped).")
+        return True
+    return False
+
+def main():
+    # Main function to list and drop open repositories.
+    print("Starting process to drop all open Sonatype staging repositories...")
+    sonatype_username, sonatype_password = _get_auth_credentials()
+    auth = (sonatype_username, sonatype_password)
+
+    open_repo_keys = _list_open_repositories(auth)
+
+    if open_repo_keys is None:
+        print("Failed to retrieve list of open repositories. Exiting.")
+        sys.exit(1)
+
+    if not open_repo_keys:
+        print("No open repositories found. Nothing to drop. Exiting successfully.")
+        sys.exit(0)
+
+    print(f"Attempting to drop {len(open_repo_keys)} open repositories...")
+    all_dropped_successfully = True
+    for key in open_repo_keys:
+        print(f"--- Processing repository key: {key} ---")
+        if not _drop_repository(auth, key):
+            all_dropped_successfully = False
+            print(f"Failed to drop repository with key: {key}")
+        print("--- Finished processing repository key ---")
+
+
+    if all_dropped_successfully:
+        print("All identified open repositories have been successfully processed (dropped or confirmed gone).")
+        sys.exit(0)
+    else:
+        print("One or more repositories could not be dropped. Please check logs.")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/move_ossrh_repository_to_central_portal.py
+++ b/scripts/move_ossrh_repository_to_central_portal.py
@@ -1,81 +1,160 @@
 import os
 import sys
 import requests
+import urllib.parse
 
-# Configuration
-TIMEOUT_SECONDS = 60
-BASE_API_URL = "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/"
+# --- Configuration ---
+SONATYPE_API_BASE_URL = "https://ossrh-staging-api.central.sonatype.com/manual"
+SEARCH_REPOSITORIES_URL = f"{SONATYPE_API_BASE_URL}/search/repositories"
+UPLOAD_REPO_BASE_URL = f"{SONATYPE_API_BASE_URL}/upload/repository" # Key will be appended
+TIMEOUT_SECONDS = 600 # This should be adjusted after the API stops throwing 401 error
 
-def _get_configuration():
-    # Retrieves and validates necessary environment variables and constructs the API URL and auth.
-    # Exits if any required environment variable is missing.
-    namespace = os.environ.get("NAMESPACE")
+def _get_env_variables():
+    # Retrieves Sonatype username, password, and publishing_type from environment variables.
+    # Exits with an error if they are not set.
+    username = os.environ.get("SONATYPE_USERNAME")
+    password = os.environ.get("SONATYPE_PASSWORD")
     publishing_type = os.environ.get("PUBLISHING_TYPE")
-    sonatype_username = os.environ.get("SONATYPE_USERNAME")
-    sonatype_password = os.environ.get("SONATYPE_PASSWORD")
 
-    required_vars = {
-        "NAMESPACE": namespace,
-        "PUBLISHING_TYPE": publishing_type,
-        "SONATYPE_USERNAME": sonatype_username,
-        "SONATYPE_PASSWORD": sonatype_password
+    required = {
+        "SONATYPE_USERNAME": username,
+        "SONATYPE_PASSWORD": password,
+        "PUBLISHING_TYPE": publishing_type
     }
-
-    for var_name, value in required_vars.items():
-        if value is None:
-            print(f"Error: Environment variable {var_name} is not set.")
+    for name, value in required.items():
+        if not value:
+            print(f"Error: Environment variable {name} must be set.")
             sys.exit(1)
 
-    api_url = f"{BASE_API_URL}{namespace}?publishing_type={publishing_type}"
-    auth = (sonatype_username, sonatype_password)
+    auth = (username, password)
+    return auth, publishing_type
 
-    return api_url, auth
+def _make_api_request(method, url, auth, params=None, headers=None, expected_success_codes=None):
+    # Makes an HTTP request and handles common errors.
+    # Returns the response object on success, None on failure or request exception.
+    if headers is None:
+        headers = {}
+    headers.setdefault("Accept", "application/json") # Default Accept header
 
-def _make_api_request(url, auth_tuple, headers_dict):
-    # Makes the POST request to the Sonatype API.
-    # Returns the response object or None if a request exception occurs.
-    print(f"Making API call to: {url}")
+    if expected_success_codes is None:
+        if method.upper() == "POST":
+            pass
+        else: # Default for GET, DELETE etc.
+            expected_success_codes = [200]
 
+    print(f"Making {method} request to: {url} with params: {params if params else 'None'}")
     try:
-        response = requests.post(url, headers=headers_dict, auth=auth_tuple, timeout=TIMEOUT_SECONDS)
+        response = requests.request(method, url, auth=auth, params=params, headers=headers, timeout=TIMEOUT_SECONDS)
+
+        print(f"Response Status: {response.status_code}")
+        # Optionally print response text for debugging, can be verbose
+        # print(f"Response Text: {response.text[:500]}...") # Print first 500 chars
+
+        # If expected_success_codes is provided, use it for validation
+        if expected_success_codes and response.status_code not in expected_success_codes:
+            print(f"Error: API request to {url} failed with status {response.status_code}.")
+            print(f"Response: {response.text}")
+            return None # Indicate failure for unexpected status
+
+        # If no expected_success_codes, or if it's in the list, return the response
         return response
+
     except requests.exceptions.RequestException as e:
-        print(f"Error: Request failed due to an exception: {e}")
+        print(f"Error: Request to {url} failed due to an exception: {e}")
         return None
 
-def _handle_response_and_exit(response):
-    # Handles the API response, prints details, and exits with appropriate status code.
-    if response is None:
-        # This means a requests.exceptions.RequestException occurred and was printed earlier
-        sys.exit(1)
+def _get_single_open_repository_key(auth):
+    # Fetches open repositories and ensures there is exactly one.
+    # Returns the key of the single open repository, or None if conditions are not met.
+    params = {"state": "open", "ip": "any"}
+    print("Searching for open repositories...")
+    # For GET, we expect a 200
+    response = _make_api_request("GET", SEARCH_REPOSITORIES_URL, auth, params=params, expected_success_codes=[200])
 
-    response_body = response.text
-    http_status_code = response.status_code
+    if response is None: # Network or request exception, or non-200 status
+        return None
 
-    print("-------------------- RESPONSE START --------------------")
-    print(response_body)
-    print("-------------------- RESPONSE END ----------------------")
-    print(f"HTTP Status Code: {http_status_code}")
+    try:
+        data = response.json()
+        repositories = data.get("repositories", [])
 
-    if http_status_code >= 400:
-        print(f"Error: Server responded with HTTP status {http_status_code}.")
-        sys.exit(1)
+        if not isinstance(repositories, list):
+            print(f"Error: Expected 'repositories' to be a list, got {type(repositories)}.")
+            print(f"Response data: {data}")
+            return None
+
+        if len(repositories) == 0:
+            print("Error: No open repositories found.")
+            return None
+        elif len(repositories) > 1:
+            print(f"Error: Expected 1 open repository, but found {len(repositories)}.")
+            for i, repo in enumerate(repositories):
+                print(f"  Repo {i+1}: Key = {repo.get('key')}, State = {repo.get('state')}")
+            return None
+        else: # Exactly one repository
+            repo_key = repositories[0].get("key")
+            if not repo_key:
+                print("Error: Found one repository, but it has no 'key'.")
+                print(f"Repository data: {repositories[0]}")
+                return None
+            print(f"Found one open repository with key: {repo_key}")
+            return repo_key
+
+    except ValueError: # Includes JSONDecodeError
+        print(f"Error: Could not decode JSON response from repository search.")
+        print(f"Response text: {response.text}")
+        return None
+
+def _upload_repository_by_key(auth, repo_key, publishing_type_value):
+    # Makes the POST request to upload/promote the repository by its key.
+    # Includes publishing_type as a query parameter.
+    # Returns True if successful (2xx), False otherwise.
+    if not repo_key:
+        print("Error: Repository key is missing for upload.")
+        return False
+
+    encoded_repo_key = urllib.parse.quote(repo_key, safe='')
+    # Construct URL with query parameter for publishing_type
+    upload_url = f"{UPLOAD_REPO_BASE_URL}/{encoded_repo_key}?publishing_type={urllib.parse.quote(publishing_type_value)}"
+
+    print(f"Attempting to publish repository with key: {repo_key} and publishing_type: {publishing_type_value}")
+    # This POST request typically does not require a body, parameters are in URL.
+    # We don't set expected_success_codes here, will check manually.
+    response = _make_api_request("POST", upload_url, auth)
+
+    if response is None: # Network or request exception
+        return False
+
+    print("-------------------- UPLOAD RESPONSE START --------------------")
+    print(response.text)
+    print("-------------------- UPLOAD RESPONSE END ----------------------")
+    print(f"Upload HTTP Status Code: {response.status_code}")
+
+    # Success conditions: 2xx status codes
+    if 200 <= response.status_code < 300:
+        print(f"Repository publish command for key '{repo_key}' processed: Status {response.status_code}. Considered successful.")
+        return True
     else:
-        print(f"Request finished successfully (HTTP Status: {http_status_code}).")
-        # Successful exit (status code 0) is implicit if not exited above
-        # but we can be explicit for clarity if preferred:
-        # sys.exit(0)
+        print(f"Error: Failed to publish repository with key '{repo_key}'. Status: {response.status_code}.")
+        return False
 
 def main():
-    # Main function to orchestrate the API call.
-    api_url, auth_credentials = _get_configuration()
+    # Main function to orchestrate the API calls.
+    print("Starting Sonatype repository publish process...")
+    auth_credentials, publishing_type = _get_env_variables()
 
-    headers = {
-        "Accept": "application/json"
-    }
+    repository_key = _get_single_open_repository_key(auth_credentials)
 
-    response = _make_api_request(api_url, auth_credentials, headers)
-    _handle_response_and_exit(response)
+    if repository_key is None:
+        # Error messages are printed within _get_single_open_repository_key
+        sys.exit(1)
+
+    if _upload_repository_by_key(auth_credentials, repository_key, publishing_type):
+        print("Repository has been published successfully.")
+        sys.exit(0)
+    else:
+        # Error messages are printed within _upload_repository_by_key
+        sys.exit(1)
 
 if __name__ == "__main__":
     main()

--- a/scripts/move_ossrh_repository_to_central_portal.py
+++ b/scripts/move_ossrh_repository_to_central_portal.py
@@ -12,13 +12,13 @@ TIMEOUT_SECONDS = 600 # This should be adjusted after the API stops throwing 401
 def _get_env_variables():
     # Retrieves Sonatype username, password, and publishing_type from environment variables.
     # Exits with an error if they are not set.
-    username = os.environ.get("SONATYPE_USERNAME")
-    password = os.environ.get("SONATYPE_PASSWORD")
+    username = os.environ.get("SONATYPE_CENTRAL_PORTAL_USERNAME")
+    password = os.environ.get("SONATYPE_CENTRAL_PORTAL_PASSWORD")
     publishing_type = os.environ.get("PUBLISHING_TYPE")
 
     required = {
-        "SONATYPE_USERNAME": username,
-        "SONATYPE_PASSWORD": password,
+        "SONATYPE_CENTRAL_PORTAL_USERNAME": username,
+        "SONATYPE_CENTRAL_PORTAL_PASSWORD": password,
         "PUBLISHING_TYPE": publishing_type
     }
     for name, value in required.items():

--- a/scripts/move_ossrh_repository_to_central_portal.py
+++ b/scripts/move_ossrh_repository_to_central_portal.py
@@ -1,0 +1,81 @@
+import os
+import sys
+import requests
+
+# Configuration
+TIMEOUT_SECONDS = 60
+BASE_API_URL = "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/"
+
+def _get_configuration():
+    # Retrieves and validates necessary environment variables and constructs the API URL and auth.
+    # Exits if any required environment variable is missing.
+    namespace = os.environ.get("NAMESPACE")
+    publishing_type = os.environ.get("PUBLISHING_TYPE")
+    sonatype_username = os.environ.get("SONATYPE_USERNAME")
+    sonatype_password = os.environ.get("SONATYPE_PASSWORD")
+
+    required_vars = {
+        "NAMESPACE": namespace,
+        "PUBLISHING_TYPE": publishing_type,
+        "SONATYPE_USERNAME": sonatype_username,
+        "SONATYPE_PASSWORD": sonatype_password
+    }
+
+    for var_name, value in required_vars.items():
+        if value is None:
+            print(f"Error: Environment variable {var_name} is not set.")
+            sys.exit(1)
+
+    api_url = f"{BASE_API_URL}{namespace}?publishing_type={publishing_type}"
+    auth = (sonatype_username, sonatype_password)
+
+    return api_url, auth
+
+def _make_api_request(url, auth_tuple, headers_dict):
+    # Makes the POST request to the Sonatype API.
+    # Returns the response object or None if a request exception occurs.
+    print(f"Making API call to: {url}")
+
+    try:
+        response = requests.post(url, headers=headers_dict, auth=auth_tuple, timeout=TIMEOUT_SECONDS)
+        return response
+    except requests.exceptions.RequestException as e:
+        print(f"Error: Request failed due to an exception: {e}")
+        return None
+
+def _handle_response_and_exit(response):
+    # Handles the API response, prints details, and exits with appropriate status code.
+    if response is None:
+        # This means a requests.exceptions.RequestException occurred and was printed earlier
+        sys.exit(1)
+
+    response_body = response.text
+    http_status_code = response.status_code
+
+    print("-------------------- RESPONSE START --------------------")
+    print(response_body)
+    print("-------------------- RESPONSE END ----------------------")
+    print(f"HTTP Status Code: {http_status_code}")
+
+    if http_status_code >= 400:
+        print(f"Error: Server responded with HTTP status {http_status_code}.")
+        sys.exit(1)
+    else:
+        print(f"Request finished successfully (HTTP Status: {http_status_code}).")
+        # Successful exit (status code 0) is implicit if not exited above
+        # but we can be explicit for clarity if preferred:
+        # sys.exit(0)
+
+def main():
+    # Main function to orchestrate the API call.
+    api_url, auth_credentials = _get_configuration()
+
+    headers = {
+        "Accept": "application/json"
+    }
+
+    response = _make_api_request(api_url, auth_credentials, headers)
+    _handle_response_and_exit(response)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description
The workflows are updated to use [OSSRH Staging API](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/) to publish artifacts to Central Portal.

A workflow run can be found [here](https://github.com/Adyen/adyen-android/actions/runs/15579793582). We still get `104` error for the last step, even though it successfully uploads the repository to Central Portal. Currently waiting for a response from Sonatype.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COSDK-475
