### PR TITLE
v5 - Fix publish docs action

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  deployments: write
+  contents: write
 
 jobs:
 


### PR DESCRIPTION
## Description
The publish docs action has not been working correctly for some time. It was due to having the wrong permissions. I updated the permission according to the [docs](https://github.com/JamesIves/github-pages-deploy-action). So it should work now.
