### PR TITLE
v6 - Make CheckoutContext implementation constructors internal

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -356,7 +356,6 @@ public abstract interface class com/adyen/checkout/core/components/CheckoutConte
 
 public final class com/adyen/checkout/core/components/CheckoutContext$Advanced : com/adyen/checkout/core/components/CheckoutContext {
 	public static final field $stable I
-	public fun <init> (Lcom/adyen/checkout/core/components/data/model/PaymentMethodsApiResponse;Lcom/adyen/checkout/core/components/CheckoutConfiguration;Lcom/adyen/checkout/core/components/CheckoutCallbacks;)V
 	public final fun component1 ()Lcom/adyen/checkout/core/components/data/model/PaymentMethodsApiResponse;
 	public final fun component2 ()Lcom/adyen/checkout/core/components/CheckoutConfiguration;
 	public final fun component3 ()Lcom/adyen/checkout/core/components/CheckoutCallbacks;
@@ -372,7 +371,6 @@ public final class com/adyen/checkout/core/components/CheckoutContext$Advanced :
 
 public final class com/adyen/checkout/core/components/CheckoutContext$Sessions : com/adyen/checkout/core/components/CheckoutContext {
 	public static final field $stable I
-	public fun <init> (Lcom/adyen/checkout/core/sessions/CheckoutSession;Lcom/adyen/checkout/core/components/CheckoutConfiguration;Lcom/adyen/checkout/core/components/CheckoutCallbacks;)V
 	public final fun component1 ()Lcom/adyen/checkout/core/sessions/CheckoutSession;
 	public final fun component2 ()Lcom/adyen/checkout/core/components/CheckoutConfiguration;
 	public final fun component3 ()Lcom/adyen/checkout/core/components/CheckoutCallbacks;

--- a/core/src/main/java/com/adyen/checkout/core/components/CheckoutContext.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/CheckoutContext.kt
@@ -13,13 +13,13 @@ import com.adyen.checkout.core.sessions.CheckoutSession
 
 // TODO - Kdocs
 sealed interface CheckoutContext {
-    data class Sessions(
+    data class Sessions internal constructor(
         val checkoutSession: CheckoutSession,
         val checkoutConfiguration: CheckoutConfiguration,
         val checkoutCallbacks: CheckoutCallbacks?
     ) : CheckoutContext
 
-    data class Advanced(
+    data class Advanced internal constructor(
         val paymentMethodsApiResponse: PaymentMethodsApiResponse,
         val checkoutConfiguration: CheckoutConfiguration,
         val checkoutCallbacks: CheckoutCallbacks


### PR DESCRIPTION
## Description
[//]: # (Include a short summary of your changes)
[//]: # (If this is a new feature: attach screenshots or a video if applicable)
[//]: # (If this is a bug fix: include a reproduction path)
This PR makes constructors of `CheckoutContext.Sessions` and `CheckoutContext.Advanced` internal so merchants cannot instantiate them manually.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COSDK-568
