### PR TITLE
Specify permissions for remaining workflows

### DIFF
--- a/.github/workflows/check_main.yml
+++ b/.github/workflows/check_main.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - 'main'
 
+permissions:
+  contents: read
+
 concurrency:
   group: 'main'
   cancel-in-progress: true

--- a/.github/workflows/generate_dependency_graph.yml
+++ b/.github/workflows/generate_dependency_graph.yml
@@ -3,6 +3,9 @@ name: Generate Dependency Graph
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   generate-dependency-graph:
     runs-on: ubuntu-latest

--- a/.github/workflows/run_ui_tests.yml
+++ b/.github/workflows/run_ui_tests.yml
@@ -6,6 +6,9 @@ on:
       - 'main'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ui-test:
     name: Run UI tests

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: '0 0 * * *'  # Run every day at midnight
 
+permissions:
+  issues: write
+
 jobs:
   close_stale_prs:
     runs-on: ubuntu-latest

--- a/.github/workflows/update_verification_metadata.yml
+++ b/.github/workflows/update_verification_metadata.yml
@@ -6,6 +6,9 @@ on:
       - 'renovate/android.gradle.plugin'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   update-verification-metadata:
     name: Update verification metadata


### PR DESCRIPTION
Set minimal permissions for all workflows related to creating releases.

[No alerts left](https://github.com/Adyen/adyen-android/security/code-scanning?query=is%3Aopen+branch%3Achore%2Fremaining_workflow_permissions)

COSDK-583