### PR TITLE
v6: Card - Enable CardPaymentMethod serialization in PaymentMethodDetails

### DIFF
--- a/core/src/main/java/com/adyen/checkout/core/components/paymentmethod/PaymentMethodDetails.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/paymentmethod/PaymentMethodDetails.kt
@@ -64,7 +64,7 @@ abstract class PaymentMethodDetails : ModelObject() {
 //                ACHDirectDebitPaymentMethod.PAYMENT_METHOD_TYPE -> ACHDirectDebitPaymentMethod.SERIALIZER
 //                BacsDirectDebitPaymentMethod.PAYMENT_METHOD_TYPE -> BacsDirectDebitPaymentMethod.SERIALIZER
 //                BlikPaymentMethod.PAYMENT_METHOD_TYPE -> BlikPaymentMethod.SERIALIZER
-//                CardPaymentMethod.PAYMENT_METHOD_TYPE -> CardPaymentMethod.SERIALIZER
+                CardPaymentMethod.PAYMENT_METHOD_TYPE -> CardPaymentMethod.SERIALIZER
 //                CashAppPayPaymentMethod.PAYMENT_METHOD_TYPE -> CashAppPayPaymentMethod.SERIALIZER
 //                ConvenienceStoresJPPaymentMethod.PAYMENT_METHOD_TYPE -> ConvenienceStoresJPPaymentMethod.SERIALIZER
 //                DotpayPaymentMethod.PAYMENT_METHOD_TYPE -> DotpayPaymentMethod.SERIALIZER


### PR DESCRIPTION
## Description
[//]: # (Include a short summary of your changes)
[//]: # (If this is a new feature: attach screenshots or a video if applicable)
[//]: # (If this is a bug fix: include a reproduction path)
Uncomment `CardPaymentMethod` line in `PaymentMethodDetails.getChildSerializer()` to be able to serialize the `CardPaymentMethod` object.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COSDK-570
