### PR TITLE
Lower JVM memory setting

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ android.defaults.buildfeatures.shaders=false
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx3072m
+org.gradle.jvmargs=-Xmx2048m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
## Description
The Renovate runners have very little memory. The previous setting was pushing the limits and caused Renovate to fail a lot.