### PR TITLE
Remove old dependencyList task

### DIFF
--- a/.github/workflows/get_dependency_list.yml
+++ b/.github/workflows/get_dependency_list.yml
@@ -31,7 +31,7 @@ jobs:
           ARTIFACT_NAME: ${{ inputs.artifact-name }}
         run: |
           DEPENDENCY_LIST_FILE_NAME=$(echo "${ARTIFACT_NAME}")
-          ./gradlew dependencyList -q --no-configuration-cache -PoutputFileName=$DEPENDENCY_LIST_FILE_NAME
+          ./gradlew aggregateDependencyLists -q -PoutputFileName=$DEPENDENCY_LIST_FILE_NAME
 
       - name: Upload dependency list artifact
         uses: actions/upload-artifact@v4

--- a/buildSrc/src/main/java/aggregate-dependency-lists.gradle.kts
+++ b/buildSrc/src/main/java/aggregate-dependency-lists.gradle.kts
@@ -71,11 +71,3 @@ val aggregateDependencyLists = tasks.register<AggregateDependencyListsTask>("agg
 
     includeModules.set(project.providers.gradleProperty("includeModules").map { it.toBoolean() })
 }
-
-// Deprecated task
-tasks.register("dependencyList") {
-    dependsOn(aggregateDependencyLists)
-    doFirst {
-        logger.warn("This task is deprecated. Use 'aggregateDependencyLists' instead.")
-    }
-}


### PR DESCRIPTION
## Description
Remove old dependencyList task and use new aggregateDependencyLists task on CI. The `no-configuration-cache` flag is now also removed, which should speedup this task.
