### PR TITLE
V5 - Fix input height when font is large

### DIFF
--- a/ui-core/src/main/res/values/styles.xml
+++ b/ui-core/src/main/res/values/styles.xml
@@ -71,7 +71,8 @@
 
     <style name="AdyenCheckout.TextInputEditText">
         <item name="android:layout_width">match_parent</item>
-        <item name="android:layout_height">@dimen/input_height</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:minHeight">@dimen/input_height</item>
         <item name="android:textCursorDrawable">@drawable/cursor_shape</item>
         <item name="android:textSize">16sp</item>
         <!-- The textDirection and textAlignment attributes ensure consistent display behaviour with RTL locales -->


### PR DESCRIPTION
## Description
This PR fixes the input fields when the device font size is large

Before:
<img width="325" height="350" alt="Screenshot 2025-08-04 at 10 56 14" src="https://github.com/user-attachments/assets/1714056e-2c9c-4afc-b710-4529aa8eecab" />

After:
<img width="335" height="333" alt="Screenshot 2025-08-04 at 10 55 28" src="https://github.com/user-attachments/assets/458c6c5d-e7e4-4e09-80e6-c535c449ac75" />

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COSDK-584

## Release notes
### Fixed
- Now when device font is large, the input fields will expand to fit the text
