### PR TITLE
Automatically label PRs based on diff size

### DIFF
--- a/.github/workflows/label_pr_size.yml
+++ b/.github/workflows/label_pr_size.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   label_pr_size:
+    runs-on: ubuntu-latest
     steps:
       - name: Label PR size
         uses: codelytv/pr-size-labeler@4ec67706cd878fbc1c8db0a5dcd28b6bb412e85a


### PR DESCRIPTION
## Description
Automatically label PRs based on diff size. Line change thresholds:
- Tiny: <= 100
- Small: <= 200
- Medium: <= 500
- Large: <= 1000
- Huge: > 1000

During the diffing deleted files, `.api` files and the verification metadata file are ignored.
