### PR TITLE
v6 - Migrate to text field state API

### DIFF
--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MbWayComponent.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MbWayComponent.kt
@@ -94,7 +94,6 @@ internal fun MbWayComponent(
             label = "Phone Number",
             isError = viewState.phoneNumberFieldState.errorMessageId != null,
             supportingText = supportingTextPhoneNumber,
-            value = viewState.phoneNumberFieldState.value,
             prefix = country.callingCode,
             onValueChange = { value ->
                 fieldChangeListener.onFieldValueChanged(MBWayFieldId.PHONE_NUMBER, value)

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MbWayComponent.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MbWayComponent.kt
@@ -42,6 +42,7 @@ import com.adyen.checkout.test.R
 import com.adyen.checkout.ui.internal.BodyEmphasized
 import com.adyen.checkout.ui.internal.CheckoutTextField
 import com.adyen.checkout.ui.internal.CheckoutThemeProvider
+import com.adyen.checkout.ui.internal.DigitOnlyInputTransformation
 import com.adyen.checkout.ui.internal.Dimensions
 import com.adyen.checkout.ui.internal.FullScreenDialog
 import com.adyen.checkout.ui.internal.SubHeadline
@@ -98,7 +99,8 @@ internal fun MbWayComponent(
             onValueChange = { value ->
                 fieldChangeListener.onFieldValueChanged(MBWayFieldId.PHONE_NUMBER, value)
             },
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone),
+            inputTransformation = DigitOnlyInputTransformation(),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
         )
     }
 

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/CheckoutTextField.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/CheckoutTextField.kt
@@ -17,10 +17,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -38,6 +41,8 @@ import com.adyen.checkout.ui.theme.CheckoutColor
 import com.adyen.checkout.ui.theme.CheckoutElements
 import com.adyen.checkout.ui.theme.CheckoutTextFieldStyle
 import com.adyen.checkout.ui.theme.CheckoutTheme
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.drop
 
 /**
  * A composable that provides a styled text field with Adyen's theming.
@@ -45,10 +50,10 @@ import com.adyen.checkout.ui.theme.CheckoutTheme
  * This function wraps [androidx.compose.foundation.text.BasicTextField] and applies
  * styling defined by [InternalTextFieldStyle].
  *
- * @param value The current text to be displayed in the text field.
  * @param onValueChange A callback that is triggered when the text in the field changes.
  * @param label The label text to be displayed for the text field.
  * @param modifier Optional [Modifier] to be applied to this composable.
+ * @param initialValue The initial text to be displayed in the text field.
  * @param enabled Controls the enabled state of the text field. When `false`, the text field
  * is not interactable.
  * @param supportingText Optional supporting text to be displayed below the text field.
@@ -67,10 +72,10 @@ import com.adyen.checkout.ui.theme.CheckoutTheme
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Composable
 fun CheckoutTextField(
-    value: String,
-    onValueChange: (String) -> Unit,
     label: String,
     modifier: Modifier = Modifier,
+    initialValue: String = "",
+    onValueChange: ((String) -> Unit)? = null,
     enabled: Boolean = true,
     supportingText: String? = null,
     isError: Boolean = false,
@@ -82,9 +87,9 @@ fun CheckoutTextField(
 ) {
     val style = CheckoutTextFieldDefaults.textFieldStyle(CheckoutThemeProvider.elements.textField)
     val innerTextStyle = CheckoutThemeProvider.textStyles.body
+    val state = rememberTextFieldState(initialValue)
     BasicTextField(
-        value = value,
-        onValueChange = onValueChange,
+        state = state,
         modifier = modifier,
         enabled = enabled,
         textStyle = TextStyle(
@@ -93,11 +98,11 @@ fun CheckoutTextField(
             fontWeight = FontWeight(innerTextStyle.weight),
             lineHeight = innerTextStyle.lineHeight.sp,
         ),
-        singleLine = true,
+        lineLimits = TextFieldLineLimits.SingleLine,
         cursorBrush = SolidColor(style.activeColor),
         keyboardOptions = keyboardOptions,
         interactionSource = interactionSource,
-        decorationBox = { innerTextField ->
+        decorator = { innerTextField ->
             CheckoutTextFieldDecorationBox(
                 label = label,
                 innerTextField = innerTextField,
@@ -111,6 +116,16 @@ fun CheckoutTextField(
             )
         },
     )
+
+    if (onValueChange != null) {
+        LaunchedEffect(state) {
+            snapshotFlow { state.text }
+                .drop(1)
+                .collectLatest { value ->
+                onValueChange(value.toString())
+            }
+        }
+    }
 }
 
 @Preview
@@ -126,14 +141,12 @@ private fun CheckoutTextFieldPreview(
                 .padding(Dimensions.Large),
         ) {
             CheckoutTextField(
-                value = "",
                 onValueChange = {},
                 label = "Label",
                 supportingText = "Description",
             )
 
             CheckoutTextField(
-                value = "Value",
                 onValueChange = {},
                 label = "Label",
                 supportingText = "Description",
@@ -149,7 +162,6 @@ private fun CheckoutTextFieldPreview(
 
             val focusRequester = remember { FocusRequester() }
             CheckoutTextField(
-                value = "Value",
                 onValueChange = {},
                 label = "Label",
                 supportingText = "Description",
@@ -160,7 +172,6 @@ private fun CheckoutTextFieldPreview(
             }
 
             CheckoutTextField(
-                value = "Value",
                 onValueChange = {},
                 label = "Label",
                 supportingText = "Description",

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/CheckoutTextField.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/CheckoutTextField.kt
@@ -17,6 +17,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.InputTransformation
+import androidx.compose.foundation.text.input.OutputTransformation
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.Icon
@@ -79,6 +81,8 @@ fun CheckoutTextField(
     enabled: Boolean = true,
     supportingText: String? = null,
     isError: Boolean = false,
+    inputTransformation: InputTransformation? = null,
+    outputTransformation: OutputTransformation? = null,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     innerIndication: Indication? = null,
@@ -92,6 +96,8 @@ fun CheckoutTextField(
         state = state,
         modifier = modifier,
         enabled = enabled,
+        inputTransformation = inputTransformation,
+        outputTransformation = outputTransformation,
         textStyle = TextStyle(
             color = style.textColor,
             fontSize = innerTextStyle.size.sp,
@@ -122,8 +128,8 @@ fun CheckoutTextField(
             snapshotFlow { state.text }
                 .drop(1)
                 .collectLatest { value ->
-                onValueChange(value.toString())
-            }
+                    onValueChange(value.toString())
+                }
         }
     }
 }

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/DigitOnlyInputTransformation.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/DigitOnlyInputTransformation.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 28/8/2025.
+ */
+
+package com.adyen.checkout.ui.internal
+
+import androidx.annotation.RestrictTo
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.InputTransformation
+import androidx.compose.foundation.text.input.TextFieldBuffer
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.core.text.isDigitsOnly
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class DigitOnlyInputTransformation : InputTransformation {
+
+    override val keyboardOptions: KeyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+
+    override fun TextFieldBuffer.transformInput() {
+        if (!asCharSequence().isDigitsOnly()) {
+            revertAllChanges()
+        }
+    }
+}

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/ValuePickerField.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/ValuePickerField.kt
@@ -52,8 +52,7 @@ fun ValuePickerField(
     val style = CheckoutTextFieldDefaults.textFieldStyle(CheckoutThemeProvider.elements.textField)
     val interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
     CheckoutTextField(
-        value = value,
-        onValueChange = {},
+        initialValue = value,
         label = label,
         // This makes sure the whole composable is clickable, but the ripple is not displayed outside of the inner field
         modifier = modifier.clickable(


### PR DESCRIPTION
## Description
As [recommended](https://medium.com/androiddevelopers/effective-state-management-for-textfield-in-compose-d6e5b070fbe5) by Google, our `CheckoutTextField` now uses the `TextFieldState` API. The main benefits are no async state management (smoother experience for users) and this API can automatically restore it's state after config changes and process death. As an extra, the MBWay input now only accepts digits as with the new API this is fairly simple. Before you could paste any text in the input field.