### PR TITLE
v5 - Update German pay button copies

### DIFF
--- a/ui-core/src/main/res/values-de-rDE/strings.xml
+++ b/ui-core/src/main/res/values-de-rDE/strings.xml
@@ -7,8 +7,8 @@
   -->
 
 <resources>
-    <string name="pay_button">Zahle</string>
-    <string name="pay_button_with_value">%s zahlen</string>
+    <string name="pay_button">Kaufen</string>
+    <string name="pay_button_with_value">Kaufen für %s</string>
     <string name="confirm_preauthorization">Vorautorisierung bestätigen</string>
 
     <string name="error_dialog_title">Fehler</string>


### PR DESCRIPTION
## Description
This PR updates the German pay button copies.

<img width="1280" height="2856" alt="image" src="https://github.com/user-attachments/assets/65442156-e62a-4d7b-961e-0f619c5672b3" />

## Ticket Number
COSDK-1040

## Release notes

### Changed
- For the `de-DE` locale, where the UI renders in German: the text on the pay button is now **Kaufen** to comply with regulations. Previously, the text was **Zahle**.