### PR TITLE
v6 - Unify payment delegate creation for sessions and advanced

### DIFF
--- a/core/src/main/java/com/adyen/checkout/core/internal/AdvancedPaymentFacilitatorFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/internal/AdvancedPaymentFacilitatorFactory.kt
@@ -25,7 +25,12 @@ internal class AdvancedPaymentFacilitatorFactory(
             )
         }
 
-        val paymentDelegate = PaymentMethodProvider.get(txVariant, coroutineScope, checkoutConfiguration)
+        val paymentDelegate = PaymentMethodProvider.get(
+            txVariant = txVariant,
+            coroutineScope = coroutineScope,
+            checkoutConfiguration = checkoutConfiguration,
+            componentSessionParams = null
+        )
 
         val componentEventHandler =
             AdvancedComponentEventHandler<BaseComponentState>(

--- a/core/src/main/java/com/adyen/checkout/core/internal/PaymentMethodFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/internal/PaymentMethodFactory.kt
@@ -10,25 +10,26 @@ package com.adyen.checkout.core.internal
 
 import com.adyen.checkout.core.CheckoutConfiguration
 import com.adyen.checkout.core.internal.ui.PaymentDelegate
-import com.adyen.checkout.core.sessions.CheckoutSession
+import com.adyen.checkout.core.internal.ui.model.SessionParams
 import kotlinx.coroutines.CoroutineScope
 
 internal interface PaymentMethodFactory<CS : BaseComponentState, T : PaymentDelegate<CS>> {
 
     /**
-     * Creates an Advanced Payment Method Delegate.
+     * Creates a [PaymentDelegate].
+     *
+     * @param coroutineScope Coroutine Scope.
+     * @param checkoutConfiguration Checkout Configuration.
+     * @param componentSessionParams Configuration from Sessions.
+     *
+     * @return A [PaymentDelegate] instance.
      */
     fun create(
         coroutineScope: CoroutineScope,
-        checkoutConfiguration: CheckoutConfiguration
-    ): T
+        checkoutConfiguration: CheckoutConfiguration,
 
-    /**
-     * Creates a Sessions Payment Method Delegate.
-     */
-    fun create(
-        coroutineScope: CoroutineScope,
-        checkoutSession: CheckoutSession,
-        checkoutConfiguration: CheckoutConfiguration
+        // TODO - Remove dependency to SessionParams. Investigate separating ComponentParams into two:
+        //  CheckoutParams and PaymentMethodParams to reflect the structure in CheckoutConfiguration.
+        componentSessionParams: SessionParams?,
     ): T
 }

--- a/core/src/main/java/com/adyen/checkout/core/internal/PaymentMethodProvider.kt
+++ b/core/src/main/java/com/adyen/checkout/core/internal/PaymentMethodProvider.kt
@@ -10,7 +10,7 @@ package com.adyen.checkout.core.internal
 
 import com.adyen.checkout.core.CheckoutConfiguration
 import com.adyen.checkout.core.internal.ui.PaymentDelegate
-import com.adyen.checkout.core.sessions.CheckoutSession
+import com.adyen.checkout.core.internal.ui.model.SessionParams
 import kotlinx.coroutines.CoroutineScope
 
 internal object PaymentMethodProvider {
@@ -26,35 +26,25 @@ internal object PaymentMethodProvider {
     }
 
     /**
-     * Advanced
+     * Create a [PaymentDelegate] via a [PaymentMethodFactory].
+     *
+     * @param txVariant Payment Method Type.
+     * @param coroutineScope Coroutine Scope.
+     * @param checkoutConfiguration Checkout Configuration.
+     * @param componentSessionParams Configuration from Sessions.
+     *
+     * @return [PaymentDelegate] for given txVariant.
      */
     fun get(
         txVariant: String,
         coroutineScope: CoroutineScope,
-        checkoutConfiguration: CheckoutConfiguration
+        checkoutConfiguration: CheckoutConfiguration,
+        componentSessionParams: SessionParams?,
     ): PaymentDelegate<BaseComponentState> {
         return factories[txVariant]?.create(
             coroutineScope = coroutineScope,
             checkoutConfiguration = checkoutConfiguration,
-        ) ?: run {
-            // TODO - Error propagation [COSDK-85]. Propagate an initialization error via onError()
-            error("Factory for payment method type: $txVariant is not registered.")
-        }
-    }
-
-    /**
-     * Sessions
-     */
-    fun get(
-        txVariant: String,
-        coroutineScope: CoroutineScope,
-        checkoutSession: CheckoutSession,
-        checkoutConfiguration: CheckoutConfiguration
-    ): PaymentDelegate<BaseComponentState> {
-        return factories[txVariant]?.create(
-            coroutineScope = coroutineScope,
-            checkoutSession = checkoutSession,
-            checkoutConfiguration = checkoutConfiguration,
+            componentSessionParams = componentSessionParams,
         ) ?: run {
             // TODO - Errors Propagation [COSDK-85]. Propagate an initialization error via onError()
             error("Factory for payment method type: $txVariant is not registered.")

--- a/core/src/main/java/com/adyen/checkout/core/internal/SessionsPaymentFacilitatorFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/internal/SessionsPaymentFacilitatorFactory.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.adyen.checkout.core.CheckoutCallback
 import com.adyen.checkout.core.CheckoutConfiguration
 import com.adyen.checkout.core.internal.data.api.HttpClientFactory
+import com.adyen.checkout.core.internal.ui.model.SessionParamsFactory
 import com.adyen.checkout.core.sessions.CheckoutSession
 import com.adyen.checkout.core.sessions.SessionInteractor
 import com.adyen.checkout.core.sessions.SessionSavedStateHandleContainer
@@ -56,8 +57,8 @@ internal class SessionsPaymentFacilitatorFactory(
         val paymentDelegate = PaymentMethodProvider.get(
             txVariant = txVariant,
             coroutineScope = coroutineScope,
-            checkoutSession = checkoutSession,
             checkoutConfiguration = checkoutConfiguration,
+            componentSessionParams = SessionParamsFactory.create(checkoutSession)
         )
 
         return PaymentFacilitator(

--- a/core/src/main/java/com/adyen/checkout/core/mbway/internal/ui/MBWayFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/mbway/internal/ui/MBWayFactory.kt
@@ -12,8 +12,7 @@ import com.adyen.checkout.core.CheckoutConfiguration
 import com.adyen.checkout.core.internal.PaymentMethodFactory
 import com.adyen.checkout.core.internal.ui.model.ButtonComponentParamsMapper
 import com.adyen.checkout.core.internal.ui.model.CommonComponentParamsMapper
-import com.adyen.checkout.core.internal.ui.model.SessionParamsFactory
-import com.adyen.checkout.core.sessions.CheckoutSession
+import com.adyen.checkout.core.internal.ui.model.SessionParams
 import kotlinx.coroutines.CoroutineScope
 import java.util.Locale
 
@@ -22,27 +21,8 @@ internal class MBWayFactory : PaymentMethodFactory<MBWayComponentState, MBWayDel
 
     override fun create(
         coroutineScope: CoroutineScope,
-        checkoutConfiguration: CheckoutConfiguration
-    ): MBWayDelegate {
-        val componentParams =
-            ButtonComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
-                checkoutConfiguration = checkoutConfiguration,
-
-                // TODO - Add locale support, For now it's hardcoded to US
-                // deviceLocale = localeProvider.getLocale(application)
-                deviceLocale = Locale.US,
-                dropInOverrideParams = null,
-                componentSessionParams = null,
-                componentConfiguration = checkoutConfiguration.getMBWayConfiguration(),
-            )
-
-        return MBWayDelegate(coroutineScope, componentParams)
-    }
-
-    override fun create(
-        coroutineScope: CoroutineScope,
-        checkoutSession: CheckoutSession,
-        checkoutConfiguration: CheckoutConfiguration
+        checkoutConfiguration: CheckoutConfiguration,
+        componentSessionParams: SessionParams?,
     ): MBWayDelegate {
         val componentParams = ButtonComponentParamsMapper(CommonComponentParamsMapper()).mapToParams(
             checkoutConfiguration = checkoutConfiguration,
@@ -51,7 +31,7 @@ internal class MBWayFactory : PaymentMethodFactory<MBWayComponentState, MBWayDel
             // deviceLocale = localeProvider.getLocale(application)
             deviceLocale = Locale.US,
             dropInOverrideParams = null,
-            componentSessionParams = SessionParamsFactory.create(checkoutSession),
+            componentSessionParams = componentSessionParams,
             componentConfiguration = checkoutConfiguration.getMBWayConfiguration(),
         )
 


### PR DESCRIPTION
## Description
[//]: # (Include a short summary of your changes)
[//]: # (If this is a new feature: attach screenshots or a video if applicable)
[//]: # (If this is a bug fix: include a reproduction path)
This draft PR is aimed to showcase the idea of moving dependency to `checkoutSession` object out of `PaymentMethodFactory` and having one `create()` function with nullable parameters to avoid duplicate implementations of the `create()` function.

COSDK-482
