### PR TITLE
v5 - Remove weak reference usage from Google Pay availability callback

### DIFF
--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/util/GooglePayAvailabilityCheck.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/util/GooglePayAvailabilityCheck.kt
@@ -17,7 +17,6 @@ import com.adyen.checkout.googlepay.internal.ui.model.GooglePayComponentParams
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.android.gms.wallet.Wallet
-import java.lang.ref.WeakReference
 
 internal class GooglePayAvailabilityCheck(
     private val application: Application,
@@ -35,21 +34,19 @@ internal class GooglePayAvailabilityCheck(
             return
         }
 
-        val callbackWeakReference = WeakReference(callback)
-
         val paymentsClient = Wallet.getPaymentsClient(application, GooglePayUtils.createWalletOptions(componentParams))
         val readyToPayRequest = GooglePayUtils.createIsReadyToPayRequest(componentParams)
         val readyToPayTask = paymentsClient.isReadyToPay(readyToPayRequest)
         readyToPayTask.addOnSuccessListener { result ->
-            callbackWeakReference.get()?.onAvailabilityResult(result == true, paymentMethod)
+            callback.onAvailabilityResult(result == true, paymentMethod)
         }
         readyToPayTask.addOnCanceledListener {
             adyenLog(AdyenLogLevel.ERROR) { "GooglePay readyToPay task is cancelled." }
-            callbackWeakReference.get()?.onAvailabilityResult(false, paymentMethod)
+            callback.onAvailabilityResult(false, paymentMethod)
         }
         readyToPayTask.addOnFailureListener {
             adyenLog(AdyenLogLevel.ERROR, it) { "GooglePay readyToPay task is failed." }
-            callbackWeakReference.get()?.onAvailabilityResult(false, paymentMethod)
+            callback.onAvailabilityResult(false, paymentMethod)
         }
     }
 }


### PR DESCRIPTION
## Description
The weak reference could be garbage collected while the task is still running, causing the GooglePayComponent to not function. Since these tasks are short-lived it should not happen that these tasks will leak memory.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
- [x] Related issues are linked

## Ticket Number
COSDK-978

## Release notes

### Fixed
- For Google Pay, the availability check callback will no longer be garbage collected while the check is running.