### PR TITLE
v5 - Fix drop-in card screen recordings

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardView.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardView.kt
@@ -7,9 +7,7 @@
  */
 package com.adyen.checkout.card.internal.ui.view
 
-import android.app.Activity
 import android.content.Context
-import android.content.ContextWrapper
 import android.os.Build
 import android.text.Editable
 import android.text.InputType
@@ -17,7 +15,6 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
 import android.view.View.OnFocusChangeListener
-import android.view.WindowManager
 import android.widget.AdapterView
 import android.widget.LinearLayout
 import androidx.annotation.RestrictTo
@@ -37,7 +34,6 @@ import com.adyen.checkout.components.core.internal.ui.model.FieldState
 import com.adyen.checkout.components.core.internal.ui.model.Validation
 import com.adyen.checkout.core.CardBrand
 import com.adyen.checkout.core.CardType
-import com.adyen.checkout.core.internal.util.BuildUtils
 import com.adyen.checkout.ui.core.internal.ui.AddressFormUIState
 import com.adyen.checkout.ui.core.internal.ui.ComponentView
 import com.adyen.checkout.ui.core.internal.ui.loadLogo
@@ -103,17 +99,12 @@ class CardView @JvmOverloads constructor(
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
-        if (!BuildUtils.isDebugBuild(context)) {
-            // Prevent taking screenshot and screen on recents.
-            getActivity(context)?.window?.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
-        }
+        setFlagSecureOnRootView(true)
     }
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
-        if (!BuildUtils.isDebugBuild(context)) {
-            getActivity(context)?.window?.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
-        }
+        setFlagSecureOnRootView(false)
     }
 
     override fun initView(delegate: ComponentDelegate, coroutineScope: CoroutineScope, localizedContext: Context) {
@@ -761,14 +752,6 @@ class CardView @JvmOverloads constructor(
             binding.autoCompleteTextViewInstallments.setText(
                 InstallmentUtils.getTextForInstallmentOption(localizedContext, outputData.installmentState.value),
             )
-        }
-    }
-
-    private fun getActivity(context: Context): Activity? {
-        return when (context) {
-            is Activity -> context
-            is ContextWrapper -> getActivity(context.baseContext)
-            else -> null
         }
     }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardViewExt.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardViewExt.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 9/2/2026.
+ */
+
+package com.adyen.checkout.card.internal.ui.view
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.view.View
+import android.view.WindowManager
+import com.adyen.checkout.core.AdyenLogLevel
+import com.adyen.checkout.core.internal.util.BuildUtils
+import com.adyen.checkout.core.internal.util.adyenLog
+
+internal fun View.setFlagSecureOnRootView(enable: Boolean) {
+    if (BuildUtils.isDebugBuild(context)) return
+
+    val rootView = rootView
+    val window = getActivity(context)?.window
+    if (window != null && rootView == window.decorView) {
+        if (enable) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        } else {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
+    } else {
+        val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as? WindowManager
+        val params = rootView.layoutParams
+        if (windowManager != null && params is WindowManager.LayoutParams) {
+            if (enable) {
+                params.flags = params.flags or WindowManager.LayoutParams.FLAG_SECURE
+            } else {
+                params.flags = params.flags and WindowManager.LayoutParams.FLAG_SECURE.inv()
+            }
+            try {
+                windowManager.updateViewLayout(rootView, params)
+            } catch (e: IllegalArgumentException) {
+                adyenLog(AdyenLogLevel.WARN, e) { "Failed to update view layout with secure flag" }
+            }
+        }
+    }
+}
+
+private fun getActivity(context: Context): Activity? {
+    return when (context) {
+        is Activity -> context
+        is ContextWrapper -> getActivity(context.baseContext)
+        else -> null
+    }
+}

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardView.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardView.kt
@@ -8,15 +8,12 @@
 
 package com.adyen.checkout.card.internal.ui.view
 
-import android.app.Activity
 import android.content.Context
-import android.content.ContextWrapper
 import android.text.Editable
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
 import android.view.View.OnFocusChangeListener
-import android.view.WindowManager
 import android.widget.LinearLayout
 import androidx.core.view.isVisible
 import com.adyen.checkout.card.CardComponent
@@ -26,7 +23,6 @@ import com.adyen.checkout.card.internal.ui.CardDelegate
 import com.adyen.checkout.card.internal.ui.model.CardOutputData
 import com.adyen.checkout.components.core.internal.ui.ComponentDelegate
 import com.adyen.checkout.components.core.internal.ui.model.Validation
-import com.adyen.checkout.core.internal.util.BuildUtils
 import com.adyen.checkout.ui.core.internal.ui.ComponentView
 import com.adyen.checkout.ui.core.internal.ui.loadLogo
 import com.adyen.checkout.ui.core.internal.ui.view.RoundCornerImageView
@@ -70,17 +66,12 @@ internal class StoredCardView @JvmOverloads constructor(
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
-        if (!BuildUtils.isDebugBuild(context)) {
-            // Prevent taking screenshot and screen on recents.
-            getActivity(context)?.window?.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
-        }
+        setFlagSecureOnRootView(true)
     }
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
-        if (!BuildUtils.isDebugBuild(context)) {
-            getActivity(context)?.window?.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
-        }
+        setFlagSecureOnRootView(false)
     }
 
     override fun initView(delegate: ComponentDelegate, coroutineScope: CoroutineScope, localizedContext: Context) {
@@ -167,12 +158,4 @@ internal class StoredCardView @JvmOverloads constructor(
     }
 
     override fun getView(): View = this
-
-    private fun getActivity(context: Context): Activity? {
-        return when (context) {
-            is Activity -> context
-            is ContextWrapper -> getActivity(context.baseContext)
-            else -> null
-        }
-    }
 }


### PR DESCRIPTION
## Description
Prevent screen recordings of the `CardView` and `StoredCardView` by setting `FLAG_SECURE` on the correct window.


https://github.com/user-attachments/assets/233796e2-bd86-4ac3-ad4d-7ff06fee9d8e

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
- [x] Related issues are linked

## Ticket Number
COSDK-977

## Release notes

### Fixed
- For cards, it is no longer possible to take screen recordings when the card view is used in a bottom sheet or dialog. This means screen recordings of the card view in drop-in are no longer possible.