### PR TITLE
Renovate - Add support for v5 branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,10 @@
   "labels": [
     "Dependencies"
   ],
+  "baseBranches": [
+    "$default",
+    "v5"
+  ],
   "packageRules": [
     {
       "groupName": "Kotlin Coroutines",


### PR DESCRIPTION
## Description
Add Renovate support to `v5` branch.

[Here](https://docs.renovatebot.com/configuration-options/#basebranches:~:text=Renovate%20always%20uses%20the%20config%20from%20the%20repository%27s%20default%20branch%2C%20even%20if%20that%20configuration%20specifies%20multiple%20baseBranches.%20Renovate%20does%20not%20read/override%20the%20config%20from%20within%20each%20base%20branch%20if%20present.) it mentions that: Renovate always uses the config from the repository's default branch, even if that configuration specifies multiple baseBranches. Renovate does not read/override the config from within each base branch if present.

COSDK-519
