### PR TITLE
v6 -Include information about integration path choices to understand and serve developer preferences

### DIFF
--- a/core/src/main/java/com/adyen/checkout/core/analytics/internal/AnalyticsPlatformParams.kt
+++ b/core/src/main/java/com/adyen/checkout/core/analytics/internal/AnalyticsPlatformParams.kt
@@ -8,36 +8,23 @@
 
 package com.adyen.checkout.core.analytics.internal
 
-import androidx.annotation.RestrictTo
-import androidx.annotation.VisibleForTesting
-import com.adyen.checkout.core.BuildConfig
+import com.adyen.checkout.core.common.internal.helper.CheckoutPlatform
+import com.adyen.checkout.core.common.internal.helper.CheckoutPlatformParams
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-object AnalyticsPlatformParams {
+internal object AnalyticsPlatformParams {
 
     @Suppress("ConstPropertyName", "ktlint:standard:property-naming")
     const val channel = "android"
 
-    var platform = AnalyticsPlatform.ANDROID.value
-        private set
+    val platform: String
+        get() = CheckoutPlatformParams.platform.toAnalyticsPlatform().value
 
-    var version = BuildConfig.CHECKOUT_VERSION
-        private set
+    val version: String
+        get() = CheckoutPlatformParams.version
 
-    @Suppress("unused")
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    fun overrideForCrossPlatform(
-        platform: AnalyticsPlatform,
-        version: String,
-    ) {
-        AnalyticsPlatformParams.platform = platform.value
-        AnalyticsPlatformParams.version = version
-    }
-
-    @Suppress("unused")
-    @VisibleForTesting
-    internal fun resetToDefaults() {
-        platform = AnalyticsPlatform.ANDROID.value
-        version = BuildConfig.CHECKOUT_VERSION
+    private fun CheckoutPlatform.toAnalyticsPlatform(): AnalyticsPlatform = when (this) {
+        CheckoutPlatform.ANDROID -> AnalyticsPlatform.ANDROID
+        CheckoutPlatform.FLUTTER -> AnalyticsPlatform.FLUTTER
+        CheckoutPlatform.REACT_NATIVE -> AnalyticsPlatform.REACT_NATIVE
     }
 }

--- a/core/src/main/java/com/adyen/checkout/core/common/internal/helper/CheckoutPlatformParams.kt
+++ b/core/src/main/java/com/adyen/checkout/core/common/internal/helper/CheckoutPlatformParams.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 11/9/2025.
+ */
+
+package com.adyen.checkout.core.common.internal.helper
+
+import androidx.annotation.RestrictTo
+import androidx.annotation.VisibleForTesting
+import com.adyen.checkout.core.BuildConfig
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+object CheckoutPlatformParams {
+
+    var platform = CheckoutPlatform.ANDROID
+        private set
+
+    var version = BuildConfig.CHECKOUT_VERSION
+        private set
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun overrideForCrossPlatform(
+        platform: CheckoutPlatform,
+        version: String,
+    ) {
+        this.platform = platform
+        this.version = version
+    }
+
+    @VisibleForTesting
+    fun resetDefaults() {
+        platform = CheckoutPlatform.ANDROID
+        version = BuildConfig.CHECKOUT_VERSION
+    }
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+enum class CheckoutPlatform {
+    ANDROID,
+    FLUTTER,
+    REACT_NATIVE,
+}

--- a/core/src/test/java/com/adyen/checkout/core/analytics/internal/AnalyticsPlatformParamsTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/analytics/internal/AnalyticsPlatformParamsTest.kt
@@ -8,9 +8,9 @@
 
 package com.adyen.checkout.core.analytics.internal
 
+import com.adyen.checkout.core.BuildConfig
 import com.adyen.checkout.core.common.internal.helper.CheckoutPlatform
 import com.adyen.checkout.core.common.internal.helper.CheckoutPlatformParams
-import com.adyen.checkout.core.BuildConfig
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach

--- a/core/src/test/java/com/adyen/checkout/core/analytics/internal/AnalyticsPlatformParamsTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/analytics/internal/AnalyticsPlatformParamsTest.kt
@@ -8,6 +8,8 @@
 
 package com.adyen.checkout.core.analytics.internal
 
+import com.adyen.checkout.core.common.internal.helper.CheckoutPlatform
+import com.adyen.checkout.core.common.internal.helper.CheckoutPlatformParams
 import com.adyen.checkout.core.BuildConfig
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -18,12 +20,12 @@ internal class AnalyticsPlatformParamsTest {
 
     @BeforeEach
     fun setup() {
-        AnalyticsPlatformParams.resetToDefaults()
+        CheckoutPlatformParams.resetDefaults()
     }
 
     @AfterEach
     fun cleanup() {
-        AnalyticsPlatformParams.resetToDefaults()
+        CheckoutPlatformParams.resetDefaults()
     }
 
     @Test
@@ -34,8 +36,8 @@ internal class AnalyticsPlatformParamsTest {
 
     @Test
     fun `when overriding, then set values are returned`() {
-        AnalyticsPlatformParams.overrideForCrossPlatform(
-            AnalyticsPlatform.FLUTTER,
+        CheckoutPlatformParams.overrideForCrossPlatform(
+            CheckoutPlatform.FLUTTER,
             "test version",
         )
 

--- a/core/src/test/java/com/adyen/checkout/core/common/internal/helper/CheckoutPlatformParamsTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/common/internal/helper/CheckoutPlatformParamsTest.kt
@@ -1,0 +1,37 @@
+package com.adyen.checkout.core.common.internal.helper
+
+import com.adyen.checkout.test.BuildConfig
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class CheckoutPlatformParamsTest {
+
+    @BeforeEach
+    fun setup() {
+        CheckoutPlatformParams.resetDefaults()
+    }
+
+    @AfterEach
+    fun cleanup() {
+        CheckoutPlatformParams.resetDefaults()
+    }
+
+    @Test
+    fun `when no overriding, then default are returned`() {
+        assertEquals(CheckoutPlatform.ANDROID, CheckoutPlatformParams.platform)
+        assertEquals(BuildConfig.CHECKOUT_VERSION, CheckoutPlatformParams.version)
+    }
+
+    @Test
+    fun `when overriding, then set values are returned`() {
+        CheckoutPlatformParams.overrideForCrossPlatform(
+            CheckoutPlatform.FLUTTER,
+            "test version",
+        )
+
+        assertEquals(CheckoutPlatform.FLUTTER, CheckoutPlatformParams.platform)
+        assertEquals("test version", CheckoutPlatformParams.version)
+    }
+}

--- a/googlepay/api/googlepay.api
+++ b/googlepay/api/googlepay.api
@@ -244,18 +244,21 @@ public final class com/adyen/checkout/googlepay/MerchantInfo : com/adyen/checkou
 	public static final field Companion Lcom/adyen/checkout/googlepay/MerchantInfo$Companion;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/old/internal/data/model/ModelObject$Serializer;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/adyen/checkout/googlepay/SoftwareInfo;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/adyen/checkout/googlepay/SoftwareInfo;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/googlepay/MerchantInfo;
-	public static synthetic fun copy$default (Lcom/adyen/checkout/googlepay/MerchantInfo;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/googlepay/MerchantInfo;
+	public final fun component3 ()Lcom/adyen/checkout/googlepay/SoftwareInfo;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/adyen/checkout/googlepay/SoftwareInfo;)Lcom/adyen/checkout/googlepay/MerchantInfo;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/googlepay/MerchantInfo;Ljava/lang/String;Ljava/lang/String;Lcom/adyen/checkout/googlepay/SoftwareInfo;ILjava/lang/Object;)Lcom/adyen/checkout/googlepay/MerchantInfo;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMerchantId ()Ljava/lang/String;
 	public final fun getMerchantName ()Ljava/lang/String;
+	public final fun getSoftwareInfo ()Lcom/adyen/checkout/googlepay/SoftwareInfo;
 	public fun hashCode ()I
 	public final fun setMerchantId (Ljava/lang/String;)V
 	public final fun setMerchantName (Ljava/lang/String;)V
+	public final fun setSoftwareInfo (Lcom/adyen/checkout/googlepay/SoftwareInfo;)V
 	public fun toString ()Ljava/lang/String;
 	public final fun writeToParcel (Landroid/os/Parcel;I)V
 }
@@ -300,6 +303,34 @@ public final class com/adyen/checkout/googlepay/ShippingAddressParameters$Creato
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/adyen/checkout/googlepay/ShippingAddressParameters;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/adyen/checkout/googlepay/ShippingAddressParameters;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/adyen/checkout/googlepay/SoftwareInfo : com/adyen/checkout/core/old/internal/data/model/ModelObject {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/adyen/checkout/googlepay/SoftwareInfo$Companion;
+	public static final field SERIALIZER Lcom/adyen/checkout/core/old/internal/data/model/ModelObject$Serializer;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/googlepay/SoftwareInfo;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/googlepay/SoftwareInfo;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/googlepay/SoftwareInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getVersion ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public final fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/adyen/checkout/googlepay/SoftwareInfo$Companion {
+}
+
+public final class com/adyen/checkout/googlepay/SoftwareInfo$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/adyen/checkout/googlepay/SoftwareInfo;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/adyen/checkout/googlepay/SoftwareInfo;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/MerchantInfo.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/MerchantInfo.kt
@@ -42,7 +42,10 @@ data class MerchantInfo(
                     JSONObject().apply {
                         putOpt(MERCHANT_NAME, modelObject.merchantName)
                         putOpt(MERCHANT_ID, modelObject.merchantId)
-                        putOpt(SOFTWARE_INFO, modelObject.softwareInfo)
+                        putOpt(
+                            SOFTWARE_INFO,
+                            ModelUtils.serializeOpt(modelObject.softwareInfo, SoftwareInfo.SERIALIZER),
+                        )
                     }
                 } catch (e: JSONException) {
                     throw ModelSerializationException(MerchantInfo::class.java, e)
@@ -52,7 +55,10 @@ data class MerchantInfo(
             override fun deserialize(jsonObject: JSONObject) = MerchantInfo(
                 merchantName = jsonObject.getStringOrNull(MERCHANT_NAME),
                 merchantId = jsonObject.getStringOrNull(MERCHANT_ID),
-                softwareInfo = ModelUtils.deserializeOpt(jsonObject.optJSONObject(SOFTWARE_INFO), SoftwareInfo.SERIALIZER),
+                softwareInfo = ModelUtils.deserializeOpt(
+                    jsonObject.optJSONObject(SOFTWARE_INFO),
+                    SoftwareInfo.SERIALIZER,
+                ),
             )
         }
     }

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/MerchantInfo.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/MerchantInfo.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Adyen N.V.
+ * Copyright (c) 2025 Adyen N.V.
  *
  * This file is open source and available under the MIT license. See the LICENSE file for more info.
  *
@@ -9,6 +9,7 @@ package com.adyen.checkout.googlepay
 
 import com.adyen.checkout.core.old.exception.ModelSerializationException
 import com.adyen.checkout.core.old.internal.data.model.ModelObject
+import com.adyen.checkout.core.old.internal.data.model.ModelUtils
 import com.adyen.checkout.core.old.internal.data.model.getStringOrNull
 import kotlinx.parcelize.Parcelize
 import org.json.JSONException
@@ -20,16 +21,19 @@ import org.json.JSONObject
  *
  * @param merchantName The name of the merchant.
  * @param merchantId The id of the merchant.
+ * @param softwareInfo Information associated with the caller of the request.
  */
 @Parcelize
 data class MerchantInfo(
     var merchantName: String? = null,
     var merchantId: String? = null,
+    var softwareInfo: SoftwareInfo? = null,
 ) : ModelObject() {
 
     companion object {
         private const val MERCHANT_NAME = "merchantName"
         private const val MERCHANT_ID = "merchantId"
+        private const val SOFTWARE_INFO = "softwareInfo"
 
         @JvmField
         val SERIALIZER: Serializer<MerchantInfo> = object : Serializer<MerchantInfo> {
@@ -38,6 +42,7 @@ data class MerchantInfo(
                     JSONObject().apply {
                         putOpt(MERCHANT_NAME, modelObject.merchantName)
                         putOpt(MERCHANT_ID, modelObject.merchantId)
+                        putOpt(SOFTWARE_INFO, modelObject.softwareInfo)
                     }
                 } catch (e: JSONException) {
                     throw ModelSerializationException(MerchantInfo::class.java, e)
@@ -47,6 +52,7 @@ data class MerchantInfo(
             override fun deserialize(jsonObject: JSONObject) = MerchantInfo(
                 merchantName = jsonObject.getStringOrNull(MERCHANT_NAME),
                 merchantId = jsonObject.getStringOrNull(MERCHANT_ID),
+                softwareInfo = ModelUtils.deserializeOpt(jsonObject.optJSONObject(SOFTWARE_INFO), SoftwareInfo.SERIALIZER),
             )
         }
     }

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/SoftwareInfo.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/SoftwareInfo.kt
@@ -7,9 +7,8 @@
  */
 package com.adyen.checkout.googlepay
 
-import com.adyen.checkout.core.exception.ModelSerializationException
-import com.adyen.checkout.core.internal.data.model.ModelObject
-import com.adyen.checkout.core.internal.data.model.getString
+import com.adyen.checkout.core.old.exception.ModelSerializationException
+import com.adyen.checkout.core.old.internal.data.model.ModelObject
 import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
@@ -23,8 +22,8 @@ import org.json.JSONObject
  */
 @Parcelize
 data class SoftwareInfo(
-    var id: String,
-    var version: String,
+    val id: String,
+    val version: String,
 ) : ModelObject() {
 
     companion object {
@@ -36,18 +35,22 @@ data class SoftwareInfo(
             override fun serialize(modelObject: SoftwareInfo): JSONObject {
                 return try {
                     JSONObject().apply {
-                        putOpt(SOFTWARE_ID, modelObject.id)
-                        putOpt(SOFTWARE_VERSION, modelObject.version)
+                        put(SOFTWARE_ID, modelObject.id)
+                        put(SOFTWARE_VERSION, modelObject.version)
                     }
                 } catch (e: JSONException) {
                     throw ModelSerializationException(SoftwareInfo::class.java, e)
                 }
             }
 
-            override fun deserialize(jsonObject: JSONObject) = SoftwareInfo(
-                id = jsonObject.getString(SOFTWARE_ID),
-                version = jsonObject.getString(SOFTWARE_VERSION),
-            )
+            override fun deserialize(jsonObject: JSONObject) = try {
+                SoftwareInfo(
+                    id = jsonObject.getString(SOFTWARE_ID),
+                    version = jsonObject.getString(SOFTWARE_VERSION),
+                )
+            } catch (e: JSONException) {
+                throw ModelSerializationException(SoftwareInfo::class.java, e)
+            }
         }
     }
 }

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/SoftwareInfo.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/SoftwareInfo.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by caiof on 30/7/2019.
+ */
+package com.adyen.checkout.googlepay
+
+import com.adyen.checkout.core.exception.ModelSerializationException
+import com.adyen.checkout.core.internal.data.model.ModelObject
+import com.adyen.checkout.core.internal.data.model.getString
+import kotlinx.parcelize.Parcelize
+import org.json.JSONException
+import org.json.JSONObject
+
+/**
+ * Pass this object to [GooglePayConfiguration.merchantInfo.softwareInfo] to set information about the caller
+ * of the API.
+ *
+ * @param id The id of the client / library making the call.
+ * @param version The version of the caller
+ */
+@Parcelize
+data class SoftwareInfo(
+    var id: String,
+    var version: String,
+) : ModelObject() {
+
+    companion object {
+        private const val SOFTWARE_ID = "id"
+        private const val SOFTWARE_VERSION = "version"
+
+        @JvmField
+        val SERIALIZER: Serializer<SoftwareInfo> = object : Serializer<SoftwareInfo> {
+            override fun serialize(modelObject: SoftwareInfo): JSONObject {
+                return try {
+                    JSONObject().apply {
+                        putOpt(SOFTWARE_ID, modelObject.id)
+                        putOpt(SOFTWARE_VERSION, modelObject.version)
+                    }
+                } catch (e: JSONException) {
+                    throw ModelSerializationException(SoftwareInfo::class.java, e)
+                }
+            }
+
+            override fun deserialize(jsonObject: JSONObject) = SoftwareInfo(
+                id = jsonObject.getString(SOFTWARE_ID),
+                version = jsonObject.getString(SOFTWARE_VERSION),
+            )
+        }
+    }
+}

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/util/GooglePayUtils.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/util/GooglePayUtils.kt
@@ -171,7 +171,7 @@ internal object GooglePayUtils {
         return PaymentDataRequestModel(
             apiVersion = MAJOR_API_VERSION,
             apiVersionMinor = MINOT_API_VERSION,
-            merchantInfo = params.merchantInfo?.addSoftwareInfo(params),
+            merchantInfo = params.merchantInfo.addSoftwareInfo(params),
             transactionInfo = createTransactionInfo(params),
             allowedPaymentMethods = getAllowedPaymentMethods(params),
             isEmailRequired = params.isEmailRequired,
@@ -180,19 +180,18 @@ internal object GooglePayUtils {
         )
     }
 
-    private fun MerchantInfo.addSoftwareInfo(params: GooglePayComponentParams): MerchantInfo {
+    private fun MerchantInfo?.addSoftwareInfo(params: GooglePayComponentParams): MerchantInfo {
         val integrationType = if (params.isCreatedByDropIn) {
             IntegrationType.DROP_IN
         } else {
             IntegrationType.COMPONENTS
         }
         val platform = CheckoutPlatformParams.platform.toGooglePayPlatform()
-        return copy(
-            softwareInfo = SoftwareInfo(
-                id = "${platform.value}/${integrationType.value}",
-                version = CheckoutPlatformParams.version,
-            ),
+        val softwareInfo = SoftwareInfo(
+            id = "${platform.value}/${integrationType.value}",
+            version = CheckoutPlatformParams.version,
         )
+        return this?.copy(softwareInfo = softwareInfo) ?: MerchantInfo(softwareInfo = softwareInfo)
     }
 
     private fun CheckoutPlatform.toGooglePayPlatform(): GooglePayPlatform = when (this) {

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/util/GooglePayUtils.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/util/GooglePayUtils.kt
@@ -61,6 +61,9 @@ internal object GooglePayUtils {
     private const val TOKEN = "token"
     private const val NOT_CURRENTLY_KNOWN = "NOT_CURRENTLY_KNOWN"
 
+    // Library information
+    private const val LIBRARY_SOFTWARE_ID = "android/adyen-dropin"
+
     /**
      * Create a [com.google.android.gms.wallet.Wallet.WalletOptions] based on the component configuration.
      *
@@ -95,6 +98,9 @@ internal object GooglePayUtils {
      */
     fun createPaymentDataRequest(params: GooglePayComponentParams): PaymentDataRequest {
         val paymentDataRequestModel = createPaymentDataRequestModel(params)
+
+        // TODO: Populate the softwareInfo property in MerchantInfo with the name and version of the library
+
         val requestJsonString = PaymentDataRequestModel.SERIALIZER.serialize(paymentDataRequestModel).toString()
         return PaymentDataRequest.fromJson(requestJsonString)
     }

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/util/GooglePayUtils.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/util/GooglePayUtils.kt
@@ -7,15 +7,14 @@
  */
 package com.adyen.checkout.googlepay.internal.util
 
-import androidx.annotation.RestrictTo
-import androidx.annotation.VisibleForTesting
 import com.adyen.checkout.components.core.internal.util.AmountFormat
 import com.adyen.checkout.components.core.paymentmethod.GooglePayPaymentMethod
+import com.adyen.checkout.core.common.internal.helper.CheckoutPlatform
+import com.adyen.checkout.core.common.internal.helper.CheckoutPlatformParams
 import com.adyen.checkout.core.old.AdyenLogLevel
 import com.adyen.checkout.core.old.exception.CheckoutException
 import com.adyen.checkout.core.old.internal.util.adyenLog
 import com.adyen.checkout.core.old.internal.util.runCompileOnly
-import com.adyen.checkout.googlepay.BuildConfig
 import com.adyen.checkout.googlepay.MerchantInfo
 import com.adyen.checkout.googlepay.SoftwareInfo
 import com.adyen.checkout.googlepay.internal.data.model.CardParameters
@@ -187,12 +186,19 @@ internal object GooglePayUtils {
         } else {
             IntegrationType.COMPONENTS
         }
+        val platform = CheckoutPlatformParams.platform.toGooglePayPlatform()
         return copy(
             softwareInfo = SoftwareInfo(
-                id = "${GooglePayParams.platform.value}/${integrationType.value}",
-                version = GooglePayParams.version,
+                id = "${platform.value}/${integrationType.value}",
+                version = CheckoutPlatformParams.version,
             ),
         )
+    }
+
+    private fun CheckoutPlatform.toGooglePayPlatform(): GooglePayPlatform = when (this) {
+        CheckoutPlatform.ANDROID -> GooglePayPlatform.ANDROID
+        CheckoutPlatform.FLUTTER -> GooglePayPlatform.FLUTTER
+        CheckoutPlatform.REACT_NATIVE -> GooglePayPlatform.REACT_NATIVE
     }
 
     internal fun getAllowedPaymentMethods(params: GooglePayComponentParams): List<GooglePayPaymentMethodModel> {
@@ -255,33 +261,10 @@ internal object GooglePayUtils {
         DROP_IN("adyen-dropin"),
         COMPONENTS("adyen-components"),
     }
-}
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-enum class GooglePayPlatform(val value: String) {
-    ANDROID("android"),
-    FLUTTER("flutter"),
-    REACT_NATIVE("react-native"),
-}
-
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-object GooglePayParams {
-
-    internal var platform: GooglePayPlatform = GooglePayPlatform.ANDROID
-    internal var version: String = BuildConfig.CHECKOUT_VERSION
-
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    fun overrideForCrossPlatform(
-        platform: GooglePayPlatform,
-        version: String,
-    ) {
-        this.platform = platform
-        this.version = version
-    }
-
-    @VisibleForTesting
-    internal fun resetDefaults() {
-        platform = GooglePayPlatform.ANDROID
-        version = BuildConfig.CHECKOUT_VERSION
+    private enum class GooglePayPlatform(val value: String) {
+        ANDROID("android"),
+        FLUTTER("flutter"),
+        REACT_NATIVE("react-native"),
     }
 }

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/util/GooglePayUtilsTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/util/GooglePayUtilsTest.kt
@@ -12,6 +12,8 @@ import com.adyen.checkout.components.core.Amount
 import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams
 import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParamsLevel
 import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParams
+import com.adyen.checkout.core.common.internal.helper.CheckoutPlatform
+import com.adyen.checkout.core.common.internal.helper.CheckoutPlatformParams
 import com.adyen.checkout.core.old.Environment
 import com.adyen.checkout.googlepay.BillingAddressParameters
 import com.adyen.checkout.googlepay.BuildConfig
@@ -251,16 +253,16 @@ internal class GooglePayUtilsTest {
     @ParameterizedTest
     @MethodSource("softwareInfoSource")
     fun `when creating payment data request, then software info is added correctly`(
-        platform: GooglePayPlatform,
+        platform: CheckoutPlatform,
         version: String?,
         isDropIn: Boolean,
         expectedId: String,
         expectedVersion: String,
     ) {
-        GooglePayParams.resetDefaults()
+        CheckoutPlatformParams.resetDefaults()
 
-        if (platform != GooglePayPlatform.ANDROID) {
-            GooglePayParams.overrideForCrossPlatform(platform, requireNotNull(version))
+        if (platform != CheckoutPlatform.ANDROID) {
+            CheckoutPlatformParams.overrideForCrossPlatform(platform, requireNotNull(version))
         }
 
         val paymentDataRequest =
@@ -356,12 +358,12 @@ internal class GooglePayUtilsTest {
         @JvmStatic
         fun softwareInfoSource() = listOf(
             // platform, version, isDropIn, expectedId, expectedVersion
-            arguments(GooglePayPlatform.ANDROID, null, true, "android/adyen-dropin", BuildConfig.CHECKOUT_VERSION),
-            arguments(GooglePayPlatform.ANDROID, null, false, "android/adyen-components", BuildConfig.CHECKOUT_VERSION),
-            arguments(GooglePayPlatform.FLUTTER, "1.2.3", true, "flutter/adyen-dropin", "1.2.3"),
-            arguments(GooglePayPlatform.FLUTTER, "3.2.1", false, "flutter/adyen-components", "3.2.1"),
-            arguments(GooglePayPlatform.REACT_NATIVE, "1.2.3", true, "react-native/adyen-dropin", "1.2.3"),
-            arguments(GooglePayPlatform.REACT_NATIVE, "3.2.1", false, "react-native/adyen-components", "3.2.1"),
+            arguments(CheckoutPlatform.ANDROID, null, true, "android/adyen-dropin", BuildConfig.CHECKOUT_VERSION),
+            arguments(CheckoutPlatform.ANDROID, null, false, "android/adyen-components", BuildConfig.CHECKOUT_VERSION),
+            arguments(CheckoutPlatform.FLUTTER, "1.2.3", true, "flutter/adyen-dropin", "1.2.3"),
+            arguments(CheckoutPlatform.FLUTTER, "3.2.1", false, "flutter/adyen-components", "3.2.1"),
+            arguments(CheckoutPlatform.REACT_NATIVE, "1.2.3", true, "react-native/adyen-dropin", "1.2.3"),
+            arguments(CheckoutPlatform.REACT_NATIVE, "3.2.1", false, "react-native/adyen-components", "3.2.1"),
         )
     }
 }

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/util/GooglePayUtilsTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/util/GooglePayUtilsTest.kt
@@ -132,6 +132,14 @@ internal class GooglePayUtilsTest {
                 {
                     "apiVersionMinor": 0,
                     "apiVersion": 2,
+                    "merchantInfo":
+                    {
+                        "softwareInfo":
+                        {
+                            "id": "android/adyen-components",
+                            "version": "develop"
+                        }
+                    },
                     "allowedPaymentMethods":
                     [
                         {


### PR DESCRIPTION
## Description
Today, developers using Adyen can add Google Pay to their applications in multiple ways (Google Pay SDK, Adyen Drop-In, components, etc). Understanding trends and developer preferences is key to improve integration offerings to satisfy ever-changing programming styles and tooling. This PR adds basic versioning telemetry to help understand these patterns and focus efforts on the preferred integration paths.

This change is intentionally incomplete, and meant as a foundational proposal about how to add library and versioning information to Google Pay's `loadPaymentData` request. See how these [fields are populated in another open source library](https://github.com/google-pay/flutter-plugin/blob/4fc0c8b76448a76b26b9fe2a3514270e977b91a4/pay_platform_interface/lib/util/configurations.dart#L44).

## Outstanding items
- [x] Decide for a location in the business logic to transparently include this information (proposing `GooglePayUtils.kt`)
- [x] Procure the version of the library in a programmatic way
- [x] Add tests
