### PR TITLE
v5 - Make status bar transparent in base theme

### DIFF
--- a/ui-core/src/main/res/values/styles.xml
+++ b/ui-core/src/main/res/values/styles.xml
@@ -27,6 +27,7 @@
         <item name="android:textColorTertiary">@color/text_color_primary</item>
         <item name="android:textColorLink">@color/textColorLink</item>
         <item name="bottomSheetDialogTheme">@style/AdyenCheckout.BottomSheetDialogTheme</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
 
     <!-- Base theme for Checkout -->


### PR DESCRIPTION
## Description
If the status bar color is not set, Material will fallback to this Material purple color. This doesn't fit with our design and looks out of place. Merchants who don't customize might be impacted by this.

| Before | After |
|--------|--------|
| ![Screenshot_20250708_104024](https://github.com/user-attachments/assets/abbc9041-ebb5-4224-987d-9dfb31888db9) | ![Screenshot_20250708_104043](https://github.com/user-attachments/assets/f8728ea1-9098-4450-9e2a-54d4879370ba) |

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COSDK-538

## Release notes

### Fixed
- For drop-in, the status bar color of the base theme is now transparent.
