### PR TITLE
Specify release workflow permissions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,6 +3,9 @@ name: Check
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/create_github_release.yml
+++ b/.github/workflows/create_github_release.yml
@@ -7,6 +7,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+
 jobs:
   create_github_release:
     runs-on: ubuntu-latest

--- a/.github/workflows/create_release_notes_pr.yml
+++ b/.github/workflows/create_release_notes_pr.yml
@@ -7,6 +7,10 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   create_release_notes_pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/finalize_release.yml
+++ b/.github/workflows/finalize_release.yml
@@ -9,6 +9,10 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+  deployments: write
+
 jobs:
   update_release_notes:
     name: Update release notes

--- a/.github/workflows/generate_release_notes.yml
+++ b/.github/workflows/generate_release_notes.yml
@@ -7,6 +7,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+
 jobs:
   get_allowed_labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/generate_version_name.yml
+++ b/.github/workflows/generate_version_name.yml
@@ -7,6 +7,9 @@ on:
         description: "The version name of the current release"
         value: ${{ jobs.generate_version_name.outputs.version-name }}
 
+permissions:
+  contents: read
+
 jobs:
   generate_version_name:
     runs-on: ubuntu-latest

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - 'release/**'
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   check:
     name: Check

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -4,6 +4,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  deployments: write
+
 jobs:
 
   publish-to-github-pages:

--- a/.github/workflows/publish_to_maven_central.yml
+++ b/.github/workflows/publish_to_maven_central.yml
@@ -14,6 +14,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   # This step should be removed when gradle plugin supports uploading to Central Portal
   drop_all_open_ossrh_repositories:

--- a/.github/workflows/update_release_notes.yml
+++ b/.github/workflows/update_release_notes.yml
@@ -9,6 +9,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+
 jobs:
   fetch_updated_release_notes_file:
     name: Fetch Updated Release Notes File


### PR DESCRIPTION
Set minimal permissions for all workflows related to creating releases.

[6 alerts left](https://github.com/Adyen/adyen-android/security/code-scanning?query=is%3Aopen+branch%3Achore%2Frelease_workflow_permissions)

COSDK-583