### PR TITLE
Specify permissions for all PR check workflows

### DIFF
--- a/.github/workflows/add_pr_label.yml
+++ b/.github/workflows/add_pr_label.yml
@@ -11,6 +11,9 @@ on:
       - 'fix/**'
       - 'hotfix/**'
 
+permissions:
+  pull-requests: write
+
 jobs:
   get_label:
     if: startsWith(github.event.pull_request.head.ref, 'feature/') || startsWith(github.event.pull_request.head.ref, 'fix/') || startsWith(github.event.pull_request.head.ref, 'chore/')

--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -3,6 +3,9 @@ name: Assemble
 on:
   workflow_call
 
+permissions:
+  contents: read
+
 jobs:
   assemble-debug:
     name: Assemble debug

--- a/.github/workflows/check_dependency_changes.yml
+++ b/.github/workflows/check_dependency_changes.yml
@@ -3,6 +3,10 @@ name: Check dependency changes
 on:
   workflow_call:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   get_base_dependency_list:
     name: Fetch dependency list in BASE

--- a/.github/workflows/check_labels.yml
+++ b/.github/workflows/check_labels.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [ synchronize, labeled, unlabeled, edited ]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true

--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened ]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 concurrency:
   group: ${{ github.head_ref }}
   cancel-in-progress: true

--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -3,6 +3,9 @@ name: Perform code analysis
 on:
   workflow_call
 
+permissions:
+  contents: read
+
 jobs:
   detekt:
     name: Run detekt

--- a/.github/workflows/get_dependency_list.yml
+++ b/.github/workflows/get_dependency_list.yml
@@ -10,6 +10,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+
 jobs:
   get_dependency_list:
     runs-on: ubuntu-latest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -3,6 +3,9 @@ name: Test
 on:
   workflow_call
 
+permissions:
+  contents: read
+
 jobs:
   unit-test:
     name: Run unit tests

--- a/.github/workflows/sonar_cloud.yml
+++ b/.github/workflows/sonar_cloud.yml
@@ -3,6 +3,9 @@ name: SonarCloud
 on:
   workflow_call
 
+permissions:
+  contents: read
+
 jobs:
   sonar_cloud:
     name: Run SonarCloud

--- a/.github/workflows/validate_dependencies.yml
+++ b/.github/workflows/validate_dependencies.yml
@@ -3,6 +3,9 @@ name: Validate dependencies
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   validate_dependencies_for_release_notes:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate_public_api.yml
+++ b/.github/workflows/validate_public_api.yml
@@ -3,6 +3,10 @@ name: Validate public API
 on:
   workflow_call
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   validate_public_api:
     name: Validate public API


### PR DESCRIPTION
Set minimal permissions for all workflows related to checking PRs.

[Only 30 alerts left](https://github.com/Adyen/adyen-android/security/code-scanning?query=is%3Aopen+branch%3Achore%2Fpr_workflow_permissions)

COSDK-583