### PR TITLE
Give create release notes PR workflow contents write permission

### DIFF
--- a/.github/workflows/create_release_notes_pr.yml
+++ b/.github/workflows/create_release_notes_pr.yml
@@ -8,7 +8,7 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
## Description
The release notes PR was not created during the release and this should solve it.
