### PR TITLE
V5 - Fix - Component recreation on lifecycle changes

### DIFF
--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/AdyenComponentView.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/AdyenComponentView.kt
@@ -70,6 +70,8 @@ class AdyenComponentView @JvmOverloads constructor(
 
     private var attachedComponent = WeakReference<Component?>(null)
 
+    private var currentViewType: ComponentViewType? = null
+
     init {
         isVisible = isInEditMode
         orientation = VERTICAL
@@ -91,6 +93,12 @@ class AdyenComponentView @JvmOverloads constructor(
 
         component.viewFlow
             .onEach { componentViewType ->
+                if (currentViewType == componentViewType) {
+                    adyenLog(AdyenLogLevel.DEBUG) { "Same component view type emitted, skipping view recreation." }
+                    return@onEach
+                }
+                currentViewType = componentViewType
+
                 binding.frameLayoutComponentContainer.removeAllViews()
 
                 if (componentViewType == null) {


### PR DESCRIPTION
## Description
Store the `componentViewType` and recreate the view only when `componentViewType` has been changed.

## Related issues
https://github.com/Adyen/adyen-android/issues/2416

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

COSDK-794

## Release notes
### Fixed
- Fixed an issue where components were recreated and lost their state when the app returned from the background.