### PR TITLE
v5 - Prevent 3DS2 challenge when cancel button is clicked

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2Delegate.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2Delegate.kt
@@ -570,8 +570,6 @@ internal class DefaultAdyen3DS2Delegate(
                 message = "Challenge completed and details cannot be created",
             )
             emitError(e)
-        } finally {
-            closeTransaction()
         }
     }
 
@@ -586,8 +584,6 @@ internal class DefaultAdyen3DS2Delegate(
                 message = "Challenge is cancelled and details cannot be created",
             )
             emitError(e)
-        } finally {
-            closeTransaction()
         }
     }
 
@@ -602,8 +598,6 @@ internal class DefaultAdyen3DS2Delegate(
                 message = "Challenge timed out and details cannot be created",
             )
             emitError(e)
-        } finally {
-            closeTransaction()
         }
     }
 
@@ -618,8 +612,6 @@ internal class DefaultAdyen3DS2Delegate(
                 message = "Challenge failed and details cannot be created",
             )
             emitError(e)
-        } finally {
-            closeTransaction()
         }
     }
 

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2Delegate.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2Delegate.kt
@@ -737,6 +737,7 @@ internal class DefaultAdyen3DS2Delegate(
     private fun clearState() {
         action = null
         SharedChallengeStatusHandler.reset()
+        closeTransaction()
     }
 
     override fun onCleared() {

--- a/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2Delegate.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/adyen3ds2/internal/ui/DefaultAdyen3DS2Delegate.kt
@@ -316,7 +316,7 @@ internal class DefaultAdyen3DS2Delegate(
             if (submitFingerprintAutomatically) {
                 submitFingerprintAutomatically(activity, encodedFingerprint)
             } else {
-                emitDetails(adyen3DS2Serializer.createFingerprintDetails(encodedFingerprint))
+                emitDetails(adyen3DS2Serializer.createFingerprintDetails(encodedFingerprint), shouldClearState = false)
             }
         }
     }
@@ -700,13 +700,16 @@ internal class DefaultAdyen3DS2Delegate(
         clearState()
     }
 
-    private fun emitDetails(details: JSONObject) {
+    private fun emitDetails(details: JSONObject, shouldClearState: Boolean = true) {
         val actionComponentData = ActionComponentData(
             details = details,
             paymentData = paymentDataRepository.paymentData,
         )
         detailsChannel.trySend(actionComponentData)
-        clearState()
+
+        if (shouldClearState) {
+            clearState()
+        }
     }
 
     private fun makeDetails(transactionStatus: String, errorDetails: String? = null): JSONObject {


### PR DESCRIPTION
## Description
Prevent the 3DS2 challenge from displaying when the cancel button is clicked by closing the transaction that was created before.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually
- [x] Related issues are linked

COSDK-607

## Release notes

### Fixed
- For 3DS2, when the cancel button is clicked before the challenge is displayed, then the challenge will no longer display.