### PR TITLE
v5 - Ignore UnknownHostException in StatusPollingRepository

### DIFF
--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/StatusRepository.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/api/StatusRepository.kt
@@ -82,6 +82,8 @@ class DefaultStatusRepository(
                 fetchStatus(it)
             }
             .filterNot {
+                // For API >= 35, apps lose connectivity if in background. That results in an UnknownHostException here.
+                // We do not emit this since connection can be recovered and thus, it's not a payment critical failure.
                 it.exceptionOrNull() is UnknownHostException
             }
             .transform { result ->


### PR DESCRIPTION
## Description
[//]: # (Include a short summary of your changes)
[//]: # (If this is a new feature: attach screenshots or a video if applicable)
[//]: # (If this is a bug fix: include a reproduction path)
From API level 35, OS pauses connectivity for apps in background causing an UnknownHostException to be thrown. This PR ignores that error, so this change results in `onError` not being triggered unnecessarily when the app goes to background and connectivity is paused temporarily.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COSDK-749

## Release notes
[//]: # (Use the headers listed below to organize your release notes. Each section should begin with ### followed by a valid label)
[//]: # (Allowed labels: `Breaking changes`, `New`, `Fixed`, `Improved`, `Changed`, `Removed`, `Deprecated`)
[//]: # (Content will be grouped under a specific label until the next header #, ##, or ### is found)
[//]: # (### New)
[//]: # (List any new features or enhancements)
[//]: # (e.g. - Added functionality for user authentication)
[//]: # (### Fixed)
[//]: # (List fixes here)
[//]: # (e.g. - Fixed issue with incorrect data rendering)

### Fixed 
- For devices running Android 15 and above, `onError()` callback is not triggered anymore for Await, QrCode and Twint actions while in background.