### PR TITLE
v5 - Checkout configuration isSubmitButtonVisible

### DIFF
--- a/ach/src/main/java/com/adyen/checkout/ach/ACHDirectDebitConfiguration.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/ACHDirectDebitConfiguration.kt
@@ -160,6 +160,7 @@ fun CheckoutConfiguration.achDirectDebit(
             shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+            isSubmitButtonVisible?.let { setSubmitButtonVisible(it) }
         }
         .apply(configuration)
         .build()
@@ -172,7 +173,14 @@ internal fun CheckoutConfiguration.getACHDirectDebitConfiguration(): ACHDirectDe
 }
 
 internal fun ACHDirectDebitConfiguration.toCheckoutConfiguration(): CheckoutConfiguration {
-    return CheckoutConfiguration(environment, clientKey, shopperLocale, amount, analyticsConfiguration) {
+    return CheckoutConfiguration(
+        environment = environment,
+        clientKey = clientKey,
+        shopperLocale = shopperLocale,
+        amount = amount,
+        analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = isSubmitButtonVisible,
+    ) {
         addConfiguration(PaymentMethodTypes.ACH, this@toCheckoutConfiguration)
 
         genericActionConfiguration.getAllConfigurations().forEach {

--- a/ach/src/main/java/com/adyen/checkout/ach/internal/ui/model/ACHDirectDebitComponentParamsMapper.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/internal/ui/model/ACHDirectDebitComponentParamsMapper.kt
@@ -41,6 +41,7 @@ internal class ACHDirectDebitComponentParamsMapper(
             commonComponentParamsMapperData.sessionParams,
             dropInOverrideParams,
             achDirectDebitConfiguration,
+            checkoutConfiguration,
         )
     }
 
@@ -49,11 +50,14 @@ internal class ACHDirectDebitComponentParamsMapper(
         sessionParams: SessionParams?,
         dropInOverrideParams: DropInOverrideParams?,
         achDirectDebitConfiguration: ACHDirectDebitConfiguration?,
+        checkoutConfiguration: CheckoutConfiguration,
     ): ACHDirectDebitComponentParams {
         return ACHDirectDebitComponentParams(
             commonComponentParams = commonComponentParams,
             isSubmitButtonVisible = dropInOverrideParams?.isSubmitButtonVisible
-                ?: achDirectDebitConfiguration?.isSubmitButtonVisible ?: true,
+                ?: achDirectDebitConfiguration?.isSubmitButtonVisible
+                ?: checkoutConfiguration.isSubmitButtonVisible
+                ?: true,
             addressParams = achDirectDebitConfiguration?.addressConfiguration?.mapToAddressParam()
                 ?: AddressParams.FullAddress(
                     supportedCountryCodes = DEFAULT_SUPPORTED_COUNTRY_LIST,

--- a/ach/src/test/java/com/adyen/checkout/ach/internal/ui/model/ACHDirectDebitComponentParamsMapperTest.kt
+++ b/ach/src/test/java/com/adyen/checkout/ach/internal/ui/model/ACHDirectDebitComponentParamsMapperTest.kt
@@ -121,6 +121,26 @@ internal class ACHDirectDebitComponentParamsMapperTest {
     }
 
     @Test
+    fun `when setSubmitButtonVisible is not set in ach component configuration and checkout configuration does set it, then it should follow that`() {
+        val configuration = CheckoutConfiguration(
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+            isSubmitButtonVisible = false,
+        ) {
+            achDirectDebit { }
+        }
+
+        val params = achDirectDebitComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+        )
+
+        assertEquals(false, params.isSubmitButtonVisible)
+    }
+
+    @Test
     fun `when a address is selected as FullAddress, addressParams should return FullAddress`() {
         val addressConfiguration =
             ACHDirectDebitAddressConfiguration.FullAddress(supportedCountryCodes = SUPPORTED_COUNTRY_LIST)

--- a/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitConfiguration.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitConfiguration.kt
@@ -124,6 +124,7 @@ fun CheckoutConfiguration.bacsDirectDebit(
             shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+            isSubmitButtonVisible?.let { setSubmitButtonVisible(it) }
         }
         .apply(configuration)
         .build()
@@ -142,6 +143,7 @@ internal fun BacsDirectDebitConfiguration.toCheckoutConfiguration(): CheckoutCon
         clientKey = clientKey,
         amount = amount,
         analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = isSubmitButtonVisible,
     ) {
         addConfiguration(PaymentMethodTypes.BACS, this@toCheckoutConfiguration)
 

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcConfiguration.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcConfiguration.kt
@@ -180,6 +180,7 @@ fun CheckoutConfiguration.bcmc(
             shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+            isSubmitButtonVisible?.let { setSubmitButtonVisible(it) }
         }
         .apply(configuration)
         .build()
@@ -198,6 +199,7 @@ internal fun BcmcConfiguration.toCheckoutConfiguration(): CheckoutConfiguration 
         clientKey = clientKey,
         amount = amount,
         analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = isSubmitButtonVisible,
     ) {
         addConfiguration(PaymentMethodTypes.BCMC, this@toCheckoutConfiguration)
 

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/internal/ui/model/BcmcComponentParamsMapper.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/internal/ui/model/BcmcComponentParamsMapper.kt
@@ -50,20 +50,25 @@ internal class BcmcComponentParamsMapper(
             dropInOverrideParams,
             bcmcConfiguration,
             paymentMethod,
+            checkoutConfiguration,
         )
     }
 
+    @Suppress("LongParameterList")
     private fun mapToParams(
         commonComponentParams: CommonComponentParams,
         sessionParams: SessionParams?,
         dropInOverrideParams: DropInOverrideParams?,
         bcmcConfiguration: BcmcConfiguration?,
         paymentMethod: PaymentMethod,
+        checkoutConfiguration: CheckoutConfiguration,
     ): CardComponentParams {
         return CardComponentParams(
             commonComponentParams = commonComponentParams,
             isSubmitButtonVisible = dropInOverrideParams?.isSubmitButtonVisible
-                ?: bcmcConfiguration?.isSubmitButtonVisible ?: true,
+                ?: bcmcConfiguration?.isSubmitButtonVisible
+                ?: checkoutConfiguration.isSubmitButtonVisible
+                ?: true,
             isHolderNameRequired = bcmcConfiguration?.isHolderNameRequired ?: false,
             shopperReference = bcmcConfiguration?.shopperReference,
             isStorePaymentFieldVisible = getStorePaymentFieldVisible(sessionParams, bcmcConfiguration),

--- a/bcmc/src/test/java/com/adyen/checkout/bcmc/internal/ui/model/BcmcComponentParamsMapperTest.kt
+++ b/bcmc/src/test/java/com/adyen/checkout/bcmc/internal/ui/model/BcmcComponentParamsMapperTest.kt
@@ -142,6 +142,27 @@ internal class BcmcComponentParamsMapperTest {
         assertEquals(true, params.isSubmitButtonVisible)
     }
 
+    @Test
+    fun `when setSubmitButtonVisible is not set in bcmc component configuration and checkout configuration does set it, then it should follow that`() {
+        val configuration = CheckoutConfiguration(
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+            isSubmitButtonVisible = false,
+        ) {
+            bcmc { }
+        }
+
+        val params = bcmcComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+            paymentMethod = PaymentMethod(),
+        )
+
+        assertEquals(false, params.isSubmitButtonVisible)
+    }
+
     @ParameterizedTest
     @MethodSource("enableStoreDetailsSource")
     @Suppress("MaxLineLength")

--- a/blik/src/main/java/com/adyen/checkout/blik/BlikConfiguration.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/BlikConfiguration.kt
@@ -123,6 +123,7 @@ fun CheckoutConfiguration.blik(
             shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+            isSubmitButtonVisible?.let { setSubmitButtonVisible(it) }
         }
         .apply(configuration)
         .build()
@@ -141,6 +142,7 @@ internal fun BlikConfiguration.toCheckoutConfiguration(): CheckoutConfiguration 
         clientKey = clientKey,
         amount = amount,
         analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = isSubmitButtonVisible,
     ) {
         addConfiguration(PaymentMethodTypes.BLIK, this@toCheckoutConfiguration)
 

--- a/boleto/src/main/java/com/adyen/checkout/boleto/BoletoConfiguration.kt
+++ b/boleto/src/main/java/com/adyen/checkout/boleto/BoletoConfiguration.kt
@@ -134,6 +134,7 @@ fun CheckoutConfiguration.boleto(
             shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+            isSubmitButtonVisible?.let { setSubmitButtonVisible(it) }
         }
         .apply(configuration)
         .build()
@@ -158,6 +159,7 @@ internal fun BoletoConfiguration.toCheckoutConfiguration(): CheckoutConfiguratio
         clientKey = clientKey,
         amount = amount,
         analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = isSubmitButtonVisible,
     ) {
         BoletoComponent.PAYMENT_METHOD_TYPES.forEach { key ->
             addConfiguration(key, this@toCheckoutConfiguration)

--- a/boleto/src/main/java/com/adyen/checkout/boleto/internal/ui/model/BoletoComponentParamsMapper.kt
+++ b/boleto/src/main/java/com/adyen/checkout/boleto/internal/ui/model/BoletoComponentParamsMapper.kt
@@ -38,7 +38,9 @@ internal class BoletoComponentParamsMapper(
         return BoletoComponentParams(
             commonComponentParams = commonComponentParams,
             isSubmitButtonVisible = dropInOverrideParams?.isSubmitButtonVisible
-                ?: boletoConfiguration?.isSubmitButtonVisible ?: true,
+                ?: boletoConfiguration?.isSubmitButtonVisible
+                ?: checkoutConfiguration.isSubmitButtonVisible
+                ?: true,
             addressParams = AddressParams.FullAddress(
                 defaultCountryCode = BRAZIL_COUNTRY_CODE,
                 supportedCountryCodes = DEFAULT_SUPPORTED_COUNTRY_LIST,

--- a/boleto/src/test/java/com/adyen/checkout/boleto/internal/ui/model/BoletoComponentParamsMapperTest.kt
+++ b/boleto/src/test/java/com/adyen/checkout/boleto/internal/ui/model/BoletoComponentParamsMapperTest.kt
@@ -122,6 +122,21 @@ internal class BoletoComponentParamsMapperTest {
     }
 
     @Test
+    fun `when setSubmitButtonVisible is not set in boleto component configuration and checkout configuration does set it, then it should follow that`() {
+        val configuration = CheckoutConfiguration(
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+            isSubmitButtonVisible = false,
+        ) {
+            boleto { }
+        }
+
+        val params = mapParams(configuration = configuration)
+
+        assertEquals(false, params.isSubmitButtonVisible)
+    }
+
+    @Test
     fun `when send email is set, them params should match`() {
         val configuration = createCheckoutConfiguration {
             setEmailVisibility(true)

--- a/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
@@ -323,6 +323,7 @@ fun CheckoutConfiguration.card(
             shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+            isSubmitButtonVisible?.let { setSubmitButtonVisible(it) }
         }
         .apply(configuration)
         .build()
@@ -341,6 +342,7 @@ internal fun CardConfiguration.toCheckoutConfiguration(): CheckoutConfiguration 
         clientKey = clientKey,
         amount = amount,
         analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = isSubmitButtonVisible,
     ) {
         addConfiguration(PaymentMethodTypes.SCHEME, this@toCheckoutConfiguration)
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapper.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapper.kt
@@ -86,21 +86,26 @@ internal class CardComponentParamsMapper(
             dropInOverrideParams,
             cardConfiguration,
             paymentMethod,
+            checkoutConfiguration,
         )
     }
 
+    @Suppress("LongParameterList")
     private fun mapToParams(
         commonComponentParams: CommonComponentParams,
         sessionParams: SessionParams?,
         dropInOverrideParams: DropInOverrideParams?,
         cardConfiguration: CardConfiguration?,
         paymentMethod: PaymentMethod?,
+        checkoutConfiguration: CheckoutConfiguration,
     ): CardComponentParams {
         return CardComponentParams(
             commonComponentParams = commonComponentParams,
             isHolderNameRequired = cardConfiguration?.isHolderNameRequired ?: false,
             isSubmitButtonVisible = dropInOverrideParams?.isSubmitButtonVisible
-                ?: cardConfiguration?.isSubmitButtonVisible ?: true,
+                ?: cardConfiguration?.isSubmitButtonVisible
+                ?: checkoutConfiguration.isSubmitButtonVisible
+                ?: true,
             supportedCardBrands = getSupportedCardBrands(cardConfiguration, paymentMethod),
             shopperReference = cardConfiguration?.shopperReference,
             isStorePaymentFieldVisible = getStorePaymentFieldVisible(sessionParams, cardConfiguration),

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapperTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapperTest.kt
@@ -197,6 +197,27 @@ internal class CardComponentParamsMapperTest {
     }
 
     @Test
+    fun `when setSubmitButtonVisible is not set in card component configuration and checkout configuration does set it, then it should follow that`() {
+        val configuration = CheckoutConfiguration(
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+            isSubmitButtonVisible = false,
+        ) {
+            card { }
+        }
+
+        val params = cardComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+            paymentMethod = PaymentMethod(),
+        )
+
+        assertEquals(false, params.isSubmitButtonVisible)
+    }
+
+    @Test
     fun `when supported card types are set in the card configuration then they should be used in the params`() {
         val configuration = createCheckoutConfiguration {
             setSupportedCardTypes(CardType.MAESTRO, CardType.BCMC)

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/CashAppPayConfiguration.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/CashAppPayConfiguration.kt
@@ -192,6 +192,7 @@ fun CheckoutConfiguration.cashAppPay(
             shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+            isSubmitButtonVisible?.let { setSubmitButtonVisible(it) }
         }
         .apply(configuration)
         .build()
@@ -210,6 +211,7 @@ internal fun CashAppPayConfiguration.toCheckoutConfiguration(): CheckoutConfigur
         clientKey = clientKey,
         amount = amount,
         analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = isSubmitButtonVisible,
     ) {
         addConfiguration(PaymentMethodTypes.CASH_APP_PAY, this@toCheckoutConfiguration)
 

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/model/CashAppPayComponentParamsMapper.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/model/CashAppPayComponentParamsMapper.kt
@@ -62,6 +62,7 @@ internal class CashAppPayComponentParamsMapper(
             clientId = clientId,
             scopeId = scopeId,
             context = context,
+            checkoutConfiguration = checkoutConfiguration,
         )
 
         if (params.returnUrl == null) {
@@ -99,6 +100,7 @@ internal class CashAppPayComponentParamsMapper(
             clientId = null,
             scopeId = null,
             context = context,
+            checkoutConfiguration = checkoutConfiguration,
         )
     }
 
@@ -111,11 +113,14 @@ internal class CashAppPayComponentParamsMapper(
         clientId: String?,
         scopeId: String?,
         context: Context,
+        checkoutConfiguration: CheckoutConfiguration,
     ): CashAppPayComponentParams {
         return CashAppPayComponentParams(
             commonComponentParams = commonComponentParams,
             isSubmitButtonVisible = dropInOverrideParams?.isSubmitButtonVisible
-                ?: cashAppPayConfiguration?.isSubmitButtonVisible ?: true,
+                ?: cashAppPayConfiguration?.isSubmitButtonVisible
+                ?: checkoutConfiguration.isSubmitButtonVisible
+                ?: true,
             cashAppPayEnvironment = getCashAppPayEnvironment(
                 commonComponentParams.environment,
                 cashAppPayConfiguration,

--- a/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/model/CashAppPayComponentParamsMapperTest.kt
+++ b/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/model/CashAppPayComponentParamsMapperTest.kt
@@ -180,6 +180,30 @@ internal class CashAppPayComponentParamsMapperTest {
         assertEquals(true, params.isSubmitButtonVisible)
     }
 
+    @Test
+    fun `when setSubmitButtonVisible is not set in cash app component configuration and checkout configuration does set it, then it should follow that`() {
+        val configuration = CheckoutConfiguration(
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+            isSubmitButtonVisible = false,
+        ) {
+            cashAppPay {
+                setReturnUrl(TEST_RETURN_URL)
+            }
+        }
+
+        val params = cashAppPayComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+            paymentMethod = getDefaultPaymentMethod(),
+            context = Application(),
+        )
+
+        assertEquals(false, params.isSubmitButtonVisible)
+    }
+
     @ParameterizedTest
     @MethodSource("enableStoreDetailsSource")
     fun `showStorePaymentField should match value set in sessions if it exists, otherwise should match configuration`(

--- a/components-core/api/components-core.api
+++ b/components-core/api/components-core.api
@@ -288,6 +288,8 @@ public final class com/adyen/checkout/components/core/CheckoutConfiguration : co
 	public synthetic fun <init> (Landroid/os/Parcel;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lcom/adyen/checkout/core/Environment;Ljava/lang/String;Ljava/util/Locale;Lcom/adyen/checkout/components/core/Amount;Lcom/adyen/checkout/components/core/AnalyticsConfiguration;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (Lcom/adyen/checkout/core/Environment;Ljava/lang/String;Ljava/util/Locale;Lcom/adyen/checkout/components/core/Amount;Lcom/adyen/checkout/components/core/AnalyticsConfiguration;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/adyen/checkout/core/Environment;Ljava/lang/String;Ljava/util/Locale;Lcom/adyen/checkout/components/core/Amount;Lcom/adyen/checkout/components/core/AnalyticsConfiguration;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lcom/adyen/checkout/core/Environment;Ljava/lang/String;Ljava/util/Locale;Lcom/adyen/checkout/components/core/Amount;Lcom/adyen/checkout/components/core/AnalyticsConfiguration;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun describeContents ()I
 	public fun getAmount ()Lcom/adyen/checkout/components/core/Amount;
 	public fun getAnalyticsConfiguration ()Lcom/adyen/checkout/components/core/AnalyticsConfiguration;

--- a/components-core/api/components-core.api
+++ b/components-core/api/components-core.api
@@ -286,14 +286,15 @@ public final class com/adyen/checkout/components/core/BuildConfig {
 public final class com/adyen/checkout/components/core/CheckoutConfiguration : com/adyen/checkout/components/core/internal/Configuration {
 	public static final field CREATOR Lcom/adyen/checkout/components/core/CheckoutConfiguration$CREATOR;
 	public synthetic fun <init> (Landroid/os/Parcel;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Lcom/adyen/checkout/core/Environment;Ljava/lang/String;Ljava/util/Locale;Lcom/adyen/checkout/components/core/Amount;Lcom/adyen/checkout/components/core/AnalyticsConfiguration;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Lcom/adyen/checkout/core/Environment;Ljava/lang/String;Ljava/util/Locale;Lcom/adyen/checkout/components/core/Amount;Lcom/adyen/checkout/components/core/AnalyticsConfiguration;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/adyen/checkout/core/Environment;Ljava/lang/String;Ljava/util/Locale;Lcom/adyen/checkout/components/core/Amount;Lcom/adyen/checkout/components/core/AnalyticsConfiguration;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lcom/adyen/checkout/core/Environment;Ljava/lang/String;Ljava/util/Locale;Lcom/adyen/checkout/components/core/Amount;Lcom/adyen/checkout/components/core/AnalyticsConfiguration;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun describeContents ()I
 	public fun getAmount ()Lcom/adyen/checkout/components/core/Amount;
 	public fun getAnalyticsConfiguration ()Lcom/adyen/checkout/components/core/AnalyticsConfiguration;
 	public fun getClientKey ()Ljava/lang/String;
 	public fun getEnvironment ()Lcom/adyen/checkout/core/Environment;
 	public fun getShopperLocale ()Ljava/util/Locale;
+	public final fun isSubmitButtonVisible ()Ljava/lang/Boolean;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 

--- a/components-core/src/main/java/com/adyen/checkout/components/core/CheckoutConfiguration.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/CheckoutConfiguration.kt
@@ -110,7 +110,7 @@ class CheckoutConfiguration(
         clientKey = requireNotNull(parcel.readString()),
         amount = parcel.readParcelable(Amount::class.java.classLoader),
         analyticsConfiguration = parcel.readParcelable(AnalyticsConfiguration::class.java.classLoader),
-        isSubmitButtonVisible = parcel.readSerializable() as? Boolean?,
+        isSubmitButtonVisible = parcel.readValue(null) as? Boolean?,
     ) {
         val size = parcel.readInt()
 
@@ -152,7 +152,7 @@ class CheckoutConfiguration(
         dest.writeString(clientKey)
         dest.writeParcelable(amount, flags)
         dest.writeParcelable(analyticsConfiguration, flags)
-        dest.writeSerializable(isSubmitButtonVisible)
+        dest.writeValue(isSubmitButtonVisible)
         dest.writeInt(availableConfigurations.size)
         availableConfigurations.forEach {
             dest.writeString(it.key)

--- a/components-core/src/main/java/com/adyen/checkout/components/core/CheckoutConfiguration.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/CheckoutConfiguration.kt
@@ -74,6 +74,23 @@ class CheckoutConfiguration(
         validateContents()
     }
 
+    constructor(
+        environment: Environment,
+        clientKey: String,
+        shopperLocale: Locale? = null,
+        amount: Amount? = null,
+        analyticsConfiguration: AnalyticsConfiguration? = null,
+        configurationBlock: CheckoutConfiguration.() -> Unit = {},
+    ) : this(
+        environment = environment,
+        clientKey = clientKey,
+        shopperLocale = shopperLocale,
+        amount = amount,
+        analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = null,
+        configurationBlock = configurationBlock,
+    )
+
     private fun validateContents() {
         shopperLocale?.let {
             if (!LocaleUtil.isValidLocale(it)) {

--- a/components-core/src/main/java/com/adyen/checkout/components/core/CheckoutConfiguration.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/CheckoutConfiguration.kt
@@ -51,8 +51,10 @@ import java.util.Locale
  * [Sessions API documentation](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions) on how to set this
  * value.
  * @param analyticsConfiguration A configuration for the internal analytics of the library.
+ * @param isSubmitButtonVisible Sets if submit button will be visible or not. In drop-in, this setting will be ignored.
  * @param configurationBlock A block that allows adding drop-in or payment method specific configurations.
  */
+@Suppress("LongParameterList")
 @CheckoutConfigurationMarker
 class CheckoutConfiguration(
     override val environment: Environment,
@@ -60,6 +62,7 @@ class CheckoutConfiguration(
     override val shopperLocale: Locale? = null,
     override val amount: Amount? = null,
     override val analyticsConfiguration: AnalyticsConfiguration? = null,
+    val isSubmitButtonVisible: Boolean? = null,
     @IgnoredOnParcel
     private val configurationBlock: CheckoutConfiguration.() -> Unit = {},
 ) : Configuration {
@@ -90,6 +93,7 @@ class CheckoutConfiguration(
         clientKey = requireNotNull(parcel.readString()),
         amount = parcel.readParcelable(Amount::class.java.classLoader),
         analyticsConfiguration = parcel.readParcelable(AnalyticsConfiguration::class.java.classLoader),
+        isSubmitButtonVisible = parcel.readSerializable() as? Boolean?,
     ) {
         val size = parcel.readInt()
 
@@ -131,6 +135,7 @@ class CheckoutConfiguration(
         dest.writeString(clientKey)
         dest.writeParcelable(amount, flags)
         dest.writeParcelable(analyticsConfiguration, flags)
+        dest.writeSerializable(isSubmitButtonVisible)
         dest.writeInt(availableConfigurations.size)
         availableConfigurations.forEach {
             dest.writeString(it.key)

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/ButtonComponentParamsMapper.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/ui/model/ButtonComponentParamsMapper.kt
@@ -28,7 +28,9 @@ class ButtonComponentParamsMapper(
         return ButtonComponentParams(
             commonComponentParams = commonComponentParams,
             isSubmitButtonVisible = dropInOverrideParams?.isSubmitButtonVisible
-                ?: (componentConfiguration as? ButtonConfiguration)?.isSubmitButtonVisible ?: true,
+                ?: (componentConfiguration as? ButtonConfiguration)?.isSubmitButtonVisible
+                ?: checkoutConfiguration.isSubmitButtonVisible
+                ?: true,
         )
     }
 }

--- a/components-core/src/test/java/com/adyen/checkout/components/core/CheckoutConfigurationTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/CheckoutConfigurationTest.kt
@@ -22,6 +22,7 @@ internal class CheckoutConfigurationTest {
             clientKey = TEST_CLIENT_KEY,
             amount = Amount("EUR", 123L),
             analyticsConfiguration = AnalyticsConfiguration(AnalyticsLevel.ALL),
+            isSubmitButtonVisible = true,
         ) {
             addConfiguration(TEST_CONFIGURATION_KEY, testConfiguration)
             addActionConfiguration(testActionConfiguration)

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/ui/model/ButtonComponentParamsMapperTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/ui/model/ButtonComponentParamsMapperTest.kt
@@ -102,6 +102,29 @@ internal class ButtonComponentParamsMapperTest {
         assertEquals(true, params.isSubmitButtonVisible)
     }
 
+    @Test
+    fun `when setSubmitButtonVisible is not set in button component configuration and checkout configuration does set it, then it should follow that`() {
+        val configuration = CheckoutConfiguration(
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+            isSubmitButtonVisible = false,
+        ) {
+            val testConfiguration = ButtonTestConfiguration.Builder(Locale.CANADA, Environment.TEST, TEST_CLIENT_KEY_1)
+                .build()
+            addConfiguration(TEST_CONFIGURATION_KEY, testConfiguration)
+        }
+
+        val params = buttonComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+            componentConfiguration = configuration.getConfiguration(TEST_CONFIGURATION_KEY),
+        )
+
+        assertEquals(false, params.isSubmitButtonVisible)
+    }
+
     @ParameterizedTest
     @MethodSource("amountSource")
     fun `amount should match value set in sessions then drop in then component configuration`(

--- a/convenience-stores-jp/src/main/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPConfiguration.kt
+++ b/convenience-stores-jp/src/main/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPConfiguration.kt
@@ -105,6 +105,7 @@ fun CheckoutConfiguration.convenienceStoresJP(
             shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+            isSubmitButtonVisible?.let { setSubmitButtonVisible(it) }
         }
         .apply(configuration)
         .build()
@@ -123,6 +124,7 @@ internal fun ConvenienceStoresJPConfiguration.toCheckoutConfiguration(): Checkou
         clientKey = clientKey,
         amount = amount,
         analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = isSubmitButtonVisible,
     ) {
         addConfiguration(PaymentMethodTypes.ECONTEXT_STORES, this@toCheckoutConfiguration)
 

--- a/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayConfiguration.kt
+++ b/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayConfiguration.kt
@@ -109,6 +109,7 @@ fun CheckoutConfiguration.dotpay(
             shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+            isSubmitButtonVisible?.let { setSubmitButtonVisible(it) }
         }
         .apply(configuration)
         .build()
@@ -127,6 +128,7 @@ internal fun DotpayConfiguration.toCheckoutConfiguration(): CheckoutConfiguratio
         clientKey = clientKey,
         amount = amount,
         analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = isSubmitButtonVisible,
     ) {
         addConfiguration(PaymentMethodTypes.DOTPAY, this@toCheckoutConfiguration)
 

--- a/entercash/src/main/java/com/adyen/checkout/entercash/EntercashConfiguration.kt
+++ b/entercash/src/main/java/com/adyen/checkout/entercash/EntercashConfiguration.kt
@@ -109,6 +109,7 @@ fun CheckoutConfiguration.entercash(
             shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+            isSubmitButtonVisible?.let { setSubmitButtonVisible(it) }
         }
         .apply(configuration)
         .build()
@@ -127,6 +128,7 @@ internal fun EntercashConfiguration.toCheckoutConfiguration(): CheckoutConfigura
         clientKey = clientKey,
         amount = amount,
         analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = isSubmitButtonVisible,
     ) {
         addConfiguration(PaymentMethodTypes.ENTERCASH, this@toCheckoutConfiguration)
 

--- a/eps/src/main/java/com/adyen/checkout/eps/EPSConfiguration.kt
+++ b/eps/src/main/java/com/adyen/checkout/eps/EPSConfiguration.kt
@@ -120,6 +120,7 @@ fun CheckoutConfiguration.eps(
             shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+            isSubmitButtonVisible?.let { setSubmitButtonVisible(it) }
         }
         .apply(configuration)
         .build()
@@ -138,6 +139,7 @@ internal fun EPSConfiguration.toCheckoutConfiguration(): CheckoutConfiguration {
         clientKey = clientKey,
         amount = amount,
         analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = isSubmitButtonVisible,
     ) {
         addConfiguration(PaymentMethodTypes.EPS, this@toCheckoutConfiguration)
 

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardConfiguration.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardConfiguration.kt
@@ -139,6 +139,7 @@ fun CheckoutConfiguration.giftCard(
             shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+            isSubmitButtonVisible?.let { setSubmitButtonVisible(it) }
         }
         .apply(configuration)
         .build()
@@ -157,6 +158,7 @@ internal fun GiftCardConfiguration.toCheckoutConfiguration(): CheckoutConfigurat
         clientKey = clientKey,
         amount = amount,
         analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = isSubmitButtonVisible,
     ) {
         addConfiguration(PaymentMethodTypes.GIFTCARD, this@toCheckoutConfiguration)
 

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/ui/model/GiftCardComponentParamsMapper.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/ui/model/GiftCardComponentParamsMapper.kt
@@ -36,7 +36,9 @@ internal class GiftCardComponentParamsMapper(
         return GiftCardComponentParams(
             commonComponentParams = commonComponentParams,
             isSubmitButtonVisible = dropInOverrideParams?.isSubmitButtonVisible
-                ?: giftCardConfiguration?.isSubmitButtonVisible ?: true,
+                ?: giftCardConfiguration?.isSubmitButtonVisible
+                ?: checkoutConfiguration.isSubmitButtonVisible
+                ?: true,
             isPinRequired = giftCardConfiguration?.isPinRequired ?: true,
             isExpiryDateRequired = false,
         )

--- a/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/ui/model/GiftCardComponentParamsMapperTest.kt
+++ b/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/ui/model/GiftCardComponentParamsMapperTest.kt
@@ -97,6 +97,21 @@ internal class GiftCardComponentParamsMapperTest {
         assertEquals(true, params.isSubmitButtonVisible)
     }
 
+    @Test
+    fun `when setSubmitButtonVisible is not set in gift card component configuration and checkout configuration does set it, then it should follow that`() {
+        val configuration = CheckoutConfiguration(
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+            isSubmitButtonVisible = false,
+        ) {
+            giftCard { }
+        }
+
+        val params = giftCardComponentParamsMapper.mapToParams(configuration, DEVICE_LOCALE, null, null)
+
+        assertEquals(false, params.isSubmitButtonVisible)
+    }
+
     @ParameterizedTest
     @MethodSource("amountSource")
     fun `amount should match value set in sessions then drop in then component configuration`(
@@ -232,7 +247,7 @@ internal class GiftCardComponentParamsMapperTest {
             ),
             isSubmitButtonVisible = isSubmitButtonVisible,
             isPinRequired = isPinRequired,
-            isExpiryDateRequired = false
+            isExpiryDateRequired = false,
         )
     }
 

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.kt
@@ -461,6 +461,7 @@ fun CheckoutConfiguration.googlePay(
             shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+            isSubmitButtonVisible?.let { setSubmitButtonVisible(it) }
         }
         .apply(configuration)
         .build()
@@ -483,6 +484,7 @@ internal fun GooglePayConfiguration.toCheckoutConfiguration(): CheckoutConfigura
         clientKey = clientKey,
         amount = amount,
         analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = isSubmitButtonVisible,
     ) {
         GooglePayComponent.PAYMENT_METHOD_TYPES.forEach { key ->
             addConfiguration(key, this@toCheckoutConfiguration)

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParamsMapper.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParamsMapper.kt
@@ -49,6 +49,7 @@ internal class GooglePayComponentParamsMapper(
             commonComponentParamsMapperData.commonComponentParams,
             googlePayConfiguration,
             paymentMethod,
+            checkoutConfiguration,
         )
     }
 
@@ -56,11 +57,16 @@ internal class GooglePayComponentParamsMapper(
         commonComponentParams: CommonComponentParams,
         googlePayConfiguration: GooglePayConfiguration?,
         paymentMethod: PaymentMethod,
+        checkoutConfiguration: CheckoutConfiguration,
     ): GooglePayComponentParams {
         return GooglePayComponentParams(
             commonComponentParams = commonComponentParams,
             amount = commonComponentParams.amount ?: DEFAULT_AMOUNT,
-            isSubmitButtonVisible = shouldShowSubmitButton(commonComponentParams, googlePayConfiguration),
+            isSubmitButtonVisible = shouldShowSubmitButton(
+                commonComponentParams,
+                googlePayConfiguration,
+                checkoutConfiguration,
+            ),
             gatewayMerchantId = googlePayConfiguration.getPreferredGatewayMerchantId(paymentMethod),
             allowedAuthMethods = googlePayConfiguration.getAvailableAuthMethods(),
             allowedCardNetworks = googlePayConfiguration.getAvailableCardNetworks(paymentMethod),
@@ -85,12 +91,15 @@ internal class GooglePayComponentParamsMapper(
     private fun shouldShowSubmitButton(
         commonComponentParams: CommonComponentParams,
         googlePayConfiguration: GooglePayConfiguration?,
+        checkoutConfiguration: CheckoutConfiguration,
     ): Boolean {
         return if (commonComponentParams.isCreatedByDropIn) {
             false
         } else {
             // TODO return true by default in v6
-            googlePayConfiguration?.isSubmitButtonVisible ?: false
+            googlePayConfiguration?.isSubmitButtonVisible
+                ?: checkoutConfiguration.isSubmitButtonVisible
+                ?: false
         }
     }
 

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParamsMapperTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParamsMapperTest.kt
@@ -547,17 +547,34 @@ internal class GooglePayComponentParamsMapperTest {
 
             assertFalse(params.isSubmitButtonVisible)
         }
+
+        @Test
+        fun `when only checkout configuration does configure, then it should follow that`() {
+            val configuration = createCheckoutConfiguration(isSubmitButtonVisible = true)
+
+            val params = googlePayComponentParamsMapper.mapToParams(
+                checkoutConfiguration = configuration,
+                deviceLocale = DEVICE_LOCALE,
+                dropInOverrideParams = null,
+                componentSessionParams = null,
+                paymentMethod = PaymentMethod(),
+            )
+
+            assertEquals(true, params.isSubmitButtonVisible)
+        }
     }
 
     private fun createCheckoutConfiguration(
         amount: Amount? = null,
         shopperLocale: Locale? = null,
+        isSubmitButtonVisible: Boolean? = null,
         configuration: GooglePayConfiguration.Builder.() -> Unit = {}
     ) = CheckoutConfiguration(
         shopperLocale = shopperLocale,
         environment = Environment.TEST,
         clientKey = TEST_CLIENT_KEY_1,
         amount = amount,
+        isSubmitButtonVisible = isSubmitButtonVisible,
     ) {
         googlePay {
             setMerchantAccount(TEST_GATEWAY_MERCHANT_ID)

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/ui/model/IssuerListComponentParamsMapper.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/ui/model/IssuerListComponentParamsMapper.kt
@@ -41,7 +41,9 @@ class IssuerListComponentParamsMapper(
         return IssuerListComponentParams(
             commonComponentParams = commonComponentParams,
             isSubmitButtonVisible = dropInOverrideParams?.isSubmitButtonVisible
-                ?: componentConfiguration?.isSubmitButtonVisible ?: true,
+                ?: componentConfiguration?.isSubmitButtonVisible
+                ?: checkoutConfiguration.isSubmitButtonVisible
+                ?: true,
             viewType = componentConfiguration?.viewType ?: IssuerListViewType.RECYCLER_VIEW,
             hideIssuerLogos = componentConfiguration?.hideIssuerLogos ?: hideIssuerLogosDefaultValue,
         )

--- a/issuer-list/src/test/java/com/adyen/checkout/issuerlist/internal/ui/model/IssuerListComponentParamsMapperTest.kt
+++ b/issuer-list/src/test/java/com/adyen/checkout/issuerlist/internal/ui/model/IssuerListComponentParamsMapperTest.kt
@@ -157,6 +157,30 @@ internal class IssuerListComponentParamsMapperTest {
         assertEquals(true, params.isSubmitButtonVisible)
     }
 
+    @Test
+    fun `when setSubmitButtonVisible is not set in issuer component configuration and checkout configuration does set it, then it should follow that`() {
+        val configuration = CheckoutConfiguration(
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+            isSubmitButtonVisible = false,
+        ) {
+            val issuerListConfiguration = TestIssuerListConfiguration.Builder(shopperLocale, environment, clientKey)
+                .build()
+            addConfiguration(TEST_CONFIGURATION_KEY, issuerListConfiguration)
+        }
+
+        val params = issuerListComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+            componentConfiguration = configuration.getConfiguration(TEST_CONFIGURATION_KEY),
+            hideIssuerLogosDefaultValue = false,
+        )
+
+        assertEquals(false, params.isSubmitButtonVisible)
+    }
+
     @ParameterizedTest
     @MethodSource("amountSource")
     fun `amount should match value set in sessions then drop in then component configuration`(

--- a/mbway/src/main/java/com/adyen/checkout/mbway/MBWayConfiguration.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/MBWayConfiguration.kt
@@ -123,6 +123,7 @@ fun CheckoutConfiguration.mbWay(
             shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+            isSubmitButtonVisible?.let { setSubmitButtonVisible(it) }
         }
         .apply(configuration)
         .build()
@@ -141,6 +142,7 @@ internal fun MBWayConfiguration.toCheckoutConfiguration(): CheckoutConfiguration
         clientKey = clientKey,
         amount = amount,
         analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = isSubmitButtonVisible,
     ) {
         addConfiguration(PaymentMethodTypes.MB_WAY, this@toCheckoutConfiguration)
 

--- a/meal-voucher-fr/src/main/java/com/adyen/checkout/mealvoucherfr/MealVoucherFRConfiguration.kt
+++ b/meal-voucher-fr/src/main/java/com/adyen/checkout/mealvoucherfr/MealVoucherFRConfiguration.kt
@@ -139,6 +139,7 @@ fun CheckoutConfiguration.mealVoucherFR(
             shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+            isSubmitButtonVisible?.let { setSubmitButtonVisible(it) }
         }
         .apply(configuration)
         .build()
@@ -163,6 +164,7 @@ internal fun MealVoucherFRConfiguration.toCheckoutConfiguration(): CheckoutConfi
         clientKey = clientKey,
         amount = amount,
         analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = isSubmitButtonVisible,
     ) {
         MealVoucherFRComponent.PAYMENT_METHOD_TYPES.forEach { key ->
             addConfiguration(key, this@toCheckoutConfiguration)

--- a/meal-voucher-fr/src/main/java/com/adyen/checkout/mealvoucherfr/internal/ui/model/MealVoucherFRComponentParamsMapper.kt
+++ b/meal-voucher-fr/src/main/java/com/adyen/checkout/mealvoucherfr/internal/ui/model/MealVoucherFRComponentParamsMapper.kt
@@ -37,7 +37,9 @@ internal class MealVoucherFRComponentParamsMapper(
         return GiftCardComponentParams(
             commonComponentParams = commonComponentParams,
             isSubmitButtonVisible = dropInOverrideParams?.isSubmitButtonVisible
-                ?: mealVoucherFRConfiguration?.isSubmitButtonVisible ?: true,
+                ?: mealVoucherFRConfiguration?.isSubmitButtonVisible
+                ?: checkoutConfiguration.isSubmitButtonVisible
+                ?: true,
             isPinRequired = mealVoucherFRConfiguration?.isSecurityCodeRequired ?: true,
             isExpiryDateRequired = true,
         )

--- a/meal-voucher-fr/src/test/java/com/adyen/checkout/mealvoucherfr/internal/ui/model/MealVoucherFRComponentParamsMapperTest.kt
+++ b/meal-voucher-fr/src/test/java/com/adyen/checkout/mealvoucherfr/internal/ui/model/MealVoucherFRComponentParamsMapperTest.kt
@@ -108,6 +108,26 @@ internal class MealVoucherFRComponentParamsMapperTest {
         assertEquals(true, params.isSubmitButtonVisible)
     }
 
+    @Test
+    fun `when setSubmitButtonVisible is not set in meal vouchers component configuration and checkout configuration does set it, then it should follow that`() {
+        val configuration = CheckoutConfiguration(
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+            isSubmitButtonVisible = false,
+        ) {
+            mealVoucherFR { }
+        }
+
+        val params = mealVoucherFRComponentParamsMapper.mapToParams(
+            checkoutConfiguration = configuration,
+            deviceLocale = DEVICE_LOCALE,
+            dropInOverrideParams = null,
+            componentSessionParams = null,
+        )
+
+        assertEquals(false, params.isSubmitButtonVisible)
+    }
+
     @ParameterizedTest
     @MethodSource("amountSource")
     fun `amount should match value set in sessions then drop in then component configuration`(

--- a/molpay/src/main/java/com/adyen/checkout/molpay/MolpayConfiguration.kt
+++ b/molpay/src/main/java/com/adyen/checkout/molpay/MolpayConfiguration.kt
@@ -108,6 +108,7 @@ fun CheckoutConfiguration.molpay(
             shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+            isSubmitButtonVisible?.let { setSubmitButtonVisible(it) }
         }
         .apply(configuration)
         .build()
@@ -132,6 +133,7 @@ internal fun MolpayConfiguration.toCheckoutConfiguration(): CheckoutConfiguratio
         clientKey = clientKey,
         amount = amount,
         analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = isSubmitButtonVisible,
     ) {
         MolpayComponent.PAYMENT_METHOD_TYPES.forEach { key ->
             addConfiguration(key, this@toCheckoutConfiguration)

--- a/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZConfiguration.kt
+++ b/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZConfiguration.kt
@@ -105,6 +105,7 @@ fun CheckoutConfiguration.onlineBankingCZ(
             shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+            isSubmitButtonVisible?.let { setSubmitButtonVisible(it) }
         }
         .apply(configuration)
         .build()
@@ -123,6 +124,7 @@ internal fun OnlineBankingCZConfiguration.toCheckoutConfiguration(): CheckoutCon
         clientKey = clientKey,
         amount = amount,
         analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = isSubmitButtonVisible,
     ) {
         addConfiguration(PaymentMethodTypes.ONLINE_BANKING_CZ, this@toCheckoutConfiguration)
 

--- a/online-banking-jp/src/main/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPConfiguration.kt
+++ b/online-banking-jp/src/main/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPConfiguration.kt
@@ -105,6 +105,7 @@ fun CheckoutConfiguration.onlineBankingJP(
             shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+            isSubmitButtonVisible?.let { setSubmitButtonVisible(it) }
         }
         .apply(configuration)
         .build()
@@ -123,6 +124,7 @@ internal fun OnlineBankingJPConfiguration.toCheckoutConfiguration(): CheckoutCon
         clientKey = clientKey,
         amount = amount,
         analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = isSubmitButtonVisible,
     ) {
         addConfiguration(PaymentMethodTypes.ECONTEXT_ONLINE, this@toCheckoutConfiguration)
 

--- a/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLConfiguration.kt
+++ b/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLConfiguration.kt
@@ -110,6 +110,7 @@ fun CheckoutConfiguration.onlineBankingPL(
             shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+            isSubmitButtonVisible?.let { setSubmitButtonVisible(it) }
         }
         .apply(configuration)
         .build()
@@ -128,6 +129,7 @@ internal fun OnlineBankingPLConfiguration.toCheckoutConfiguration(): CheckoutCon
         clientKey = clientKey,
         amount = amount,
         analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = isSubmitButtonVisible,
     ) {
         addConfiguration(PaymentMethodTypes.ONLINE_BANKING_PL, this@toCheckoutConfiguration)
 

--- a/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKConfiguration.kt
+++ b/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKConfiguration.kt
@@ -105,6 +105,7 @@ fun CheckoutConfiguration.onlineBankingSK(
             shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+            isSubmitButtonVisible?.let { setSubmitButtonVisible(it) }
         }
         .apply(configuration)
         .build()
@@ -123,6 +124,7 @@ internal fun OnlineBankingSKConfiguration.toCheckoutConfiguration(): CheckoutCon
         clientKey = clientKey,
         amount = amount,
         analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = isSubmitButtonVisible,
     ) {
         addConfiguration(PaymentMethodTypes.ONLINE_BANKING_SK, this@toCheckoutConfiguration)
 

--- a/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingConfiguration.kt
+++ b/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingConfiguration.kt
@@ -109,6 +109,7 @@ fun CheckoutConfiguration.openBanking(
             shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+            isSubmitButtonVisible?.let { setSubmitButtonVisible(it) }
         }
         .apply(configuration)
         .build()
@@ -127,6 +128,7 @@ internal fun OpenBankingConfiguration.toCheckoutConfiguration(): CheckoutConfigu
         clientKey = clientKey,
         amount = amount,
         analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = isSubmitButtonVisible,
     ) {
         addConfiguration(PaymentMethodTypes.OPEN_BANKING, this@toCheckoutConfiguration)
 

--- a/payeasy/src/main/java/com/adyen/checkout/payeasy/PayEasyConfiguration.kt
+++ b/payeasy/src/main/java/com/adyen/checkout/payeasy/PayEasyConfiguration.kt
@@ -105,6 +105,7 @@ fun CheckoutConfiguration.payEasy(
             shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+            isSubmitButtonVisible?.let { setSubmitButtonVisible(it) }
         }
         .apply(configuration)
         .build()
@@ -123,6 +124,7 @@ internal fun PayEasyConfiguration.toCheckoutConfiguration(): CheckoutConfigurati
         clientKey = clientKey,
         amount = amount,
         analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = isSubmitButtonVisible,
     ) {
         addConfiguration(PaymentMethodTypes.ECONTEXT_ATM, this@toCheckoutConfiguration)
 

--- a/payto/src/main/java/com/adyen/checkout/payto/PayToConfiguration.kt
+++ b/payto/src/main/java/com/adyen/checkout/payto/PayToConfiguration.kt
@@ -124,6 +124,7 @@ fun CheckoutConfiguration.payTo(
             shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+            isSubmitButtonVisible?.let { setSubmitButtonVisible(it) }
         }
         .apply(configuration)
         .build()
@@ -142,6 +143,7 @@ internal fun PayToConfiguration.toCheckoutConfiguration(): CheckoutConfiguration
         clientKey = clientKey,
         amount = amount,
         analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = isSubmitButtonVisible,
     ) {
         addConfiguration(PaymentMethodTypes.PAY_TO, this@toCheckoutConfiguration)
 

--- a/sepa/src/main/java/com/adyen/checkout/sepa/SepaConfiguration.kt
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/SepaConfiguration.kt
@@ -123,6 +123,7 @@ fun CheckoutConfiguration.sepa(
             shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+            isSubmitButtonVisible?.let { setSubmitButtonVisible(it) }
         }
         .apply(configuration)
         .build()
@@ -141,6 +142,7 @@ internal fun SepaConfiguration.toCheckoutConfiguration(): CheckoutConfiguration 
         clientKey = clientKey,
         amount = amount,
         analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = isSubmitButtonVisible,
     ) {
         addConfiguration(PaymentMethodTypes.SEPA, this@toCheckoutConfiguration)
 

--- a/seven-eleven/src/main/java/com/adyen/checkout/seveneleven/SevenElevenConfiguration.kt
+++ b/seven-eleven/src/main/java/com/adyen/checkout/seveneleven/SevenElevenConfiguration.kt
@@ -105,6 +105,7 @@ fun CheckoutConfiguration.sevenEleven(
             shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+            isSubmitButtonVisible?.let { setSubmitButtonVisible(it) }
         }
         .apply(configuration)
         .build()
@@ -123,6 +124,7 @@ internal fun SevenElevenConfiguration.toCheckoutConfiguration(): CheckoutConfigu
         clientKey = clientKey,
         amount = amount,
         analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = isSubmitButtonVisible,
     ) {
         addConfiguration(PaymentMethodTypes.ECONTEXT_SEVEN_ELEVEN, this@toCheckoutConfiguration)
 

--- a/twint/src/main/java/com/adyen/checkout/twint/TwintConfiguration.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/TwintConfiguration.kt
@@ -154,6 +154,7 @@ fun CheckoutConfiguration.twint(
             shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+            isSubmitButtonVisible?.let { setSubmitButtonVisible(it) }
         }
         .apply(configuration)
         .build()
@@ -172,6 +173,7 @@ internal fun TwintConfiguration.toCheckoutConfiguration(): CheckoutConfiguration
         clientKey = clientKey,
         amount = amount,
         analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = isSubmitButtonVisible,
     ) {
         addConfiguration(PaymentMethodTypes.TWINT, this@toCheckoutConfiguration)
 

--- a/twint/src/main/java/com/adyen/checkout/twint/internal/ui/model/TwintComponentParamsMapper.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/internal/ui/model/TwintComponentParamsMapper.kt
@@ -42,6 +42,7 @@ internal class TwintComponentParamsMapper(
             sessionParams = commonComponentParamsMapperData.sessionParams,
             dropInOverrideParams = dropInOverrideParams,
             twintConfiguration = twintConfiguration,
+            checkoutConfiguration = checkoutConfiguration,
         )
     }
 
@@ -50,11 +51,14 @@ internal class TwintComponentParamsMapper(
         sessionParams: SessionParams?,
         dropInOverrideParams: DropInOverrideParams?,
         twintConfiguration: TwintConfiguration?,
+        checkoutConfiguration: CheckoutConfiguration,
     ): TwintComponentParams {
         return TwintComponentParams(
             commonComponentParams = commonComponentParams,
             isSubmitButtonVisible = dropInOverrideParams?.isSubmitButtonVisible
-                ?: twintConfiguration?.isSubmitButtonVisible ?: true,
+                ?: twintConfiguration?.isSubmitButtonVisible
+                ?: checkoutConfiguration.isSubmitButtonVisible
+                ?: true,
             showStorePaymentField = getShowStorePaymentField(sessionParams, twintConfiguration),
             actionHandlingMethod = twintConfiguration?.actionHandlingMethod ?: ActionHandlingMethod.PREFER_NATIVE,
         )

--- a/twint/src/test/java/com/adyen/checkout/twint/internal/ui/model/TwintComponentParamsMapperTest.kt
+++ b/twint/src/test/java/com/adyen/checkout/twint/internal/ui/model/TwintComponentParamsMapperTest.kt
@@ -148,6 +148,21 @@ internal class TwintComponentParamsMapperTest {
         assertEquals(true, params.isSubmitButtonVisible)
     }
 
+    @Test
+    fun `when setSubmitButtonVisible is not set in gift card component configuration and checkout configuration does set it, then it should follow that`() {
+        val configuration = CheckoutConfiguration(
+            environment = Environment.EUROPE,
+            clientKey = TEST_CLIENT_KEY_2,
+            isSubmitButtonVisible = false,
+        ) {
+            twint { }
+        }
+
+        val params = twintComponentParamsMapper.mapToParams(configuration, DEVICE_LOCALE, null, null)
+
+        assertEquals(false, params.isSubmitButtonVisible)
+    }
+
     @ParameterizedTest
     @MethodSource("enableStoreDetailsSource")
     fun `showStorePaymentField should match value set in sessions if it exists, otherwise should match configuration`(

--- a/upi/src/main/java/com/adyen/checkout/upi/UPIConfiguration.kt
+++ b/upi/src/main/java/com/adyen/checkout/upi/UPIConfiguration.kt
@@ -121,6 +121,7 @@ fun CheckoutConfiguration.upi(
             shopperLocale?.let { setShopperLocale(it) }
             amount?.let { setAmount(it) }
             analyticsConfiguration?.let { setAnalyticsConfiguration(it) }
+            isSubmitButtonVisible?.let { setSubmitButtonVisible(it) }
         }
         .apply(configuration)
         .build()
@@ -145,6 +146,7 @@ internal fun UPIConfiguration.toCheckoutConfiguration(): CheckoutConfiguration {
         clientKey = clientKey,
         amount = amount,
         analyticsConfiguration = analyticsConfiguration,
+        isSubmitButtonVisible = isSubmitButtonVisible,
     ) {
         UPIComponent.PAYMENT_METHOD_TYPES.forEach { key ->
             addConfiguration(key, this@toCheckoutConfiguration)


### PR DESCRIPTION
## Description
Submit button visibility is now configurable on a global level through `CheckoutConfiguration`. The changes are backwards compatible.

Note: deprecation warning will be added in a follow up PR.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

## Release notes

### Deprecated
- The `setSubmitButtonVisible` method for configuration objects is now deprecated. Instead use `CheckoutConfiguration`:
```kotlin
CheckoutConfiguration(
    ...
    isSubmitButtonVisible = false
) {
    ...
}
```