### PR TITLE
v6 - Use correct permission for publish docs workflow

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  deployments: write
+  contents: write
 
 jobs:
 


### PR DESCRIPTION
## Description
This PR fixes the same issue as we fixed before on the v5 branch, where the publish docs workflow failed because it didn't have the correct permission.
