### PR TITLE
v6 - Trigger onFinished when payment succeeds

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1005,14 +1005,12 @@ public final class com/adyen/checkout/core/components/CheckoutResult$Error : com
 
 public final class com/adyen/checkout/core/components/CheckoutResult$Finished : com/adyen/checkout/core/components/CheckoutResult {
 	public static final field $stable I
-	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/adyen/checkout/core/components/CheckoutResult$Finished;
-	public static synthetic fun copy$default (Lcom/adyen/checkout/core/components/CheckoutResult$Finished;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/core/components/CheckoutResult$Finished;
+	public fun <init> (Lcom/adyen/checkout/core/common/PaymentResult;)V
+	public final fun component1 ()Lcom/adyen/checkout/core/common/PaymentResult;
+	public final fun copy (Lcom/adyen/checkout/core/common/PaymentResult;)Lcom/adyen/checkout/core/components/CheckoutResult$Finished;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/core/components/CheckoutResult$Finished;Lcom/adyen/checkout/core/common/PaymentResult;ILjava/lang/Object;)Lcom/adyen/checkout/core/components/CheckoutResult$Finished;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getTemp ()Ljava/lang/String;
+	public final fun getPaymentResult ()Lcom/adyen/checkout/core/common/PaymentResult;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/CheckoutResult.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/CheckoutResult.kt
@@ -8,6 +8,7 @@
 
 package com.adyen.checkout.core.components
 
+import com.adyen.checkout.core.common.PaymentResult
 import com.adyen.checkout.core.common.exception.CheckoutError
 import com.adyen.checkout.core.action.data.Action as ActionResponse
 
@@ -18,8 +19,7 @@ import com.adyen.checkout.core.action.data.Action as ActionResponse
 sealed interface CheckoutResult {
 
     /** Indicates the payment process has finished successfully. */
-    // TODO - Replace temp parameter with actual value
-    data class Finished(val temp: String? = null) : CheckoutResult
+    data class Finished(val paymentResult: PaymentResult) : CheckoutResult
 
     /** Indicates that an additional action is required from the shopper. */
     data class Action(val action: ActionResponse) : CheckoutResult

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/AdvancedComponentEventHandler.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/AdvancedComponentEventHandler.kt
@@ -19,7 +19,11 @@ internal class AdvancedComponentEventHandler<T : BasePaymentComponentState>(
         return when (event) {
             is PaymentComponentEvent.Submit -> {
                 componentCallbacks.beforeSubmit(event.state)
-                componentCallbacks.onSubmit(event.state)
+                val result = componentCallbacks.onSubmit(event.state)
+                if (result is CheckoutResult.Finished) {
+                    componentCallbacks.onFinished(result.paymentResult)
+                }
+                result
             }
 
             is PaymentComponentEvent.Error -> {
@@ -31,7 +35,14 @@ internal class AdvancedComponentEventHandler<T : BasePaymentComponentState>(
 
     override suspend fun onActionComponentEvent(event: ActionComponentEvent): CheckoutResult {
         return when (event) {
-            is ActionComponentEvent.ActionDetails -> componentCallbacks.onAdditionalDetails(event.data)
+            is ActionComponentEvent.ActionDetails -> {
+                val result = componentCallbacks.onAdditionalDetails(event.data)
+                if (result is CheckoutResult.Finished) {
+                    componentCallbacks.onFinished(result.paymentResult)
+                }
+                result
+            }
+
             is ActionComponentEvent.Error -> {
                 componentCallbacks.onError(event.error)
                 CheckoutResult.Error(event.error)

--- a/core/src/main/java/com/adyen/checkout/core/sessions/SessionPaymentResult.kt
+++ b/core/src/main/java/com/adyen/checkout/core/sessions/SessionPaymentResult.kt
@@ -9,6 +9,7 @@
 package com.adyen.checkout.core.sessions
 
 import android.os.Parcelable
+import com.adyen.checkout.core.common.PaymentResult
 import com.adyen.checkout.core.components.data.OrderResponse
 import kotlinx.parcelize.Parcelize
 
@@ -30,3 +31,13 @@ data class SessionPaymentResult(
     val resultCode: String?,
     val order: OrderResponse?,
 ) : Parcelable
+
+internal fun SessionPaymentResult.toPaymentResult(): PaymentResult {
+    return PaymentResult(
+        sessionId = sessionId,
+        sessionResult = sessionResult,
+        sessionData = sessionData,
+        resultCode = resultCode.orEmpty(),
+        order = order,
+    )
+}

--- a/core/src/main/java/com/adyen/checkout/core/sessions/internal/SessionsComponentEventHandler.kt
+++ b/core/src/main/java/com/adyen/checkout/core/sessions/internal/SessionsComponentEventHandler.kt
@@ -16,6 +16,7 @@ import com.adyen.checkout.core.components.internal.PaymentComponentEvent
 import com.adyen.checkout.core.components.internal.SessionsComponentCallbacks
 import com.adyen.checkout.core.components.paymentmethod.PaymentComponentState
 import com.adyen.checkout.core.sessions.SessionError
+import com.adyen.checkout.core.sessions.toPaymentResult
 
 internal class SessionsComponentEventHandler<T : PaymentComponentState<*>>(
     private val sessionInteractor: SessionInteractor,
@@ -25,7 +26,6 @@ internal class SessionsComponentEventHandler<T : PaymentComponentState<*>>(
     override suspend fun onPaymentComponentEvent(event: PaymentComponentEvent<T>): CheckoutResult {
         return when (event) {
             is PaymentComponentEvent.Submit -> {
-                // TODO - Sessions Flow. If not taken over make call
                 if (componentCallbacks.onSubmit == null) {
                     makePaymentsCall(event.state)
                 } else {
@@ -50,7 +50,11 @@ internal class SessionsComponentEventHandler<T : PaymentComponentState<*>>(
                 ),
             )
             // TODO - Implement Finished case
-            is SessionCallResult.Payments.Finished -> CheckoutResult.Finished()
+            is SessionCallResult.Payments.Finished -> {
+                val paymentResult = sessionResult.result.toPaymentResult()
+                componentCallbacks.onFinished(paymentResult)
+                CheckoutResult.Finished()
+            }
         }
     }
 
@@ -81,7 +85,11 @@ internal class SessionsComponentEventHandler<T : PaymentComponentState<*>>(
                 ),
             )
             // TODO - Propagate session result to CheckoutResult.Finished once its data class is updated.
-            is SessionCallResult.Details.Finished -> CheckoutResult.Finished()
+            is SessionCallResult.Details.Finished -> {
+                val paymentResult = sessionResult.result.toPaymentResult()
+                componentCallbacks.onFinished(paymentResult)
+                CheckoutResult.Finished()
+            }
         }
     }
 }

--- a/core/src/main/java/com/adyen/checkout/core/sessions/internal/SessionsComponentEventHandler.kt
+++ b/core/src/main/java/com/adyen/checkout/core/sessions/internal/SessionsComponentEventHandler.kt
@@ -49,11 +49,10 @@ internal class SessionsComponentEventHandler<T : PaymentComponentState<*>>(
                     cause = sessionResult.throwable,
                 ),
             )
-            // TODO - Implement Finished case
             is SessionCallResult.Payments.Finished -> {
                 val paymentResult = sessionResult.result.toPaymentResult()
                 componentCallbacks.onFinished(paymentResult)
-                CheckoutResult.Finished()
+                CheckoutResult.Finished(paymentResult)
             }
         }
     }
@@ -84,11 +83,10 @@ internal class SessionsComponentEventHandler<T : PaymentComponentState<*>>(
                     cause = sessionResult.throwable,
                 ),
             )
-            // TODO - Propagate session result to CheckoutResult.Finished once its data class is updated.
             is SessionCallResult.Details.Finished -> {
                 val paymentResult = sessionResult.result.toPaymentResult()
                 componentCallbacks.onFinished(paymentResult)
-                CheckoutResult.Finished()
+                CheckoutResult.Finished(paymentResult)
             }
         }
     }

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/AdvancedComponentCallbacksTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/AdvancedComponentCallbacksTest.kt
@@ -140,7 +140,7 @@ internal class AdvancedComponentCallbacksTest(
         fun callbacksSource() = listOf(
             arguments(
                 CheckoutCallbacks(
-                    onAdditionalDetails = { CheckoutResult.Finished() },
+                    onAdditionalDetails = { CheckoutResult.Finished(PaymentResult("", null, null, null, null)) },
                     beforeSubmit = { false },
                     onError = {},
                     onFinished = {},
@@ -149,7 +149,7 @@ internal class AdvancedComponentCallbacksTest(
             ),
             arguments(
                 CheckoutCallbacks(
-                    onSubmit = { CheckoutResult.Finished() },
+                    onSubmit = { CheckoutResult.Finished(PaymentResult("", null, null, null, null)) },
                     beforeSubmit = { false },
                     onError = {},
                     onFinished = {},
@@ -158,8 +158,8 @@ internal class AdvancedComponentCallbacksTest(
             ),
             arguments(
                 CheckoutCallbacks(
-                    onSubmit = { CheckoutResult.Finished() },
-                    onAdditionalDetails = { CheckoutResult.Finished() },
+                    onSubmit = { CheckoutResult.Finished(PaymentResult("", null, null, null, null)) },
+                    onAdditionalDetails = { CheckoutResult.Finished(PaymentResult("", null, null, null, null)) },
                     beforeSubmit = { false },
                     onFinished = {},
                 ),

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/AdvancedComponentEventHandlerTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/AdvancedComponentEventHandlerTest.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.core.components.internal
 
 import com.adyen.checkout.core.action.data.ActionComponentData
 import com.adyen.checkout.core.action.internal.ActionComponentEvent
+import com.adyen.checkout.core.common.PaymentResult
 import com.adyen.checkout.core.components.CheckoutResult
 import com.adyen.checkout.core.components.paymentmethod.TestPaymentComponentState
 import com.adyen.checkout.core.sessions.SessionError
@@ -47,7 +48,7 @@ internal class AdvancedComponentEventHandlerTest(
 
         @Test
         fun `with Submit event, then beforeSubmit and onSubmit are called and result is returned`() = runTest {
-            val expectedResult = CheckoutResult.Finished()
+            val expectedResult = CheckoutResult.Finished(PaymentResult("", null, null, null, null))
             whenever(componentCallbacks.beforeSubmit(any())) doReturn true
             whenever(componentCallbacks.onSubmit(any())) doReturn expectedResult
 
@@ -77,7 +78,7 @@ internal class AdvancedComponentEventHandlerTest(
 
         @Test
         fun `with ActionDetails event, then onAdditionalDetails is called and result is returned`() = runTest {
-            val expectedResult = CheckoutResult.Finished()
+            val expectedResult = CheckoutResult.Finished(PaymentResult("", null, null, null, null))
             whenever(componentCallbacks.onAdditionalDetails(any())) doReturn expectedResult
 
             val data = ActionComponentData(paymentData = "test")

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/SessionsComponentCallbacksTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/SessionsComponentCallbacksTest.kt
@@ -28,6 +28,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -78,7 +79,7 @@ class SessionsComponentCallbacksTest(
                 onError = onErrorCallback,
             )
 
-            whenever(onSubmitCallback.onSubmit(any())) doReturn CheckoutResult.Finished()
+            whenever(onSubmitCallback.onSubmit(any())) doReturn CheckoutResult.Finished(mock())
 
             val actualSessionsComponentCallbacks = checkoutCallbacks.toSessionsComponentCallbacks()
 
@@ -95,7 +96,7 @@ class SessionsComponentCallbacksTest(
                 onError = onErrorCallback,
             )
 
-            whenever(onAdditionalDetailsCallback.onAdditionalDetails(any())) doReturn CheckoutResult.Finished()
+            whenever(onAdditionalDetailsCallback.onAdditionalDetails(any())) doReturn CheckoutResult.Finished(mock())
 
             val actualSessionsComponentCallbacks = checkoutCallbacks.toSessionsComponentCallbacks()
 

--- a/core/src/test/java/com/adyen/checkout/core/sessions/internal/SessionsComponentEventHandlerTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/sessions/internal/SessionsComponentEventHandlerTest.kt
@@ -12,6 +12,7 @@ import com.adyen.checkout.core.components.paymentmethod.PaymentComponentState
 import com.adyen.checkout.core.components.paymentmethod.TestPaymentComponentState
 import com.adyen.checkout.core.sessions.SessionError
 import com.adyen.checkout.core.sessions.SessionPaymentResult
+import com.adyen.checkout.core.sessions.toPaymentResult
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -96,6 +97,26 @@ internal class SessionsComponentEventHandlerTest(
         } else {
             assertEquals(expectedResult, result)
         }
+    }
+
+    @Test
+    fun `when session interactor submits payment and payment is finished, then onFinished is called`() = runTest {
+        val sessionPaymentResult = SessionPaymentResult(
+            sessionId = "test_session_id",
+            sessionResult = "test_session_result",
+            sessionData = "test_session_data",
+            resultCode = "Authorised",
+            order = null,
+        )
+        whenever(componentCallbacks.beforeSubmit(any())) doReturn false
+        whenever(
+            sessionInteractor.submitPayment(any())
+        ) doReturn SessionCallResult.Payments.Finished(sessionPaymentResult,)
+
+        val state = TestPaymentComponentState()
+        sessionsComponentEventHandler.onPaymentComponentEvent(PaymentComponentEvent.Submit(state))
+
+        verify(componentCallbacks).onFinished(sessionPaymentResult.toPaymentResult())
     }
 
     @Test

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6SessionsViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6SessionsViewModel.kt
@@ -17,6 +17,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.adyen.checkout.core.common.Environment
+import com.adyen.checkout.core.common.PaymentResult
 import com.adyen.checkout.core.common.exception.CheckoutError
 import com.adyen.checkout.core.components.Checkout
 import com.adyen.checkout.core.components.CheckoutCallbacks
@@ -28,6 +29,7 @@ import com.adyen.checkout.example.extensions.getLogTag
 import com.adyen.checkout.example.repositories.PaymentsRepository
 import com.adyen.checkout.example.service.getSessionRequest
 import com.adyen.checkout.example.service.getSettingsInstallmentOptionsMode
+import com.adyen.checkout.example.ui.compose.ResultState
 import com.adyen.checkout.example.ui.compose.UIText
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -86,6 +88,7 @@ internal class V6SessionsViewModel @Inject constructor(
                 checkoutContext = result.checkoutContext,
                 checkoutCallbacks = CheckoutCallbacks(
                     onError = ::onError,
+                    onFinished = ::onFinished,
                 ),
                 paymentMethods = result.checkoutContext.getPaymentMethods(),
             )
@@ -94,6 +97,10 @@ internal class V6SessionsViewModel @Inject constructor(
 
     private fun onError(error: CheckoutError) {
         Log.d(TAG, "onError: ${error.message}")
+    }
+
+    private fun onFinished(paymentResult: PaymentResult) {
+        uiState = V6UiState.Final(ResultState.get(paymentResult.resultCode))
     }
 
     fun handleIntent(intent: Intent) {

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6ViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6ViewModel.kt
@@ -23,6 +23,7 @@ import com.adyen.checkout.card.onBinValue
 import com.adyen.checkout.core.action.data.Action
 import com.adyen.checkout.core.action.data.ActionComponentData
 import com.adyen.checkout.core.common.Environment
+import com.adyen.checkout.core.common.PaymentResult
 import com.adyen.checkout.core.common.exception.CheckoutError
 import com.adyen.checkout.core.common.exception.ComponentError
 import com.adyen.checkout.core.components.Checkout
@@ -100,6 +101,7 @@ internal class V6ViewModel @Inject constructor(
                     onSubmit = ::onSubmit,
                     onAdditionalDetails = ::onAdditionalDetails,
                     onError = ::onError,
+                    onFinished = ::onFinished,
                 ) {
                     card {
                         onBinValue(::onBinValue)
@@ -151,15 +153,26 @@ internal class V6ViewModel @Inject constructor(
             }
 
             else -> {
-                // TODO - move to onFinished callback after it's introduced
-                uiState = V6UiState.Final(ResultState.get(json.optString("resultCode")))
-                CheckoutResult.Finished()
+                val resultCode = json.optString("resultCode")
+                CheckoutResult.Finished(
+                    PaymentResult(
+                        resultCode = resultCode,
+                        sessionId = null,
+                        sessionResult = null,
+                        sessionData = null,
+                        order = null
+                    )
+                )
             }
         }
     }
 
     private fun onError(error: CheckoutError) {
         uiState = V6UiState.Error(UIText.String(error.message.orEmpty()))
+    }
+
+    private fun onFinished(paymentResult: PaymentResult) {
+        uiState = V6UiState.Final(ResultState.get(paymentResult.resultCode))
     }
 
     fun handleIntent(intent: Intent) {


### PR DESCRIPTION
## Description
[//]: # (Include a short summary of your changes)
[//]: # (If this is a new feature: attach screenshots or a video if applicable)
[//]: # (If this is a bug fix: include a reproduction path)
This PR adds the functionality to trigger `onFinished` callback with the `PaymentResult` once it's successful. 

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually
