### PR TITLE
v6 - Payment method objects - PayPal

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1529,6 +1529,27 @@ public final class com/adyen/checkout/core/components/data/model/paymentmethod/P
 public final class com/adyen/checkout/core/components/data/model/paymentmethod/PayByBankUSPaymentMethod$Companion {
 }
 
+public final class com/adyen/checkout/core/components/data/model/paymentmethod/PayPalPaymentMethod : com/adyen/checkout/core/components/data/model/paymentmethod/PaymentMethod {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/adyen/checkout/core/components/data/model/paymentmethod/PayPalPaymentMethod$Companion;
+	public static final field SERIALIZER Lcom/adyen/checkout/core/common/internal/model/ModelObject$Serializer;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/core/components/data/model/paymentmethod/PayPalPaymentMethod;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/core/components/data/model/paymentmethod/PayPalPaymentMethod;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/core/components/data/model/paymentmethod/PayPalPaymentMethod;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public final fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/adyen/checkout/core/components/data/model/paymentmethod/PayPalPaymentMethod$Companion {
+}
+
 public final class com/adyen/checkout/core/components/data/model/paymentmethod/PayToPaymentMethod : com/adyen/checkout/core/components/data/model/paymentmethod/PaymentMethod {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
@@ -1817,6 +1838,33 @@ public final class com/adyen/checkout/core/components/data/model/paymentmethod/S
 }
 
 public final class com/adyen/checkout/core/components/data/model/paymentmethod/StoredPayByBankUSPaymentMethod$Companion {
+}
+
+public final class com/adyen/checkout/core/components/data/model/paymentmethod/StoredPayPalPaymentMethod : com/adyen/checkout/core/components/data/model/paymentmethod/StoredPaymentMethod {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/adyen/checkout/core/components/data/model/paymentmethod/StoredPayPalPaymentMethod$Companion;
+	public static final field SERIALIZER Lcom/adyen/checkout/core/common/internal/model/ModelObject$Serializer;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)Lcom/adyen/checkout/core/components/data/model/paymentmethod/StoredPayPalPaymentMethod;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/core/components/data/model/paymentmethod/StoredPayPalPaymentMethod;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/core/components/data/model/paymentmethod/StoredPayPalPaymentMethod;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getId ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public final fun getShopperEmail ()Ljava/lang/String;
+	public fun getSupportedShopperInteractions ()Ljava/util/List;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public final fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/adyen/checkout/core/components/data/model/paymentmethod/StoredPayPalPaymentMethod$Companion {
 }
 
 public final class com/adyen/checkout/core/components/data/model/paymentmethod/StoredPayToPaymentMethod : com/adyen/checkout/core/components/data/model/paymentmethod/StoredPaymentMethod {

--- a/core/src/main/java/com/adyen/checkout/core/components/data/model/paymentmethod/PayPalPaymentMethod.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/data/model/paymentmethod/PayPalPaymentMethod.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 6/3/2026.
+ */
+
+package com.adyen.checkout.core.components.data.model.paymentmethod
+
+import com.adyen.checkout.core.common.exception.ModelSerializationException
+import kotlinx.parcelize.Parcelize
+import org.json.JSONException
+import org.json.JSONObject
+
+/**
+ * A [PaymentMethod] representing a PayPal payment method.
+ */
+@Parcelize
+data class PayPalPaymentMethod(
+    override val type: String,
+    override val name: String,
+) : PaymentMethod() {
+
+    companion object {
+        @JvmField
+        val SERIALIZER: Serializer<PayPalPaymentMethod> = object : Serializer<PayPalPaymentMethod> {
+            override fun serialize(modelObject: PayPalPaymentMethod): JSONObject {
+                return try {
+                    JSONObject().apply {
+                        put(TYPE, modelObject.type)
+                        put(NAME, modelObject.name)
+                    }
+                } catch (e: JSONException) {
+                    throw ModelSerializationException(PayPalPaymentMethod::class.java, e)
+                }
+            }
+
+            override fun deserialize(jsonObject: JSONObject): PayPalPaymentMethod {
+                return try {
+                    PayPalPaymentMethod(
+                        type = jsonObject.getString(TYPE),
+                        name = jsonObject.getString(NAME),
+                    )
+                } catch (e: JSONException) {
+                    throw ModelSerializationException(PayPalPaymentMethod::class.java, e)
+                }
+            }
+        }
+    }
+}

--- a/core/src/main/java/com/adyen/checkout/core/components/data/model/paymentmethod/PaymentMethod.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/data/model/paymentmethod/PaymentMethod.kt
@@ -95,6 +95,7 @@ constructor() : PaymentMethodResponse() {
                 PaymentMethodTypes.BOLETOBANCARIO_SANTANDER,
                 PaymentMethodTypes.BOLETO_PRIMEIRO_PAY -> BoletoPaymentMethod.SERIALIZER
                 PaymentMethodTypes.CASH_APP_PAY -> CashAppPayPaymentMethod.SERIALIZER
+                PaymentMethodTypes.PAYPAL -> PayPalPaymentMethod.SERIALIZER
                 PaymentMethodTypes.TWINT -> TwintPaymentMethod.SERIALIZER
                 PaymentMethodTypes.PAY_BY_BANK -> PayByBankPaymentMethod.SERIALIZER
                 PaymentMethodTypes.PAY_BY_BANK_US -> PayByBankUSPaymentMethod.SERIALIZER

--- a/core/src/main/java/com/adyen/checkout/core/components/data/model/paymentmethod/StoredPayPalPaymentMethod.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/data/model/paymentmethod/StoredPayPalPaymentMethod.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 6/3/2026.
+ */
+
+package com.adyen.checkout.core.components.data.model.paymentmethod
+
+import com.adyen.checkout.core.common.exception.ModelSerializationException
+import com.adyen.checkout.core.common.internal.model.JsonUtils.parseStringList
+import com.adyen.checkout.core.common.internal.model.JsonUtils.serializeStringList
+import kotlinx.parcelize.Parcelize
+import org.json.JSONException
+import org.json.JSONObject
+
+/**
+ * A [StoredPaymentMethod] representing a PayPal stored payment method.
+ */
+@Parcelize
+data class StoredPayPalPaymentMethod(
+    override val type: String,
+    override val name: String,
+    override val id: String,
+    override val supportedShopperInteractions: List<String>,
+    val shopperEmail: String,
+) : StoredPaymentMethod() {
+
+    companion object {
+        private const val SHOPPER_EMAIL = "shopperEmail"
+
+        @JvmField
+        val SERIALIZER: Serializer<StoredPayPalPaymentMethod> = object : Serializer<StoredPayPalPaymentMethod> {
+            override fun serialize(modelObject: StoredPayPalPaymentMethod): JSONObject {
+                return try {
+                    JSONObject().apply {
+                        put(TYPE, modelObject.type)
+                        put(NAME, modelObject.name)
+                        put(ID, modelObject.id)
+                        put(
+                            SUPPORTED_SHOPPER_INTERACTIONS,
+                            serializeStringList(modelObject.supportedShopperInteractions),
+                        )
+                        put(SHOPPER_EMAIL, modelObject.shopperEmail)
+                    }
+                } catch (e: JSONException) {
+                    throw ModelSerializationException(StoredPayPalPaymentMethod::class.java, e)
+                }
+            }
+
+            override fun deserialize(jsonObject: JSONObject): StoredPayPalPaymentMethod {
+                return try {
+                    StoredPayPalPaymentMethod(
+                        type = jsonObject.getString(TYPE),
+                        name = jsonObject.getString(NAME),
+                        id = jsonObject.getString(ID),
+                        supportedShopperInteractions = parseStringList(
+                            jsonObject.getJSONArray(SUPPORTED_SHOPPER_INTERACTIONS),
+                        ),
+                        shopperEmail = jsonObject.getString(SHOPPER_EMAIL),
+                    )
+                } catch (e: JSONException) {
+                    throw ModelSerializationException(StoredPayPalPaymentMethod::class.java, e)
+                }
+            }
+        }
+    }
+}

--- a/core/src/main/java/com/adyen/checkout/core/components/data/model/paymentmethod/StoredPaymentMethod.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/data/model/paymentmethod/StoredPaymentMethod.kt
@@ -72,6 +72,7 @@ constructor() : PaymentMethodResponse() {
                 PaymentMethodTypes.BLIK -> StoredBLIKPaymentMethod.SERIALIZER
                 PaymentMethodTypes.ACH -> StoredACHDirectDebitPaymentMethod.SERIALIZER
                 PaymentMethodTypes.CASH_APP_PAY -> StoredCashAppPayPaymentMethod.SERIALIZER
+                PaymentMethodTypes.PAYPAL -> StoredPayPalPaymentMethod.SERIALIZER
                 PaymentMethodTypes.TWINT -> StoredTwintPaymentMethod.SERIALIZER
                 PaymentMethodTypes.PAY_BY_BANK_US -> StoredPayByBankUSPaymentMethod.SERIALIZER
                 PaymentMethodTypes.PAY_TO -> StoredPayToPaymentMethod.SERIALIZER

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/helper/StoredPaymentMethodFormatter.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/helper/StoredPaymentMethodFormatter.kt
@@ -12,6 +12,7 @@ import com.adyen.checkout.core.components.data.model.paymentmethod.StoredACHDire
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredCardPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredCashAppPayPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPayByBankUSPaymentMethod
+import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPayPalPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPayToPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPaymentMethod
 
@@ -35,7 +36,7 @@ internal object StoredPaymentMethodFormatter {
                 "•••• ${storedPaymentMethod.bankAccountNumber.takeLast(LAST_DIGITS_COUNT)}"
             }
             is StoredCardPaymentMethod -> "•••• ${storedPaymentMethod.lastFour}"
-            // TODO - COSDK-998: Create StoredPayPalPaymentMethod with shopperEmail field and handle it here
+            is StoredPayPalPaymentMethod -> storedPaymentMethod.shopperEmail
             else -> storedPaymentMethod.name
         }
     }
@@ -46,9 +47,9 @@ internal object StoredPaymentMethodFormatter {
             is StoredCashAppPayPaymentMethod,
             is StoredPayByBankUSPaymentMethod,
             is StoredPayToPaymentMethod,
+            is StoredPayPalPaymentMethod,
             is StoredCardPaymentMethod -> storedPaymentMethod.name
 
-            // TODO - COSDK-998: Create StoredPayPalPaymentMethod with shopperEmail field and return name here
             else -> null
         }
     }

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/internal/helper/StoredPaymentMethodFormatterTest.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/internal/helper/StoredPaymentMethodFormatterTest.kt
@@ -14,6 +14,7 @@ import com.adyen.checkout.core.components.data.model.paymentmethod.StoredCardPay
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredCashAppPayPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredInstantPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPayByBankUSPaymentMethod
+import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPayPalPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPayToPaymentMethod
 import com.adyen.checkout.core.components.paymentmethod.PaymentMethodTypes
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -101,19 +102,19 @@ internal class StoredPaymentMethodFormatterTest {
         assertEquals("label", result)
     }
 
-    // TODO - COSDK-998: Create StoredPayPalPaymentMethod with shopperEmail field and test it here
     @Test
-    fun `when type is paypal, then title is name`() {
-        val storedPaymentMethod = StoredInstantPaymentMethod(
+    fun `when type is paypal, then title is shopperEmail`() {
+        val storedPaymentMethod = StoredPayPalPaymentMethod(
             type = PaymentMethodTypes.PAYPAL,
             name = "name",
             id = "id",
             supportedShopperInteractions = emptyList(),
+            shopperEmail = "shopperEmail"
         )
 
         val result = StoredPaymentMethodFormatter.getTitle(storedPaymentMethod)
 
-        assertEquals("name", result)
+        assertEquals("shopperEmail", result)
     }
 
     @Test
@@ -195,19 +196,19 @@ internal class StoredPaymentMethodFormatterTest {
         assertEquals("name", result)
     }
 
-    // TODO - COSDK-998: Create StoredPayPalPaymentMethod with shopperEmail field and test it here
     @Test
-    fun `when type is paypal, then subtitle is null`() {
-        val storedPaymentMethod = StoredInstantPaymentMethod(
+    fun `when type is paypal, then subtitle is name`() {
+        val storedPaymentMethod = StoredPayPalPaymentMethod(
             type = PaymentMethodTypes.PAYPAL,
             name = "name",
             id = "id",
             supportedShopperInteractions = emptyList(),
+            shopperEmail = "shopperEmail",
         )
 
         val result = StoredPaymentMethodFormatter.getSubtitle(storedPaymentMethod)
 
-        assertNull(result)
+        assertEquals("name", result)
     }
 
     @Test


### PR DESCRIPTION
## Description
- Add `PayPalPaymentMethod` and `StoredPayPalPaymentMethod` with `shopperEmail`
- Update `StoredPaymentMethodFormatter` to format `StoredPayPalPaymentMethod`
- Remove TODOs related to PayPal object creation

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested

## Ticket Number
COSDK-998
