### PR TITLE
Do not comment on forked PRs

### DIFF
--- a/.github/workflows/validate_public_api.yml
+++ b/.github/workflows/validate_public_api.yml
@@ -38,7 +38,8 @@ jobs:
       - name: Comment on PR
         # This step will only run on pull_request events.
         # PR information is only available when workflow gets triggered with pull_request event.
-        if: github.event_name == 'pull_request'
+        # We also check that the PR is not from a fork, because this action will fail if it is.
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
           file-path: "${{ github.workspace }}/api_changes.md"
@@ -46,7 +47,7 @@ jobs:
           mode: recreate
 
       - name: Check if successful
-        run : |
+        run: |
           if [ -s api_changes.txt ]
           then
             # Fail workflow if there are API changes


### PR DESCRIPTION
## Description
This PR skips commenting on forked PRs, so the CI for external PRs can succeed and we can merge them.
