### PR TITLE
Filter out unsupported payment methods for v6 components implementation

### DIFF
--- a/example-app/src/main/java/com/adyen/checkout/example/ui/v6/CheckoutContextExt.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/v6/CheckoutContextExt.kt
@@ -10,6 +10,12 @@ package com.adyen.checkout.example.ui.v6
 
 import com.adyen.checkout.core.common.CheckoutContext
 import com.adyen.checkout.core.components.data.model.PaymentMethod
+import com.adyen.checkout.core.components.paymentmethod.PaymentMethodTypes
+
+private val SUPPORTED_V6_PAYMENT_METHODS = listOf(
+    PaymentMethodTypes.MB_WAY,
+    PaymentMethodTypes.SCHEME,
+)
 
 @Suppress("RestrictedApi")
 internal fun CheckoutContext.getPaymentMethods(): List<PaymentMethod> {
@@ -19,5 +25,7 @@ internal fun CheckoutContext.getPaymentMethods(): List<PaymentMethod> {
             this.checkoutSession.sessionSetupResponse.paymentMethodsApiResponse?.paymentMethods
     }
 
-    return paymentMethods.orEmpty()
+    return paymentMethods
+        .orEmpty()
+        .filter { SUPPORTED_V6_PAYMENT_METHODS.contains(it.type) }
 }


### PR DESCRIPTION
## Description
Filter out unsupported payment methods for v6 components implementation. This prevents a crash from when an unsupported payment method is selected from the drop down.
