### PR TITLE
v6- Move AdyenLogger to core module

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -171,6 +171,34 @@ public final class com/adyen/checkout/core/analytics/internal/data/remote/model/
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/adyen/checkout/core/common/AdyenLogLevel : java/lang/Enum {
+	public static final field ASSERT Lcom/adyen/checkout/core/common/AdyenLogLevel;
+	public static final field DEBUG Lcom/adyen/checkout/core/common/AdyenLogLevel;
+	public static final field ERROR Lcom/adyen/checkout/core/common/AdyenLogLevel;
+	public static final field INFO Lcom/adyen/checkout/core/common/AdyenLogLevel;
+	public static final field NONE Lcom/adyen/checkout/core/common/AdyenLogLevel;
+	public static final field VERBOSE Lcom/adyen/checkout/core/common/AdyenLogLevel;
+	public static final field WARN Lcom/adyen/checkout/core/common/AdyenLogLevel;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getPriority ()I
+	public static fun valueOf (Ljava/lang/String;)Lcom/adyen/checkout/core/common/AdyenLogLevel;
+	public static fun values ()[Lcom/adyen/checkout/core/common/AdyenLogLevel;
+}
+
+public abstract interface class com/adyen/checkout/core/common/AdyenLogger {
+	public static final field Companion Lcom/adyen/checkout/core/common/AdyenLogger$Companion;
+	public abstract fun log (Lcom/adyen/checkout/core/common/AdyenLogLevel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public abstract fun setLogLevel (Lcom/adyen/checkout/core/common/AdyenLogLevel;)V
+	public abstract fun shouldLog (Lcom/adyen/checkout/core/common/AdyenLogLevel;)Z
+}
+
+public final class com/adyen/checkout/core/common/AdyenLogger$Companion {
+	public final fun getLogger ()Lcom/adyen/checkout/core/common/AdyenLogger;
+	public final fun resetLogger ()V
+	public final fun setLogLevel (Lcom/adyen/checkout/core/common/AdyenLogLevel;)V
+	public final fun setLogger (Lcom/adyen/checkout/core/common/AdyenLogger;)V
+}
+
 public final class com/adyen/checkout/core/common/Environment : android/os/Parcelable {
 	public static final field $stable I
 	public static final field APSE Lcom/adyen/checkout/core/common/Environment;

--- a/core/src/main/java/com/adyen/checkout/core/common/AdyenLogLevel.kt
+++ b/core/src/main/java/com/adyen/checkout/core/common/AdyenLogLevel.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ozgur on 21/7/2025.
+ */
+
+package com.adyen.checkout.core.common
+
+import android.util.Log
+
+enum class AdyenLogLevel(
+    val priority: Int,
+) {
+    VERBOSE(Log.VERBOSE),
+    DEBUG(Log.DEBUG),
+    INFO(Log.INFO),
+    WARN(Log.WARN),
+    ERROR(Log.ERROR),
+    ASSERT(Log.ASSERT),
+
+    @Suppress("MagicNumber")
+    NONE(100),
+}

--- a/core/src/main/java/com/adyen/checkout/core/common/AdyenLogger.kt
+++ b/core/src/main/java/com/adyen/checkout/core/common/AdyenLogger.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 17/6/2025.
+ */
+
+package com.adyen.checkout.core.common
+
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.core.common.internal.helper.LogcatLogger
+
+/**
+ * Utility class to configure the Adyen logger.
+ */
+interface AdyenLogger {
+
+    fun shouldLog(level: AdyenLogLevel): Boolean
+
+    fun setLogLevel(level: AdyenLogLevel)
+
+    fun log(
+        level: AdyenLogLevel,
+        tag: String,
+        message: String,
+        throwable: Throwable?,
+    )
+
+    companion object {
+
+        @PublishedApi
+        @Volatile
+        internal var logger: AdyenLogger = LogcatLogger()
+            private set
+
+        private var didSetLogLevelManually = false
+
+        /**
+         * Sets the minimum level to be logged.
+         */
+        fun setLogLevel(level: AdyenLogLevel) {
+            didSetLogLevelManually = true
+            logger.setLogLevel(level)
+        }
+
+        /**
+         * Set your own custom instance of [AdyenLogger].
+         */
+        fun setLogger(logger: AdyenLogger) {
+            Companion.logger = logger
+        }
+
+        /**
+         * Reset the logger instance back to the default.
+         */
+        fun resetLogger() {
+            logger = LogcatLogger()
+            didSetLogLevelManually = false
+        }
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        fun setInitialLogLevel(level: AdyenLogLevel) {
+            if (!didSetLogLevelManually) {
+                logger.setLogLevel(level)
+            }
+        }
+    }
+}

--- a/core/src/main/java/com/adyen/checkout/core/common/internal/helper/AdyenLog.kt
+++ b/core/src/main/java/com/adyen/checkout/core/common/internal/helper/AdyenLog.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 2/2/2024.
+ */
+
+package com.adyen.checkout.core.common.internal.helper
+
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.core.common.AdyenLogLevel
+import com.adyen.checkout.core.common.AdyenLogger
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+inline fun Any.adyenLog(
+    level: AdyenLogLevel,
+    throwable: Throwable? = null,
+    log: () -> String,
+) {
+    if (AdyenLogger.logger.shouldLog(level)) {
+        val fullClassName = this::class.java.name
+        val outerClassName = fullClassName.substringBefore('$').substringAfterLast('.')
+        val tag = "CO." + if (outerClassName.isEmpty()) {
+            fullClassName
+        } else {
+            outerClassName.removeSuffix("Kt")
+        }
+
+        AdyenLogger.logger.log(level, tag, log(), throwable)
+    }
+}
+
+/**
+ * This is only meant for top level function where we cannot access `this`.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+inline fun adyenLog(
+    level: AdyenLogLevel,
+    tag: String,
+    throwable: Throwable? = null,
+    log: () -> String,
+) {
+    if (AdyenLogger.logger.shouldLog(level)) {
+        AdyenLogger.logger.log(level, "CO.$tag", log(), throwable)
+    }
+}

--- a/core/src/main/java/com/adyen/checkout/core/common/internal/helper/LogcatLogger.kt
+++ b/core/src/main/java/com/adyen/checkout/core/common/internal/helper/LogcatLogger.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2024 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 1/2/2024.
+ */
+
+package com.adyen.checkout.core.common.internal.helper
+
+import android.annotation.SuppressLint
+import android.os.Build
+import android.util.Log
+import com.adyen.checkout.core.common.AdyenLogLevel
+import com.adyen.checkout.core.common.AdyenLogger
+
+internal class LogcatLogger : AdyenLogger {
+
+    private var minLogLevel: AdyenLogLevel = AdyenLogLevel.NONE
+
+    override fun shouldLog(level: AdyenLogLevel): Boolean {
+        return level.priority >= minLogLevel.priority
+    }
+
+    override fun setLogLevel(level: AdyenLogLevel) {
+        minLogLevel = level
+    }
+
+    override fun log(level: AdyenLogLevel, tag: String, message: String, throwable: Throwable?) {
+        // Before API 26 tags have a max length
+        val trimmedTag = if (tag.length <= MAX_TAG_LENGTH || Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            tag
+        } else {
+            tag.substring(0, MAX_TAG_LENGTH)
+        }
+
+        val fullMessage = concatThrowable(message, throwable)
+
+        if (fullMessage.length < MAX_LOG_LENGTH) {
+            logToLogcat(level.priority, trimmedTag, fullMessage)
+            return
+        }
+
+        val divisions = fullMessage.length / MAX_LOG_LENGTH
+        for (i in 0..divisions) {
+            val newMessage: String = if (i != divisions) {
+                fullMessage.substring(i * MAX_LOG_LENGTH, (i + 1) * MAX_LOG_LENGTH)
+            } else {
+                fullMessage.substring(i * MAX_LOG_LENGTH)
+            }
+            logToLogcat(level.priority, "$trimmedTag-$i", newMessage)
+        }
+    }
+
+    private fun concatThrowable(message: String, throwable: Throwable?): String {
+        return if (throwable != null) {
+            "$message: ${Log.getStackTraceString(throwable)}"
+        } else {
+            message
+        }
+    }
+
+    @SuppressLint("NotAdyenLog")
+    private fun logToLogcat(
+        priority: Int,
+        tag: String,
+        message: String,
+    ) {
+        when (priority) {
+            AdyenLogLevel.NONE.priority -> Unit
+
+            Log.ASSERT -> {
+                Log.wtf(tag, message)
+            }
+
+            else -> {
+                Log.println(priority, tag, message)
+            }
+        }
+    }
+
+    companion object {
+        private const val MAX_TAG_LENGTH = 23
+        private const val MAX_LOG_LENGTH = 2048
+    }
+}

--- a/core/src/test/java/com/adyen/checkout/core/common/internal/helper/AdyenLoggerTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/common/internal/helper/AdyenLoggerTest.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2025 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 17/6/2025.
+ */
+
+package com.adyen.checkout.core.common.internal.helper
+
+import android.util.Log
+import com.adyen.checkout.core.common.AdyenLogLevel
+import com.adyen.checkout.core.common.AdyenLogger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.provider.Arguments.arguments
+
+internal class AdyenLoggerTest {
+
+    private lateinit var logger: TestLogger
+
+    @BeforeEach
+    fun setup() {
+        AdyenLogger.resetLogger()
+        logger = TestLogger()
+    }
+
+    @Test
+    fun `when logger is set, then logger instance is of correct type`() {
+        AdyenLogger.setLogger(logger)
+
+        assertEquals(logger, AdyenLogger.logger)
+    }
+
+    @Test
+    fun `when logger is set, then logging is correctly propagated`() {
+        AdyenLogger.setLogger(logger)
+        AdyenLogger.setLogLevel(AdyenLogLevel.VERBOSE)
+
+        // TODO - Error Propagation
+        val exception = RuntimeException("Test")
+
+        adyenLog(AdyenLogLevel.INFO, exception) { "test" }
+
+        val expected = LogData(AdyenLogLevel.INFO, "CO.AdyenLoggerTest", "test", exception)
+        logger.assertLogCalled(expected)
+    }
+
+    @Test
+    fun `when logger is reset, then logger is back to default type`() {
+        AdyenLogger.setLogger(logger)
+
+        AdyenLogger.resetLogger()
+
+        assertInstanceOf(LogcatLogger::class.java, AdyenLogger.logger)
+    }
+
+    @Test
+    fun `when log level is set, then it is correctly propagated`() {
+        AdyenLogger.setLogger(logger)
+
+        AdyenLogger.setLogLevel(AdyenLogLevel.ASSERT)
+
+        logger.assertLogLevel(AdyenLogLevel.ASSERT)
+    }
+
+    @Test
+    fun `when log level is set, then log is not executed`() {
+        AdyenLogger.setLogger(logger)
+        AdyenLogger.setLogLevel(AdyenLogLevel.ERROR)
+
+        adyenLog(AdyenLogLevel.VERBOSE) { "test" }
+
+        logger.assertLogNotCalled()
+    }
+
+    @Test
+    fun `when log level is set manually, then setting the initial level has no effect`() {
+        AdyenLogger.setLogger(logger)
+        AdyenLogger.setLogLevel(AdyenLogLevel.ASSERT)
+
+        AdyenLogger.setInitialLogLevel(AdyenLogLevel.ERROR)
+
+        logger.assertLogLevel(AdyenLogLevel.ASSERT)
+    }
+
+    @Test
+    fun `when log level is not set manually, then setting the initial level has effect`() {
+        AdyenLogger.setLogger(logger)
+
+        AdyenLogger.setInitialLogLevel(AdyenLogLevel.ERROR)
+
+        logger.assertLogLevel(AdyenLogLevel.ERROR)
+    }
+
+    private class TestLogger : AdyenLogger {
+
+        private var minLogLevel: AdyenLogLevel = AdyenLogLevel.NONE
+
+        private var lastLog: LogData? = null
+
+        override fun shouldLog(level: AdyenLogLevel): Boolean {
+            return level.priority >= minLogLevel.priority
+        }
+
+        override fun setLogLevel(level: AdyenLogLevel) {
+            this.minLogLevel = level
+        }
+
+        override fun log(level: AdyenLogLevel, tag: String, message: String, throwable: Throwable?) {
+            lastLog = LogData(level, tag, message, throwable)
+        }
+
+        fun assertLogLevel(expected: AdyenLogLevel) {
+            assertEquals(expected, minLogLevel)
+        }
+
+        fun assertLogCalled(expected: LogData) {
+            assertEquals(expected, lastLog)
+        }
+
+        fun assertLogNotCalled() {
+            assertNull(lastLog)
+        }
+    }
+
+    private data class LogData(
+        val level: AdyenLogLevel,
+        val tag: String,
+        val message: String,
+        val throwable: Throwable?,
+    )
+
+    companion object {
+
+        @Suppress("DEPRECATION")
+        @JvmStatic
+        fun logLevelSource() = listOf(
+            arguments(Log.VERBOSE, AdyenLogLevel.VERBOSE),
+            arguments(Log.DEBUG, AdyenLogLevel.DEBUG),
+            arguments(Log.INFO, AdyenLogLevel.INFO),
+            arguments(Log.WARN, AdyenLogLevel.WARN),
+            arguments(Log.ERROR, AdyenLogLevel.ERROR),
+            arguments(Log.ASSERT, AdyenLogLevel.NONE),
+        )
+    }
+}

--- a/core/src/testFixtures/java/com/adyen/checkout/test/PrintLogger.kt
+++ b/core/src/testFixtures/java/com/adyen/checkout/test/PrintLogger.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 5/2/2024.
+ */
+
+package com.adyen.checkout.test
+
+import com.adyen.checkout.core.common.AdyenLogLevel
+import com.adyen.checkout.core.common.AdyenLogger
+import java.io.PrintWriter
+import java.io.StringWriter
+
+internal class PrintLogger : AdyenLogger {
+
+    override fun shouldLog(level: AdyenLogLevel): Boolean = true
+
+    override fun setLogLevel(level: AdyenLogLevel) = Unit
+
+    override fun log(level: AdyenLogLevel, tag: String, message: String, throwable: Throwable?) {
+        println("${getLogColor(level)}${concatThrowable(message, throwable)}$RESET_COLOR")
+    }
+
+    private fun getLogColor(level: AdyenLogLevel): String {
+        return when (level) {
+            AdyenLogLevel.WARN -> YELLOW_COLOR
+            AdyenLogLevel.ERROR,
+            AdyenLogLevel.ASSERT -> RED_COLOR
+
+            else -> ""
+        }
+    }
+
+    private fun concatThrowable(message: String, throwable: Throwable?): String {
+        return if (throwable != null) {
+            val stringWriter = StringWriter(STRING_WRITER_SIZE)
+            val printWriter = PrintWriter(stringWriter, false)
+            throwable.printStackTrace(printWriter)
+            printWriter.flush()
+            "$message: $stringWriter"
+        } else {
+            message
+        }
+    }
+
+    companion object {
+        private const val YELLOW_COLOR = "\u001B[33m"
+        private const val RED_COLOR = "\u001B[31m"
+        private const val RESET_COLOR = "\u001B[0m"
+
+        private const val STRING_WRITER_SIZE = 16
+    }
+}


### PR DESCRIPTION
## Description
[//]: # (Include a short summary of your changes)
[//]: # (If this is a new feature: attach screenshots or a video if applicable)
[//]: # (If this is a bug fix: include a reproduction path)
`AdyenLogger` and related classes are moved to `core` module. Also removed the deprecated `setLogLevel` function.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COSDK-512
