### PR TITLE
v6: Card - Fix expiry date focus changed callback

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardComponent.kt
@@ -52,7 +52,7 @@ internal fun CardComponent(
             ExpiryDateField(
                 expiryDateState = viewState.expiryDate,
                 onExpiryDateChanged = changeListener::onExpiryDateChanged,
-                onExpiryDateFocusChanged = changeListener::onCardNumberFocusChanged,
+                onExpiryDateFocusChanged = changeListener::onExpiryDateFocusChanged,
             )
         }
     }


### PR DESCRIPTION
## Description
[//]: # (Include a short summary of your changes)
[//]: # (If this is a new feature: attach screenshots or a video if applicable)
[//]: # (If this is a bug fix: include a reproduction path)
Expiry date focus change callback was incorrectly assigned to `onCardNumberFocusChanged`. This change fixes that issue.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COSDK-570