### PR TITLE
V5 - Sepa - Fix view state

### DIFF
--- a/sepa/src/main/java/com/adyen/checkout/sepa/internal/ui/view/SepaView.kt
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/internal/ui/view/SepaView.kt
@@ -60,6 +60,8 @@ internal class SepaView @JvmOverloads constructor(
         this.localizedContext = localizedContext
         initLocalizedStrings(localizedContext)
 
+        updateInputFields(sepaDelegate.outputData)
+
         binding.editTextHolderName.setOnChangeListener {
             sepaDelegate.updateInputData { name = binding.editTextHolderName.rawValue }
             binding.textInputLayoutHolderName.hideError()
@@ -89,6 +91,11 @@ internal class SepaView @JvmOverloads constructor(
             R.style.AdyenCheckout_Sepa_AccountNumberInput,
             localizedContext,
         )
+    }
+
+    private fun updateInputFields(outputData: SepaOutputData) {
+        binding.editTextHolderName.setText(outputData.ownerNameField.value)
+        binding.editTextIbanNumber.setText(outputData.ibanNumberField.value)
     }
 
     override fun highlightValidationErrors() {


### PR DESCRIPTION
## Description
Assigned back values to the text views when the view is recreated

## Related issues
https://github.com/Adyen/adyen-android/issues/2372

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COSDK-687

## Release notes
[//]: # (Use the headers listed below to organize your release notes. Each section should begin with ### followed by a valid label)
[//]: # (Allowed labels: `Breaking changes`, `New`, `Fixed`, `Improved`, `Changed`, `Removed`, `Deprecated`)
[//]: # (Content will be grouped under a specific label until the next header #, ##, or ### is found)
[//]: # (### New)
[//]: # (List any new features or enhancements)
[//]: # (e.g. - Added functionality for user authentication)
### Fixed
[//]: # (List fixes here)
- The SEPA component now remembers its previous state when you return to the app after switching away.
