### PR TITLE
V6 - Add Await Component UI

### DIFF
--- a/await/src/main/java/com/adyen/checkout/await/internal/ui/AwaitComponent.kt
+++ b/await/src/main/java/com/adyen/checkout/await/internal/ui/AwaitComponent.kt
@@ -8,15 +8,15 @@
 
 package com.adyen.checkout.await.internal.ui
 
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.adyen.checkout.await.internal.ui.view.AwaitComponent
 import com.adyen.checkout.core.action.internal.ActionComponent
 
 internal class AwaitComponent : ActionComponent {
 
     @Composable
     override fun ViewFactory(modifier: Modifier) {
-        Text("I am AWAIT")
+        AwaitComponent(modifier = modifier)
     }
 }

--- a/await/src/main/java/com/adyen/checkout/await/internal/ui/view/AwaitComponent.kt
+++ b/await/src/main/java/com/adyen/checkout/await/internal/ui/view/AwaitComponent.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 23/7/2025.
+ */
+
+package com.adyen.checkout.await.internal.ui.view
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.adyen.checkout.ui.internal.Body
+import com.adyen.checkout.ui.internal.Dimensions
+import com.adyen.checkout.ui.internal.ProgressBar
+
+@Composable
+internal fun AwaitComponent(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier.padding(Dimensions.Medium),
+    ) {
+        ProgressBar()
+        Spacer(Modifier.size(Dimensions.Large))
+        // TODO - Localisation, add the correct text
+        Body("Awaiting confirmation...")
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AwaitComponentPreview() {
+    AwaitComponent()
+}

--- a/ui/api/ui.api
+++ b/ui/api/ui.api
@@ -21,6 +21,12 @@ public final class com/adyen/checkout/ui/internal/ComposableSingletons$ButtonsKt
 	public final fun getLambda$437627562$ui_release ()Lkotlin/jvm/functions/Function2;
 }
 
+public final class com/adyen/checkout/ui/internal/ComposableSingletons$ProgressBarKt {
+	public static final field INSTANCE Lcom/adyen/checkout/ui/internal/ComposableSingletons$ProgressBarKt;
+	public fun <init> ()V
+	public final fun getLambda$1982827567$ui_release ()Lkotlin/jvm/functions/Function2;
+}
+
 public final class com/adyen/checkout/ui/internal/ComposableSingletons$StepperKt {
 	public static final field INSTANCE Lcom/adyen/checkout/ui/internal/ComposableSingletons$StepperKt;
 	public fun <init> ()V

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/ProgressBar.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/ProgressBar.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 23/7/2025.
+ */
+
+package com.adyen.checkout.ui.internal
+
+import androidx.annotation.RestrictTo
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.adyen.checkout.ui.theme.AdyenCheckoutTheme as Theme
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Composable
+fun ProgressBar(
+    modifier: Modifier = Modifier,
+) {
+    val colors = AdyenCheckoutTheme.colors
+
+    CircularProgressIndicator(
+        modifier = modifier,
+        color = colors.primary,
+        trackColor = colors.disabled,
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ProgressBarPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: Theme,
+) {
+    AdyenCheckoutTheme(theme) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(Dimensions.Large),
+            modifier = Modifier
+                .background(AdyenCheckoutTheme.colors.background)
+                .padding(Dimensions.Large),
+        ) {
+            ProgressBar()
+        }
+    }
+}


### PR DESCRIPTION
## Description
Add the UI for Await component.

It currently looks like this:
<img width="317" height="121" alt="image" src="https://github.com/user-attachments/assets/2f020ce7-d091-41af-a3c9-a006d61b4b96" />

In future PRs we can more more UI elements.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COSDK-547
