### PR TITLE
v5 - session component provider key

### DIFF
--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/provider/SessionPaymentComponentProvider.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/internal/provider/SessionPaymentComponentProvider.kt
@@ -99,6 +99,7 @@ interface SessionPaymentComponentProvider<
             paymentMethod = paymentMethod,
             checkoutConfiguration = checkoutSession.getConfiguration(),
             componentCallback = componentCallback,
+            key = key,
         )
     }
 
@@ -169,6 +170,7 @@ interface SessionPaymentComponentProvider<
             paymentMethod = paymentMethod,
             checkoutConfiguration = checkoutSession.getConfiguration(),
             componentCallback = componentCallback,
+            key = key,
         )
     }
 


### PR DESCRIPTION
## Description
This is a cherry picked PR from the main branch (#2512). It fixes the key parameter properly being propagated when trying to obtain a component.

## Release notes

### Fixed
- The key is properly passed when trying to obtain a component while using sessions