### PR TITLE
Add --write-verification-metadata sha256 to generate the missing SHA-…

### DIFF
--- a/.github/workflows/release_snaphot.yml
+++ b/.github/workflows/release_snaphot.yml
@@ -50,4 +50,4 @@ jobs:
           SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
         run: |
           VERSION_NAME=$(date +%Y.%m.%d-SNAPSHOT)
-          ./gradlew publishReleasePublicationToSonatypeRepository -Pversion-name=$VERSION_NAME --no-parallel
+          ./gradlew publishReleasePublicationToSonatypeRepository --write-verification-metadata sha256 -Pversion-name=$VERSION_NAME --no-parallel


### PR DESCRIPTION
…256 checksums for the Dokka dependencies during the publish step.

## Description
This addition will generate the missing SHA-256 checksums for Dokka dependencies during the build, allowing it to proceed.
