### PR TITLE
V5 - SdkData - Limit SdkData creation

### DIFF
--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/model/sdkData/DirectSdkDataCreation.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/model/sdkData/DirectSdkDataCreation.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 27/10/2025.
+ */
+
+package com.adyen.checkout.components.core.internal.data.model.sdkData
+
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.components.core.internal.provider.SdkDataProvider
+
+/**
+ * Marks the constructor of [SdkData] to require an opt-in.
+ *
+ * Avoid creating [SdkData] directly. Instead, use the [SdkDataProvider] to ensure all fields are
+ * populated correctly.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@RequiresOptIn("Avoid creating SdkData directly, use SdkDataProvider instead")
+@Target(AnnotationTarget.CONSTRUCTOR)
+@Retention(AnnotationRetention.BINARY)
+annotation class DirectSdkDataCreation

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/provider/SdkDataProvider.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/provider/SdkDataProvider.kt
@@ -12,6 +12,7 @@ import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.core.internal.analytics.AnalyticsManager
 import com.adyen.checkout.components.core.internal.data.model.sdkData.Analytics
 import com.adyen.checkout.components.core.internal.data.model.sdkData.Authentication
+import com.adyen.checkout.components.core.internal.data.model.sdkData.DirectSdkDataCreation
 import com.adyen.checkout.components.core.internal.data.model.sdkData.SdkData
 import com.adyen.checkout.core.AdyenLogLevel
 import com.adyen.checkout.core.internal.util.adyenLog
@@ -23,6 +24,7 @@ import kotlin.io.encoding.ExperimentalEncodingApi
 /**
  * A provider that creates an [SdkData] object with the necessary information.
  */
+@OptIn(DirectSdkDataCreation::class)
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class SdkDataProvider(
     private val analyticsManager: AnalyticsManager


### PR DESCRIPTION
## Description
Limited creation of the SdkData, for it to always happen through the SdkDataProvider.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COSDK-513
