### PR TITLE
v6 - Fix value picker (after new TextFieldState API)

### DIFF
--- a/ui/src/main/java/com/adyen/checkout/ui/internal/CheckoutTextField.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/CheckoutTextField.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.InputTransformation
 import androidx.compose.foundation.text.input.OutputTransformation
 import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
@@ -54,10 +55,10 @@ import kotlinx.coroutines.flow.drop
  * This function wraps [androidx.compose.foundation.text.BasicTextField] and applies
  * styling defined by [InternalTextFieldStyle].
  *
- * @param onValueChange A callback that is triggered when the text in the field changes.
  * @param label The label text to be displayed for the text field.
  * @param modifier Optional [Modifier] to be applied to this composable.
  * @param initialValue The initial text to be displayed in the text field.
+ * @param onValueChange A callback that is triggered when the text in the field changes.
  * @param enabled Controls the enabled state of the text field. When `false`, the text field
  * is not interactable.
  * @param supportingText Optional supporting text to be displayed below the text field.
@@ -91,11 +92,45 @@ fun CheckoutTextField(
     prefix: String? = null,
     trailingIcon: @Composable (() -> Unit)? = null,
 ) {
+    CheckoutTextField(
+        label = label,
+        inputState = rememberTextFieldState(initialValue),
+        modifier = modifier,
+        onValueChange = onValueChange,
+        enabled = enabled,
+        supportingText = supportingText,
+        isError = isError,
+        inputTransformation = inputTransformation,
+        outputTransformation = outputTransformation,
+        keyboardOptions = keyboardOptions,
+        interactionSource = interactionSource,
+        innerIndication = innerIndication,
+        prefix = prefix,
+        trailingIcon = trailingIcon,
+    )
+}
+
+@Composable
+internal fun CheckoutTextField(
+    label: String,
+    inputState: TextFieldState,
+    modifier: Modifier = Modifier,
+    onValueChange: ((String) -> Unit)? = null,
+    enabled: Boolean = true,
+    supportingText: String? = null,
+    isError: Boolean = false,
+    inputTransformation: InputTransformation? = null,
+    outputTransformation: OutputTransformation? = null,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    innerIndication: Indication? = null,
+    prefix: String? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+) {
     val style = CheckoutTextFieldDefaults.textFieldStyle(CheckoutThemeProvider.elements.textField)
     val innerTextStyle = CheckoutThemeProvider.textStyles.body
-    val state = rememberTextFieldState(initialValue)
     BasicTextField(
-        state = state,
+        state = inputState,
         modifier = modifier,
         enabled = enabled,
         inputTransformation = inputTransformation,
@@ -127,8 +162,8 @@ fun CheckoutTextField(
 
     if (onValueChange != null) {
         val currentOnValueChange by rememberUpdatedState(onValueChange)
-        LaunchedEffect(state) {
-            snapshotFlow { state.text }
+        LaunchedEffect(inputState) {
+            snapshotFlow { inputState.text }
                 .drop(1)
                 .collectLatest { value ->
                     currentOnValueChange(value.toString())

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/ValuePickerField.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/ValuePickerField.kt
@@ -10,7 +10,9 @@ package com.adyen.checkout.ui.internal
 
 import androidx.annotation.RestrictTo
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -21,6 +23,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -54,12 +58,17 @@ fun ValuePickerField(
     CheckoutTextField(
         initialValue = value,
         label = label,
-        // This makes sure the whole composable is clickable, but the ripple is not displayed outside of the inner field
-        modifier = modifier.clickable(
-            interactionSource = interactionSource,
-            indication = null,
-            onClick = onClick,
-        ),
+        // Because we disable the CheckoutTextField we need to override focus and input events
+        modifier = modifier
+            .pointerInput(onClick) {
+                awaitEachGesture {
+                    awaitFirstDown(pass = PointerEventPass.Initial)
+                    val up = waitForUpOrCancellation(pass = PointerEventPass.Initial)
+                    if (up != null) {
+                        onClick()
+                    }
+                }
+            },
         enabled = false,
         supportingText = supportingText,
         isError = isError,

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/ValuePickerField.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/ValuePickerField.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
@@ -62,9 +63,11 @@ fun ValuePickerField(
 ) {
     val style = CheckoutTextFieldDefaults.textFieldStyle(CheckoutThemeProvider.elements.textField)
     val interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
+    val state = remember(value) { TextFieldState(value) }
+
     CheckoutTextField(
-        initialValue = value,
         label = label,
+        inputState = state,
         // Because we disable the CheckoutTextField we need to override focus and input events
         modifier = modifier
             .focusable(interactionSource = interactionSource)

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/ValuePickerField.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/ValuePickerField.kt
@@ -24,6 +24,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.vectorResource
@@ -70,6 +76,13 @@ fun ValuePickerField(
                         onClick()
                     }
                 }
+            }
+            .onKeyEvent { event ->
+                if (event.type == KeyEventType.KeyUp && event.isEnter) {
+                    onClick()
+                    return@onKeyEvent true
+                }
+                return@onKeyEvent false
             },
         enabled = false,
         supportingText = supportingText,
@@ -85,6 +98,16 @@ fun ValuePickerField(
         innerIndication = ripple(color = style.textColor),
     )
 }
+
+private val KeyEvent.isEnter: Boolean
+    get() = when (key) {
+        Key.DirectionCenter,
+        Key.Enter,
+        Key.NumPadEnter,
+        Key.Spacebar -> true
+
+        else -> false
+    }
 
 @Preview
 @Composable

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/ValuePickerField.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/ValuePickerField.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.ui.internal
 
 import androidx.annotation.RestrictTo
 import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.waitForUpOrCancellation
@@ -60,6 +61,7 @@ fun ValuePickerField(
         label = label,
         // Because we disable the CheckoutTextField we need to override focus and input events
         modifier = modifier
+            .focusable(interactionSource = interactionSource)
             .pointerInput(onClick) {
                 awaitEachGesture {
                     awaitFirstDown(pass = PointerEventPass.Initial)


### PR DESCRIPTION
## Description
The new TextFieldState API broke our `ValuePickerField`. It was no longer reacting to clicks and the value couldn't be updated. To workaround this it is necessary to manually handle focus and input events.