### PR TITLE
v5 - Fix payment method list simultaneous clicks crash

### DIFF
--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodAdapter.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodAdapter.kt
@@ -93,6 +93,18 @@ internal class PaymentMethodAdapter @JvmOverloads constructor(
         }
     }
 
+    override fun onViewRecycled(holder: RecyclerView.ViewHolder) {
+        super.onViewRecycled(holder)
+
+        when (holder) {
+            is StoredPaymentMethodVH -> holder.unbind()
+            is PaymentMethodVH -> holder.unbind()
+            is GiftCardPaymentMethodVH -> holder.unbind()
+            is HeaderVH -> holder.unbind()
+            is NoteVH -> holder.unbind()
+        }
+    }
+
     override fun getItemCount(): Int = currentList.size
 
     private class StoredPaymentMethodVH(
@@ -153,10 +165,18 @@ internal class PaymentMethodAdapter @JvmOverloads constructor(
                     dialog.dismiss()
                 }
                 .setNegativeButton(R.string.checkout_giftcard_remove_gift_cards_negative_button) { dialog, _ ->
-                    (binding.root as? AdyenSwipeToRevealLayout)?.collapseUnderlay()
+                    binding.root.collapseUnderlay()
                     dialog.dismiss()
                 }
                 .show()
+        }
+
+        fun unbind() {
+            binding.paymentMethodItemUnderlayButton.setOnClickListener(null)
+            binding.swipeToRevealLayout.apply {
+                removeUnderlayListener()
+                setOnMainClickListener(null)
+            }
         }
     }
 
@@ -187,6 +207,10 @@ internal class PaymentMethodAdapter @JvmOverloads constructor(
             val adapter = LogoTextAdapter(binding.root.context)
             recyclerViewBrandList.adapter = adapter
             adapter.submitList(model.brandList)
+        }
+
+        fun unbind() {
+            itemView.setOnClickListener(null)
         }
     }
 
@@ -227,6 +251,10 @@ internal class PaymentMethodAdapter @JvmOverloads constructor(
             }
             itemView.setOnClickListener(null)
         }
+
+        fun unbind() {
+            itemView.setOnClickListener(null)
+        }
     }
 
     private class HeaderVH(private val binding: PaymentMethodsListHeaderBinding) :
@@ -248,12 +276,18 @@ internal class PaymentMethodAdapter @JvmOverloads constructor(
                 }
             }
         }
+
+        fun unbind() {
+            binding.paymentMethodHeaderAction.setOnClickListener(null)
+        }
     }
 
     private class NoteVH(private val binding: PaymentMethodsListNoteBinding) : RecyclerView.ViewHolder(binding.root) {
         fun bind(model: PaymentMethodNote) = with(binding) {
             paymentMethodNote.text = model.note
         }
+
+        fun unbind() = Unit
     }
 
     interface OnPaymentMethodSelectedCallback {

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/AdyenSwipeToRevealLayout.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/internal/ui/view/AdyenSwipeToRevealLayout.kt
@@ -431,7 +431,7 @@ class AdyenSwipeToRevealLayout @JvmOverloads constructor(
      *
      * @param onMainClickListener the click listener
      */
-    fun setOnMainClickListener(onMainClickListener: OnMainClickListener) {
+    fun setOnMainClickListener(onMainClickListener: OnMainClickListener?) {
         this.onMainClickListener = onMainClickListener
     }
 


### PR DESCRIPTION
## Description
View holders in the payment method list now unbind. This fixes a bug where if a stored payment method entry and a regular payment method entry are clicked simultaneously would crash.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
- [x] Related issues are linked

## Ticket Number
COSDK-1021

## Release notes

### Fixed
- For drop-in, clicking on a stored payment method and a regular payment method simultaneously no longer crashes.