### PR TITLE
V6 - Thread safety - PaymentMethodProvider

### DIFF
--- a/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentMethodProvider.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentMethodProvider.kt
@@ -9,15 +9,17 @@
 package com.adyen.checkout.core.components.internal
 
 import androidx.annotation.RestrictTo
+import androidx.annotation.VisibleForTesting
 import com.adyen.checkout.core.components.CheckoutConfiguration
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
 import com.adyen.checkout.core.sessions.internal.model.SessionParams
 import kotlinx.coroutines.CoroutineScope
+import java.util.concurrent.ConcurrentHashMap
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 object PaymentMethodProvider {
 
-    private val factories = mutableMapOf<String, PaymentMethodFactory<*, *>>()
+    private val factories = ConcurrentHashMap<String, PaymentMethodFactory<*, *>>()
 
     fun register(
         txVariant: String,
@@ -51,5 +53,21 @@ object PaymentMethodProvider {
             // TODO - Errors Propagation [COSDK-85]. Propagate an initialization error via onError()
             error("Factory for payment method type: $txVariant is not registered.")
         }
+    }
+
+    /**
+     * Clears all registered factories. Should only be used in tests.
+     */
+    @VisibleForTesting
+    internal fun clear() {
+        factories.clear()
+    }
+
+    /**
+     * Returns the number of registered factories. Should only be used in tests.
+     */
+    @VisibleForTesting
+    internal fun getFactoriesCount(): Int {
+        return factories.size
     }
 }

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentMethodProviderTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentMethodProviderTest.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2025 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 18/7/2025.
+ */
+
+package com.adyen.checkout.core.components.internal
+
+import com.adyen.checkout.core.common.Environment
+import com.adyen.checkout.core.components.CheckoutConfiguration
+import com.adyen.checkout.core.components.internal.ui.PaymentComponent
+import com.adyen.checkout.core.components.internal.ui.TestPaymentComponent
+import com.adyen.checkout.core.sessions.internal.model.SessionParams
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.Locale
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+internal class PaymentMethodProviderTest {
+
+    private val component = TestPaymentComponent()
+    private val factory = generateFactory(
+        paymentComponent = component,
+    )
+
+    @Before
+    fun setUp() {
+        PaymentMethodProvider.clear()
+    }
+
+    @Test
+    fun `when register is called concurrently from multiple threads, then provider should not lose any data`() {
+        val threadCount = 10
+        val registrationsPerThread = 100
+        val totalRegistrations = threadCount * registrationsPerThread
+        val executor = Executors.newFixedThreadPool(threadCount)
+
+        // Submit all registration tasks to the thread pool
+        for (i in 0 until totalRegistrations) {
+            executor.submit {
+                PaymentMethodProvider.register("test_method_$i", factory)
+            }
+        }
+
+        // Wait for all tasks to complete
+        executor.shutdown()
+        // Giving it a generous timeout to finish all tasks
+        val completed = executor.awaitTermination(5, TimeUnit.SECONDS)
+        assertTrue("Executor tasks did not complete in time.", completed)
+        assertEquals(totalRegistrations, PaymentMethodProvider.getFactoriesCount())
+    }
+
+    @Test
+    fun `when register is called with an existing txVariant, then the factory is overwritten`() =
+        runTest {
+            val secondaryComponent = TestPaymentComponent()
+            val secondaryFactory = generateFactory(
+                paymentComponent = secondaryComponent,
+            )
+
+            PaymentMethodProvider.register("txVariant", factory)
+            PaymentMethodProvider.register("txVariant", secondaryFactory)
+
+            val actualComponent = PaymentMethodProvider.get(
+                txVariant = "txVariant",
+                coroutineScope = this,
+                checkoutConfiguration = generateCheckoutConfiguration(),
+                componentSessionParams = null,
+            )
+            assertEquals(1, PaymentMethodProvider.getFactoriesCount())
+            assertEquals(secondaryComponent, actualComponent)
+            assertNotSame(component, actualComponent)
+        }
+
+    @Test
+    fun `when register is called for different txVariants, then all factories are stored`() {
+        PaymentMethodProvider.register("txVariant_one", factory)
+        PaymentMethodProvider.register("txVariant_two", factory)
+
+        assertEquals(2, PaymentMethodProvider.getFactoriesCount())
+    }
+
+    @Test
+    fun `when get is called for a registered factory, then the correct component is returned`() =
+        runTest {
+            PaymentMethodProvider.register("txVariant", factory)
+
+            val actualComponent = PaymentMethodProvider.get(
+                txVariant = "txVariant",
+                coroutineScope = this,
+                checkoutConfiguration = generateCheckoutConfiguration(),
+                componentSessionParams = null,
+            )
+            assertEquals(1, PaymentMethodProvider.getFactoriesCount())
+            Assert.assertSame(component, actualComponent)
+        }
+
+    @Test
+    fun `when get is called for an unregistered factory, then an error is thrown`() = runTest {
+        assertThrows<IllegalStateException> {
+            PaymentMethodProvider.get(
+                txVariant = "unregistered_txVariant",
+                coroutineScope = this,
+                checkoutConfiguration = generateCheckoutConfiguration(),
+                componentSessionParams = null,
+            )
+        }
+    }
+
+    @Test
+    fun `when clear is called, then all factories are removed`() {
+        PaymentMethodProvider.register("txVariant_one", factory)
+        PaymentMethodProvider.register("txVariant_two", factory)
+        assertEquals(2, PaymentMethodProvider.getFactoriesCount())
+
+        PaymentMethodProvider.clear()
+
+        assertEquals(0, PaymentMethodProvider.getFactoriesCount())
+    }
+
+    private fun generateFactory(paymentComponent: PaymentComponent<BasePaymentComponentState>) =
+        object :
+            PaymentMethodFactory<BasePaymentComponentState, PaymentComponent<BasePaymentComponentState>> {
+            override fun create(
+                coroutineScope: CoroutineScope,
+                checkoutConfiguration: CheckoutConfiguration,
+                componentSessionParams: SessionParams?
+            ) = paymentComponent
+        }
+
+    private fun generateCheckoutConfiguration() = CheckoutConfiguration(
+        shopperLocale = Locale.US,
+        environment = Environment.TEST,
+        clientKey = "test_key_12345",
+    )
+}

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/ui/TestPaymentComponent.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/ui/TestPaymentComponent.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 18/7/2025.
+ */
+
+package com.adyen.checkout.core.components.internal.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.adyen.checkout.core.components.internal.BasePaymentComponentState
+import com.adyen.checkout.core.components.internal.PaymentComponentEvent
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import java.util.UUID
+
+internal data class TestPaymentComponent(
+    private val id: String = UUID.randomUUID().toString(),
+) : PaymentComponent<BasePaymentComponentState> {
+    override fun submit() {
+        // No-op
+    }
+
+    @Composable
+    override fun ViewFactory(modifier: Modifier) {
+        // No-op
+    }
+
+    override val eventFlow: Flow<PaymentComponentEvent<BasePaymentComponentState>>
+        get() = flowOf()
+}


### PR DESCRIPTION
## Description
In general Initializers should run sequentially, but it is future proof to support thread safety, in case we register factories from a different location or if in the future initializer logic change.
- Added thread safety to the `PaymentMethodProvider`. In a future PR we will add the same for `ActionComponentProvider`.
- Used `ConcurrentHashMap` Java class, since Kotlin does not have an equivalent. As an alternative Kotlin `synchronized(lock)` could be used, but we need to wrap every operation with it, which is more error prone.
- Written tests for `PaymentMethodProvider`, including concurrency operations.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

COSDK-550
