### PR TITLE
v6 - Make ktlint task incremental

### DIFF
--- a/buildSrc/src/main/java/ktlint-convention.gradle.kts
+++ b/buildSrc/src/main/java/ktlint-convention.gradle.kts
@@ -24,9 +24,21 @@ val ktLintTask = tasks.register<JavaExec>("ktlint") {
     description = "Check Kotlin code style"
     group = LifecycleBasePlugin.VERIFICATION_GROUP
 
+    val inputFiles = project.fileTree("src") {
+        include("**/*.kt", "**/*.kts")
+        exclude("**/build/**", "**/.gradle/**")
+    }
+    inputs.files(inputFiles)
+
+    val outputDir = project.layout.buildDirectory.dir("reports/ktlint").get()
+    val outputFile = outputDir.file("ktlint-report.txt")
+    outputs.file(outputFile)
+
     classpath = ktlint
     mainClass.set("com.pinterest.ktlint.Main")
     args(
+        "--reporter=plain",
+        "--reporter=plain,output=${outputFile}",
         "**/src/**/main/**/*.kt",
         "**.kts",
         "!**/build/**",


### PR DESCRIPTION
## Description
The ktlint task is now configured with inputs and outputs making it possible for Gradle to cache the results of the task. In a local build without changes this made `./gradlew check` go from 13 seconds to 1 second.