### PR TITLE
v6 - Errors - Checkout setup

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -847,12 +847,12 @@ public abstract interface class com/adyen/checkout/core/components/Checkout$Resu
 
 public final class com/adyen/checkout/core/components/Checkout$Result$Error : com/adyen/checkout/core/components/Checkout$Result {
 	public static final field $stable I
-	public fun <init> (Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/adyen/checkout/core/components/Checkout$Result$Error;
-	public static synthetic fun copy$default (Lcom/adyen/checkout/core/components/Checkout$Result$Error;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/core/components/Checkout$Result$Error;
+	public fun <init> (Lcom/adyen/checkout/core/error/CheckoutError;)V
+	public final fun component1 ()Lcom/adyen/checkout/core/error/CheckoutError;
+	public final fun copy (Lcom/adyen/checkout/core/error/CheckoutError;)Lcom/adyen/checkout/core/components/Checkout$Result$Error;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/core/components/Checkout$Result$Error;Lcom/adyen/checkout/core/error/CheckoutError;ILjava/lang/Object;)Lcom/adyen/checkout/core/components/Checkout$Result$Error;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getErrorReason ()Ljava/lang/String;
+	public final fun getError ()Lcom/adyen/checkout/core/error/CheckoutError;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/Checkout.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/Checkout.kt
@@ -11,6 +11,7 @@ package com.adyen.checkout.core.components
 import com.adyen.checkout.core.common.CheckoutContext
 import com.adyen.checkout.core.components.data.model.PaymentMethodsApiResponse
 import com.adyen.checkout.core.components.internal.CheckoutInitializer
+import com.adyen.checkout.core.error.CheckoutError
 import com.adyen.checkout.core.sessions.SessionResponse
 
 object Checkout {
@@ -25,9 +26,12 @@ object Checkout {
         )
 
         return when {
-            initializationData.checkoutSession == null -> {
-                Result.Error("Failed to initialize sessions.")
-            }
+            initializationData.checkoutSession == null -> Result.Error(
+                CheckoutError(
+                    code = CheckoutError.ErrorCode.SESSION_SETUP_FAILURE,
+                    message = "Failed to initialize sessions.",
+                ),
+            )
 
             else -> Result.Success(
                 checkoutContext = CheckoutContext.Sessions(
@@ -61,6 +65,6 @@ object Checkout {
 
     sealed interface Result<T : CheckoutContext> {
         data class Success<T : CheckoutContext>(val checkoutContext: T) : Result<T>
-        data class Error<T : CheckoutContext>(val errorReason: String) : Result<T>
+        data class Error<T : CheckoutContext>(val error: CheckoutError) : Result<T>
     }
 }

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6SessionsViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6SessionsViewModel.kt
@@ -81,7 +81,7 @@ internal class V6SessionsViewModel @Inject constructor(
         )
 
         uiState = when (result) {
-            is Checkout.Result.Error -> V6UiState.Error(UIText.String(result.errorReason))
+            is Checkout.Result.Error -> V6UiState.Error(UIText.String(result.error.message.orEmpty()))
             is Checkout.Result.Success -> V6UiState.Component(
                 checkoutContext = result.checkoutContext,
                 checkoutCallbacks = CheckoutCallbacks(

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6ViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6ViewModel.kt
@@ -92,7 +92,7 @@ internal class V6ViewModel @Inject constructor(
         )
 
         uiState = when (result) {
-            is Checkout.Result.Error -> V6UiState.Error(UIText.String(result.errorReason))
+            is Checkout.Result.Error -> V6UiState.Error(UIText.String(result.error.message.orEmpty()))
             is Checkout.Result.Success -> V6UiState.Component(
                 checkoutContext = result.checkoutContext,
                 checkoutCallbacks = CheckoutCallbacks(


### PR DESCRIPTION
## Description
- Change `Result.Error` parameter from `errorReason: String` to `error: CheckoutError`
- Update sessions `setup` function to return `SESSION_SETUP_FAILURE` error code when session initialization fails

## Checklist
- [x] Code is unit tested
- [x] Changes are tested manually

## Ticket
COSDK-975