### PR TITLE
v6 - Add acceptance build type to example.local.gradle

### DIFF
--- a/example-app/example.local.gradle
+++ b/example-app/example.local.gradle
@@ -18,5 +18,10 @@ android {
             initWith debug
             matchingFallbacks = ['debug']
         }
+
+        acceptance {
+            initWith debug
+            matchingFallbacks = ['debug']
+        }
     }
 }


### PR DESCRIPTION
## Description
Currently gradle check fails locally if `local.gradle` does not contain a block defining build configs for the acceptance flavor. Adding this block to `example.local.gradle` to prevent this issue for new users.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually