### PR TITLE
v5 - Hide keyboard automatically on pay button click

### DIFF
--- a/ui-core/api/ui-core.api
+++ b/ui-core/api/ui-core.api
@@ -45,6 +45,10 @@ public final class com/adyen/checkout/ui/core/internal/ui/ButtonComponentViewTyp
 	public final fun getDEFAULT_BUTTON_TEXT_RES_ID ()I
 }
 
+public final class com/adyen/checkout/ui/core/internal/ui/PaymentComponentUIEvent$HideKeyboard : com/adyen/checkout/ui/core/internal/ui/PaymentComponentUIEvent {
+	public static final field INSTANCE Lcom/adyen/checkout/ui/core/internal/ui/PaymentComponentUIEvent$HideKeyboard;
+}
+
 public final class com/adyen/checkout/ui/core/internal/ui/PaymentComponentUIEvent$InvalidUI : com/adyen/checkout/ui/core/internal/ui/PaymentComponentUIEvent {
 	public static final field INSTANCE Lcom/adyen/checkout/ui/core/internal/ui/PaymentComponentUIEvent$InvalidUI;
 }

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/AdyenComponentView.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/AdyenComponentView.kt
@@ -141,6 +141,7 @@ class AdyenComponentView @JvmOverloads constructor(
             uiStateDelegate?.uiEventFlow?.onEach {
                 when (it) {
                     PaymentComponentUIEvent.InvalidUI -> highlightValidationErrors()
+                    PaymentComponentUIEvent.HideKeyboard -> hideKeyboard()
                 }
             }?.launchIn(coroutineScope)
 

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/PaymentComponentUIState.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/PaymentComponentUIState.kt
@@ -35,4 +35,5 @@ sealed class PaymentComponentUIState {
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 sealed class PaymentComponentUIEvent {
     object InvalidUI : PaymentComponentUIEvent()
+    object HideKeyboard : PaymentComponentUIEvent()
 }

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/SubmitHandler.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/SubmitHandler.kt
@@ -60,7 +60,10 @@ class SubmitHandler<ComponentStateT : PaymentComponentState<*>>(
     fun onSubmit(state: ComponentStateT) {
         when {
             !state.isInputValid -> uiEventChannel.trySend(PaymentComponentUIEvent.InvalidUI)
-            state.isValid -> submitChannel.trySend(state)
+            state.isValid -> {
+                uiEventChannel.trySend(PaymentComponentUIEvent.HideKeyboard)
+                submitChannel.trySend(state)
+            }
             !state.isReady -> _uiStateFlow.tryEmit(PaymentComponentUIState.PendingSubmit)
             else -> resetUIState() // unreachable state
         }

--- a/ui-core/src/test/java/com/adyen/checkout/ui/core/internal/ui/SubmitHandlerTest.kt
+++ b/ui-core/src/test/java/com/adyen/checkout/ui/core/internal/ui/SubmitHandlerTest.kt
@@ -67,7 +67,7 @@ internal class SubmitHandlerTest {
     inner class OnSubmitTest {
 
         @Test
-        fun `input is invalid, then InvalidUI state should be emitted`() = runTest {
+        fun `input is invalid, then InvalidUI event should be emitted`() = runTest {
             submitHandler = createSubmitHandler()
             submitHandler.initialize(CoroutineScope(UnconfinedTestDispatcher()), flowOf())
 
@@ -77,13 +77,14 @@ internal class SubmitHandlerTest {
         }
 
         @Test
-        fun `component state is valid, then component state should be emitted`() = runTest {
+        fun `component state is valid, then component state and HideKeyboard event should be emitted`() = runTest {
             submitHandler = createSubmitHandler()
             submitHandler.initialize(CoroutineScope(UnconfinedTestDispatcher()), flowOf())
 
             val componentState = createComponentState(isInputValid = true, isReady = true)
             submitHandler.onSubmit(componentState)
 
+            assertEquals(PaymentComponentUIEvent.HideKeyboard, submitHandler.uiEventFlow.first())
             assertEquals(componentState, submitHandler.submitFlow.first())
         }
 


### PR DESCRIPTION
## Description
[//]: # (Include a short summary of your changes)
[//]: # (If this is a new feature: attach screenshots or a video if applicable)
[//]: # (If this is a bug fix: include a reproduction path)
This PR makes sure that we hide keyboard automatically when a shopper clicks on the pay button.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COSDK-571

## Release notes
[//]: # (Use the headers listed below to organize your release notes. Each section should begin with ### followed by a valid label)
[//]: # (Allowed labels: `Breaking changes`, `New`, `Fixed`, `Improved`, `Changed`, `Removed`, `Deprecated`)
[//]: # (Content will be grouped under a specific label until the next header #, ##, or ### is found)
[//]: # (### New)
[//]: # (List any new features or enhancements)
[//]: # (e.g. - Added functionality for user authentication)
[//]: # (### Fixed)
[//]: # (List fixes here)
[//]: # (e.g. - Fixed issue with incorrect data rendering)

### Fixed
- The keyboard now automatically hides when shoppers tap the Pay button.