### PR TITLE
V6 - Card - Drop shadow for network logo

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
@@ -13,24 +13,16 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.maxLength
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.dropShadow
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.shadow.Shadow
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.DpOffset
-import androidx.compose.ui.unit.dp
 import com.adyen.checkout.card.R
 import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.common.CardType
@@ -40,7 +32,6 @@ import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputState
 import com.adyen.checkout.ui.internal.CheckoutTextField
-import com.adyen.checkout.ui.internal.CheckoutThemeProvider
 import com.adyen.checkout.ui.internal.DigitOnlyInputTransformation
 import com.adyen.checkout.ui.internal.Dimensions
 
@@ -115,10 +106,7 @@ private fun CardNumberInputField(
         shouldFocus = cardNumberState.isFocused,
         trailingIcon = {
             CheckoutNetworkLogo(
-                modifier = Modifier
-                    .height(16.dp)
-                    .width(24.dp)
-                    .clip(RoundedCornerShape(Dimensions.CornerRadius)),
+                modifier = Modifier.size(Dimensions.LogoSize.small),
                 txVariant = detectedBrand?.txVariant.orEmpty(),
                 placeholder = R.drawable.ic_card_placeholder,
                 errorFallback = R.drawable.ic_card_placeholder,
@@ -144,17 +132,7 @@ private fun CardBrandsList(
         ) {
             for (cardBrand in cardBrands) {
                 CheckoutNetworkLogo(
-                    modifier = Modifier
-                        .size(24.dp, 16.dp)
-                        .dropShadow(
-                            shape = RoundedCornerShape(Dimensions.CornerRadius),
-                            shadow = Shadow(
-                                radius = 1.dp,
-                                offset = DpOffset(x = 0.dp, 2.dp),
-                                color = CheckoutThemeProvider.colors.container,
-                            ),
-                        )
-                        .clip(RoundedCornerShape(Dimensions.CornerRadius)),
+                    modifier = Modifier.size(Dimensions.LogoSize.small),
                     txVariant = cardBrand.txVariant,
                 )
             }

--- a/core/src/main/java/com/adyen/checkout/core/common/internal/ui/CheckoutNetworkLogo.kt
+++ b/core/src/main/java/com/adyen/checkout/core/common/internal/ui/CheckoutNetworkLogo.kt
@@ -10,15 +10,22 @@ package com.adyen.checkout.core.common.internal.ui
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.RestrictTo
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.dropShadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.shadow.Shadow
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalResources
-import com.adyen.checkout.core.common.Environment
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
 import com.adyen.checkout.core.common.internal.helper.LocalEnvironment
 import com.adyen.checkout.core.common.internal.imageLoader
 import com.adyen.checkout.test.R
+import com.adyen.checkout.ui.internal.Dimensions
 import com.adyen.checkout.ui.internal.ImageLoader
 import com.adyen.checkout.ui.internal.LogoSize
 import com.adyen.checkout.ui.internal.NetworkImage
@@ -27,7 +34,6 @@ import com.adyen.checkout.ui.internal.NetworkImage
  * Composable that loads a logo using the Adyen environment and txVariant.
  *
  * @param txVariant The txVariant to be handled.
- * @param environment The [Environment] to be used for internal network calls.
  * @param modifier The modifier to be applied to the Image.
  * @param imageLoader The ImageLoader instance to use. Defaults to the one provided by the Context.
  * @param size The [LogoSize] required to download the correct sized image.
@@ -56,9 +62,21 @@ fun CheckoutNetworkLogo(
         environment.checkoutShopperBaseUrl.toString() + logoPath
     }
 
+    @Suppress("MagicNumber")
     NetworkImage(
         url = fullUrl,
-        modifier = modifier,
+        modifier = modifier
+            .dropShadow(
+                shape = RoundedCornerShape(Dimensions.CornerRadius),
+                shadow = Shadow(
+                    radius = 1.dp,
+                    offset = DpOffset(x = 0.dp, 2.dp),
+                    // TODO - Colors: Move this color to the Internal colors file, but not expose to the public layer
+                    color = Color(0xFF121212),
+                    alpha = 0.04f,
+                ),
+            )
+            .clip(RoundedCornerShape(Dimensions.CornerRadius)),
         contentDescription = contentDescription,
         imageLoader = imageLoader,
         placeholder = placeholder,

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/Dimensions.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/Dimensions.kt
@@ -9,11 +9,13 @@
 package com.adyen.checkout.ui.internal
 
 import androidx.annotation.RestrictTo
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 object Dimensions {
 
+    // TODO - Dimensions: Move all spacing dimensions inside Spacing object
     val ExtraSmall = 4.dp
 
     val Small = 8.dp
@@ -31,4 +33,11 @@ object Dimensions {
     val MinTouchTarget = 48.dp
 
     val CornerRadius = 4.dp
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    object LogoSize {
+        val small = DpSize(width = 27.dp, height = 18.dp)
+
+        val large = DpSize(width = 40.dp, height = 26.dp)
+    }
 }


### PR DESCRIPTION
## Description
- Drop shadow to CheckoutNetworkLogo, since it should be shown for all payment method/brand icons.
- Added background inverse color from the design system

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COSDK-660
