### PR TITLE
Add coverage for UC5 use case (brand logos visibility behavior)

### DIFF
--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2025 Adyen N.V.
+ * Copyright (c) 2026 Adyen N.V.
  *
  * This file is open source and available under the MIT license. See the LICENSE file for more info.
  *
- * Created by andriim on 22/1/2025.
+ * Created by andriim on 22/1/2026.
  */
 
 package com.adyen.checkout.card.internal.ui.state


### PR DESCRIPTION
## Description
COSDK-886

Add test coverage for use-case UC5 from the cross-platform form validation specification. 
This PR introduces `CardViewStateProducerTest` to validate the `isSupportedCardBrandsShown` logic in `CardViewStateProducer`.

**Context:**
This work is part of a cross-platform effort to align form validation behavior between iOS and Android. The UC5 specification defines when supported card brand logos should be shown or hidden based on card brand detection.

**This is the first iteration** focusing on UC5 to establish the testing pattern and demonstrate cross-platform alignment. Additional use cases (UC1-UC4, UC6-UC13) will be covered in future PRs as the team expands test coverage.
Collaboration is encouraged.

**Reference:**
- [Main spec](https://github.com/Adyen/adyen-checkout-sdk-meta/blob/aea1796b9ea9f04f14bfe7425115956dc6df24e1/specs/FORM_VALIDATION_SPECS.md#uc5-brand-detection-hides-placeholder-no-error)
- [iOS equivalent](https://github.com/Adyen/adyen-ios/blob/ed481fcb97a0e8bf5ea3f8ebb23f8098c9db9d4e/Tests/IntegrationTests/Card%20Tests/Items/CardNumberItem/FormCardNumberValidationTests.swift)
- [Test coverage mapping](https://github.com/Adyen/adyen-checkout-sdk-meta/blob/aea1796b9ea9f04f14bfe7425115956dc6df24e1/specs/FORM_VALIDATION_SPECS.md#test-case-references)

## Checklist <!-- Remove any line that's not applicable -->
- [x] If applicable, make sure Breaking change label is added.
- [x] Code is unit tested
- [x] Changes are tested manually
- [x] Related issues are linked
