### PR TITLE
V5 - SdkData - Move sdkData to paymentMethod object

### DIFF
--- a/ach/src/main/java/com/adyen/checkout/ach/internal/ui/DefaultACHDirectDebitDelegate.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/internal/ui/DefaultACHDirectDebitDelegate.kt
@@ -301,6 +301,7 @@ internal class DefaultACHDirectDebitDelegate(
             val achPaymentMethod = ACHDirectDebitPaymentMethod(
                 type = ACHDirectDebitPaymentMethod.PAYMENT_METHOD_TYPE,
                 checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
+                sdkData = sdkDataProvider.createEncodedSdkData(),
                 encryptedBankAccountNumber = encryptedBankAccountNumber,
                 encryptedBankLocationId = encryptedBankLocationId,
                 ownerName = outputData.ownerName.value,
@@ -310,7 +311,6 @@ internal class DefaultACHDirectDebitDelegate(
                 storePaymentMethod = if (showStorePaymentField()) outputData.shouldStorePaymentMethod else null,
                 paymentMethod = achPaymentMethod,
                 amount = componentParams.amount,
-                sdkData = sdkDataProvider.createEncodedSdkData(),
             )
 
             if (isAddressRequired(outputData.addressUIState)) {

--- a/ach/src/main/java/com/adyen/checkout/ach/internal/ui/StoredACHDirectDebitDelegate.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/internal/ui/StoredACHDirectDebitDelegate.kt
@@ -127,6 +127,7 @@ internal class StoredACHDirectDebitDelegate(
         val paymentMethod = ACHDirectDebitPaymentMethod(
             type = ACHDirectDebitPaymentMethod.PAYMENT_METHOD_TYPE,
             checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
+            sdkData = sdkDataProvider.createEncodedSdkData(),
             storedPaymentMethodId = storedPaymentMethod.id,
         )
 
@@ -134,7 +135,6 @@ internal class StoredACHDirectDebitDelegate(
             paymentMethod = paymentMethod,
             order = order,
             amount = componentParams.amount,
-            sdkData = sdkDataProvider.createEncodedSdkData(),
         )
 
         return ACHDirectDebitComponentState(

--- a/bacs/src/main/java/com/adyen/checkout/bacs/internal/ui/DefaultBacsDirectDebitDelegate.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/internal/ui/DefaultBacsDirectDebitDelegate.kt
@@ -197,6 +197,7 @@ internal class DefaultBacsDirectDebitDelegate(
         val bacsDirectDebitPaymentMethod = BacsDirectDebitPaymentMethod(
             type = BacsDirectDebitPaymentMethod.PAYMENT_METHOD_TYPE,
             checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
+            sdkData = sdkDataProvider.createEncodedSdkData(),
             holderName = outputData.holderNameState.value,
             bankAccountNumber = outputData.bankAccountNumberState.value,
             bankLocationId = outputData.sortCodeState.value,
@@ -207,7 +208,6 @@ internal class DefaultBacsDirectDebitDelegate(
             paymentMethod = bacsDirectDebitPaymentMethod,
             order = order,
             amount = componentParams.amount,
-            sdkData = sdkDataProvider.createEncodedSdkData(),
         )
 
         return BacsDirectDebitComponentState(

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/DefaultBlikDelegate.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/DefaultBlikDelegate.kt
@@ -137,6 +137,7 @@ internal class DefaultBlikDelegate(
         val paymentMethod = BlikPaymentMethod(
             type = BlikPaymentMethod.PAYMENT_METHOD_TYPE,
             checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
+            sdkData = sdkDataProvider.createEncodedSdkData(),
             blikCode = outputData.blikCodeField.value,
         )
 
@@ -144,7 +145,6 @@ internal class DefaultBlikDelegate(
             paymentMethod = paymentMethod,
             order = order,
             amount = componentParams.amount,
-            sdkData = sdkDataProvider.createEncodedSdkData(),
         )
 
         return BlikComponentState(

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/StoredBlikDelegate.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/StoredBlikDelegate.kt
@@ -126,6 +126,7 @@ internal class StoredBlikDelegate(
         val paymentMethod = BlikPaymentMethod(
             type = BlikPaymentMethod.PAYMENT_METHOD_TYPE,
             checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
+            sdkData = sdkDataProvider.createEncodedSdkData(),
             storedPaymentMethodId = storedPaymentMethod.id,
         )
 
@@ -133,7 +134,6 @@ internal class StoredBlikDelegate(
             paymentMethod = paymentMethod,
             order = order,
             amount = componentParams.amount,
-            sdkData = sdkDataProvider.createEncodedSdkData(),
         )
 
         return BlikComponentState(

--- a/boleto/src/main/java/com/adyen/checkout/boleto/internal/ui/DefaultBoletoDelegate.kt
+++ b/boleto/src/main/java/com/adyen/checkout/boleto/internal/ui/DefaultBoletoDelegate.kt
@@ -239,6 +239,7 @@ internal class DefaultBoletoDelegate(
             paymentMethod = GenericPaymentMethod(
                 type = paymentMethod.type,
                 checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
+                sdkData = sdkDataProvider.createEncodedSdkData(),
                 subtype = null,
             ),
             order = order,
@@ -248,7 +249,6 @@ internal class DefaultBoletoDelegate(
                 firstName = outputData.firstNameState.value,
                 lastName = outputData.lastNameState.value,
             ),
-            sdkData = sdkDataProvider.createEncodedSdkData(),
         )
         if (outputData.isSendEmailSelected) {
             paymentComponentData.shopperEmail = outputData.shopperEmailState.value

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegate.kt
@@ -756,9 +756,13 @@ class DefaultCardDelegate(
         firstCardBrand: CardBrand?,
         binValue: String
     ): CardComponentState {
+        val sdkData = sdkDataProvider.createEncodedSdkData(
+            threeDS2SdkVersion = runCompileOnly { ThreeDS2Service.INSTANCE.sdkVersion },
+        )
         val cardPaymentMethod = CardPaymentMethod(
             type = CardPaymentMethod.PAYMENT_METHOD_TYPE,
             checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
+            sdkData = sdkData,
         ).apply {
             encryptedCardNumber = encryptedCard.encryptedCardNumber
             encryptedExpiryMonth = encryptedCard.encryptedExpiryMonth
@@ -825,9 +829,6 @@ class DefaultCardDelegate(
             shopperReference = componentParams.shopperReference,
             order = order,
             amount = componentParams.amount,
-            sdkData = sdkDataProvider.createEncodedSdkData(
-                threeDS2SdkVersion = runCompileOnly { ThreeDS2Service.INSTANCE.sdkVersion },
-            ),
         ).apply {
             if (isSocialSecurityNumberRequired()) {
                 socialSecurityNumber = stateOutputData.socialSecurityNumberState.value

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/StoredCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/StoredCardDelegate.kt
@@ -361,6 +361,9 @@ internal class StoredCardDelegate(
         val cardPaymentMethod = CardPaymentMethod(
             type = CardPaymentMethod.PAYMENT_METHOD_TYPE,
             checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
+            sdkData = sdkDataProvider.createEncodedSdkData(
+                threeDS2SdkVersion = runCompileOnly { ThreeDS2Service.INSTANCE.sdkVersion },
+            ),
         ).apply {
             storedPaymentMethodId = getPaymentMethodId()
 
@@ -393,9 +396,6 @@ internal class StoredCardDelegate(
             shopperReference = componentParams.shopperReference,
             order = order,
             amount = componentParams.amount,
-            sdkData = sdkDataProvider.createEncodedSdkData(
-                threeDS2SdkVersion = runCompileOnly { ThreeDS2Service.INSTANCE.sdkVersion },
-            ),
         )
     }
 

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegateTest.kt
@@ -806,7 +806,6 @@ internal class DefaultCardDelegateTest(
                     assertNull(shopperEmail)
                     assertNull(shopperName)
                     assertNull(telephoneNumber)
-                    assertNull(sdkData)
                 }
 
                 with(requireNotNull(paymentComponentData.paymentMethod)) {
@@ -928,7 +927,6 @@ internal class DefaultCardDelegateTest(
                     assertNull(shopperEmail)
                     assertNull(shopperName)
                     assertNull(telephoneNumber)
-                    assertNull(sdkData)
                 }
 
                 with(requireNotNull(paymentComponentData.paymentMethod)) {

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/StoredCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/StoredCardDelegateTest.kt
@@ -343,7 +343,6 @@ internal class StoredCardDelegateTest(
                     assertNull(shopperEmail)
                     assertNull(shopperName)
                     assertNull(telephoneNumber)
-                    assertNull(sdkData)
                 }
 
                 with(requireNotNull(paymentComponentData.paymentMethod)) {

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/DefaultCashAppPayDelegate.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/DefaultCashAppPayDelegate.kt
@@ -175,6 +175,7 @@ constructor(
         val cashAppPayPaymentMethod = CashAppPayPaymentMethod(
             type = paymentMethod.type,
             checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
+            sdkData = sdkDataProvider.createEncodedSdkData(),
             grantId = oneTimeData?.grantId,
             customerId = onFileData?.customerId ?: oneTimeData?.customerId,
             onFileGrantId = onFileData?.grantId,
@@ -186,7 +187,6 @@ constructor(
             order = order,
             amount = componentParams.amount,
             storePaymentMethod = onFileData != null,
-            sdkData = sdkDataProvider.createEncodedSdkData(),
         )
 
         return CashAppPayComponentState(

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/StoredCashAppPayDelegate.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/internal/ui/StoredCashAppPayDelegate.kt
@@ -110,6 +110,7 @@ internal class StoredCashAppPayDelegate(
         val cashAppPayPaymentMethod = CashAppPayPaymentMethod(
             type = paymentMethod.type,
             checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
+            sdkData = sdkDataProvider.createEncodedSdkData(),
             storedPaymentMethodId = paymentMethod.id,
         )
 
@@ -117,7 +118,6 @@ internal class StoredCashAppPayDelegate(
             paymentMethod = cashAppPayPaymentMethod,
             order = order,
             amount = componentParams.amount,
-            sdkData = sdkDataProvider.createEncodedSdkData(),
         )
 
         return CashAppPayComponentState(

--- a/components-core/api/components-core.api
+++ b/components-core/api/components-core.api
@@ -731,15 +731,14 @@ public final class com/adyen/checkout/components/core/PaymentComponentData : com
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/adyen/checkout/components/core/PaymentComponentData$Companion;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
-	public fun <init> (Lcom/adyen/checkout/components/core/paymentmethod/PaymentMethodDetails;Lcom/adyen/checkout/components/core/OrderRequest;Lcom/adyen/checkout/components/core/Amount;Ljava/lang/Boolean;Ljava/lang/String;Lcom/adyen/checkout/components/core/Address;Lcom/adyen/checkout/components/core/Address;Lcom/adyen/checkout/components/core/ShopperName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/adyen/checkout/components/core/Installments;Ljava/lang/Boolean;Ljava/lang/String;)V
-	public synthetic fun <init> (Lcom/adyen/checkout/components/core/paymentmethod/PaymentMethodDetails;Lcom/adyen/checkout/components/core/OrderRequest;Lcom/adyen/checkout/components/core/Amount;Ljava/lang/Boolean;Ljava/lang/String;Lcom/adyen/checkout/components/core/Address;Lcom/adyen/checkout/components/core/Address;Lcom/adyen/checkout/components/core/ShopperName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/adyen/checkout/components/core/Installments;Ljava/lang/Boolean;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/adyen/checkout/components/core/paymentmethod/PaymentMethodDetails;Lcom/adyen/checkout/components/core/OrderRequest;Lcom/adyen/checkout/components/core/Amount;Ljava/lang/Boolean;Ljava/lang/String;Lcom/adyen/checkout/components/core/Address;Lcom/adyen/checkout/components/core/Address;Lcom/adyen/checkout/components/core/ShopperName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/adyen/checkout/components/core/Installments;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Lcom/adyen/checkout/components/core/paymentmethod/PaymentMethodDetails;Lcom/adyen/checkout/components/core/OrderRequest;Lcom/adyen/checkout/components/core/Amount;Ljava/lang/Boolean;Ljava/lang/String;Lcom/adyen/checkout/components/core/Address;Lcom/adyen/checkout/components/core/Address;Lcom/adyen/checkout/components/core/ShopperName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/adyen/checkout/components/core/Installments;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/adyen/checkout/components/core/paymentmethod/PaymentMethodDetails;
 	public final fun component10 ()Ljava/lang/String;
 	public final fun component11 ()Ljava/lang/String;
 	public final fun component12 ()Ljava/lang/String;
 	public final fun component13 ()Lcom/adyen/checkout/components/core/Installments;
 	public final fun component14 ()Ljava/lang/Boolean;
-	public final fun component15 ()Ljava/lang/String;
 	public final fun component2 ()Lcom/adyen/checkout/components/core/OrderRequest;
 	public final fun component3 ()Lcom/adyen/checkout/components/core/Amount;
 	public final fun component4 ()Ljava/lang/Boolean;
@@ -748,8 +747,8 @@ public final class com/adyen/checkout/components/core/PaymentComponentData : com
 	public final fun component7 ()Lcom/adyen/checkout/components/core/Address;
 	public final fun component8 ()Lcom/adyen/checkout/components/core/ShopperName;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Lcom/adyen/checkout/components/core/paymentmethod/PaymentMethodDetails;Lcom/adyen/checkout/components/core/OrderRequest;Lcom/adyen/checkout/components/core/Amount;Ljava/lang/Boolean;Ljava/lang/String;Lcom/adyen/checkout/components/core/Address;Lcom/adyen/checkout/components/core/Address;Lcom/adyen/checkout/components/core/ShopperName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/adyen/checkout/components/core/Installments;Ljava/lang/Boolean;Ljava/lang/String;)Lcom/adyen/checkout/components/core/PaymentComponentData;
-	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/PaymentComponentData;Lcom/adyen/checkout/components/core/paymentmethod/PaymentMethodDetails;Lcom/adyen/checkout/components/core/OrderRequest;Lcom/adyen/checkout/components/core/Amount;Ljava/lang/Boolean;Ljava/lang/String;Lcom/adyen/checkout/components/core/Address;Lcom/adyen/checkout/components/core/Address;Lcom/adyen/checkout/components/core/ShopperName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/adyen/checkout/components/core/Installments;Ljava/lang/Boolean;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/PaymentComponentData;
+	public final fun copy (Lcom/adyen/checkout/components/core/paymentmethod/PaymentMethodDetails;Lcom/adyen/checkout/components/core/OrderRequest;Lcom/adyen/checkout/components/core/Amount;Ljava/lang/Boolean;Ljava/lang/String;Lcom/adyen/checkout/components/core/Address;Lcom/adyen/checkout/components/core/Address;Lcom/adyen/checkout/components/core/ShopperName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/adyen/checkout/components/core/Installments;Ljava/lang/Boolean;)Lcom/adyen/checkout/components/core/PaymentComponentData;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/PaymentComponentData;Lcom/adyen/checkout/components/core/paymentmethod/PaymentMethodDetails;Lcom/adyen/checkout/components/core/OrderRequest;Lcom/adyen/checkout/components/core/Amount;Ljava/lang/Boolean;Ljava/lang/String;Lcom/adyen/checkout/components/core/Address;Lcom/adyen/checkout/components/core/Address;Lcom/adyen/checkout/components/core/ShopperName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/adyen/checkout/components/core/Installments;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/PaymentComponentData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAmount ()Lcom/adyen/checkout/components/core/Amount;
 	public final fun getBillingAddress ()Lcom/adyen/checkout/components/core/Address;
@@ -758,7 +757,6 @@ public final class com/adyen/checkout/components/core/PaymentComponentData : com
 	public final fun getInstallments ()Lcom/adyen/checkout/components/core/Installments;
 	public final fun getOrder ()Lcom/adyen/checkout/components/core/OrderRequest;
 	public final fun getPaymentMethod ()Lcom/adyen/checkout/components/core/paymentmethod/PaymentMethodDetails;
-	public final fun getSdkData ()Ljava/lang/String;
 	public final fun getShopperEmail ()Ljava/lang/String;
 	public final fun getShopperName ()Lcom/adyen/checkout/components/core/ShopperName;
 	public final fun getShopperReference ()Ljava/lang/String;
@@ -1911,22 +1909,24 @@ public final class com/adyen/checkout/components/core/paymentmethod/ACHDirectDeb
 	public static final field Companion Lcom/adyen/checkout/components/core/paymentmethod/ACHDirectDebitPaymentMethod$Companion;
 	public static final field PAYMENT_METHOD_TYPE Ljava/lang/String;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/ACHDirectDebitPaymentMethod;
-	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/ACHDirectDebitPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/ACHDirectDebitPaymentMethod;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/ACHDirectDebitPaymentMethod;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/ACHDirectDebitPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/ACHDirectDebitPaymentMethod;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getCheckoutAttemptId ()Ljava/lang/String;
 	public final fun getEncryptedBankAccountNumber ()Ljava/lang/String;
 	public final fun getEncryptedBankLocationId ()Ljava/lang/String;
 	public final fun getOwnerName ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public final fun getStoredPaymentMethodId ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -1934,6 +1934,7 @@ public final class com/adyen/checkout/components/core/paymentmethod/ACHDirectDeb
 	public final fun setEncryptedBankAccountNumber (Ljava/lang/String;)V
 	public final fun setEncryptedBankLocationId (Ljava/lang/String;)V
 	public final fun setOwnerName (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public final fun setStoredPaymentMethodId (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
 	public fun toString ()Ljava/lang/String;
@@ -1956,26 +1957,30 @@ public final class com/adyen/checkout/components/core/paymentmethod/BacsDirectDe
 	public static final field Companion Lcom/adyen/checkout/components/core/paymentmethod/BacsDirectDebitPaymentMethod$Companion;
 	public static final field PAYMENT_METHOD_TYPE Ljava/lang/String;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/BacsDirectDebitPaymentMethod;
-	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/BacsDirectDebitPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/BacsDirectDebitPaymentMethod;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/BacsDirectDebitPaymentMethod;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/BacsDirectDebitPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/BacsDirectDebitPaymentMethod;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBankAccountNumber ()Ljava/lang/String;
 	public final fun getBankLocationId ()Ljava/lang/String;
 	public fun getCheckoutAttemptId ()Ljava/lang/String;
 	public final fun getHolderName ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
 	public fun hashCode ()I
 	public final fun setBankAccountNumber (Ljava/lang/String;)V
 	public final fun setBankLocationId (Ljava/lang/String;)V
 	public fun setCheckoutAttemptId (Ljava/lang/String;)V
 	public final fun setHolderName (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
@@ -1997,23 +2002,26 @@ public final class com/adyen/checkout/components/core/paymentmethod/BlikPaymentM
 	public static final field Companion Lcom/adyen/checkout/components/core/paymentmethod/BlikPaymentMethod$Companion;
 	public static final field PAYMENT_METHOD_TYPE Ljava/lang/String;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/BlikPaymentMethod;
-	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/BlikPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/BlikPaymentMethod;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/BlikPaymentMethod;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/BlikPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/BlikPaymentMethod;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBlikCode ()Ljava/lang/String;
 	public fun getCheckoutAttemptId ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public final fun getStoredPaymentMethodId ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
 	public fun hashCode ()I
 	public final fun setBlikCode (Ljava/lang/String;)V
 	public fun setCheckoutAttemptId (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public final fun setStoredPaymentMethodId (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
 	public fun toString ()Ljava/lang/String;
@@ -2036,13 +2044,14 @@ public final class com/adyen/checkout/components/core/paymentmethod/CardPaymentM
 	public static final field Companion Lcom/adyen/checkout/components/core/paymentmethod/CardPaymentMethod$Companion;
 	public static final field PAYMENT_METHOD_TYPE Ljava/lang/String;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Ljava/lang/String;
 	public final fun component11 ()Ljava/lang/String;
 	public final fun component12 ()Ljava/lang/String;
 	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
@@ -2051,8 +2060,8 @@ public final class com/adyen/checkout/components/core/paymentmethod/CardPaymentM
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Ljava/lang/String;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/CardPaymentMethod;
-	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/CardPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/CardPaymentMethod;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/CardPaymentMethod;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/CardPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/CardPaymentMethod;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBrand ()Ljava/lang/String;
@@ -2064,6 +2073,7 @@ public final class com/adyen/checkout/components/core/paymentmethod/CardPaymentM
 	public final fun getEncryptedSecurityCode ()Ljava/lang/String;
 	public final fun getFundingSource ()Ljava/lang/String;
 	public final fun getHolderName ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public final fun getStoredPaymentMethodId ()Ljava/lang/String;
 	public final fun getTaxNumber ()Ljava/lang/String;
 	public final fun getThreeDS2SdkVersion ()Ljava/lang/String;
@@ -2078,6 +2088,7 @@ public final class com/adyen/checkout/components/core/paymentmethod/CardPaymentM
 	public final fun setEncryptedSecurityCode (Ljava/lang/String;)V
 	public final fun setFundingSource (Ljava/lang/String;)V
 	public final fun setHolderName (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public final fun setStoredPaymentMethodId (Ljava/lang/String;)V
 	public final fun setTaxNumber (Ljava/lang/String;)V
 	public final fun setThreeDS2SdkVersion (Ljava/lang/String;)V
@@ -2101,8 +2112,8 @@ public final class com/adyen/checkout/components/core/paymentmethod/CashAppPayPa
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/adyen/checkout/components/core/paymentmethod/CashAppPayPaymentMethod$Companion;
 	public static final field PAYMENT_METHOD_TYPE Ljava/lang/String;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
@@ -2110,8 +2121,9 @@ public final class com/adyen/checkout/components/core/paymentmethod/CashAppPayPa
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/CashAppPayPaymentMethod;
-	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/CashAppPayPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/CashAppPayPaymentMethod;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/CashAppPayPaymentMethod;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/CashAppPayPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/CashAppPayPaymentMethod;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCashtag ()Ljava/lang/String;
@@ -2119,6 +2131,7 @@ public final class com/adyen/checkout/components/core/paymentmethod/CashAppPayPa
 	public final fun getCustomerId ()Ljava/lang/String;
 	public final fun getGrantId ()Ljava/lang/String;
 	public final fun getOnFileGrantId ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public final fun getStoredPaymentMethodId ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -2127,6 +2140,7 @@ public final class com/adyen/checkout/components/core/paymentmethod/CashAppPayPa
 	public final fun setCustomerId (Ljava/lang/String;)V
 	public final fun setGrantId (Ljava/lang/String;)V
 	public final fun setOnFileGrantId (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public final fun setStoredPaymentMethodId (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
 	public fun toString ()Ljava/lang/String;
@@ -2151,18 +2165,20 @@ public final class com/adyen/checkout/components/core/paymentmethod/ConvenienceS
 	public static final field PAYMENT_METHOD_TYPE Ljava/lang/String;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun describeContents ()I
 	public fun getCheckoutAttemptId ()Ljava/lang/String;
 	public fun getFirstName ()Ljava/lang/String;
 	public fun getLastName ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public fun getShopperEmail ()Ljava/lang/String;
 	public fun getTelephoneNumber ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
 	public fun setCheckoutAttemptId (Ljava/lang/String;)V
 	public fun setFirstName (Ljava/lang/String;)V
 	public fun setLastName (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public fun setShopperEmail (Ljava/lang/String;)V
 	public fun setTelephoneNumber (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
@@ -2186,21 +2202,24 @@ public final class com/adyen/checkout/components/core/paymentmethod/DotpayPaymen
 	public static final field PAYMENT_METHOD_TYPE Ljava/lang/String;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/DotpayPaymentMethod;
-	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/DotpayPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/DotpayPaymentMethod;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/DotpayPaymentMethod;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/DotpayPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/DotpayPaymentMethod;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getCheckoutAttemptId ()Ljava/lang/String;
 	public fun getIssuer ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun setCheckoutAttemptId (Ljava/lang/String;)V
 	public fun setIssuer (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
@@ -2243,21 +2262,24 @@ public final class com/adyen/checkout/components/core/paymentmethod/EPSPaymentMe
 	public static final field PAYMENT_METHOD_TYPE Ljava/lang/String;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/EPSPaymentMethod;
-	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/EPSPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/EPSPaymentMethod;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/EPSPaymentMethod;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/EPSPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/EPSPaymentMethod;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getCheckoutAttemptId ()Ljava/lang/String;
 	public fun getIssuer ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun setCheckoutAttemptId (Ljava/lang/String;)V
 	public fun setIssuer (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
@@ -2280,14 +2302,16 @@ public final class com/adyen/checkout/components/core/paymentmethod/EntercashPay
 	public static final field PAYMENT_METHOD_TYPE Ljava/lang/String;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun describeContents ()I
 	public fun getCheckoutAttemptId ()Ljava/lang/String;
 	public fun getIssuer ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
 	public fun setCheckoutAttemptId (Ljava/lang/String;)V
 	public fun setIssuer (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
@@ -2307,19 +2331,23 @@ public final class com/adyen/checkout/components/core/paymentmethod/GenericPayme
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/adyen/checkout/components/core/paymentmethod/GenericPaymentMethod$Companion;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/GenericPaymentMethod;
-	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/GenericPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/GenericPaymentMethod;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/GenericPaymentMethod;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/GenericPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/GenericPaymentMethod;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getCheckoutAttemptId ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public final fun getSubtype ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun setCheckoutAttemptId (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public final fun setSubtype (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
 	public fun toString ()Ljava/lang/String;
@@ -2342,7 +2370,8 @@ public final class com/adyen/checkout/components/core/paymentmethod/GiftCardPaym
 	public static final field Companion Lcom/adyen/checkout/components/core/paymentmethod/GiftCardPaymentMethod$Companion;
 	public static final field PAYMENT_METHOD_TYPE Ljava/lang/String;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun describeContents ()I
 	public final fun getBrand ()Ljava/lang/String;
 	public fun getCheckoutAttemptId ()Ljava/lang/String;
@@ -2350,6 +2379,7 @@ public final class com/adyen/checkout/components/core/paymentmethod/GiftCardPaym
 	public final fun getEncryptedExpiryMonth ()Ljava/lang/String;
 	public final fun getEncryptedExpiryYear ()Ljava/lang/String;
 	public final fun getEncryptedSecurityCode ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
 	public final fun setBrand (Ljava/lang/String;)V
 	public fun setCheckoutAttemptId (Ljava/lang/String;)V
@@ -2357,6 +2387,7 @@ public final class com/adyen/checkout/components/core/paymentmethod/GiftCardPaym
 	public final fun setEncryptedExpiryMonth (Ljava/lang/String;)V
 	public final fun setEncryptedExpiryYear (Ljava/lang/String;)V
 	public final fun setEncryptedSecurityCode (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
@@ -2376,26 +2407,29 @@ public final class com/adyen/checkout/components/core/paymentmethod/GooglePayPay
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/adyen/checkout/components/core/paymentmethod/GooglePayPaymentMethod$Companion;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/GooglePayPaymentMethod;
-	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/GooglePayPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/GooglePayPaymentMethod;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/GooglePayPaymentMethod;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/GooglePayPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/GooglePayPaymentMethod;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getCheckoutAttemptId ()Ljava/lang/String;
 	public final fun getGooglePayCardNetwork ()Ljava/lang/String;
 	public final fun getGooglePayToken ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public final fun getThreeDS2SdkVersion ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun setCheckoutAttemptId (Ljava/lang/String;)V
 	public final fun setGooglePayCardNetwork (Ljava/lang/String;)V
 	public final fun setGooglePayToken (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public final fun setThreeDS2SdkVersion (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
 	public fun toString ()Ljava/lang/String;
@@ -2419,14 +2453,16 @@ public final class com/adyen/checkout/components/core/paymentmethod/IdealPayment
 	public static final field PAYMENT_METHOD_TYPE Ljava/lang/String;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun describeContents ()I
 	public fun getCheckoutAttemptId ()Ljava/lang/String;
 	public fun getIssuer ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
 	public fun setCheckoutAttemptId (Ljava/lang/String;)V
 	public fun setIssuer (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
@@ -2458,12 +2494,15 @@ public final class com/adyen/checkout/components/core/paymentmethod/MBWayPayment
 	public static final field Companion Lcom/adyen/checkout/components/core/paymentmethod/MBWayPaymentMethod$Companion;
 	public static final field PAYMENT_METHOD_TYPE Ljava/lang/String;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun describeContents ()I
 	public fun getCheckoutAttemptId ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public final fun getTelephoneNumber ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
 	public fun setCheckoutAttemptId (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public final fun setTelephoneNumber (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
 	public fun writeToParcel (Landroid/os/Parcel;I)V
@@ -2485,14 +2524,16 @@ public final class com/adyen/checkout/components/core/paymentmethod/MolpayPaymen
 	public static final field Companion Lcom/adyen/checkout/components/core/paymentmethod/MolpayPaymentMethod$Companion;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun describeContents ()I
 	public fun getCheckoutAttemptId ()Ljava/lang/String;
 	public fun getIssuer ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
 	public fun setCheckoutAttemptId (Ljava/lang/String;)V
 	public fun setIssuer (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
@@ -2514,21 +2555,24 @@ public final class com/adyen/checkout/components/core/paymentmethod/OnlineBankin
 	public static final field PAYMENT_METHOD_TYPE Ljava/lang/String;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/OnlineBankingCZPaymentMethod;
-	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/OnlineBankingCZPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/OnlineBankingCZPaymentMethod;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/OnlineBankingCZPaymentMethod;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/OnlineBankingCZPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/OnlineBankingCZPaymentMethod;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getCheckoutAttemptId ()Ljava/lang/String;
 	public fun getIssuer ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun setCheckoutAttemptId (Ljava/lang/String;)V
 	public fun setIssuer (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
@@ -2551,18 +2595,20 @@ public final class com/adyen/checkout/components/core/paymentmethod/OnlineBankin
 	public static final field PAYMENT_METHOD_TYPE Ljava/lang/String;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun describeContents ()I
 	public fun getCheckoutAttemptId ()Ljava/lang/String;
 	public fun getFirstName ()Ljava/lang/String;
 	public fun getLastName ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public fun getShopperEmail ()Ljava/lang/String;
 	public fun getTelephoneNumber ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
 	public fun setCheckoutAttemptId (Ljava/lang/String;)V
 	public fun setFirstName (Ljava/lang/String;)V
 	public fun setLastName (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public fun setShopperEmail (Ljava/lang/String;)V
 	public fun setTelephoneNumber (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
@@ -2586,14 +2632,16 @@ public final class com/adyen/checkout/components/core/paymentmethod/OnlineBankin
 	public static final field PAYMENT_METHOD_TYPE Ljava/lang/String;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun describeContents ()I
 	public fun getCheckoutAttemptId ()Ljava/lang/String;
 	public fun getIssuer ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
 	public fun setCheckoutAttemptId (Ljava/lang/String;)V
 	public fun setIssuer (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
@@ -2615,21 +2663,24 @@ public final class com/adyen/checkout/components/core/paymentmethod/OnlineBankin
 	public static final field PAYMENT_METHOD_TYPE Ljava/lang/String;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/OnlineBankingSKPaymentMethod;
-	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/OnlineBankingSKPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/OnlineBankingSKPaymentMethod;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/OnlineBankingSKPaymentMethod;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/OnlineBankingSKPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/OnlineBankingSKPaymentMethod;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getCheckoutAttemptId ()Ljava/lang/String;
 	public fun getIssuer ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun setCheckoutAttemptId (Ljava/lang/String;)V
 	public fun setIssuer (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
@@ -2652,14 +2703,16 @@ public final class com/adyen/checkout/components/core/paymentmethod/OpenBankingP
 	public static final field PAYMENT_METHOD_TYPE Ljava/lang/String;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun describeContents ()I
 	public fun getCheckoutAttemptId ()Ljava/lang/String;
 	public fun getIssuer ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
 	public fun setCheckoutAttemptId (Ljava/lang/String;)V
 	public fun setIssuer (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
@@ -2681,14 +2734,16 @@ public final class com/adyen/checkout/components/core/paymentmethod/PayByBankPay
 	public static final field PAYMENT_METHOD_TYPE Ljava/lang/String;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun describeContents ()I
 	public fun getCheckoutAttemptId ()Ljava/lang/String;
 	public fun getIssuer ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
 	public fun setCheckoutAttemptId (Ljava/lang/String;)V
 	public fun setIssuer (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
@@ -2708,13 +2763,15 @@ public final class com/adyen/checkout/components/core/paymentmethod/PayByBankUSP
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/adyen/checkout/components/core/paymentmethod/PayByBankUSPaymentMethod$Companion;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun describeContents ()I
 	public fun getCheckoutAttemptId ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public final fun getStoredPaymentMethodId ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
 	public fun setCheckoutAttemptId (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public final fun setStoredPaymentMethodId (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
 	public fun writeToParcel (Landroid/os/Parcel;I)V
@@ -2737,18 +2794,20 @@ public final class com/adyen/checkout/components/core/paymentmethod/PayEasyPayme
 	public static final field PAYMENT_METHOD_TYPE Ljava/lang/String;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun describeContents ()I
 	public fun getCheckoutAttemptId ()Ljava/lang/String;
 	public fun getFirstName ()Ljava/lang/String;
 	public fun getLastName ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public fun getShopperEmail ()Ljava/lang/String;
 	public fun getTelephoneNumber ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
 	public fun setCheckoutAttemptId (Ljava/lang/String;)V
 	public fun setFirstName (Ljava/lang/String;)V
 	public fun setLastName (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public fun setShopperEmail (Ljava/lang/String;)V
 	public fun setTelephoneNumber (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
@@ -2771,22 +2830,25 @@ public final class com/adyen/checkout/components/core/paymentmethod/PayToPayment
 	public static final field Companion Lcom/adyen/checkout/components/core/paymentmethod/PayToPaymentMethod$Companion;
 	public static final field PAYMENT_METHOD_TYPE Ljava/lang/String;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/PayToPaymentMethod;
-	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/PayToPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/PayToPaymentMethod;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/PayToPaymentMethod;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/PayToPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/PayToPaymentMethod;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getCheckoutAttemptId ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public final fun getShopperAccountIdentifier ()Ljava/lang/String;
 	public final fun getStoredPaymentMethodId ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun setCheckoutAttemptId (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public final fun setShopperAccountIdentifier (Ljava/lang/String;)V
 	public final fun setStoredPaymentMethodId (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
@@ -2808,12 +2870,15 @@ public final class com/adyen/checkout/components/core/paymentmethod/PayToPayment
 public abstract class com/adyen/checkout/components/core/paymentmethod/PaymentMethodDetails : com/adyen/checkout/core/internal/data/model/ModelObject {
 	public static final field CHECKOUT_ATTEMPT_ID Ljava/lang/String;
 	public static final field Companion Lcom/adyen/checkout/components/core/paymentmethod/PaymentMethodDetails$Companion;
+	public static final field SDK_DATA Ljava/lang/String;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
 	public static final field TYPE Ljava/lang/String;
 	public fun <init> ()V
 	public abstract fun getCheckoutAttemptId ()Ljava/lang/String;
+	public abstract fun getSdkData ()Ljava/lang/String;
 	public abstract fun getType ()Ljava/lang/String;
 	public abstract fun setCheckoutAttemptId (Ljava/lang/String;)V
+	public abstract fun setSdkData (Ljava/lang/String;)V
 	public abstract fun setType (Ljava/lang/String;)V
 }
 
@@ -2826,15 +2891,18 @@ public final class com/adyen/checkout/components/core/paymentmethod/SepaPaymentM
 	public static final field Companion Lcom/adyen/checkout/components/core/paymentmethod/SepaPaymentMethod$Companion;
 	public static final field PAYMENT_METHOD_TYPE Ljava/lang/String;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun describeContents ()I
 	public fun getCheckoutAttemptId ()Ljava/lang/String;
 	public final fun getIban ()Ljava/lang/String;
 	public final fun getOwnerName ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
 	public fun setCheckoutAttemptId (Ljava/lang/String;)V
 	public final fun setIban (Ljava/lang/String;)V
 	public final fun setOwnerName (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
@@ -2856,18 +2924,20 @@ public final class com/adyen/checkout/components/core/paymentmethod/SevenElevenP
 	public static final field PAYMENT_METHOD_TYPE Ljava/lang/String;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun describeContents ()I
 	public fun getCheckoutAttemptId ()Ljava/lang/String;
 	public fun getFirstName ()Ljava/lang/String;
 	public fun getLastName ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public fun getShopperEmail ()Ljava/lang/String;
 	public fun getTelephoneNumber ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
 	public fun setCheckoutAttemptId (Ljava/lang/String;)V
 	public fun setFirstName (Ljava/lang/String;)V
 	public fun setLastName (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public fun setShopperEmail (Ljava/lang/String;)V
 	public fun setTelephoneNumber (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
@@ -2889,22 +2959,25 @@ public final class com/adyen/checkout/components/core/paymentmethod/TwintPayment
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/adyen/checkout/components/core/paymentmethod/TwintPaymentMethod$Companion;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/TwintPaymentMethod;
-	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/TwintPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/TwintPaymentMethod;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/TwintPaymentMethod;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/TwintPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/TwintPaymentMethod;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getCheckoutAttemptId ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public final fun getStoredPaymentMethodId ()Ljava/lang/String;
 	public final fun getSubtype ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun setCheckoutAttemptId (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public final fun setStoredPaymentMethodId (Ljava/lang/String;)V
 	public final fun setSubtype (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
@@ -2927,22 +3000,26 @@ public final class com/adyen/checkout/components/core/paymentmethod/UPIPaymentMe
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/adyen/checkout/components/core/paymentmethod/UPIPaymentMethod$Companion;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/internal/data/model/ModelObject$Serializer;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/UPIPaymentMethod;
-	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/UPIPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/UPIPaymentMethod;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/components/core/paymentmethod/UPIPaymentMethod;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/components/core/paymentmethod/UPIPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/components/core/paymentmethod/UPIPaymentMethod;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAppId ()Ljava/lang/String;
 	public fun getCheckoutAttemptId ()Ljava/lang/String;
+	public fun getSdkData ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
 	public final fun getVirtualPaymentAddress ()Ljava/lang/String;
 	public fun hashCode ()I
 	public final fun setAppId (Ljava/lang/String;)V
 	public fun setCheckoutAttemptId (Ljava/lang/String;)V
+	public fun setSdkData (Ljava/lang/String;)V
 	public fun setType (Ljava/lang/String;)V
 	public final fun setVirtualPaymentAddress (Ljava/lang/String;)V
 	public fun toString ()Ljava/lang/String;

--- a/components-core/src/main/java/com/adyen/checkout/components/core/PaymentComponentData.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/PaymentComponentData.kt
@@ -41,7 +41,6 @@ data class PaymentComponentData<PaymentMethodDetailsT : PaymentMethodDetails>(
     var installments: Installments? = null,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     var supportNativeRedirect: Boolean? = true,
-    val sdkData: String? = null
 ) : ModelObject() {
 
     companion object {
@@ -59,7 +58,6 @@ data class PaymentComponentData<PaymentMethodDetailsT : PaymentMethodDetails>(
         private const val INSTALLMENTS = "installments"
         private const val ORDER = "order"
         private const val SUPPORT_NATIVE_REDIRECT = "supportNativeRedirect"
-        private const val SDK_DATA = "sdkData"
 
         @JvmField
         val SERIALIZER: Serializer<PaymentComponentData<*>> = object : Serializer<PaymentComponentData<*>> {
@@ -80,7 +78,6 @@ data class PaymentComponentData<PaymentMethodDetailsT : PaymentMethodDetails>(
                         putOpt(SOCIAL_SECURITY_NUMBER, modelObject.socialSecurityNumber)
                         putOpt(INSTALLMENTS, serializeOpt(modelObject.installments, Installments.SERIALIZER))
                         putOpt(SUPPORT_NATIVE_REDIRECT, modelObject.supportNativeRedirect)
-                        putOpt(SDK_DATA, modelObject.sdkData)
                     }
                 } catch (e: JSONException) {
                     throw ModelSerializationException(PaymentComponentData::class.java, e)
@@ -106,7 +103,6 @@ data class PaymentComponentData<PaymentMethodDetailsT : PaymentMethodDetails>(
                     socialSecurityNumber = jsonObject.getStringOrNull(SOCIAL_SECURITY_NUMBER),
                     installments = deserializeOpt(jsonObject.optJSONObject(INSTALLMENTS), Installments.SERIALIZER),
                     supportNativeRedirect = jsonObject.getBooleanOrNull(SUPPORT_NATIVE_REDIRECT),
-                    sdkData = jsonObject.getStringOrNull(SDK_DATA),
                 )
             }
         }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/ACHDirectDebitPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/ACHDirectDebitPaymentMethod.kt
@@ -20,6 +20,7 @@ data class ACHDirectDebitPaymentMethod(
     override var type: String?,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String?,
+    override var sdkData: String? = null,
     var encryptedBankAccountNumber: String? = null,
     var encryptedBankLocationId: String? = null,
     var ownerName: String? = null,
@@ -40,6 +41,7 @@ data class ACHDirectDebitPaymentMethod(
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
                         putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
+                        putOpt(SDK_DATA, modelObject.sdkData)
                         putOpt(ENCRYPTED_BANK_ACCOUNT_NUMBER, modelObject.encryptedBankAccountNumber)
                         putOpt(ENCRYPTED_BANK_LOCATION_ID, modelObject.encryptedBankLocationId)
                         putOpt(OWNER_NAME, modelObject.ownerName)
@@ -54,6 +56,7 @@ data class ACHDirectDebitPaymentMethod(
                 return ACHDirectDebitPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
                     checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
+                    sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     encryptedBankAccountNumber = jsonObject.getStringOrNull(ENCRYPTED_BANK_ACCOUNT_NUMBER),
                     encryptedBankLocationId = jsonObject.getStringOrNull(ENCRYPTED_BANK_LOCATION_ID),
                     ownerName = jsonObject.getStringOrNull(OWNER_NAME),

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/BacsDirectDebitPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/BacsDirectDebitPaymentMethod.kt
@@ -19,6 +19,7 @@ data class BacsDirectDebitPaymentMethod(
     override var type: String?,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String?,
+    override var sdkData: String? = null,
     var holderName: String?,
     var bankAccountNumber: String?,
     var bankLocationId: String?,
@@ -39,6 +40,7 @@ data class BacsDirectDebitPaymentMethod(
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
                         putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
+                        putOpt(SDK_DATA, modelObject.sdkData)
                         putOpt(HOLDER_NAME, modelObject.holderName)
                         putOpt(BANK_ACCOUNT_NUMBER, modelObject.bankAccountNumber)
                         putOpt(BANK_LOCATION_ID, modelObject.bankLocationId)
@@ -52,6 +54,7 @@ data class BacsDirectDebitPaymentMethod(
                 return BacsDirectDebitPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
                     checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
+                    sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     holderName = jsonObject.getStringOrNull(HOLDER_NAME),
                     bankAccountNumber = jsonObject.getStringOrNull(BANK_ACCOUNT_NUMBER),
                     bankLocationId = jsonObject.getStringOrNull(BANK_LOCATION_ID)

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/BlikPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/BlikPaymentMethod.kt
@@ -19,6 +19,7 @@ data class BlikPaymentMethod(
     override var type: String?,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String?,
+    override var sdkData: String? = null,
     var blikCode: String? = null,
     var storedPaymentMethodId: String? = null,
 ) : PaymentMethodDetails() {
@@ -35,6 +36,7 @@ data class BlikPaymentMethod(
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
                         putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
+                        putOpt(SDK_DATA, modelObject.sdkData)
                         putOpt(BLIK_CODE, modelObject.blikCode)
                         putOpt(STORED_PAYMENT_METHOD_ID, modelObject.storedPaymentMethodId)
                     }
@@ -47,6 +49,7 @@ data class BlikPaymentMethod(
                 return BlikPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
                     checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
+                    sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     blikCode = jsonObject.getStringOrNull(BLIK_CODE),
                     storedPaymentMethodId = jsonObject.getStringOrNull(STORED_PAYMENT_METHOD_ID)
                 )

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/CardPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/CardPaymentMethod.kt
@@ -19,6 +19,7 @@ data class CardPaymentMethod(
     override var type: String?,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String?,
+    override var sdkData: String? = null,
     var encryptedCardNumber: String? = null,
     var encryptedExpiryMonth: String? = null,
     var encryptedExpiryYear: String? = null,
@@ -54,6 +55,7 @@ data class CardPaymentMethod(
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
                         putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
+                        putOpt(SDK_DATA, modelObject.sdkData)
                         putOpt(ENCRYPTED_CARD_NUMBER, modelObject.encryptedCardNumber)
                         putOpt(ENCRYPTED_EXPIRY_MONTH, modelObject.encryptedExpiryMonth)
                         putOpt(ENCRYPTED_EXPIRY_YEAR, modelObject.encryptedExpiryYear)
@@ -75,6 +77,7 @@ data class CardPaymentMethod(
                 return CardPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
                     checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
+                    sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     encryptedCardNumber = jsonObject.getStringOrNull(ENCRYPTED_CARD_NUMBER),
                     encryptedExpiryMonth = jsonObject.getStringOrNull(ENCRYPTED_EXPIRY_MONTH),
                     encryptedExpiryYear = jsonObject.getStringOrNull(ENCRYPTED_EXPIRY_YEAR),

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/CashAppPayPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/CashAppPayPaymentMethod.kt
@@ -12,6 +12,7 @@ data class CashAppPayPaymentMethod(
     override var type: String?,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String?,
+    override var sdkData: String? = null,
     var grantId: String? = null,
     var onFileGrantId: String? = null,
     var customerId: String? = null,
@@ -34,6 +35,7 @@ data class CashAppPayPaymentMethod(
                 try {
                     putOpt(TYPE, modelObject.type)
                     putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
+                    putOpt(SDK_DATA, modelObject.sdkData)
                     putOpt(GRANT_ID, modelObject.grantId)
                     putOpt(ON_FILE_GRANT_ID, modelObject.onFileGrantId)
                     putOpt(CUSTOMER_ID, modelObject.customerId)
@@ -47,6 +49,7 @@ data class CashAppPayPaymentMethod(
             override fun deserialize(jsonObject: JSONObject): CashAppPayPaymentMethod = CashAppPayPaymentMethod(
                 type = jsonObject.getStringOrNull(TYPE),
                 checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
+                sdkData = jsonObject.getStringOrNull(SDK_DATA),
                 grantId = jsonObject.getStringOrNull(GRANT_ID),
                 onFileGrantId = jsonObject.getStringOrNull(ON_FILE_GRANT_ID),
                 customerId = jsonObject.getStringOrNull(CUSTOMER_ID),

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/ConvenienceStoresJPPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/ConvenienceStoresJPPaymentMethod.kt
@@ -15,11 +15,13 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Suppress("LongParameterList")
 @Parcelize
 class ConvenienceStoresJPPaymentMethod(
     override var type: String? = null,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String? = null,
+    override var sdkData: String? = null,
     override var firstName: String? = null,
     override var lastName: String? = null,
     override var telephoneNumber: String? = null,
@@ -37,6 +39,7 @@ class ConvenienceStoresJPPaymentMethod(
                         JSONObject().apply {
                             putOpt(TYPE, modelObject.type)
                             putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
+                            putOpt(SDK_DATA, modelObject.sdkData)
                             putOpt(FIRST_NAME, modelObject.firstName)
                             putOpt(LAST_NAME, modelObject.lastName)
                             putOpt(TELEPHONE_NUMBER, modelObject.telephoneNumber)
@@ -51,6 +54,7 @@ class ConvenienceStoresJPPaymentMethod(
                     return ConvenienceStoresJPPaymentMethod(
                         type = jsonObject.getStringOrNull(TYPE),
                         checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
+                        sdkData = jsonObject.getStringOrNull(SDK_DATA),
                         firstName = jsonObject.getStringOrNull(FIRST_NAME),
                         lastName = jsonObject.getStringOrNull(LAST_NAME),
                         telephoneNumber = jsonObject.getStringOrNull(TELEPHONE_NUMBER),

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/DotpayPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/DotpayPaymentMethod.kt
@@ -19,6 +19,7 @@ data class DotpayPaymentMethod(
     override var type: String? = null,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String? = null,
+    override var sdkData: String? = null,
     override var issuer: String? = null,
 ) : IssuerListPaymentMethod() {
 
@@ -32,6 +33,7 @@ data class DotpayPaymentMethod(
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
                         putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
+                        putOpt(SDK_DATA, modelObject.sdkData)
                         putOpt(ISSUER, modelObject.issuer)
                     }
                 } catch (e: JSONException) {
@@ -43,6 +45,7 @@ data class DotpayPaymentMethod(
                 return DotpayPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
                     checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
+                    sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     issuer = jsonObject.getStringOrNull(ISSUER)
                 )
             }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/EPSPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/EPSPaymentMethod.kt
@@ -19,6 +19,7 @@ data class EPSPaymentMethod(
     override var type: String? = null,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String? = null,
+    override var sdkData: String? = null,
     override var issuer: String? = null,
 ) : IssuerListPaymentMethod() {
 
@@ -32,6 +33,7 @@ data class EPSPaymentMethod(
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
                         putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
+                        putOpt(SDK_DATA, modelObject.sdkData)
                         putOpt(ISSUER, modelObject.issuer)
                     }
                 } catch (e: JSONException) {
@@ -43,6 +45,7 @@ data class EPSPaymentMethod(
                 return EPSPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
                     checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
+                    sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     issuer = jsonObject.getStringOrNull(ISSUER)
                 )
             }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/EntercashPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/EntercashPaymentMethod.kt
@@ -19,6 +19,7 @@ class EntercashPaymentMethod(
     override var type: String? = null,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String? = null,
+    override var sdkData: String? = null,
     override var issuer: String? = null,
 ) : IssuerListPaymentMethod() {
 
@@ -32,6 +33,7 @@ class EntercashPaymentMethod(
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
                         putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
+                        putOpt(SDK_DATA, modelObject.sdkData)
                         putOpt(ISSUER, modelObject.issuer)
                     }
                 } catch (e: JSONException) {
@@ -43,6 +45,7 @@ class EntercashPaymentMethod(
                 return EntercashPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
                     checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
+                    sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     issuer = jsonObject.getStringOrNull(ISSUER)
                 )
             }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/GenericPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/GenericPaymentMethod.kt
@@ -18,6 +18,7 @@ data class GenericPaymentMethod(
     override var type: String?,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String?,
+    override var sdkData: String? = null,
     var subtype: String?,
 ) : PaymentMethodDetails() {
 
@@ -32,6 +33,7 @@ data class GenericPaymentMethod(
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
                         putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
+                        putOpt(SDK_DATA, modelObject.sdkData)
                         putOpt(SUBTYPE, modelObject.subtype)
                     }
                 } catch (e: JSONException) {
@@ -43,6 +45,7 @@ data class GenericPaymentMethod(
                 return GenericPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
                     checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
+                    sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     subtype = jsonObject.getStringOrNull(SUBTYPE)
                 )
             }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/GiftCardPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/GiftCardPaymentMethod.kt
@@ -20,6 +20,7 @@ class GiftCardPaymentMethod(
     override var type: String?,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String?,
+    override var sdkData: String? = null,
     var encryptedCardNumber: String?,
     var encryptedSecurityCode: String?,
     var encryptedExpiryMonth: String?,
@@ -42,6 +43,7 @@ class GiftCardPaymentMethod(
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
                         putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
+                        putOpt(SDK_DATA, modelObject.sdkData)
                         putOpt(ENCRYPTED_CARD_NUMBER, modelObject.encryptedCardNumber)
                         putOpt(ENCRYPTED_SECURITY_CODE, modelObject.encryptedSecurityCode)
                         putOpt(ENCRYPTED_EXPIRY_MONTH, modelObject.encryptedExpiryMonth)
@@ -57,6 +59,7 @@ class GiftCardPaymentMethod(
                 return GiftCardPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
                     checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
+                    sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     encryptedCardNumber = jsonObject.getStringOrNull(ENCRYPTED_CARD_NUMBER),
                     encryptedSecurityCode = jsonObject.getStringOrNull(ENCRYPTED_SECURITY_CODE),
                     encryptedExpiryMonth = jsonObject.getStringOrNull(ENCRYPTED_EXPIRY_MONTH),

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/GooglePayPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/GooglePayPaymentMethod.kt
@@ -18,6 +18,7 @@ data class GooglePayPaymentMethod(
     override var type: String?,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String?,
+    override var sdkData: String? = null,
     var googlePayToken: String? = null,
     var googlePayCardNetwork: String? = null,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
@@ -36,6 +37,7 @@ data class GooglePayPaymentMethod(
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
                         putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
+                        putOpt(SDK_DATA, modelObject.sdkData)
                         putOpt(GOOGLE_PAY_TOKEN, modelObject.googlePayToken)
                         putOpt(GOOGLE_PAY_CARD_NETWORK, modelObject.googlePayCardNetwork)
                         putOpt(THREEDS2_SDK_VERSION, modelObject.threeDS2SdkVersion)
@@ -49,6 +51,7 @@ data class GooglePayPaymentMethod(
                 return GooglePayPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
                     checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
+                    sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     googlePayToken = jsonObject.getStringOrNull(GOOGLE_PAY_TOKEN),
                     googlePayCardNetwork = jsonObject.getStringOrNull(GOOGLE_PAY_CARD_NETWORK),
                     threeDS2SdkVersion = jsonObject.getStringOrNull(THREEDS2_SDK_VERSION),

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/IdealPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/IdealPaymentMethod.kt
@@ -19,6 +19,7 @@ class IdealPaymentMethod(
     override var type: String? = null,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String? = null,
+    override var sdkData: String? = null,
     override var issuer: String? = null,
 ) : IssuerListPaymentMethod() {
 
@@ -32,6 +33,7 @@ class IdealPaymentMethod(
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
                         putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
+                        putOpt(SDK_DATA, modelObject.sdkData)
                         putOpt(ISSUER, modelObject.issuer)
                     }
                 } catch (e: JSONException) {
@@ -43,6 +45,7 @@ class IdealPaymentMethod(
                 return IdealPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
                     checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
+                    sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     issuer = jsonObject.getStringOrNull(ISSUER)
                 )
             }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/MBWayPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/MBWayPaymentMethod.kt
@@ -19,6 +19,7 @@ class MBWayPaymentMethod(
     override var type: String?,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String?,
+    override var sdkData: String? = null,
     var telephoneNumber: String?,
 ) : PaymentMethodDetails() {
 
@@ -34,6 +35,7 @@ class MBWayPaymentMethod(
                         putOpt(TYPE, modelObject.type)
                         putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
                         putOpt(TELEPHONE_NUMBER, modelObject.telephoneNumber)
+                        putOpt(SDK_DATA, modelObject.sdkData)
                     }
                 } catch (e: JSONException) {
                     throw ModelSerializationException(GooglePayPaymentMethod::class.java, e)
@@ -45,6 +47,7 @@ class MBWayPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
                     checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
                     telephoneNumber = jsonObject.getStringOrNull(TELEPHONE_NUMBER),
+                    sdkData = jsonObject.getStringOrNull(SDK_DATA),
                 )
             }
         }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/MolpayPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/MolpayPaymentMethod.kt
@@ -18,6 +18,7 @@ class MolpayPaymentMethod(
     override var type: String? = null,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String? = null,
+    override var sdkData: String? = null,
     override var issuer: String? = null,
 ) : IssuerListPaymentMethod() {
 
@@ -30,6 +31,7 @@ class MolpayPaymentMethod(
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
                         putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
+                        putOpt(SDK_DATA, modelObject.sdkData)
                         putOpt(ISSUER, modelObject.issuer)
                     }
                 } catch (e: JSONException) {
@@ -41,6 +43,7 @@ class MolpayPaymentMethod(
                 return MolpayPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
                     checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
+                    sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     issuer = jsonObject.getStringOrNull(ISSUER),
                 )
             }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OnlineBankingCZPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OnlineBankingCZPaymentMethod.kt
@@ -20,6 +20,7 @@ data class OnlineBankingCZPaymentMethod(
     override var type: String? = null,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String? = null,
+    override var sdkData: String? = null,
     override var issuer: String? = null,
 ) : IssuerListPaymentMethod() {
 
@@ -33,6 +34,7 @@ data class OnlineBankingCZPaymentMethod(
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
                         putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
+                        putOpt(SDK_DATA, modelObject.sdkData)
                         putOpt(ISSUER, modelObject.issuer)
                     }
                 } catch (e: JSONException) {
@@ -44,6 +46,7 @@ data class OnlineBankingCZPaymentMethod(
                 return OnlineBankingCZPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
                     checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
+                    sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     issuer = jsonObject.getStringOrNull(ISSUER)
                 )
             }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OnlineBankingJPPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OnlineBankingJPPaymentMethod.kt
@@ -15,11 +15,13 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Suppress("LongParameterList")
 @Parcelize
 class OnlineBankingJPPaymentMethod(
     override var type: String? = null,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String? = null,
+    override var sdkData: String? = null,
     override var firstName: String? = null,
     override var lastName: String? = null,
     override var telephoneNumber: String? = null,
@@ -36,6 +38,7 @@ class OnlineBankingJPPaymentMethod(
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
                         putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
+                        putOpt(SDK_DATA, modelObject.sdkData)
                         putOpt(FIRST_NAME, modelObject.firstName)
                         putOpt(LAST_NAME, modelObject.lastName)
                         putOpt(TELEPHONE_NUMBER, modelObject.telephoneNumber)
@@ -50,6 +53,7 @@ class OnlineBankingJPPaymentMethod(
                 return OnlineBankingJPPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
                     checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
+                    sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     firstName = jsonObject.getStringOrNull(FIRST_NAME),
                     lastName = jsonObject.getStringOrNull(LAST_NAME),
                     telephoneNumber = jsonObject.getStringOrNull(TELEPHONE_NUMBER),

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OnlineBankingPLPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OnlineBankingPLPaymentMethod.kt
@@ -20,6 +20,7 @@ class OnlineBankingPLPaymentMethod(
     override var type: String? = null,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String? = null,
+    override var sdkData: String? = null,
     override var issuer: String? = null,
 ) : IssuerListPaymentMethod() {
 
@@ -33,6 +34,7 @@ class OnlineBankingPLPaymentMethod(
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
                         putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
+                        putOpt(SDK_DATA, modelObject.sdkData)
                         putOpt(ISSUER, modelObject.issuer)
                     }
                 } catch (e: JSONException) {
@@ -44,6 +46,7 @@ class OnlineBankingPLPaymentMethod(
                 return OnlineBankingPLPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
                     checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
+                    sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     issuer = jsonObject.getStringOrNull(ISSUER)
                 )
             }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OnlineBankingSKPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OnlineBankingSKPaymentMethod.kt
@@ -20,6 +20,7 @@ data class OnlineBankingSKPaymentMethod(
     override var type: String? = null,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String? = null,
+    override var sdkData: String? = null,
     override var issuer: String? = null,
 ) : IssuerListPaymentMethod() {
 
@@ -33,6 +34,7 @@ data class OnlineBankingSKPaymentMethod(
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
                         putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
+                        putOpt(SDK_DATA, modelObject.sdkData)
                         putOpt(ISSUER, modelObject.issuer)
                     }
                 } catch (e: JSONException) {
@@ -44,6 +46,7 @@ data class OnlineBankingSKPaymentMethod(
                 return OnlineBankingSKPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
                     checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
+                    sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     issuer = jsonObject.getStringOrNull(ISSUER)
                 )
             }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OpenBankingPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OpenBankingPaymentMethod.kt
@@ -19,6 +19,7 @@ class OpenBankingPaymentMethod(
     override var type: String? = null,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String? = null,
+    override var sdkData: String? = null,
     override var issuer: String? = null,
 ) : IssuerListPaymentMethod() {
 
@@ -32,6 +33,7 @@ class OpenBankingPaymentMethod(
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
                         putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
+                        putOpt(SDK_DATA, modelObject.sdkData)
                         putOpt(ISSUER, modelObject.issuer)
                     }
                 } catch (e: JSONException) {
@@ -43,6 +45,7 @@ class OpenBankingPaymentMethod(
                 return OpenBankingPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
                     checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
+                    sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     issuer = jsonObject.getStringOrNull(ISSUER),
                 )
             }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/PayByBankPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/PayByBankPaymentMethod.kt
@@ -20,6 +20,7 @@ class PayByBankPaymentMethod(
     override var type: String? = null,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String? = null,
+    override var sdkData: String? = null,
     override var issuer: String? = null,
 ) : IssuerListPaymentMethod() {
 
@@ -33,6 +34,7 @@ class PayByBankPaymentMethod(
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
                         putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
+                        putOpt(SDK_DATA, modelObject.sdkData)
                         putOpt(ISSUER, modelObject.issuer)
                     }
                 } catch (e: JSONException) {
@@ -44,6 +46,7 @@ class PayByBankPaymentMethod(
                 return PayByBankPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
                     checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
+                    sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     issuer = jsonObject.getStringOrNull(ISSUER)
                 )
             }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/PayByBankUSPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/PayByBankUSPaymentMethod.kt
@@ -19,6 +19,7 @@ class PayByBankUSPaymentMethod(
     override var type: String?,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String?,
+    override var sdkData: String? = null,
     var storedPaymentMethodId: String? = null,
 ) : PaymentMethodDetails() {
 
@@ -33,6 +34,7 @@ class PayByBankUSPaymentMethod(
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
                         putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
+                        putOpt(SDK_DATA, modelObject.sdkData)
                         putOpt(STORED_PAYMENT_METHOD_ID, modelObject.storedPaymentMethodId)
                     }
                 } catch (e: JSONException) {
@@ -44,6 +46,7 @@ class PayByBankUSPaymentMethod(
                 return PayByBankUSPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
                     checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
+                    sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     storedPaymentMethodId = jsonObject.getStringOrNull(STORED_PAYMENT_METHOD_ID),
                 )
             }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/PayEasyPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/PayEasyPaymentMethod.kt
@@ -15,11 +15,13 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Suppress("LongParameterList")
 @Parcelize
 class PayEasyPaymentMethod(
     override var type: String? = null,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String? = null,
+    override var sdkData: String? = null,
     override var firstName: String? = null,
     override var lastName: String? = null,
     override var telephoneNumber: String? = null,
@@ -36,6 +38,7 @@ class PayEasyPaymentMethod(
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
                         putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
+                        putOpt(SDK_DATA, modelObject.sdkData)
                         putOpt(FIRST_NAME, modelObject.firstName)
                         putOpt(LAST_NAME, modelObject.lastName)
                         putOpt(TELEPHONE_NUMBER, modelObject.telephoneNumber)
@@ -50,6 +53,7 @@ class PayEasyPaymentMethod(
                 return PayEasyPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
                     checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
+                    sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     firstName = jsonObject.getStringOrNull(FIRST_NAME),
                     lastName = jsonObject.getStringOrNull(LAST_NAME),
                     telephoneNumber = jsonObject.getStringOrNull(TELEPHONE_NUMBER),

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/PayToPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/PayToPaymentMethod.kt
@@ -20,6 +20,7 @@ data class PayToPaymentMethod(
     override var type: String?,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String?,
+    override var sdkData: String? = null,
     var shopperAccountIdentifier: String? = null,
     var storedPaymentMethodId: String? = null,
 ) : PaymentMethodDetails() {
@@ -37,6 +38,7 @@ data class PayToPaymentMethod(
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
                         putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
+                        putOpt(SDK_DATA, modelObject.sdkData)
                         putOpt(SHOPPER_ACCOUNT_IDENTIFIER, modelObject.shopperAccountIdentifier)
                         putOpt(STORED_PAYMENT_METHOD_ID, modelObject.storedPaymentMethodId)
                     }
@@ -49,6 +51,7 @@ data class PayToPaymentMethod(
                 return PayToPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
                     checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
+                    sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     shopperAccountIdentifier = jsonObject.getStringOrNull(SHOPPER_ACCOUNT_IDENTIFIER),
                     storedPaymentMethodId = jsonObject.getStringOrNull(STORED_PAYMENT_METHOD_ID),
                 )

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/PaymentMethodDetails.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/PaymentMethodDetails.kt
@@ -27,9 +27,12 @@ abstract class PaymentMethodDetails : ModelObject() {
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     abstract var checkoutAttemptId: String?
 
+    abstract var sdkData: String?
+
     companion object {
         const val TYPE = "type"
         const val CHECKOUT_ATTEMPT_ID = "checkoutAttemptId"
+        const val SDK_DATA = "sdkData"
 
         @JvmField
         val SERIALIZER: Serializer<PaymentMethodDetails> = object : Serializer<PaymentMethodDetails> {

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/SepaPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/SepaPaymentMethod.kt
@@ -19,6 +19,7 @@ class SepaPaymentMethod(
     override var type: String?,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String?,
+    override var sdkData: String? = null,
     var ownerName: String?,
     var iban: String?,
 ) : PaymentMethodDetails() {
@@ -35,6 +36,7 @@ class SepaPaymentMethod(
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
                         putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
+                        putOpt(SDK_DATA, modelObject.sdkData)
                         putOpt(OWNER_NAME, modelObject.ownerName)
                         putOpt(IBAN, modelObject.iban)
                     }
@@ -47,6 +49,7 @@ class SepaPaymentMethod(
                 return SepaPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
                     checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
+                    sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     ownerName = jsonObject.getStringOrNull(OWNER_NAME),
                     iban = jsonObject.getStringOrNull(IBAN),
                 )

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/SevenElevenPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/SevenElevenPaymentMethod.kt
@@ -15,11 +15,13 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Suppress("LongParameterList")
 @Parcelize
 class SevenElevenPaymentMethod(
     override var type: String? = null,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String? = null,
+    override var sdkData: String? = null,
     override var firstName: String? = null,
     override var lastName: String? = null,
     override var telephoneNumber: String? = null,
@@ -36,6 +38,7 @@ class SevenElevenPaymentMethod(
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
                         putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
+                        putOpt(SDK_DATA, modelObject.sdkData)
                         putOpt(FIRST_NAME, modelObject.firstName)
                         putOpt(LAST_NAME, modelObject.lastName)
                         putOpt(TELEPHONE_NUMBER, modelObject.telephoneNumber)
@@ -50,6 +53,7 @@ class SevenElevenPaymentMethod(
                 return SevenElevenPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
                     checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
+                    sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     firstName = jsonObject.getStringOrNull(FIRST_NAME),
                     lastName = jsonObject.getStringOrNull(LAST_NAME),
                     telephoneNumber = jsonObject.getStringOrNull(TELEPHONE_NUMBER),

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/TwintPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/TwintPaymentMethod.kt
@@ -19,6 +19,7 @@ data class TwintPaymentMethod(
     override var type: String?,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String?,
+    override var sdkData: String? = null,
     var subtype: String? = null,
     var storedPaymentMethodId: String? = null,
 ) : PaymentMethodDetails() {
@@ -34,6 +35,7 @@ data class TwintPaymentMethod(
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
                         putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
+                        putOpt(SDK_DATA, modelObject.sdkData)
                         putOpt(SUBTYPE, modelObject.subtype)
                         putOpt(STORED_PAYMENT_METHOD_ID, modelObject.storedPaymentMethodId)
                     }
@@ -46,6 +48,7 @@ data class TwintPaymentMethod(
                 return TwintPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
                     checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
+                    sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     subtype = jsonObject.getStringOrNull(SUBTYPE),
                     storedPaymentMethodId = jsonObject.getStringOrNull(STORED_PAYMENT_METHOD_ID),
                 )

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/UPIPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/UPIPaymentMethod.kt
@@ -19,6 +19,7 @@ data class UPIPaymentMethod(
     override var type: String?,
     @Deprecated("This property is deprecated. Use the SERIALIZER to send the payment data to your backend.")
     override var checkoutAttemptId: String?,
+    override var sdkData: String? = null,
     var virtualPaymentAddress: String?,
     var appId: String?,
 ) : PaymentMethodDetails() {
@@ -34,6 +35,7 @@ data class UPIPaymentMethod(
                     JSONObject().apply {
                         putOpt(TYPE, modelObject.type)
                         putOpt(CHECKOUT_ATTEMPT_ID, modelObject.checkoutAttemptId)
+                        putOpt(SDK_DATA, modelObject.sdkData)
                         putOpt(VIRTUAL_PAYMENT_ADDRESS, modelObject.virtualPaymentAddress)
                         putOpt(APP_ID, modelObject.appId)
                     }
@@ -46,6 +48,7 @@ data class UPIPaymentMethod(
                 return UPIPaymentMethod(
                     type = jsonObject.getStringOrNull(TYPE),
                     checkoutAttemptId = jsonObject.getStringOrNull(CHECKOUT_ATTEMPT_ID),
+                    sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     virtualPaymentAddress = jsonObject.getStringOrNull(VIRTUAL_PAYMENT_ADDRESS),
                     appId = jsonObject.getStringOrNull(APP_ID),
                 )

--- a/components-core/src/test/java/com/adyen/checkout/components/core/PaymentComponentDataTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/PaymentComponentDataTest.kt
@@ -10,7 +10,7 @@ internal class PaymentComponentDataTest {
 
     @Test
     fun `when serializing, then all fields should be serialized correctly`() {
-        val paymentMethod = GenericPaymentMethod("type", "checkoutAttemptId", "subtype")
+        val paymentMethod = GenericPaymentMethod("type", "checkoutAttemptId", null, "subtype")
         val order = OrderRequest("pspReference", "orderData")
         val amount = Amount("EUR", 1L)
         val billingAddress = Address(city = "city")
@@ -32,7 +32,6 @@ internal class PaymentComponentDataTest {
             socialSecurityNumber = "socialSecurityNumber",
             installments = installments,
             supportNativeRedirect = true,
-            sdkData = "sdkData",
         )
 
         val actual = PaymentComponentData.SERIALIZER.serialize(request)
@@ -52,14 +51,13 @@ internal class PaymentComponentDataTest {
             .put("socialSecurityNumber", "socialSecurityNumber")
             .put("installments", Installments.SERIALIZER.serialize(installments))
             .put("supportNativeRedirect", true)
-            .put("sdkData", "sdkData")
 
         assertEquals(expected.toString(), actual.toString())
     }
 
     @Test
     fun `when deserializing, then all fields should be deserializing correctly`() {
-        val paymentMethod = GenericPaymentMethod("type", "checkoutAttemptId", "subtype")
+        val paymentMethod = GenericPaymentMethod("type", "checkoutAttemptId", null, "subtype")
         val order = OrderRequest("pspReference", "orderData")
         val amount = Amount("EUR", 1L)
         val billingAddress = Address(city = "city")
@@ -81,7 +79,6 @@ internal class PaymentComponentDataTest {
             .put("socialSecurityNumber", "socialSecurityNumber")
             .put("installments", Installments.SERIALIZER.serialize(installments))
             .put("supportNativeRedirect", true)
-            .put("sdkData", "sdkData")
 
         val actual = PaymentComponentData.SERIALIZER.deserialize(response)
 
@@ -100,7 +97,6 @@ internal class PaymentComponentDataTest {
             socialSecurityNumber = "socialSecurityNumber",
             installments = installments,
             supportNativeRedirect = true,
-            sdkData = "sdkData",
         )
 
         assertEquals(expected, actual)

--- a/econtext/src/main/java/com/adyen/checkout/econtext/internal/ui/DefaultEContextDelegate.kt
+++ b/econtext/src/main/java/com/adyen/checkout/econtext/internal/ui/DefaultEContextDelegate.kt
@@ -125,6 +125,7 @@ internal class DefaultEContextDelegate<
         val eContextPaymentMethod = typedPaymentMethodFactory().apply {
             type = getPaymentMethodType()
             checkoutAttemptId = analyticsManager.getCheckoutAttemptId()
+            sdkData = sdkDataProvider.createEncodedSdkData()
             firstName = outputData.firstNameState.value
             lastName = outputData.lastNameState.value
             telephoneNumber = outputData.phoneNumberState.value
@@ -135,7 +136,6 @@ internal class DefaultEContextDelegate<
             paymentMethod = eContextPaymentMethod,
             order = order,
             amount = componentParams.amount,
-            sdkData = sdkDataProvider.createEncodedSdkData(),
         )
         return componentStateFactory(paymentComponentData, isInputValid, true)
     }

--- a/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextPaymentMethod.kt
+++ b/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextPaymentMethod.kt
@@ -11,10 +11,12 @@ package com.adyen.checkout.econtext
 import android.os.Parcel
 import com.adyen.checkout.components.core.paymentmethod.EContextPaymentMethod
 
+@Suppress("LongParameterList")
 internal class TestEContextPaymentMethod(
     override var firstName: String? = "firstName",
     @Deprecated("This property is deprecated.")
     override var checkoutAttemptId: String? = "checkoutAttemptId",
+    override var sdkData: String? = "sdkData",
     override var lastName: String? = "lastName",
     override var telephoneNumber: String? = "telephoneNumber",
     override var shopperEmail: String? = "shopperEmail",

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/ui/DefaultGiftCardDelegate.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/ui/DefaultGiftCardDelegate.kt
@@ -237,6 +237,7 @@ class DefaultGiftCardDelegate(
             paymentMethod = paymentMethod,
             encryptedCard = encryptedCard,
             checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
+            sdkData = sdkDataProvider.createEncodedSdkData(),
         )
 
         val lastDigits = outputData.numberFieldState.value.takeLast(LAST_DIGITS_LENGTH)
@@ -245,7 +246,6 @@ class DefaultGiftCardDelegate(
             paymentMethod = giftCardPaymentMethod,
             order = order,
             amount = componentParams.amount,
-            sdkData = sdkDataProvider.createEncodedSdkData(),
         )
 
         return GiftCardComponentState(

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/ui/protocol/DefaultGiftCardProtocol.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/ui/protocol/DefaultGiftCardProtocol.kt
@@ -22,11 +22,13 @@ internal class DefaultGiftCardProtocol : GiftCardProtocol {
     override fun createPaymentMethod(
         paymentMethod: PaymentMethod,
         encryptedCard: EncryptedCard,
-        checkoutAttemptId: String?
+        checkoutAttemptId: String?,
+        sdkData: String?
     ): GiftCardPaymentMethod {
         return GiftCardPaymentMethod(
             type = paymentMethod.type,
             checkoutAttemptId = checkoutAttemptId,
+            sdkData = sdkData,
             encryptedCardNumber = encryptedCard.encryptedCardNumber,
             encryptedSecurityCode = encryptedCard.encryptedSecurityCode,
             encryptedExpiryMonth = encryptedCard.encryptedExpiryMonth,

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/ui/protocol/GiftCardProtocol.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/internal/ui/protocol/GiftCardProtocol.kt
@@ -22,6 +22,7 @@ interface GiftCardProtocol {
     fun createPaymentMethod(
         paymentMethod: PaymentMethod,
         encryptedCard: EncryptedCard,
-        checkoutAttemptId: String?
+        checkoutAttemptId: String?,
+        sdkData: String?
     ): GiftCardPaymentMethod
 }

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/DefaultGooglePayDelegate.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/DefaultGooglePayDelegate.kt
@@ -183,14 +183,14 @@ internal class DefaultGooglePayDelegate(
             paymentData = paymentData,
             paymentMethodType = paymentMethod.type,
             checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
+            sdkData = sdkDataProvider.createEncodedSdkData(
+                threeDS2SdkVersion = runCompileOnly { ThreeDS2Service.INSTANCE.sdkVersion },
+            ),
         )
         val paymentComponentData = PaymentComponentData(
             paymentMethod = paymentMethod,
             order = order,
             amount = componentParams.amount,
-            sdkData = sdkDataProvider.createEncodedSdkData(
-                threeDS2SdkVersion = runCompileOnly { ThreeDS2Service.INSTANCE.sdkVersion },
-            ),
         )
 
         val isReady = isAvailable

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/util/GooglePayUtils.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/util/GooglePayUtils.kt
@@ -132,7 +132,8 @@ internal object GooglePayUtils {
     fun createGooglePayPaymentMethod(
         paymentData: PaymentData?,
         paymentMethodType: String?,
-        checkoutAttemptId: String?
+        checkoutAttemptId: String?,
+        sdkData: String?
     ): GooglePayPaymentMethod? {
         if (paymentData == null) {
             return null
@@ -140,6 +141,7 @@ internal object GooglePayUtils {
         return GooglePayPaymentMethod(
             type = paymentMethodType,
             checkoutAttemptId = checkoutAttemptId,
+            sdkData = sdkData,
         ).apply {
             try {
                 val paymentDataJson = JSONObject(paymentData.toJson())

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/DefaultGooglePayDelegateTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/DefaultGooglePayDelegateTest.kt
@@ -150,6 +150,7 @@ internal class DefaultGooglePayDelegateTest(
                 paymentData = paymentData,
                 paymentMethodType = TEST_PAYMENT_METHOD_TYPE,
                 checkoutAttemptId = TestAnalyticsManager.CHECKOUT_ATTEMPT_ID_NOT_FETCHED,
+                sdkData = null,
             )
             assertEquals(expectedPaymentMethod, paymentComponentData.paymentMethod)
 

--- a/ideal/src/main/java/com/adyen/checkout/ideal/internal/ui/DefaultIdealDelegate.kt
+++ b/ideal/src/main/java/com/adyen/checkout/ideal/internal/ui/DefaultIdealDelegate.kt
@@ -93,12 +93,12 @@ internal class DefaultIdealDelegate(
             paymentMethod = IdealPaymentMethod(
                 type = paymentMethod.type,
                 checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
+                sdkData = sdkDataProvider.createEncodedSdkData(),
                 // Set issuer to null to force redirect flow (ideal 2.0)
                 issuer = null,
             ),
             order = order,
             amount = componentParams.amount,
-            sdkData = sdkDataProvider.createEncodedSdkData(),
         )
         return IdealComponentState(paymentComponentData, isInputValid = true, isReady = true)
     }

--- a/instant/src/main/java/com/adyen/checkout/instant/internal/ui/DefaultInstantPaymentDelegate.kt
+++ b/instant/src/main/java/com/adyen/checkout/instant/internal/ui/DefaultInstantPaymentDelegate.kt
@@ -63,11 +63,11 @@ internal class DefaultInstantPaymentDelegate(
             paymentMethod = GenericPaymentMethod(
                 type = paymentMethod.type,
                 checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
+                sdkData = sdkDataProvider.createEncodedSdkData(),
                 subtype = getSubtype(paymentMethod),
             ),
             order = order,
             amount = componentParams.amount,
-            sdkData = sdkDataProvider.createEncodedSdkData(),
         )
         return InstantComponentState(paymentComponentData, isInputValid = true, isReady = true)
     }

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/ui/DefaultIssuerListDelegate.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/internal/ui/DefaultIssuerListDelegate.kt
@@ -163,6 +163,7 @@ internal class DefaultIssuerListDelegate<
         val issuerListPaymentMethod = typedPaymentMethodFactory().apply {
             type = getPaymentMethodType()
             checkoutAttemptId = analyticsManager.getCheckoutAttemptId()
+            sdkData = sdkDataProvider.createEncodedSdkData()
             issuer = outputData.selectedIssuer?.id.orEmpty()
         }
 
@@ -170,7 +171,6 @@ internal class DefaultIssuerListDelegate<
             paymentMethod = issuerListPaymentMethod,
             order = order,
             amount = componentParams.amount,
-            sdkData = sdkDataProvider.createEncodedSdkData(),
         )
 
         return componentStateFactory(paymentComponentData, outputData.isValid, true)

--- a/issuer-list/src/test/java/com/adyen/checkout/issuerlist/utils/TestIssuerPaymentMethod.kt
+++ b/issuer-list/src/test/java/com/adyen/checkout/issuerlist/utils/TestIssuerPaymentMethod.kt
@@ -15,6 +15,7 @@ internal class TestIssuerPaymentMethod(
     override var issuer: String? = "issuer",
     @Deprecated("This property is deprecated.")
     override var checkoutAttemptId: String? = "checkoutAttemptId",
+    override var sdkData: String? = "sdkData",
     override var type: String? = "type"
 ) : IssuerListPaymentMethod() {
 

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/DefaultMBWayDelegate.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/DefaultMBWayDelegate.kt
@@ -142,13 +142,13 @@ internal class DefaultMBWayDelegate(
             type = MBWayPaymentMethod.PAYMENT_METHOD_TYPE,
             checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
             telephoneNumber = outputData.mobilePhoneNumberFieldState.value,
+            sdkData = sdkDataProvider.createEncodedSdkData(),
         )
 
         val paymentComponentData = PaymentComponentData(
             paymentMethod = paymentMethod,
             order = order,
             amount = componentParams.amount,
-            sdkData = sdkDataProvider.createEncodedSdkData(),
         )
 
         return MBWayComponentState(

--- a/meal-voucher-fr/src/main/java/com/adyen/checkout/mealvoucherfr/internal/ui/protocol/MealVoucherFRProtocol.kt
+++ b/meal-voucher-fr/src/main/java/com/adyen/checkout/mealvoucherfr/internal/ui/protocol/MealVoucherFRProtocol.kt
@@ -24,11 +24,13 @@ internal class MealVoucherFRProtocol : GiftCardProtocol {
     override fun createPaymentMethod(
         paymentMethod: PaymentMethod,
         encryptedCard: EncryptedCard,
-        checkoutAttemptId: String?
+        checkoutAttemptId: String?,
+        sdkData: String?
     ): GiftCardPaymentMethod {
         return GiftCardPaymentMethod(
             type = PaymentMethodTypes.MEAL_VOUCHER_FR,
             checkoutAttemptId = checkoutAttemptId,
+            sdkData = sdkData,
             encryptedCardNumber = encryptedCard.encryptedCardNumber,
             encryptedSecurityCode = encryptedCard.encryptedSecurityCode,
             encryptedExpiryMonth = encryptedCard.encryptedExpiryMonth,

--- a/online-banking-core/src/main/java/com/adyen/checkout/onlinebankingcore/internal/ui/DefaultOnlineBankingDelegate.kt
+++ b/online-banking-core/src/main/java/com/adyen/checkout/onlinebankingcore/internal/ui/DefaultOnlineBankingDelegate.kt
@@ -159,6 +159,7 @@ internal class DefaultOnlineBankingDelegate<
         val issuerListPaymentMethod = paymentMethodFactory().apply {
             type = getPaymentMethodType()
             checkoutAttemptId = analyticsManager.getCheckoutAttemptId()
+            sdkData = sdkDataProvider.createEncodedSdkData()
             issuer = outputData.selectedIssuer?.id
         }
 
@@ -166,7 +167,6 @@ internal class DefaultOnlineBankingDelegate<
             paymentMethod = issuerListPaymentMethod,
             order = order,
             amount = componentParams.amount,
-            sdkData = sdkDataProvider.createEncodedSdkData(),
         )
 
         return componentStateFactory(paymentComponentData, outputData.isValid, true)

--- a/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/utils/TestOnlineBankingPaymentMethod.kt
+++ b/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/utils/TestOnlineBankingPaymentMethod.kt
@@ -15,6 +15,7 @@ internal class TestOnlineBankingPaymentMethod(
     override var issuer: String? = "issuer",
     @Deprecated("This property is deprecated.")
     override var checkoutAttemptId: String? = "checkoutAttemptId",
+    override var sdkData: String? = "sdkData",
     override var type: String? = "type"
 ) : IssuerListPaymentMethod() {
 

--- a/paybybank-us/src/main/java/com/adyen/checkout/paybybankus/internal/DefaultPayByBankUSDelegate.kt
+++ b/paybybank-us/src/main/java/com/adyen/checkout/paybybankus/internal/DefaultPayByBankUSDelegate.kt
@@ -108,13 +108,13 @@ internal class DefaultPayByBankUSDelegate(
         val payByBankUsPaymentMethod = PayByBankUSPaymentMethod(
             type = getPaymentMethodType(),
             checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
+            sdkData = sdkDataProvider.createEncodedSdkData(),
         )
 
         val paymentComponentData = PaymentComponentData(
             paymentMethod = payByBankUsPaymentMethod,
             order = order,
             amount = componentParams.amount,
-            sdkData = sdkDataProvider.createEncodedSdkData(),
         )
 
         return PayByBankUSComponentState(

--- a/paybybank-us/src/main/java/com/adyen/checkout/paybybankus/internal/StoredPayByBankUSDelegate.kt
+++ b/paybybank-us/src/main/java/com/adyen/checkout/paybybankus/internal/StoredPayByBankUSDelegate.kt
@@ -118,6 +118,7 @@ internal class StoredPayByBankUSDelegate(
         val payByBankUsPaymentMethod = PayByBankUSPaymentMethod(
             type = getPaymentMethodType(),
             checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
+            sdkData = sdkDataProvider.createEncodedSdkData(),
             storedPaymentMethodId = storedPaymentMethod.id,
         )
 
@@ -125,7 +126,6 @@ internal class StoredPayByBankUSDelegate(
             paymentMethod = payByBankUsPaymentMethod,
             order = order,
             amount = componentParams.amount,
-            sdkData = sdkDataProvider.createEncodedSdkData(),
         )
 
         return PayByBankUSComponentState(

--- a/paybybank/src/main/java/com/adyen/checkout/paybybank/internal/ui/DefaultPayByBankDelegate.kt
+++ b/paybybank/src/main/java/com/adyen/checkout/paybybank/internal/ui/DefaultPayByBankDelegate.kt
@@ -149,6 +149,7 @@ internal class DefaultPayByBankDelegate(
         val payByBankPaymentMethod = PayByBankPaymentMethod(
             type = getPaymentMethodType(),
             checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
+            sdkData = sdkDataProvider.createEncodedSdkData(),
             issuer = outputData?.selectedIssuer?.id,
         )
 
@@ -156,7 +157,6 @@ internal class DefaultPayByBankDelegate(
             paymentMethod = payByBankPaymentMethod,
             order = order,
             amount = componentParams.amount,
-            sdkData = sdkDataProvider.createEncodedSdkData(),
         )
 
         return PayByBankComponentState(

--- a/payto/src/main/java/com/adyen/checkout/payto/internal/ui/DefaultPayToDelegate.kt
+++ b/payto/src/main/java/com/adyen/checkout/payto/internal/ui/DefaultPayToDelegate.kt
@@ -150,6 +150,7 @@ internal class DefaultPayToDelegate(
         val paymentMethod = PayToPaymentMethod(
             type = getPaymentMethodType(),
             checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
+            sdkData = sdkDataProvider.createEncodedSdkData(),
             shopperAccountIdentifier = getShopperAccountIdentifier(outputData),
         )
 
@@ -161,7 +162,6 @@ internal class DefaultPayToDelegate(
                 firstName = outputData.firstNameFieldState.value,
                 lastName = outputData.lastNameFieldState.value,
             ),
-            sdkData = sdkDataProvider.createEncodedSdkData(),
         )
 
         return PayToComponentState(

--- a/payto/src/main/java/com/adyen/checkout/payto/internal/ui/StoredPayToDelegate.kt
+++ b/payto/src/main/java/com/adyen/checkout/payto/internal/ui/StoredPayToDelegate.kt
@@ -143,6 +143,7 @@ internal class StoredPayToDelegate(
         val paymentMethod = PayToPaymentMethod(
             type = getPaymentMethodType(),
             checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
+            sdkData = sdkDataProvider.createEncodedSdkData(),
             storedPaymentMethodId = storedPaymentMethod.id,
         )
 
@@ -150,7 +151,6 @@ internal class StoredPayToDelegate(
             paymentMethod = paymentMethod,
             order = order,
             amount = componentParams.amount,
-            sdkData = sdkDataProvider.createEncodedSdkData(),
         )
 
         return PayToComponentState(

--- a/sepa/src/main/java/com/adyen/checkout/sepa/internal/ui/DefaultSepaDelegate.kt
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/internal/ui/DefaultSepaDelegate.kt
@@ -128,6 +128,7 @@ internal class DefaultSepaDelegate(
         val paymentMethod = SepaPaymentMethod(
             type = SepaPaymentMethod.PAYMENT_METHOD_TYPE,
             checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
+            sdkData = sdkDataProvider.createEncodedSdkData(),
             ownerName = outputData.ownerNameField.value,
             iban = outputData.ibanNumberField.value,
         )
@@ -135,7 +136,6 @@ internal class DefaultSepaDelegate(
             paymentMethod = paymentMethod,
             order = order,
             amount = componentParams.amount,
-            sdkData = sdkDataProvider.createEncodedSdkData(),
         )
         return SepaComponentState(
             data = paymentComponentData,

--- a/sessions-core/src/test/java/com/adyen/checkout/sessions/core/TestPaymentMethod.kt
+++ b/sessions-core/src/test/java/com/adyen/checkout/sessions/core/TestPaymentMethod.kt
@@ -15,6 +15,7 @@ internal class TestPaymentMethod(
     override var type: String? = null,
     @Deprecated("This property is deprecated.")
     override var checkoutAttemptId: String? = null,
+    override var sdkData: String? = null,
 ) : PaymentMethodDetails() {
     override fun writeToParcel(dest: Parcel, flags: Int) {
         // noop

--- a/twint/src/main/java/com/adyen/checkout/twint/internal/ui/DefaultTwintDelegate.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/internal/ui/DefaultTwintDelegate.kt
@@ -125,6 +125,7 @@ internal class DefaultTwintDelegate(
         val paymentMethod = TwintPaymentMethod(
             type = paymentMethod.type,
             checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
+            sdkData = sdkDataProvider.createEncodedSdkData(),
             subtype = getSubtype(),
         )
 
@@ -133,7 +134,6 @@ internal class DefaultTwintDelegate(
             order = order,
             amount = componentParams.amount,
             storePaymentMethod = if (componentParams.showStorePaymentField) outputData.isStorePaymentSelected else null,
-            sdkData = sdkDataProvider.createEncodedSdkData(),
         )
 
         return TwintComponentState(

--- a/twint/src/main/java/com/adyen/checkout/twint/internal/ui/StoredTwintDelegate.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/internal/ui/StoredTwintDelegate.kt
@@ -108,6 +108,7 @@ internal class StoredTwintDelegate(
         val twintPaymentMethod = TwintPaymentMethod(
             type = paymentMethod.type,
             checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
+            sdkData = sdkDataProvider.createEncodedSdkData(),
             storedPaymentMethodId = paymentMethod.id,
         )
 
@@ -115,7 +116,6 @@ internal class StoredTwintDelegate(
             paymentMethod = twintPaymentMethod,
             order = order,
             amount = componentParams.amount,
-            sdkData = sdkDataProvider.createEncodedSdkData(),
         )
 
         return TwintComponentState(

--- a/upi/src/main/java/com/adyen/checkout/upi/internal/ui/DefaultUPIDelegate.kt
+++ b/upi/src/main/java/com/adyen/checkout/upi/internal/ui/DefaultUPIDelegate.kt
@@ -205,6 +205,7 @@ internal class DefaultUPIDelegate(
         val paymentMethod = UPIPaymentMethod(
             type = getUPIPaymentMethodType(outputData),
             checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
+            sdkData = sdkDataProvider.createEncodedSdkData(),
             appId = getIntentItemAppIdForComponentStateOrNull(outputData),
             virtualPaymentAddress = getVirtualPaymentAddress(outputData),
         )
@@ -213,7 +214,6 @@ internal class DefaultUPIDelegate(
             paymentMethod = paymentMethod,
             order = order,
             amount = componentParams.amount,
-            sdkData = sdkDataProvider.createEncodedSdkData(),
         )
 
         return UPIComponentState(


### PR DESCRIPTION
## Description
Based on latest api changes, the `sdkData` field has been moved to the `paymentMethod` object.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

COSDK-513
