### PR TITLE
Fix CodeQL

### DIFF
--- a/example-app/ci.local.gradle
+++ b/example-app/ci.local.gradle
@@ -42,7 +42,10 @@ android {
             buildConfigField "String", "AUTHORIZATION_HEADER_VALUE", "\"\""
             buildConfigField "String", "CLIENT_KEY", "\"$accClientKey\""
 
-            signingConfig signingConfigs.acceptance
+            def filePath = System.getenv("SIGNING_STORE_FILE")
+            if (filePath) {
+                signingConfig signingConfigs.acceptance
+            }
         }
     }
 }


### PR DESCRIPTION
Only set up signing on CI if env variables are available. This will make sure acceptance builds pass on places where we don't need signing.