### PR TITLE
v6 - Pass component params to PaymentFacilitator

### DIFF
--- a/core/src/main/java/com/adyen/checkout/core/internal/AdvancedPaymentFacilitatorFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/internal/AdvancedPaymentFacilitatorFactory.kt
@@ -10,7 +10,11 @@ package com.adyen.checkout.core.internal
 
 import com.adyen.checkout.core.CheckoutCallback
 import com.adyen.checkout.core.CheckoutConfiguration
+import com.adyen.checkout.core.internal.ui.model.ButtonComponentParamsMapper
+import com.adyen.checkout.core.internal.ui.model.CommonComponentParamsMapper
+import com.adyen.checkout.core.mbway.internal.ui.getMBWayConfiguration
 import kotlinx.coroutines.CoroutineScope
+import java.util.Locale
 
 internal class AdvancedPaymentFacilitatorFactory(
     private val checkoutConfiguration: CheckoutConfiguration,
@@ -18,13 +22,22 @@ internal class AdvancedPaymentFacilitatorFactory(
 ) : PaymentFacilitatorFactory {
 
     override fun create(coroutineScope: CoroutineScope): PaymentFacilitator {
+        val componentParams = ButtonComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+            checkoutConfiguration = checkoutConfiguration,
+
+            // TODO - Add locale support, For now it's hardcoded to US
+//        deviceLocale = localeProvider.getLocale(application)
+            deviceLocale = Locale.US,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+            componentConfiguration = checkoutConfiguration.getMBWayConfiguration(),
+        )
         // TODO - Advanced Flow
         return PaymentFacilitator(
             coroutineScope = coroutineScope,
-            checkoutSession = null,
-            checkoutConfiguration = checkoutConfiguration,
             checkoutCallback = checkoutCallback,
             sessionInteractor = null,
+            componentParams = componentParams,
         )
     }
 }

--- a/core/src/main/java/com/adyen/checkout/core/internal/PaymentFacilitator.kt
+++ b/core/src/main/java/com/adyen/checkout/core/internal/PaymentFacilitator.kt
@@ -13,43 +13,24 @@ import androidx.compose.ui.Modifier
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import com.adyen.checkout.core.CheckoutCallback
-import com.adyen.checkout.core.CheckoutConfiguration
 import com.adyen.checkout.core.internal.ui.PaymentDelegate
-import com.adyen.checkout.core.internal.ui.model.ButtonComponentParamsMapper
-import com.adyen.checkout.core.internal.ui.model.CommonComponentParamsMapper
-import com.adyen.checkout.core.internal.ui.model.SessionParamsFactory
+import com.adyen.checkout.core.internal.ui.model.ButtonComponentParams
 import com.adyen.checkout.core.mbway.internal.ui.MBWayComponentState
 import com.adyen.checkout.core.mbway.internal.ui.MBWayDelegate
-import com.adyen.checkout.core.mbway.internal.ui.getMBWayConfiguration
-import com.adyen.checkout.core.sessions.CheckoutSession
 import com.adyen.checkout.core.sessions.SessionInteractor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import java.util.Locale
 
-// TODO - Have separate facilitators for sessions and advanced?
 internal class PaymentFacilitator(
     private val coroutineScope: CoroutineScope,
-    private val checkoutSession: CheckoutSession?,
-    private val checkoutConfiguration: CheckoutConfiguration,
     private val checkoutCallback: CheckoutCallback,
-    private val sessionInteractor: SessionInteractor?
+    private val sessionInteractor: SessionInteractor?,
+
+    // TODO - Switch to Component Params
+    private val componentParams: ButtonComponentParams,
 ) {
-
-    private val componentParams = ButtonComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
-        checkoutConfiguration = checkoutConfiguration,
-
-        // TODO - Add locale support, For now it's hardcoded to US
-//        deviceLocale = localeProvider.getLocale(application)
-        deviceLocale = Locale.US,
-        dropInOverrideParams = null,
-        componentSessionParams = checkoutSession?.let {
-            SessionParamsFactory.create(checkoutSession)
-        },
-        componentConfiguration = checkoutConfiguration.getMBWayConfiguration(),
-    )
 
     // TODO - Make it a val, initialize it based on txVariant?
     private val paymentDelegate: PaymentDelegate<MBWayComponentState> = MBWayDelegate(coroutineScope, componentParams)

--- a/core/src/main/java/com/adyen/checkout/core/internal/SessionsPaymentFacilitatorFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/internal/SessionsPaymentFacilitatorFactory.kt
@@ -12,12 +12,17 @@ import androidx.lifecycle.SavedStateHandle
 import com.adyen.checkout.core.CheckoutCallback
 import com.adyen.checkout.core.CheckoutConfiguration
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
+import com.adyen.checkout.core.internal.ui.model.ButtonComponentParamsMapper
+import com.adyen.checkout.core.internal.ui.model.CommonComponentParamsMapper
+import com.adyen.checkout.core.internal.ui.model.SessionParamsFactory
+import com.adyen.checkout.core.mbway.internal.ui.getMBWayConfiguration
 import com.adyen.checkout.core.sessions.CheckoutSession
 import com.adyen.checkout.core.sessions.SessionInteractor
 import com.adyen.checkout.core.sessions.SessionSavedStateHandleContainer
 import com.adyen.checkout.core.sessions.internal.data.api.SessionRepository
 import com.adyen.checkout.core.sessions.internal.data.api.SessionService
 import kotlinx.coroutines.CoroutineScope
+import java.util.Locale
 
 internal class SessionsPaymentFacilitatorFactory(
     private val checkoutSession: CheckoutSession,
@@ -29,6 +34,17 @@ internal class SessionsPaymentFacilitatorFactory(
     override fun create(
         coroutineScope: CoroutineScope,
     ): PaymentFacilitator {
+        val componentParams = ButtonComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
+            checkoutConfiguration = checkoutConfiguration,
+
+            // TODO - Add locale support, For now it's hardcoded to US
+//        deviceLocale = localeProvider.getLocale(application)
+            deviceLocale = Locale.US,
+            dropInOverrideParams = null,
+            componentSessionParams = SessionParamsFactory.create(checkoutSession),
+            componentConfiguration = checkoutConfiguration.getMBWayConfiguration(),
+        )
+
         val sessionSavedStateHandleContainer = SessionSavedStateHandleContainer(
             savedStateHandle = savedStateHandle,
             checkoutSession = checkoutSession,
@@ -36,8 +52,6 @@ internal class SessionsPaymentFacilitatorFactory(
 
         return PaymentFacilitator(
             coroutineScope = coroutineScope,
-            checkoutSession = checkoutSession,
-            checkoutConfiguration = checkoutConfiguration,
             checkoutCallback = checkoutCallback,
 
             sessionInteractor = SessionInteractor(
@@ -51,6 +65,7 @@ internal class SessionsPaymentFacilitatorFactory(
                 sessionModel = sessionSavedStateHandleContainer.getSessionModel(),
                 isFlowTakenOver = sessionSavedStateHandleContainer.isFlowTakenOver ?: false,
             ),
+            componentParams = componentParams,
         )
     }
 }


### PR DESCRIPTION
Making `PaymentFacilitator` flow agnostic will make it easier for us to manage the payment flow. This PR removes `checkoutSession` and `checkoutConfiguration` from PaymentFacilitator so it only depends on `componentParams`.

## Description
[//]: # (Include a short summary of your changes)
[//]: # (If this is a new feature: attach screenshots or a video if applicable)
[//]: # (If this is a bug fix: include a reproduction path)

- [x] Changes are tested manually

COSDK-142