### PR TITLE
v5 - PayTo allow leading zeros

### DIFF
--- a/payto/src/main/java/com/adyen/checkout/payto/internal/ui/DefaultPayToDelegate.kt
+++ b/payto/src/main/java/com/adyen/checkout/payto/internal/ui/DefaultPayToDelegate.kt
@@ -122,7 +122,7 @@ internal class DefaultPayToDelegate(
     private fun createOutputData() = PayToOutputData(
         mode = inputData.mode,
         payIdTypeModel = inputData.payIdTypeModel,
-        mobilePhoneNumber = inputData.phoneNumber.trimStart('0'),
+        mobilePhoneNumber = inputData.phoneNumber,
         emailAddress = inputData.emailAddress,
         abnNumber = inputData.abnNumber,
         organizationId = inputData.organizationId,

--- a/payto/src/main/java/com/adyen/checkout/payto/internal/util/PayToValidationUtils.kt
+++ b/payto/src/main/java/com/adyen/checkout/payto/internal/util/PayToValidationUtils.kt
@@ -12,7 +12,7 @@ import java.util.regex.Pattern
 
 internal object PayToValidationUtils {
 
-    private const val PHONE_NUMBER_REGEX = "^[1-9]{1,1}[0-9]{1,29}$"
+    private const val PHONE_NUMBER_REGEX = "^[0-9]{1,30}$"
     private val PHONE_NUMBER_PATTERN = Pattern.compile(PHONE_NUMBER_REGEX)
 
     private const val ABN_NUMBER_REGEX = "^((\\d{9})|(\\d{11}))\$"

--- a/payto/src/test/java/com/adyen/checkout/payto/internal/util/PayToValidationUtilsTest.kt
+++ b/payto/src/test/java/com/adyen/checkout/payto/internal/util/PayToValidationUtilsTest.kt
@@ -50,6 +50,7 @@ internal class PayToValidationUtilsTest {
         @JvmStatic
         fun getPhoneNumberTestCases() = listOf(
             // phoneNumber, expectedValidationResult
+            arguments("0123456789", true),
             arguments("123456789", true),
             arguments("789456123", true),
             arguments("9876543210", true),
@@ -57,11 +58,11 @@ internal class PayToValidationUtilsTest {
             arguments("1523456789", true),
             arguments("412345678", true),
             arguments("9076543210", true),
+            arguments("000000000000000000000000000000", true),
             arguments("+31-123456789", false),
             arguments("+1-", false),
             arguments("abc", false),
             arguments("++1-123456789", false),
-            arguments("000000000000000000000000000000", false),
             arguments("+1-00000000000000000000000000000", false),
         )
 


### PR DESCRIPTION
## Description
Allow leading zeros in the PayTo phone number input

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

COSDK-619

## Release notes

### Improved
- For the PayTo payment method, the phone number input now allows leading zeros.
