### PR TITLE
v6 - Errors - Decouple CheckoutResult.Error from CheckoutError hierarchy

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -993,12 +993,12 @@ public final class com/adyen/checkout/core/components/CheckoutResult$Action : co
 
 public final class com/adyen/checkout/core/components/CheckoutResult$Error : com/adyen/checkout/core/components/CheckoutResult {
 	public static final field $stable I
-	public fun <init> (Lcom/adyen/checkout/core/common/exception/CheckoutError;)V
-	public final fun component1 ()Lcom/adyen/checkout/core/common/exception/CheckoutError;
-	public final fun copy (Lcom/adyen/checkout/core/common/exception/CheckoutError;)Lcom/adyen/checkout/core/components/CheckoutResult$Error;
-	public static synthetic fun copy$default (Lcom/adyen/checkout/core/components/CheckoutResult$Error;Lcom/adyen/checkout/core/common/exception/CheckoutError;ILjava/lang/Object;)Lcom/adyen/checkout/core/components/CheckoutResult$Error;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/adyen/checkout/core/components/CheckoutResult$Error;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/core/components/CheckoutResult$Error;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/core/components/CheckoutResult$Error;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getError ()Lcom/adyen/checkout/core/common/exception/CheckoutError;
+	public final fun getErrorMessage ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/CheckoutResult.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/CheckoutResult.kt
@@ -8,7 +8,6 @@
 
 package com.adyen.checkout.core.components
 
-import com.adyen.checkout.core.common.exception.CheckoutError
 import com.adyen.checkout.core.action.data.Action as ActionResponse
 
 // TODO - KDocs, revisit later after having parameters
@@ -24,6 +23,7 @@ sealed interface CheckoutResult {
     /** Indicates that an additional action is required from the shopper. */
     data class Action(val action: ActionResponse) : CheckoutResult
 
+    // TODO - Error propagation: Revisit error type.
     /** Indicates an error occurred during the payment process. */
-    data class Error(val error: CheckoutError) : CheckoutResult
+    data class Error(val errorMessage: String) : CheckoutResult
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/AdvancedComponentEventHandler.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/AdvancedComponentEventHandler.kt
@@ -24,7 +24,7 @@ internal class AdvancedComponentEventHandler<T : BasePaymentComponentState>(
 
             is PaymentComponentEvent.Error -> {
                 componentCallbacks.onError(event.error)
-                CheckoutResult.Error(event.error)
+                CheckoutResult.Error(event.error.message.orEmpty())
             }
         }
     }
@@ -34,7 +34,7 @@ internal class AdvancedComponentEventHandler<T : BasePaymentComponentState>(
             is ActionComponentEvent.ActionDetails -> componentCallbacks.onAdditionalDetails(event.data)
             is ActionComponentEvent.Error -> {
                 componentCallbacks.onError(event.error)
-                CheckoutResult.Error(event.error)
+                CheckoutResult.Error(event.error.message.orEmpty())
             }
         }
     }

--- a/core/src/main/java/com/adyen/checkout/core/sessions/internal/SessionsComponentEventHandler.kt
+++ b/core/src/main/java/com/adyen/checkout/core/sessions/internal/SessionsComponentEventHandler.kt
@@ -15,7 +15,6 @@ import com.adyen.checkout.core.components.internal.ComponentEventHandler
 import com.adyen.checkout.core.components.internal.PaymentComponentEvent
 import com.adyen.checkout.core.components.internal.SessionsComponentCallbacks
 import com.adyen.checkout.core.components.paymentmethod.PaymentComponentState
-import com.adyen.checkout.core.sessions.SessionError
 
 internal class SessionsComponentEventHandler<T : PaymentComponentState<*>>(
     private val sessionInteractor: SessionInteractor,
@@ -35,7 +34,7 @@ internal class SessionsComponentEventHandler<T : PaymentComponentState<*>>(
 
             is PaymentComponentEvent.Error -> {
                 componentCallbacks.onError(event.error)
-                CheckoutResult.Error(event.error)
+                CheckoutResult.Error(event.error.message.orEmpty())
             }
         }
     }
@@ -44,10 +43,7 @@ internal class SessionsComponentEventHandler<T : PaymentComponentState<*>>(
         return when (val sessionResult = sessionInteractor.submitPayment(paymentComponentState)) {
             is SessionCallResult.Payments.Action -> CheckoutResult.Action(sessionResult.action)
             is SessionCallResult.Payments.Error -> CheckoutResult.Error(
-                SessionError(
-                    message = sessionResult.throwable.message.orEmpty(),
-                    cause = sessionResult.throwable,
-                ),
+                sessionResult.throwable.message.orEmpty(),
             )
             // TODO - Implement Finished case
             is SessionCallResult.Payments.Finished -> CheckoutResult.Finished()
@@ -66,7 +62,7 @@ internal class SessionsComponentEventHandler<T : PaymentComponentState<*>>(
 
             is ActionComponentEvent.Error -> {
                 componentCallbacks.onError(event.error)
-                CheckoutResult.Error(event.error)
+                CheckoutResult.Error(event.error.message.orEmpty())
             }
         }
     }
@@ -75,10 +71,7 @@ internal class SessionsComponentEventHandler<T : PaymentComponentState<*>>(
         return when (val sessionResult = sessionInteractor.submitDetails(actionComponentData)) {
             is SessionCallResult.Details.Action -> CheckoutResult.Action(sessionResult.action)
             is SessionCallResult.Details.Error -> CheckoutResult.Error(
-                SessionError(
-                    message = sessionResult.throwable.message.orEmpty(),
-                    cause = sessionResult.throwable,
-                ),
+                sessionResult.throwable.message.orEmpty(),
             )
             // TODO - Propagate session result to CheckoutResult.Finished once its data class is updated.
             is SessionCallResult.Details.Finished -> CheckoutResult.Finished()

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/AdvancedComponentEventHandlerTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/AdvancedComponentEventHandlerTest.kt
@@ -10,9 +10,9 @@ package com.adyen.checkout.core.components.internal
 
 import com.adyen.checkout.core.action.data.ActionComponentData
 import com.adyen.checkout.core.action.internal.ActionComponentEvent
+import com.adyen.checkout.core.common.exception.ComponentError
 import com.adyen.checkout.core.components.CheckoutResult
 import com.adyen.checkout.core.components.paymentmethod.TestPaymentComponentState
-import com.adyen.checkout.core.sessions.SessionError
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -61,13 +61,13 @@ internal class AdvancedComponentEventHandlerTest(
 
         @Test
         fun `with Error event, then onError is called and error result is returned`() = runTest {
-            val error = SessionError(message = "test_error")
+            val error = ComponentError(message = "test_error")
             val event = PaymentComponentEvent.Error<TestPaymentComponentState>(error)
 
             val result = advancedComponentEventHandler.onPaymentComponentEvent(event)
 
             verify(componentCallbacks).onError(error)
-            assertEquals(CheckoutResult.Error(error), result)
+            assertEquals(CheckoutResult.Error("test_error"), result)
         }
     }
 
@@ -89,13 +89,13 @@ internal class AdvancedComponentEventHandlerTest(
 
         @Test
         fun `with Error event, then onError is called and error result is returned`() = runTest {
-            val error = SessionError(message = "test_error")
+            val error = ComponentError(message = "test_error")
             val event = ActionComponentEvent.Error(error)
 
             val result = advancedComponentEventHandler.onActionComponentEvent(event)
 
             verify(componentCallbacks).onError(error)
-            assertEquals(CheckoutResult.Error(error), result)
+            assertEquals(CheckoutResult.Error("test_error"), result)
         }
     }
 }

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6ViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6ViewModel.kt
@@ -24,7 +24,6 @@ import com.adyen.checkout.core.action.data.Action
 import com.adyen.checkout.core.action.data.ActionComponentData
 import com.adyen.checkout.core.common.Environment
 import com.adyen.checkout.core.common.exception.CheckoutError
-import com.adyen.checkout.core.common.exception.ComponentError
 import com.adyen.checkout.core.components.Checkout
 import com.adyen.checkout.core.components.CheckoutCallbacks
 import com.adyen.checkout.core.components.CheckoutConfiguration
@@ -144,7 +143,7 @@ internal class V6ViewModel @Inject constructor(
 
     private fun handleResponse(json: JSONObject?): CheckoutResult {
         return when {
-            json == null -> CheckoutResult.Error(ComponentError(message = "Network error"))
+            json == null -> CheckoutResult.Error("Network error")
             json.has("action") -> {
                 val action = Action.SERIALIZER.deserialize(json.getJSONObject("action"))
                 CheckoutResult.Action(action)


### PR DESCRIPTION
## Description
Decouple CheckoutResult.Error from the CheckoutError hierarchy by changing it to use a simple String error message.

This is the first step in flattening the error handling framework, allowing the internal error hierarchy to evolve independently from the public API.

## Checklist
- [x] Code is unit tested
- [x] Changes are tested manually

COSDK-979