### PR TITLE
v6 - Disable co-badged for not supported brands

### DIFF
--- a/card/api/card.api
+++ b/card/api/card.api
@@ -528,3 +528,6 @@ public final class com/adyen/checkout/card/internal/ui/view/CardNumberInput : co
 public final class com/adyen/checkout/card/internal/ui/view/CardNumberInput$Companion {
 }
 
+public final class com/adyen/checkout/card/internal/util/DualBrandedCardHandler$Companion {
+}
+

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/model/DualBrandData.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/model/DualBrandData.kt
@@ -14,5 +14,6 @@ import com.adyen.checkout.card.CardBrand
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class DualBrandData(
     val selectedBrand: CardBrand?,
-    val brandOptions: List<CardBrandItem>
+    val brandOptions: List<CardBrandItem>,
+    val selectable: Boolean
 )

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardView.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardView.kt
@@ -786,11 +786,11 @@ class CardView @JvmOverloads constructor(
     }
 
     private fun setCoBadgeBrands(dualBrandData: DualBrandData?) {
-        val isDualBranded = dualBrandData != null
-        binding.recyclerViewCobadgeBrands.isVisible = isDualBranded
-        binding.textViewCobadgeBrandsHeader.isVisible = isDualBranded
-        binding.textViewCobadgeBrandsDescription.isVisible = isDualBranded
-        if (isDualBranded) {
+        val shouldDisplaySelection = dualBrandData != null && dualBrandData.selectable
+        binding.recyclerViewCobadgeBrands.isVisible = shouldDisplaySelection
+        binding.textViewCobadgeBrandsHeader.isVisible = shouldDisplaySelection
+        binding.textViewCobadgeBrandsDescription.isVisible = shouldDisplaySelection
+        if (shouldDisplaySelection) {
             if (cardBrandAdapter == null) {
                 cardBrandAdapter = CardBrandAdapter { cardBrandItem ->
                     cardDelegate.updateInputData {

--- a/card/src/main/java/com/adyen/checkout/card/internal/util/DualBrandedCardHandler.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/util/DualBrandedCardHandler.kt
@@ -13,6 +13,7 @@ import com.adyen.checkout.card.CardBrand
 import com.adyen.checkout.card.internal.data.model.DetectedCardType
 import com.adyen.checkout.card.internal.ui.model.CardBrandItem
 import com.adyen.checkout.card.internal.ui.model.DualBrandData
+import com.adyen.checkout.core.old.CardType
 import com.adyen.checkout.core.old.Environment
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -23,19 +24,53 @@ class DualBrandedCardHandler(private val environment: Environment) {
         selectedBrand: CardBrand?
     ): DualBrandData? {
         if (!isDualBrandedFlow(detectedCardTypes)) return null
-        val brandOptions = mapToCardBrandItemList(detectedCardTypes, selectedBrand)
-        return DualBrandData(
-            selectedBrand = getSelectedCardType(detectedCardTypes, selectedBrand)?.cardBrand
-                ?: brandOptions.firstOrNull()?.brand,
+
+        val isSelectable = isSelectable(detectedCardTypes = detectedCardTypes)
+        val brandOptions = mapToCardBrandItemList(
+            detectedCardTypes = detectedCardTypes,
+            selectedBrand = selectedBrand,
+            isSelectable = isSelectable,
+        )
+
+        val selectedCardBrand = getSelectedCardBrand(
+            isSelectable = isSelectable,
+            detectedCardTypes = detectedCardTypes,
+            selectedBrand = selectedBrand,
             brandOptions = brandOptions,
+        )
+
+        return DualBrandData(
+            selectedBrand = selectedCardBrand,
+            brandOptions = brandOptions,
+            selectable = isSelectable,
         )
     }
 
-    private fun getSelectedCardType(
+    private fun isSelectable(detectedCardTypes: List<DetectedCardType>): Boolean {
+        return detectedCardTypes.filter { it.isSupported && it.isReliable }.any {
+            it.cardBrand.txVariant in SUPPORTED_CARD_BRANDS
+        }
+    }
+
+    private fun getSelectedCardBrand(
+        isSelectable: Boolean,
+        detectedCardTypes: List<DetectedCardType>,
+        selectedBrand: CardBrand?,
+        brandOptions: List<CardBrandItem>
+    ): CardBrand? {
+        return if (isSelectable) {
+            findSelectedCardType(detectedCardTypes, selectedBrand)?.cardBrand
+                ?: brandOptions.firstOrNull()?.brand
+        } else {
+            null
+        }
+    }
+
+    private fun findSelectedCardType(
         detectedCardTypes: List<DetectedCardType>,
         selectedBrand: CardBrand?
     ): DetectedCardType? {
-        return detectedCardTypes.firstOrNull { it.cardBrand.txVariant == selectedBrand?.txVariant }
+        return detectedCardTypes.find { it.cardBrand.txVariant == selectedBrand?.txVariant }
     }
 
     private fun isDualBrandedFlow(detectedCardTypes: List<DetectedCardType>): Boolean {
@@ -44,15 +79,16 @@ class DualBrandedCardHandler(private val environment: Environment) {
 
     private fun mapToCardBrandItemList(
         detectedCardTypes: List<DetectedCardType>,
-        selectedBrand: CardBrand?
+        selectedBrand: CardBrand?,
+        isSelectable: Boolean,
     ): List<CardBrandItem> {
         val filteredCardBrands = detectedCardTypes.filter { it.isSupported && it.isReliable }
         return filteredCardBrands.mapIndexed { index, detectedCardType ->
             if (selectedBrand == null) {
-                detectedCardType.mapToCardBrandItem(index == 0)
+                detectedCardType.mapToCardBrandItem(isSelectable && index == 0)
             } else {
                 detectedCardType.mapToCardBrandItem(
-                    detectedCardType.cardBrand.txVariant == selectedBrand.txVariant,
+                    isSelectable && detectedCardType.cardBrand.txVariant == selectedBrand.txVariant,
                 )
             }
         }
@@ -64,4 +100,12 @@ class DualBrandedCardHandler(private val environment: Environment) {
         isSelected = isSelected,
         environment = environment,
     )
+
+    companion object {
+        private val SUPPORTED_CARD_BRANDS = listOf(
+            CardType.CARTEBANCAIRE,
+            CardType.BCMC,
+            CardType.DANKORT,
+        ).map { it.txVariant }
+    }
 }

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegateTest.kt
@@ -898,6 +898,7 @@ internal class DefaultCardDelegateTest(
                                     environment = Environment.TEST,
                                 ),
                             ),
+                            selectable = true,
                         ),
                     ),
                 )

--- a/card/src/test/java/com/adyen/checkout/card/internal/util/DualBrandedCardHandlerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/util/DualBrandedCardHandlerTest.kt
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2025 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ozgur on 4/7/2025.
+ */
+
+package com.adyen.checkout.card.internal.util
+
+import com.adyen.checkout.card.internal.data.model.Brand
+import com.adyen.checkout.card.internal.data.model.DetectedCardType
+import com.adyen.checkout.card.internal.ui.model.CardBrandItem
+import com.adyen.checkout.card.internal.ui.model.DualBrandData
+import com.adyen.checkout.core.old.CardBrand
+import com.adyen.checkout.core.old.CardType
+import com.adyen.checkout.core.old.Environment
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+internal class DualBrandedCardHandlerTest {
+
+    private val dualBrandedCardHandler = DualBrandedCardHandler(Environment.TEST)
+
+    @ParameterizedTest
+    @MethodSource("dualBrandedCardHandlerSource")
+    fun `given detected card types and selected brand, expected dual brand data should be created`(
+        detectedCardTypes: List<DetectedCardType>,
+        selectedBrand: CardBrand?,
+        expectedDualBrandData: DualBrandData?
+    ) {
+        val actual = dualBrandedCardHandler.processDetectedCardTypes(detectedCardTypes, selectedBrand)
+        assertEquals(expectedDualBrandData, actual)
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun dualBrandedCardHandlerSource() = listOf(
+            // detected card types, selected brand, expected dual brand data
+            arguments(
+                emptyList<DetectedCardType>(),
+                null,
+                null
+            ),
+            arguments(
+                listOf(
+                    DetectedCardType(
+                        CardBrand(CardType.VISA),
+                        isReliable = true,
+                        enableLuhnCheck = true,
+                        cvcPolicy = Brand.FieldPolicy.REQUIRED,
+                        expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
+                        isSupported = true,
+                        panLength = null,
+                        paymentMethodVariant = null,
+                        localizedBrand = "Visa",
+                    ),
+                    DetectedCardType(
+                        CardBrand(CardType.CARTEBANCAIRE),
+                        isReliable = false,
+                        enableLuhnCheck = true,
+                        cvcPolicy = Brand.FieldPolicy.REQUIRED,
+                        expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
+                        isSupported = true,
+                        panLength = null,
+                        paymentMethodVariant = null,
+                        localizedBrand = "Cartes Bancaire",
+                    ),
+                ),
+                null,
+                null,
+            ),
+            arguments(
+                listOf(
+                    DetectedCardType(
+                        CardBrand(CardType.VISA),
+                        isReliable = true,
+                        enableLuhnCheck = true,
+                        cvcPolicy = Brand.FieldPolicy.REQUIRED,
+                        expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
+                        isSupported = true,
+                        panLength = null,
+                        paymentMethodVariant = null,
+                        localizedBrand = "Visa",
+                    ),
+                    DetectedCardType(
+                        CardBrand(CardType.CARTEBANCAIRE),
+                        isReliable = true,
+                        enableLuhnCheck = true,
+                        cvcPolicy = Brand.FieldPolicy.REQUIRED,
+                        expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
+                        isSupported = true,
+                        panLength = null,
+                        paymentMethodVariant = null,
+                        localizedBrand = "Cartes Bancaire",
+                    ),
+                ),
+                null,
+                DualBrandData(
+                    brandOptions = listOf(
+                        CardBrandItem(
+                            name = "Visa",
+                            brand = CardBrand(CardType.VISA),
+                            isSelected = true,
+                            environment = Environment.TEST,
+                        ),
+                        CardBrandItem(
+                            name = "Cartes Bancaire",
+                            brand = CardBrand(CardType.CARTEBANCAIRE),
+                            isSelected = false,
+                            environment = Environment.TEST,
+                        ),
+                    ),
+                    selectedBrand = CardBrand(CardType.VISA),
+                    selectable = true,
+                ),
+            ),
+            arguments(
+                listOf(
+                    DetectedCardType(
+                        CardBrand(CardType.VISA),
+                        isReliable = true,
+                        enableLuhnCheck = true,
+                        cvcPolicy = Brand.FieldPolicy.REQUIRED,
+                        expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
+                        isSupported = true,
+                        panLength = null,
+                        paymentMethodVariant = null,
+                        localizedBrand = "Visa",
+                    ),
+                    DetectedCardType(
+                        CardBrand(CardType.DANKORT),
+                        isReliable = true,
+                        enableLuhnCheck = true,
+                        cvcPolicy = Brand.FieldPolicy.REQUIRED,
+                        expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
+                        isSupported = true,
+                        panLength = null,
+                        paymentMethodVariant = null,
+                        localizedBrand = "Dankort",
+                    ),
+                ),
+                CardBrand(CardType.DANKORT),
+                DualBrandData(
+                    brandOptions = listOf(
+                        CardBrandItem(
+                            name = "Visa",
+                            brand = CardBrand(CardType.VISA),
+                            isSelected = false,
+                            environment = Environment.TEST,
+                        ),
+                        CardBrandItem(
+                            name = "Dankort",
+                            brand = CardBrand(CardType.DANKORT),
+                            isSelected = true,
+                            environment = Environment.TEST,
+                        ),
+                    ),
+                    selectedBrand = CardBrand(CardType.DANKORT),
+                    selectable = true,
+                ),
+            ),
+            arguments(
+                listOf(
+                    DetectedCardType(
+                        CardBrand(CardType.MASTERCARD),
+                        isReliable = true,
+                        enableLuhnCheck = true,
+                        cvcPolicy = Brand.FieldPolicy.REQUIRED,
+                        expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
+                        isSupported = true,
+                        panLength = null,
+                        paymentMethodVariant = null,
+                        localizedBrand = "Mastercard",
+                    ),
+                    DetectedCardType(
+                        CardBrand("eft_pos"),
+                        isReliable = true,
+                        enableLuhnCheck = true,
+                        cvcPolicy = Brand.FieldPolicy.REQUIRED,
+                        expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
+                        isSupported = true,
+                        panLength = null,
+                        paymentMethodVariant = null,
+                        localizedBrand = "eftpos_australia",
+                    ),
+                ),
+                null,
+                DualBrandData(
+                    brandOptions = listOf(
+                        CardBrandItem(
+                            name = "Mastercard",
+                            brand = CardBrand(CardType.MASTERCARD),
+                            isSelected = false,
+                            environment = Environment.TEST,
+                        ),
+                        CardBrandItem(
+                            name = "eftpos_australia",
+                            brand = CardBrand("eft_pos"),
+                            isSelected = false,
+                            environment = Environment.TEST,
+                        ),
+                    ),
+                    selectedBrand = null,
+                    selectable = false,
+                ),
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Description
[//]: # (Include a short summary of your changes)
[//]: # (If this is a new feature: attach screenshots or a video if applicable)
[//]: # (If this is a bug fix: include a reproduction path)
This change makes sure we only display co-badged selection for cards that contain Bcmc, Carte Bancaire or Dankort.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

COSDK-529
