### PR TITLE
v6 - Environments - Rename live environment constants

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -418,15 +418,15 @@ public final class com/adyen/checkout/core/common/CheckoutCurrency$Companion {
 
 public final class com/adyen/checkout/core/common/Environment : android/os/Parcelable {
 	public static final field $stable I
-	public static final field APSE Lcom/adyen/checkout/core/common/Environment;
-	public static final field AUSTRALIA Lcom/adyen/checkout/core/common/Environment;
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/adyen/checkout/core/common/Environment$Companion;
-	public static final field EUROPE Lcom/adyen/checkout/core/common/Environment;
-	public static final field INDIA Lcom/adyen/checkout/core/common/Environment;
-	public static final field NEA Lcom/adyen/checkout/core/common/Environment;
+	public static final field LIVE_APSE Lcom/adyen/checkout/core/common/Environment;
+	public static final field LIVE_AUSTRALIA Lcom/adyen/checkout/core/common/Environment;
+	public static final field LIVE_EUROPE Lcom/adyen/checkout/core/common/Environment;
+	public static final field LIVE_INDIA Lcom/adyen/checkout/core/common/Environment;
+	public static final field LIVE_NEA Lcom/adyen/checkout/core/common/Environment;
+	public static final field LIVE_UNITED_STATES Lcom/adyen/checkout/core/common/Environment;
 	public static final field TEST Lcom/adyen/checkout/core/common/Environment;
-	public static final field UNITED_STATES Lcom/adyen/checkout/core/common/Environment;
 	public final fun component1 ()Ljava/net/URL;
 	public final fun component2 ()Ljava/net/URL;
 	public final fun copy (Ljava/net/URL;Ljava/net/URL;)Lcom/adyen/checkout/core/common/Environment;

--- a/core/src/main/java/com/adyen/checkout/core/common/Environment.kt
+++ b/core/src/main/java/com/adyen/checkout/core/common/Environment.kt
@@ -30,37 +30,37 @@ data class Environment internal constructor(
         )
 
         @JvmField
-        val EUROPE: Environment = Environment(
+        val LIVE_EUROPE: Environment = Environment(
             checkoutShopperBaseUrl = URL("https://checkoutshopper-live.adyen.com/checkoutshopper/"),
             checkoutAnalyticsBaseUrl = URL("https://checkoutanalytics-live.adyen.com/checkoutanalytics/")
         )
 
         @JvmField
-        val UNITED_STATES: Environment = Environment(
+        val LIVE_UNITED_STATES: Environment = Environment(
             checkoutShopperBaseUrl = URL("https://checkoutshopper-live-us.adyen.com/checkoutshopper/"),
             checkoutAnalyticsBaseUrl = URL("https://checkoutanalytics-live-us.adyen.com/checkoutanalytics/")
         )
 
         @JvmField
-        val AUSTRALIA: Environment = Environment(
+        val LIVE_AUSTRALIA: Environment = Environment(
             checkoutShopperBaseUrl = URL("https://checkoutshopper-live-au.adyen.com/checkoutshopper/"),
             checkoutAnalyticsBaseUrl = URL("https://checkoutanalytics-live-au.adyen.com/checkoutanalytics/")
         )
 
         @JvmField
-        val INDIA: Environment = Environment(
+        val LIVE_INDIA: Environment = Environment(
             checkoutShopperBaseUrl = URL("https://checkoutshopper-live-in.adyen.com/checkoutshopper/"),
             checkoutAnalyticsBaseUrl = URL("https://checkoutanalytics-live-in.adyen.com/checkoutanalytics/")
         )
 
         @JvmField
-        val APSE: Environment = Environment(
+        val LIVE_APSE: Environment = Environment(
             checkoutShopperBaseUrl = URL("https://checkoutshopper-live-apse.adyen.com/checkoutshopper/"),
             checkoutAnalyticsBaseUrl = URL("https://checkoutanalytics-live-apse.adyen.com/checkoutanalytics/")
         )
 
         @JvmField
-        val NEA: Environment = Environment(
+        val LIVE_NEA: Environment = Environment(
             checkoutShopperBaseUrl = URL("https://checkoutshopper-live-nea.adyen.com/checkoutshopper/"),
             checkoutAnalyticsBaseUrl = URL("https://checkoutanalytics-live-nea.adyen.com/checkoutanalytics/")
         )

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParamsMapperTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParamsMapperTest.kt
@@ -70,7 +70,7 @@ internal class GooglePayComponentParamsMapperTest {
 
         val componentParamsBundle = createComponentParamsBundle(
             shopperLocale = Locale.FRANCE,
-            environment = Environment.APSE,
+            environment = Environment.LIVE_APSE,
             clientKey = TEST_CLIENT_KEY_2,
             amount = amount,
         )
@@ -104,7 +104,7 @@ internal class GooglePayComponentParamsMapperTest {
 
         val expected = getGooglePayComponentParams(
             shopperLocale = Locale.FRANCE,
-            environment = Environment.APSE,
+            environment = Environment.LIVE_APSE,
             clientKey = TEST_CLIENT_KEY_2,
             analyticsParams = AnalyticsParams(AnalyticsParamsLevel.ALL),
             amount = amount,
@@ -270,7 +270,7 @@ internal class GooglePayComponentParamsMapperTest {
     fun `when google pay environment is not set and environment is a live one then google pay environment should be ENVIRONMENT_PRODUCTION`() {
         val componentParamsBundle = createComponentParamsBundle(
             shopperLocale = Locale.CHINA,
-            environment = Environment.UNITED_STATES,
+            environment = Environment.LIVE_UNITED_STATES,
             clientKey = TEST_CLIENT_KEY_2,
         )
         val googlePayConfiguration = createGooglePayConfiguration(
@@ -285,7 +285,7 @@ internal class GooglePayComponentParamsMapperTest {
 
         val expected = getGooglePayComponentParams(
             shopperLocale = Locale.CHINA,
-            environment = Environment.UNITED_STATES,
+            environment = Environment.LIVE_UNITED_STATES,
             clientKey = TEST_CLIENT_KEY_2,
             googlePayEnvironment = WalletConstants.ENVIRONMENT_PRODUCTION,
         )


### PR DESCRIPTION
## Description

Rename live environment constants in `Environment.kt` to use the `LIVE_` prefix for consistency with other platforms:

- `EUROPE` → `LIVE_EUROPE`
- `UNITED_STATES` → `LIVE_UNITED_STATES`
- `AUSTRALIA` → `LIVE_AUSTRALIA`
- `APSE` → `LIVE_APSE`
- `INDIA` → `LIVE_INDIA`
- `NEA` → `LIVE_NEA`

Only the new v6 `com.adyen.checkout.core.common.Environment` is affected. The old compat layer (`core.old.Environment`) is unchanged.

## Ticket Number

COSDK-867