### PR TITLE
v5 - Co-badged cards - Trigger bin lookup after 8 digits

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/internal/data/api/DefaultDetectCardTypeRepository.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/data/api/DefaultDetectCardTypeRepository.kt
@@ -214,6 +214,6 @@ class DefaultDetectCardTypeRepository(
     companion object {
         private val NO_CVC_BRANDS: Set<CardBrand> = hashSetOf(CardBrand(cardType = CardType.BCMC))
 
-        private const val REQUIRED_BIN_SIZE = 11
+        private const val REQUIRED_BIN_SIZE = 8
     }
 }


### PR DESCRIPTION
## Description
We should trigger bin lookup after 8 digits instead of 11 digits

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

## Ticket Number
COSDK-1062
