### PR TITLE
[v5] Add checkoutOption configuration to Google Pay 

### DIFF
--- a/example-app/src/main/java/com/adyen/checkout/example/ui/configuration/CheckoutConfigurationProvider.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/configuration/CheckoutConfigurationProvider.kt
@@ -91,6 +91,7 @@ internal class CheckoutConfigurationProvider @Inject constructor(
             googlePay {
                 setSubmitButtonVisible(true)
                 setCountryCode(keyValueStorage.getCountry())
+                setCheckoutOption("COMPLETE_IMMEDIATE_PURCHASE")
             }
 
             instantPayment {

--- a/googlepay/api/googlepay.api
+++ b/googlepay/api/googlepay.api
@@ -162,13 +162,14 @@ public final class com/adyen/checkout/googlepay/GooglePayComponentState : com/ad
 
 public final class com/adyen/checkout/googlepay/GooglePayConfiguration : com/adyen/checkout/components/core/internal/ButtonConfiguration, com/adyen/checkout/components/core/internal/Configuration {
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public synthetic fun <init> (Ljava/util/Locale;Lcom/adyen/checkout/core/Environment;Ljava/lang/String;Lcom/adyen/checkout/components/core/AnalyticsConfiguration;Lcom/adyen/checkout/components/core/Amount;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lcom/adyen/checkout/googlepay/MerchantInfo;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/adyen/checkout/googlepay/ShippingAddressParameters;Ljava/lang/Boolean;Lcom/adyen/checkout/googlepay/BillingAddressParameters;Lcom/adyen/checkout/googlepay/GooglePayButtonStyling;Lcom/adyen/checkout/action/core/GenericActionConfiguration;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/Locale;Lcom/adyen/checkout/core/Environment;Ljava/lang/String;Lcom/adyen/checkout/components/core/AnalyticsConfiguration;Lcom/adyen/checkout/components/core/Amount;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lcom/adyen/checkout/googlepay/MerchantInfo;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/adyen/checkout/googlepay/ShippingAddressParameters;Ljava/lang/Boolean;Lcom/adyen/checkout/googlepay/BillingAddressParameters;Ljava/lang/String;Lcom/adyen/checkout/googlepay/GooglePayButtonStyling;Lcom/adyen/checkout/action/core/GenericActionConfiguration;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun describeContents ()I
 	public final fun getAllowedAuthMethods ()Ljava/util/List;
 	public final fun getAllowedCardNetworks ()Ljava/util/List;
 	public fun getAmount ()Lcom/adyen/checkout/components/core/Amount;
 	public fun getAnalyticsConfiguration ()Lcom/adyen/checkout/components/core/AnalyticsConfiguration;
 	public final fun getBillingAddressParameters ()Lcom/adyen/checkout/googlepay/BillingAddressParameters;
+	public final fun getCheckoutOption ()Ljava/lang/String;
 	public fun getClientKey ()Ljava/lang/String;
 	public final fun getCountryCode ()Ljava/lang/String;
 	public fun getEnvironment ()Lcom/adyen/checkout/core/Environment;
@@ -204,6 +205,7 @@ public final class com/adyen/checkout/googlepay/GooglePayConfiguration$Builder :
 	public final fun setAssuranceDetailsRequired (Z)Lcom/adyen/checkout/googlepay/GooglePayConfiguration$Builder;
 	public final fun setBillingAddressParameters (Lcom/adyen/checkout/googlepay/BillingAddressParameters;)Lcom/adyen/checkout/googlepay/GooglePayConfiguration$Builder;
 	public final fun setBillingAddressRequired (Z)Lcom/adyen/checkout/googlepay/GooglePayConfiguration$Builder;
+	public final fun setCheckoutOption (Ljava/lang/String;)Lcom/adyen/checkout/googlepay/GooglePayConfiguration$Builder;
 	public final fun setCountryCode (Ljava/lang/String;)Lcom/adyen/checkout/googlepay/GooglePayConfiguration$Builder;
 	public final fun setEmailRequired (Z)Lcom/adyen/checkout/googlepay/GooglePayConfiguration$Builder;
 	public final fun setExistingPaymentMethodRequired (Z)Lcom/adyen/checkout/googlepay/GooglePayConfiguration$Builder;

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.kt
@@ -54,6 +54,7 @@ class GooglePayConfiguration private constructor(
     val shippingAddressParameters: ShippingAddressParameters?,
     val isBillingAddressRequired: Boolean?,
     val billingAddressParameters: BillingAddressParameters?,
+    val checkoutOption: String?,
     val googlePayButtonStyling: GooglePayButtonStyling?,
     internal val genericActionConfiguration: GenericActionConfiguration,
 ) : Configuration, ButtonConfiguration {
@@ -81,6 +82,7 @@ class GooglePayConfiguration private constructor(
         private var isBillingAddressRequired: Boolean? = null
         private var billingAddressParameters: BillingAddressParameters? = null
         private var totalPriceStatus: String? = null
+        private var checkoutOption: String? = null
         private var googlePayButtonStyling: GooglePayButtonStyling? = null
         private var isSubmitButtonVisible: Boolean? = null
 
@@ -366,6 +368,18 @@ class GooglePayConfiguration private constructor(
         }
 
         /**
+         * Sets the checkout option. This affects the submit button text displayed in the Google Pay sheet.
+         *
+         * Check the
+         * [Google Pay docs](https://developers.google.com/pay/api/android/reference/request-objects#TransactionInfo)
+         * for more details.
+         */
+        fun setCheckoutOption(checkoutOption: String): Builder {
+            this.checkoutOption = checkoutOption
+            return this
+        }
+
+        /**
          * Sets the amount of the transaction.
          *
          * Default is 0 USD.
@@ -431,6 +445,7 @@ class GooglePayConfiguration private constructor(
                 shippingAddressParameters = shippingAddressParameters,
                 isBillingAddressRequired = isBillingAddressRequired,
                 billingAddressParameters = billingAddressParameters,
+                checkoutOption = checkoutOption,
                 googlePayButtonStyling = googlePayButtonStyling,
                 genericActionConfiguration = genericActionConfigurationBuilder.build(),
             )

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParams.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParams.kt
@@ -37,5 +37,6 @@ internal data class GooglePayComponentParams(
     val shippingAddressParameters: ShippingAddressParameters?,
     val isBillingAddressRequired: Boolean,
     val billingAddressParameters: BillingAddressParameters?,
+    val checkoutOption: String?,
     val googlePayButtonStyling: GooglePayButtonStyling?,
 ) : ComponentParams by commonComponentParams, ButtonParams

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParamsMapper.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParamsMapper.kt
@@ -77,6 +77,7 @@ internal class GooglePayComponentParamsMapper(
             shippingAddressParameters = googlePayConfiguration?.shippingAddressParameters,
             isBillingAddressRequired = googlePayConfiguration?.isBillingAddressRequired ?: false,
             billingAddressParameters = googlePayConfiguration?.billingAddressParameters,
+            checkoutOption = googlePayConfiguration?.checkoutOption,
             googlePayButtonStyling = googlePayConfiguration?.googlePayButtonStyling,
         )
     }

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/util/GooglePayUtils.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/util/GooglePayUtils.kt
@@ -221,6 +221,7 @@ internal object GooglePayUtils {
             countryCode = params.countryCode,
             totalPriceStatus = params.totalPriceStatus,
             currencyCode = params.amount.currency,
+            checkoutOption = params.checkoutOption,
         ).apply {
             // Google requires to not pass the price when the price status is NOT_CURRENTLY_KNOWN
             if (params.totalPriceStatus == NOT_CURRENTLY_KNOWN) return@apply

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParamsMapperTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParamsMapperTest.kt
@@ -106,6 +106,7 @@ internal class GooglePayComponentParamsMapperTest {
                 setShippingAddressParameters(shippingAddressParameters)
                 setShippingAddressRequired(true)
                 setTotalPriceStatus("STATUS")
+                setCheckoutOption("DEFAULT")
                 setGooglePayButtonStyling(googlePayButtonStyling)
             }
         }
@@ -141,6 +142,7 @@ internal class GooglePayComponentParamsMapperTest {
             shippingAddressParameters = shippingAddressParameters,
             isBillingAddressRequired = true,
             billingAddressParameters = billingAddressParameters,
+            checkoutOption = "DEFAULT",
             googlePayButtonStyling = googlePayButtonStyling,
         )
 
@@ -609,6 +611,7 @@ internal class GooglePayComponentParamsMapperTest {
         shippingAddressParameters: ShippingAddressParameters? = null,
         isBillingAddressRequired: Boolean = false,
         billingAddressParameters: BillingAddressParameters? = null,
+        checkoutOption: String? = null,
         googlePayButtonStyling: GooglePayButtonStyling? = null,
     ) = GooglePayComponentParams(
         commonComponentParams = CommonComponentParams(
@@ -637,6 +640,7 @@ internal class GooglePayComponentParamsMapperTest {
         shippingAddressParameters = shippingAddressParameters,
         isBillingAddressRequired = isBillingAddressRequired,
         billingAddressParameters = billingAddressParameters,
+        checkoutOption = checkoutOption,
         googlePayButtonStyling = googlePayButtonStyling,
     )
 

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/util/GooglePayUtilsTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/util/GooglePayUtilsTest.kt
@@ -228,7 +228,8 @@ internal class GooglePayUtilsTest {
                         "totalPrice": "13.37",
                         "countryCode": "COUNTRY_CODE",
                         "totalPriceStatus": "TOTAL_PRICE_STATUS",
-                        "currencyCode": "EUR"
+                        "currencyCode": "EUR",
+                        "checkoutOption": "DEFAULT"
                     }
                 }
             """.trimIndent(),
@@ -265,6 +266,7 @@ internal class GooglePayUtilsTest {
             shippingAddressParameters = null,
             isBillingAddressRequired = false,
             billingAddressParameters = null,
+            checkoutOption = null,
             googlePayButtonStyling = null,
         )
     }
@@ -306,6 +308,7 @@ internal class GooglePayUtilsTest {
                 format = "FORMAT",
                 isPhoneNumberRequired = true,
             ),
+            checkoutOption = "DEFAULT",
             googlePayButtonStyling = null,
         )
     }


### PR DESCRIPTION
## Description
`checkoutOption` influences the submit button text inside of the Google Pay sheet. By setting a certain value you can change the text from "Pay" to "Pay now" for example.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually
- [x] Related issues are linked

COSDK-502

## Release notes

### New
- Add `checkoutOption` to the Google Pay configuration. With this value you can change the submit button text displayed inside of the Google Pay sheet.