### PR TITLE
Fix security alert in Github workflow

### DIFF
--- a/.github/workflows/add_pr_label.yml
+++ b/.github/workflows/add_pr_label.yml
@@ -27,9 +27,11 @@ jobs:
 
       - name: Get label
         id: get_label
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
         run: |
           chmod +x scripts/generate_pr_label.sh
-          branch_name="${{github.event.pull_request.head.ref}}"
+          branch_name="$BRANCH_NAME"
           LABEL=$(./scripts/generate_pr_label.sh "$branch_name")
           echo -e "label=$LABEL" >> $GITHUB_OUTPUT
           echo -e $LABEL


### PR DESCRIPTION
## Description
Don't use user-controlled data directly in a run block of add_pr_label workflow.
