### PR TITLE
v6 - Move core test class to test fixtures

### DIFF
--- a/core/src/test/java/com/adyen/checkout/core/common/internal/ui/state/DefaultDelegateStateManagerTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/common/internal/ui/state/DefaultDelegateStateManagerTest.kt
@@ -11,6 +11,7 @@ package com.adyen.checkout.core.common.internal.ui.state
 import com.adyen.checkout.core.components.internal.ui.state.DefaultDelegateStateManager
 import com.adyen.checkout.core.components.internal.ui.state.model.DelegateFieldState
 import com.adyen.checkout.core.components.internal.ui.state.model.Validation
+import com.adyen.checkout.test.ui.state.TestFieldTransformerRegistry
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue

--- a/core/src/testFixtures/java/com/adyen/checkout/test/ui/state/TestFieldTransformerRegistry.kt
+++ b/core/src/testFixtures/java/com/adyen/checkout/test/ui/state/TestFieldTransformerRegistry.kt
@@ -6,7 +6,7 @@
  * Created by ararat on 6/3/2025.
  */
 
-package com.adyen.checkout.core.common.internal.ui.state
+package com.adyen.checkout.test.ui.state
 
 import com.adyen.checkout.core.components.internal.ui.state.model.FieldId
 import com.adyen.checkout.core.components.internal.ui.state.transformer.FieldTransformerRegistry

--- a/mbway/build.gradle
+++ b/mbway/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     implementation libs.material
 
     //Tests
+    testImplementation testFixtures(project(':core'))
     testImplementation testFixtures(project(':test-core'))
     testImplementation testFixtures(project(':components-core'))
     testImplementation testFixtures(project(':ui-core'))

--- a/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/MBWayComponentStateTest.kt
+++ b/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/MBWayComponentStateTest.kt
@@ -8,30 +8,28 @@
 
 package com.adyen.checkout.mbway.internal.ui
 
-// import com.adyen.checkout.core.common.internal.ui.state.TestFieldTransformerRegistry
 import com.adyen.checkout.core.components.data.OrderRequest
 import com.adyen.checkout.core.components.data.model.Amount
 import com.adyen.checkout.core.components.internal.ui.model.CountryModel
 import com.adyen.checkout.core.components.internal.ui.state.model.DelegateFieldState
 import com.adyen.checkout.core.components.internal.ui.state.model.Validation
 import com.adyen.checkout.mbway.internal.ui.model.MBWayDelegateState
+import com.adyen.checkout.mbway.internal.ui.state.MBWayFieldId
+import com.adyen.checkout.test.ui.state.TestFieldTransformerRegistry
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
 
-// TODO - move TestFieldTransformerRegistry to :core test fixtures
 internal class MBWayComponentStateTest {
 
-    //    private lateinit var fieldTransformerRegistry: TestFieldTransformerRegistry<MBWayFieldId>
+    private lateinit var fieldTransformerRegistry: TestFieldTransformerRegistry<MBWayFieldId>
     private lateinit var initialState: MBWayDelegateState
     private lateinit var orderRequest: OrderRequest
     private lateinit var amount: Amount
 
     @BeforeEach
     fun setup() {
-//        fieldTransformerRegistry = TestFieldTransformerRegistry()
+        fieldTransformerRegistry = TestFieldTransformerRegistry()
 
         val countryModel = CountryModel(isoCode = "NL", countryName = "Netherlands", callingCode = "+31")
         val countryCodeFieldState = DelegateFieldState(value = countryModel, validation = Validation.Valid)
@@ -47,7 +45,6 @@ internal class MBWayComponentStateTest {
         amount = Amount(currency = "EUR", value = 1000L)
     }
 
-    @Disabled("TestFieldTransformerRegistry is currently not available")
     @Test
     fun `when toComponentState is called with valid inputs, then MBWayComponentState should be created correctly`() {
         val updatedState = initialState.copy(
@@ -57,7 +54,7 @@ internal class MBWayComponentStateTest {
 
         val componentState = updatedState.toComponentState(
             checkoutAttemptId = "",
-            fieldTransformerRegistry = mock(),
+            fieldTransformerRegistry = fieldTransformerRegistry,
             order = orderRequest,
             amount = amount,
         )
@@ -68,7 +65,6 @@ internal class MBWayComponentStateTest {
         assertEquals(true, componentState.isValid)
     }
 
-    @Disabled("TestFieldTransformerRegistry is currently not available")
     @Test
     fun `when toComponentState is called with isValid false, then MBWayComponentState should be created correctly`() {
         val updatedState = initialState.copy(
@@ -82,7 +78,7 @@ internal class MBWayComponentStateTest {
 
         val componentState = updatedState.toComponentState(
             checkoutAttemptId = "",
-            fieldTransformerRegistry = mock(),
+            fieldTransformerRegistry = fieldTransformerRegistry,
             order = orderRequest,
             amount = amount,
         )
@@ -93,14 +89,13 @@ internal class MBWayComponentStateTest {
         assertEquals(false, componentState.isValid)
     }
 
-    @Disabled("TestFieldTransformerRegistry is currently not available")
     @Test
     fun `when transform function changes phone number, then component state should reflect the change`() {
-//        fieldTransformerRegistry.setTransformation(MBWayFieldId.PHONE_NUMBER, "123456789", "987654321")
+        fieldTransformerRegistry.setTransformation(MBWayFieldId.PHONE_NUMBER, "123456789", "987654321")
 
         val componentState = initialState.toComponentState(
             checkoutAttemptId = "",
-            fieldTransformerRegistry = mock(),
+            fieldTransformerRegistry = fieldTransformerRegistry,
             order = orderRequest,
             amount = amount,
         )
@@ -108,12 +103,11 @@ internal class MBWayComponentStateTest {
         assertEquals("+31987654321", componentState.data.paymentMethod?.telephoneNumber)
     }
 
-    @Disabled("TestFieldTransformerRegistry is currently not available")
     @Test
     fun `when toComponentState is called with null order and amount, then MBWayComponentState should be created correctly`() {
         val componentState = initialState.toComponentState(
             checkoutAttemptId = "",
-            fieldTransformerRegistry = mock(),
+            fieldTransformerRegistry = fieldTransformerRegistry,
             order = null,
             amount = null,
         )


### PR DESCRIPTION
## Description
To let the mbway module use a test class from the core module they needed to be moved to test fixtures. After that the disabled tests could be re-enabled.