### PR TITLE
v5 - Deprecate old 3DS2 actions

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/provider/Adyen3DS2ComponentProvider.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/provider/Adyen3DS2ComponentProvider.kt
@@ -132,6 +132,7 @@ constructor(
     }
 
     override val supportedActionTypes: List<String>
+        @Suppress("DEPRECATION")
         get() = listOf(
             Threeds2FingerprintAction.ACTION_TYPE,
             Threeds2ChallengeAction.ACTION_TYPE,

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2Delegate.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2Delegate.kt
@@ -135,6 +135,7 @@ internal class DefaultAdyen3DS2Delegate(
 
         val paymentData = action.paymentData
         paymentDataRepository.paymentData = paymentData
+        @Suppress("DEPRECATION")
         when (action) {
             is Threeds2FingerprintAction -> handleThreeds2FingerprintAction(action, activity)
             is Threeds2ChallengeAction -> handleThreeds2ChallengeAction(action, activity)
@@ -143,6 +144,7 @@ internal class DefaultAdyen3DS2Delegate(
     }
 
     private fun handleThreeds2FingerprintAction(
+        @Suppress("DEPRECATION")
         action: Threeds2FingerprintAction,
         activity: Activity,
     ) {
@@ -165,6 +167,7 @@ internal class DefaultAdyen3DS2Delegate(
     }
 
     private fun handleThreeds2ChallengeAction(
+        @Suppress("DEPRECATION")
         action: Threeds2ChallengeAction,
         activity: Activity,
     ) {

--- a/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2DelegateTest.kt
+++ b/3ds2/src/test/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2DelegateTest.kt
@@ -134,6 +134,7 @@ internal class DefaultAdyen3DS2DelegateTest(
     @DisplayName("when handling")
     inner class HandleActionTest {
 
+        @Suppress("DEPRECATION")
         @Test
         fun `Threeds2FingerprintAction and token is null, then an exception is thrown`() = runTest {
             delegate.initialize(this)
@@ -144,6 +145,7 @@ internal class DefaultAdyen3DS2DelegateTest(
             assertTrue(exceptionFlow.latestValue is ComponentException)
         }
 
+        @Suppress("DEPRECATION")
         @Test
         fun `Threeds2ChallengeAction and token is null, then an exception is thrown`() = runTest {
             delegate.initialize(this)
@@ -533,6 +535,7 @@ internal class DefaultAdyen3DS2DelegateTest(
     @Nested
     inner class AnalyticsTest {
 
+        @Suppress("DEPRECATION")
         @Test
         fun `when handleAction is called for Threeds2FingerprintAction, then action event is tracked`() {
             delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
@@ -551,6 +554,7 @@ internal class DefaultAdyen3DS2DelegateTest(
             analyticsManager.assertHasEventEquals(expectedEvent)
         }
 
+        @Suppress("DEPRECATION")
         @Test
         fun `when handleAction is called for Threeds2ChallengeAction, then action event is tracked`() {
             delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
@@ -676,6 +680,7 @@ internal class DefaultAdyen3DS2DelegateTest(
             analyticsManager.assertLastEventEquals(expectedEvent)
         }
 
+        @Suppress("DEPRECATION")
         @Test
         fun `when action is Threeds2FingerprintAction and token is null, then error event is tracked`() = runTest {
             delegate.initialize(this)
@@ -688,6 +693,7 @@ internal class DefaultAdyen3DS2DelegateTest(
             analyticsManager.assertLastEventEquals(expectedEvent)
         }
 
+        @Suppress("DEPRECATION")
         @Test
         fun `when action is Threeds2ChallengeAction and token is null, then error event is tracked`() = runTest {
             delegate.initialize(this)

--- a/action-core/src/main/java/com/adyen/checkout/action/core/internal/provider/GenericActionComponentProvider.kt
+++ b/action-core/src/main/java/com/adyen/checkout/action/core/internal/provider/GenericActionComponentProvider.kt
@@ -122,6 +122,7 @@ constructor(
     }
 
     override val supportedActionTypes: List<String>
+        @Suppress("DEPRECATION")
         get() = listOf(
             AwaitAction.ACTION_TYPE,
             QrCodeAction.ACTION_TYPE,

--- a/action-core/src/main/java/com/adyen/checkout/action/core/internal/ui/DefaultGenericActionDelegate.kt
+++ b/action-core/src/main/java/com/adyen/checkout/action/core/internal/ui/DefaultGenericActionDelegate.kt
@@ -156,6 +156,7 @@ internal class DefaultGenericActionDelegate(
         observeViewFlow(delegate)
     }
 
+    @Suppress("DEPRECATION")
     private fun isOld3DS2Flow(action: Action): Boolean {
         return runCompileOnly { _delegate is Adyen3DS2Delegate && action is Threeds2ChallengeAction } ?: false
     }

--- a/action-core/src/test/java/com/adyen/checkout/action/core/internal/ui/ActionDelegateProviderTest.kt
+++ b/action-core/src/test/java/com/adyen/checkout/action/core/internal/ui/ActionDelegateProviderTest.kt
@@ -100,6 +100,7 @@ internal class ActionDelegateProviderTest(
 
     companion object {
 
+        @Suppress("DEPRECATION")
         @JvmStatic
         fun actionSource() = listOf(
             arguments(AwaitAction(), AwaitDelegate::class.java),

--- a/action-core/src/test/java/com/adyen/checkout/action/core/ui/DefaultGenericActionDelegateTest.kt
+++ b/action-core/src/test/java/com/adyen/checkout/action/core/ui/DefaultGenericActionDelegateTest.kt
@@ -198,6 +198,7 @@ internal class DefaultGenericActionDelegateTest(
         assertTrue(testDelegate.refreshStatusCalled)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun `when handleAction is called with a Threeds2ChallengeAction the inner delegate is not re-created`() = runTest {
         val adyen3DS2Delegate = Test3DS2Delegate()

--- a/components-core/src/main/java/com/adyen/checkout/components/core/action/Action.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/action/Action.kt
@@ -48,6 +48,7 @@ abstract class Action : ModelObject() {
             }
         }
 
+        @Suppress("DEPRECATION")
         fun getChildSerializer(actionType: String): Serializer<Action> {
             val childSerializer = when (actionType) {
                 RedirectAction.ACTION_TYPE,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/action/Threeds2ChallengeAction.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/action/Threeds2ChallengeAction.kt
@@ -29,6 +29,7 @@ data class Threeds2ChallengeAction(
         const val ACTION_TYPE = ActionTypes.THREEDS2_CHALLENGE
         private const val TOKEN = "token"
 
+        @Suppress("DEPRECATION")
         @JvmField
         val SERIALIZER: Serializer<Threeds2ChallengeAction> = object : Serializer<Threeds2ChallengeAction> {
             override fun serialize(modelObject: Threeds2ChallengeAction): JSONObject {

--- a/components-core/src/main/java/com/adyen/checkout/components/core/action/Threeds2ChallengeAction.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/action/Threeds2ChallengeAction.kt
@@ -14,6 +14,10 @@ import org.json.JSONException
 import org.json.JSONObject
 
 @Parcelize
+@Deprecated(
+    "The 3DS2 flow with separate fingerprint and challenge actions is deprecated. Use Threeds2Action instead.",
+    ReplaceWith("Threeds2Action", "com.adyen.checkout.components.core.action.Threeds2Action"),
+)
 data class Threeds2ChallengeAction(
     override var type: String? = null,
     override var paymentData: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/action/Threeds2FingerprintAction.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/action/Threeds2FingerprintAction.kt
@@ -14,6 +14,10 @@ import org.json.JSONException
 import org.json.JSONObject
 
 @Parcelize
+@Deprecated(
+    "The 3DS2 flow with separate fingerprint and challenge actions is deprecated. Use Threeds2Action instead.",
+    ReplaceWith("Threeds2Action", "com.adyen.checkout.components.core.action.Threeds2Action"),
+)
 data class Threeds2FingerprintAction(
     override var type: String? = null,
     override var paymentData: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/action/Threeds2FingerprintAction.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/action/Threeds2FingerprintAction.kt
@@ -29,6 +29,7 @@ data class Threeds2FingerprintAction(
         const val ACTION_TYPE = ActionTypes.THREEDS2_FINGERPRINT
         private const val TOKEN = "token"
 
+        @Suppress("DEPRECATION")
         @JvmField
         val SERIALIZER: Serializer<Threeds2FingerprintAction> = object : Serializer<Threeds2FingerprintAction> {
             override fun serialize(modelObject: Threeds2FingerprintAction): JSONObject {


### PR DESCRIPTION
## Description
The old 2 action 3DS2 flow is deprecated for v5. To communicate this clearly the specific action classes are now marked deprecated.

COSDK-569

## Release notes

### Deprecated
- The `Threeds2FingerprintAction` and `Threeds2ChallengeAction` actions are now deprecated. Use `Threeds2Action` instead.

