### PR TITLE
v6 - Remove amount from PaymentComponentData

### DIFF
--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/BlikComponent.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/BlikComponent.kt
@@ -27,7 +27,6 @@ import com.adyen.checkout.core.common.internal.helper.bufferedChannel
 import com.adyen.checkout.core.components.internal.PaymentComponentEvent
 import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
-import com.adyen.checkout.core.components.internal.ui.model.ComponentParams
 import com.adyen.checkout.core.components.internal.ui.navigation.CheckoutNavEntry
 import com.adyen.checkout.core.components.internal.ui.state.ComponentStateFlow
 import com.adyen.checkout.core.components.internal.ui.state.viewState
@@ -38,7 +37,6 @@ import kotlinx.coroutines.flow.receiveAsFlow
 // TODO - Remove UnusedPrivateProperty suppression once analytics are done
 @Suppress("LongParameterList", "UnusedPrivateProperty")
 internal class BlikComponent(
-    private val componentParams: ComponentParams,
     private val analyticsManager: AnalyticsManager,
     private val sdkDataProvider: SdkDataProvider,
     private val componentStateValidator: BlikComponentStateValidator,
@@ -78,7 +76,6 @@ internal class BlikComponent(
     override fun submit() {
         if (componentStateValidator.isValid(componentState.value)) {
             val paymentComponentState = componentState.value.toPaymentComponentState(
-                amount = componentParams.amount,
                 sdkDataProvider = sdkDataProvider,
             )
             eventChannel.trySend(

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/BlikFactory.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/BlikFactory.kt
@@ -36,9 +36,7 @@ internal class BlikFactory :
         componentParamsBundle: ComponentParamsBundle,
         checkoutCallbacks: CheckoutCallbacks,
     ): BlikComponent {
-        val componentParams = componentParamsBundle.commonComponentParams
         return BlikComponent(
-            componentParams = componentParams,
             analyticsManager = analyticsManager,
             sdkDataProvider = DefaultSdkDataProvider(analyticsManager),
             componentStateFactory = BlikComponentStateFactory(),
@@ -57,11 +55,9 @@ internal class BlikFactory :
         componentParamsBundle: ComponentParamsBundle,
         @Suppress("UNUSED_PARAMETER") checkoutCallbacks: CheckoutCallbacks,
     ): StoredBlikComponent {
-        val componentParams = componentParamsBundle.commonComponentParams
         return StoredBlikComponent(
             storedPaymentMethod = storedPaymentMethod,
             analyticsManager = analyticsManager,
-            componentParams = componentParams,
             sdkDataProvider = DefaultSdkDataProvider(analyticsManager),
             coroutineScope = coroutineScope,
         )

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/StoredBlikComponent.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/StoredBlikComponent.kt
@@ -24,7 +24,6 @@ import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPayment
 import com.adyen.checkout.core.components.internal.PaymentComponentEvent
 import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
-import com.adyen.checkout.core.components.internal.ui.model.ComponentParams
 import com.adyen.checkout.core.components.internal.ui.navigation.CheckoutNavEntry
 import com.adyen.checkout.core.components.paymentmethod.BlikDetails
 import kotlinx.coroutines.CoroutineScope
@@ -35,7 +34,6 @@ import kotlinx.coroutines.flow.receiveAsFlow
 internal class StoredBlikComponent(
     private val storedPaymentMethod: StoredPaymentMethod,
     private val analyticsManager: AnalyticsManager,
-    private val componentParams: ComponentParams,
     private val sdkDataProvider: SdkDataProvider,
     coroutineScope: CoroutineScope,
 ) : PaymentComponent<BlikPaymentComponentState> {
@@ -86,7 +84,6 @@ internal class StoredBlikComponent(
         val paymentComponentData = PaymentComponentData(
             paymentMethod = blikDetails,
             order = null,
-            amount = componentParams.amount,
         )
 
         return BlikPaymentComponentState(

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/state/BlikComponentStateExt.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/state/BlikComponentStateExt.kt
@@ -9,12 +9,10 @@
 package com.adyen.checkout.blik.internal.ui.state
 
 import com.adyen.checkout.core.components.data.PaymentComponentData
-import com.adyen.checkout.core.components.data.model.Amount
 import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.core.components.paymentmethod.BlikDetails
 
 internal fun BlikComponentState.toPaymentComponentState(
-    amount: Amount?,
     sdkDataProvider: SdkDataProvider,
 ): BlikPaymentComponentState {
     val blikDetails = BlikDetails(
@@ -27,7 +25,6 @@ internal fun BlikComponentState.toPaymentComponentState(
     val paymentComponentData = PaymentComponentData(
         paymentMethod = blikDetails,
         order = null,
-        amount = amount,
     )
 
     return BlikPaymentComponentState(

--- a/blik/src/test/java/com/adyen/checkout/blik/internal/ui/state/BlikComponentStateExtTest.kt
+++ b/blik/src/test/java/com/adyen/checkout/blik/internal/ui/state/BlikComponentStateExtTest.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.blik.internal.ui.state
 
 import com.adyen.checkout.core.components.data.PaymentComponentData
-import com.adyen.checkout.core.components.data.model.Amount
 import com.adyen.checkout.core.components.internal.data.provider.TestSdkDataProvider
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
 import com.adyen.checkout.core.components.paymentmethod.BlikDetails
@@ -29,7 +28,6 @@ internal class BlikComponentStateExtTest {
 
     @Test
     fun `when toPaymentComponentState is called, then a valid component state is created`() {
-        val amount = Amount("PLN", 1000)
         val componentState = BlikComponentState(
             blikCode = TextInputComponentState(
                 text = "123456",
@@ -38,7 +36,6 @@ internal class BlikComponentStateExtTest {
         )
 
         val paymentComponentState = componentState.toPaymentComponentState(
-            amount = amount,
             sdkDataProvider = sdkDataProvider,
         )
 
@@ -51,7 +48,6 @@ internal class BlikComponentStateExtTest {
         val expectedPaymentComponentData = PaymentComponentData(
             paymentMethod = expectedBlikDetails,
             order = null,
-            amount = amount,
         )
         val expectedPaymentComponentState = BlikPaymentComponentState(
             data = expectedPaymentComponentData,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateExt.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateExt.kt
@@ -118,7 +118,6 @@ private fun createPaymentComponentData(
     storePaymentMethod = storePaymentMethod,
     shopperReference = componentParams.shopperReference,
     order = null,
-    amount = componentParams.amount,
     socialSecurityNumber = socialSecurityNumber,
 )
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardComponentStateExt.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardComponentStateExt.kt
@@ -82,7 +82,6 @@ private fun createPaymentComponentData(
     storePaymentMethod = null,
     shopperReference = componentParams.shopperReference,
     order = null,
-    amount = componentParams.amount,
 )
 
 private fun createPaymentComponentState(

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -994,26 +994,24 @@ public final class com/adyen/checkout/core/components/data/PaymentComponentData 
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/adyen/checkout/core/components/data/PaymentComponentData$Companion;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/common/internal/model/ModelObject$Serializer;
-	public fun <init> (Lcom/adyen/checkout/core/components/paymentmethod/PaymentMethodDetails;Lcom/adyen/checkout/core/components/data/OrderRequest;Lcom/adyen/checkout/core/components/data/model/Amount;Ljava/lang/Boolean;Ljava/lang/String;Lcom/adyen/checkout/core/components/data/Address;Lcom/adyen/checkout/core/components/data/Address;Lcom/adyen/checkout/core/components/data/ShopperName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/adyen/checkout/core/components/data/Installments;Ljava/lang/Boolean;)V
-	public synthetic fun <init> (Lcom/adyen/checkout/core/components/paymentmethod/PaymentMethodDetails;Lcom/adyen/checkout/core/components/data/OrderRequest;Lcom/adyen/checkout/core/components/data/model/Amount;Ljava/lang/Boolean;Ljava/lang/String;Lcom/adyen/checkout/core/components/data/Address;Lcom/adyen/checkout/core/components/data/Address;Lcom/adyen/checkout/core/components/data/ShopperName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/adyen/checkout/core/components/data/Installments;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/adyen/checkout/core/components/paymentmethod/PaymentMethodDetails;Lcom/adyen/checkout/core/components/data/OrderRequest;Ljava/lang/Boolean;Ljava/lang/String;Lcom/adyen/checkout/core/components/data/Address;Lcom/adyen/checkout/core/components/data/Address;Lcom/adyen/checkout/core/components/data/ShopperName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/adyen/checkout/core/components/data/Installments;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Lcom/adyen/checkout/core/components/paymentmethod/PaymentMethodDetails;Lcom/adyen/checkout/core/components/data/OrderRequest;Ljava/lang/Boolean;Ljava/lang/String;Lcom/adyen/checkout/core/components/data/Address;Lcom/adyen/checkout/core/components/data/Address;Lcom/adyen/checkout/core/components/data/ShopperName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/adyen/checkout/core/components/data/Installments;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/adyen/checkout/core/components/paymentmethod/PaymentMethodDetails;
 	public final fun component10 ()Ljava/lang/String;
 	public final fun component11 ()Ljava/lang/String;
-	public final fun component12 ()Ljava/lang/String;
-	public final fun component13 ()Lcom/adyen/checkout/core/components/data/Installments;
-	public final fun component14 ()Ljava/lang/Boolean;
+	public final fun component12 ()Lcom/adyen/checkout/core/components/data/Installments;
+	public final fun component13 ()Ljava/lang/Boolean;
 	public final fun component2 ()Lcom/adyen/checkout/core/components/data/OrderRequest;
-	public final fun component3 ()Lcom/adyen/checkout/core/components/data/model/Amount;
-	public final fun component4 ()Ljava/lang/Boolean;
-	public final fun component5 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Lcom/adyen/checkout/core/components/data/Address;
 	public final fun component6 ()Lcom/adyen/checkout/core/components/data/Address;
-	public final fun component7 ()Lcom/adyen/checkout/core/components/data/Address;
-	public final fun component8 ()Lcom/adyen/checkout/core/components/data/ShopperName;
+	public final fun component7 ()Lcom/adyen/checkout/core/components/data/ShopperName;
+	public final fun component8 ()Ljava/lang/String;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Lcom/adyen/checkout/core/components/paymentmethod/PaymentMethodDetails;Lcom/adyen/checkout/core/components/data/OrderRequest;Lcom/adyen/checkout/core/components/data/model/Amount;Ljava/lang/Boolean;Ljava/lang/String;Lcom/adyen/checkout/core/components/data/Address;Lcom/adyen/checkout/core/components/data/Address;Lcom/adyen/checkout/core/components/data/ShopperName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/adyen/checkout/core/components/data/Installments;Ljava/lang/Boolean;)Lcom/adyen/checkout/core/components/data/PaymentComponentData;
-	public static synthetic fun copy$default (Lcom/adyen/checkout/core/components/data/PaymentComponentData;Lcom/adyen/checkout/core/components/paymentmethod/PaymentMethodDetails;Lcom/adyen/checkout/core/components/data/OrderRequest;Lcom/adyen/checkout/core/components/data/model/Amount;Ljava/lang/Boolean;Ljava/lang/String;Lcom/adyen/checkout/core/components/data/Address;Lcom/adyen/checkout/core/components/data/Address;Lcom/adyen/checkout/core/components/data/ShopperName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/adyen/checkout/core/components/data/Installments;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/adyen/checkout/core/components/data/PaymentComponentData;
+	public final fun copy (Lcom/adyen/checkout/core/components/paymentmethod/PaymentMethodDetails;Lcom/adyen/checkout/core/components/data/OrderRequest;Ljava/lang/Boolean;Ljava/lang/String;Lcom/adyen/checkout/core/components/data/Address;Lcom/adyen/checkout/core/components/data/Address;Lcom/adyen/checkout/core/components/data/ShopperName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/adyen/checkout/core/components/data/Installments;Ljava/lang/Boolean;)Lcom/adyen/checkout/core/components/data/PaymentComponentData;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/core/components/data/PaymentComponentData;Lcom/adyen/checkout/core/components/paymentmethod/PaymentMethodDetails;Lcom/adyen/checkout/core/components/data/OrderRequest;Ljava/lang/Boolean;Ljava/lang/String;Lcom/adyen/checkout/core/components/data/Address;Lcom/adyen/checkout/core/components/data/Address;Lcom/adyen/checkout/core/components/data/ShopperName;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/adyen/checkout/core/components/data/Installments;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/adyen/checkout/core/components/data/PaymentComponentData;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAmount ()Lcom/adyen/checkout/core/components/data/model/Amount;
 	public final fun getBillingAddress ()Lcom/adyen/checkout/core/components/data/Address;
 	public final fun getDateOfBirth ()Ljava/lang/String;
 	public final fun getDeliveryAddress ()Lcom/adyen/checkout/core/components/data/Address;

--- a/core/src/main/java/com/adyen/checkout/core/components/data/PaymentComponentData.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/data/PaymentComponentData.kt
@@ -13,7 +13,6 @@ import com.adyen.checkout.core.common.internal.model.ModelUtils.deserializeOpt
 import com.adyen.checkout.core.common.internal.model.ModelUtils.serializeOpt
 import com.adyen.checkout.core.common.internal.model.getBooleanOrNull
 import com.adyen.checkout.core.common.internal.model.getStringOrNull
-import com.adyen.checkout.core.components.data.model.Amount
 import com.adyen.checkout.core.components.paymentmethod.PaymentMethodDetails
 import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
@@ -28,7 +27,6 @@ import org.json.JSONObject
 data class PaymentComponentData<PaymentMethodDetailsT : PaymentMethodDetails>(
     val paymentMethod: PaymentMethodDetailsT?,
     val order: OrderRequest?,
-    val amount: Amount?,
     val storePaymentMethod: Boolean? = null,
     val shopperReference: String? = null,
     val billingAddress: Address? = null,
@@ -46,7 +44,6 @@ data class PaymentComponentData<PaymentMethodDetailsT : PaymentMethodDetails>(
         private const val PAYMENT_METHOD = "paymentMethod"
         private const val STORE_PAYMENT_METHOD = "storePaymentMethod"
         private const val SHOPPER_REFERENCE = "shopperReference"
-        private const val AMOUNT = "amount"
         private const val BILLING_ADDRESS = "billingAddress"
         private const val DELIVERY_ADDRESS = "deliveryAddress"
         private const val SHOPPER_NAME = "shopperName"
@@ -67,24 +64,23 @@ data class PaymentComponentData<PaymentMethodDetailsT : PaymentMethodDetails>(
                             PAYMENT_METHOD,
                             serializeOpt(
                                 modelObject.paymentMethod,
-                                PaymentMethodDetails.SERIALIZER
-                            )
+                                PaymentMethodDetails.SERIALIZER,
+                            ),
                         )
                         putOpt(ORDER, serializeOpt(modelObject.order, OrderRequest.SERIALIZER))
-                        putOpt(AMOUNT, serializeOpt(modelObject.amount, Amount.SERIALIZER))
                         putOpt(STORE_PAYMENT_METHOD, modelObject.storePaymentMethod)
                         putOpt(SHOPPER_REFERENCE, modelObject.shopperReference)
                         putOpt(
                             BILLING_ADDRESS,
-                            serializeOpt(modelObject.billingAddress, Address.SERIALIZER)
+                            serializeOpt(modelObject.billingAddress, Address.SERIALIZER),
                         )
                         putOpt(
                             DELIVERY_ADDRESS,
-                            serializeOpt(modelObject.deliveryAddress, Address.SERIALIZER)
+                            serializeOpt(modelObject.deliveryAddress, Address.SERIALIZER),
                         )
                         putOpt(
                             SHOPPER_NAME,
-                            serializeOpt(modelObject.shopperName, ShopperName.SERIALIZER)
+                            serializeOpt(modelObject.shopperName, ShopperName.SERIALIZER),
                         )
                         putOpt(TELEPHONE_NUMBER, modelObject.telephoneNumber)
                         putOpt(SHOPPER_EMAIL, modelObject.shopperEmail)
@@ -92,7 +88,7 @@ data class PaymentComponentData<PaymentMethodDetailsT : PaymentMethodDetails>(
                         putOpt(SOCIAL_SECURITY_NUMBER, modelObject.socialSecurityNumber)
                         putOpt(
                             INSTALLMENTS,
-                            serializeOpt(modelObject.installments, Installments.SERIALIZER)
+                            serializeOpt(modelObject.installments, Installments.SERIALIZER),
                         )
                         putOpt(SUPPORT_NATIVE_REDIRECT, modelObject.supportNativeRedirect)
                     }
@@ -106,25 +102,21 @@ data class PaymentComponentData<PaymentMethodDetailsT : PaymentMethodDetails>(
                         ),
                         order = deserializeOpt(
                             jsonObject.optJSONObject(ORDER),
-                            OrderRequest.SERIALIZER
-                        ),
-                        amount = deserializeOpt(
-                            jsonObject.optJSONObject(AMOUNT),
-                            Amount.SERIALIZER
+                            OrderRequest.SERIALIZER,
                         ),
                         storePaymentMethod = jsonObject.getBooleanOrNull(STORE_PAYMENT_METHOD),
                         shopperReference = jsonObject.getStringOrNull(SHOPPER_REFERENCE),
                         billingAddress = deserializeOpt(
                             jsonObject.optJSONObject(BILLING_ADDRESS),
-                            Address.SERIALIZER
+                            Address.SERIALIZER,
                         ),
                         deliveryAddress = deserializeOpt(
                             jsonObject.optJSONObject(DELIVERY_ADDRESS),
-                            Address.SERIALIZER
+                            Address.SERIALIZER,
                         ),
                         shopperName = deserializeOpt(
                             jsonObject.optJSONObject(SHOPPER_NAME),
-                            ShopperName.SERIALIZER
+                            ShopperName.SERIALIZER,
                         ),
                         telephoneNumber = jsonObject.getStringOrNull(TELEPHONE_NUMBER),
                         shopperEmail = jsonObject.getStringOrNull(SHOPPER_EMAIL),
@@ -132,7 +124,7 @@ data class PaymentComponentData<PaymentMethodDetailsT : PaymentMethodDetails>(
                         socialSecurityNumber = jsonObject.getStringOrNull(SOCIAL_SECURITY_NUMBER),
                         installments = deserializeOpt(
                             jsonObject.optJSONObject(INSTALLMENTS),
-                            Installments.SERIALIZER
+                            Installments.SERIALIZER,
                         ),
                         supportNativeRedirect = jsonObject.getBooleanOrNull(SUPPORT_NATIVE_REDIRECT),
                     )

--- a/core/src/test/java/com/adyen/checkout/core/components/paymentmethod/TestPaymentComponentState.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/paymentmethod/TestPaymentComponentState.kt
@@ -9,13 +9,11 @@
 package com.adyen.checkout.core.components.paymentmethod
 
 import com.adyen.checkout.core.components.data.PaymentComponentData
-import com.adyen.checkout.core.components.data.model.Amount
 
 class TestPaymentComponentState(
     override val data: PaymentComponentData<TestPaymentDetails> = PaymentComponentData(
         paymentMethod = TestPaymentDetails(),
         order = null,
-        amount = Amount(currency = "EUR"),
     ),
     override val isValid: Boolean = true,
 ) : PaymentComponentState<TestPaymentDetails>

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/state/GooglePayComponentStateExt.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/state/GooglePayComponentStateExt.kt
@@ -9,12 +9,10 @@
 package com.adyen.checkout.googlepay.internal.ui.state
 
 import com.adyen.checkout.core.components.data.PaymentComponentData
-import com.adyen.checkout.core.components.data.model.Amount
 import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.googlepay.internal.helper.GooglePayUtils
 
 internal fun GooglePayComponentState.toPaymentComponentState(
-    amount: Amount?,
     paymentMethodType: String?,
     sdkDataProvider: SdkDataProvider,
 ): GooglePayPaymentComponentState {
@@ -27,7 +25,6 @@ internal fun GooglePayComponentState.toPaymentComponentState(
     val paymentComponentData = PaymentComponentData(
         paymentMethod = googlePayDetails,
         order = null,
-        amount = amount,
     )
 
     val isValid = paymentData != null && GooglePayUtils.findToken(paymentData).isNotEmpty()

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/state/GooglePayComponentStateExtTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/state/GooglePayComponentStateExtTest.kt
@@ -8,7 +8,6 @@
 
 package com.adyen.checkout.googlepay.internal.ui.state
 
-import com.adyen.checkout.core.components.data.model.Amount
 import com.adyen.checkout.core.components.internal.data.provider.TestSdkDataProvider
 import com.adyen.checkout.googlepay.internal.helper.GooglePayUtils
 import com.google.android.gms.wallet.PaymentData
@@ -39,7 +38,6 @@ internal class GooglePayComponentStateExtTest {
     @Test
     fun `when toPaymentComponentState is called with valid payment data, then a valid component state is created`() {
         whenever(paymentData.toJson()).thenReturn(TEST_PAYMENT_DATA_JSON)
-        val amount = Amount("EUR", 1337)
         val paymentMethodType = "googlepay"
         val componentState = GooglePayComponentState(
             isButtonVisible = true,
@@ -49,7 +47,6 @@ internal class GooglePayComponentStateExtTest {
         )
 
         val paymentComponentState = componentState.toPaymentComponentState(
-            amount = amount,
             paymentMethodType = paymentMethodType,
             sdkDataProvider = sdkDataProvider,
         )
@@ -61,7 +58,6 @@ internal class GooglePayComponentStateExtTest {
         )
 
         assertEquals(expectedGooglePayDetails, paymentComponentState.data.paymentMethod)
-        assertEquals(amount, paymentComponentState.data.amount)
         assertNull(paymentComponentState.data.order)
         assertTrue(paymentComponentState.isValid)
     }
@@ -76,32 +72,12 @@ internal class GooglePayComponentStateExtTest {
         )
 
         val paymentComponentState = componentState.toPaymentComponentState(
-            amount = null,
             paymentMethodType = "googlepay",
             sdkDataProvider = sdkDataProvider,
         )
 
         assertFalse(paymentComponentState.isValid)
         assertNull(paymentComponentState.data.paymentMethod)
-    }
-
-    @Test
-    fun `when amount is null, then payment component data has null amount`() {
-        whenever(paymentData.toJson()).thenReturn(TEST_PAYMENT_DATA_JSON)
-        val componentState = GooglePayComponentState(
-            isButtonVisible = true,
-            isLoading = false,
-            isAvailable = true,
-            paymentData = paymentData,
-        )
-
-        val paymentComponentState = componentState.toPaymentComponentState(
-            amount = null,
-            paymentMethodType = "googlepay",
-            sdkDataProvider = sdkDataProvider,
-        )
-
-        assertNull(paymentComponentState.data.amount)
     }
 
     companion object {

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/MBWayComponent.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/MBWayComponent.kt
@@ -18,7 +18,6 @@ import com.adyen.checkout.core.common.internal.helper.bufferedChannel
 import com.adyen.checkout.core.components.internal.PaymentComponentEvent
 import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
-import com.adyen.checkout.core.components.internal.ui.model.ComponentParams
 import com.adyen.checkout.core.components.internal.ui.navigation.CheckoutNavEntry
 import com.adyen.checkout.core.components.internal.ui.state.ComponentStateFlow
 import com.adyen.checkout.core.components.internal.ui.state.viewState
@@ -40,7 +39,6 @@ import kotlinx.coroutines.flow.receiveAsFlow
 
 @Suppress("LongParameterList")
 internal class MBWayComponent(
-    private val componentParams: ComponentParams,
     private val analyticsManager: AnalyticsManager,
     private val sdkDataProvider: SdkDataProvider,
     private val componentStateValidator: MBWayComponentStateValidator,
@@ -86,7 +84,6 @@ internal class MBWayComponent(
     override fun submit() {
         if (componentStateValidator.isValid(componentState.value)) {
             val paymentComponentState = componentState.value.toPaymentComponentState(
-                amount = componentParams.amount,
                 sdkData = sdkDataProvider.createEncodedSdkData(),
             )
             eventChannel.trySend(

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/MBWayFactory.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/MBWayFactory.kt
@@ -34,7 +34,6 @@ internal class MBWayFactory : PaymentComponentFactory<MBWayPaymentComponentState
     ): MBWayComponent {
         val componentParams = componentParamsBundle.commonComponentParams
         return MBWayComponent(
-            componentParams = componentParams,
             analyticsManager = analyticsManager,
             sdkDataProvider = DefaultSdkDataProvider(analyticsManager),
             componentStateFactory = MBWayComponentStateFactory(componentParams),

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/MBWayViewModel.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/MBWayViewModel.kt
@@ -47,11 +47,11 @@ internal class MBWayViewModel(
 
     init {
         val paymentComponentStateFlow = componentState
-            .map { it.toPaymentComponentState(amount = null, sdkData = "") }
+            .map { it.toPaymentComponentState(sdkData = "") }
             .stateIn(
                 scope = viewModelScope,
                 started = SharingStarted.Eagerly,
-                initialValue = componentState.value.toPaymentComponentState(amount = null, sdkData = ""),
+                initialValue = componentState.value.toPaymentComponentState(sdkData = ""),
             )
 
         controller.registerComponentState(paymentComponentStateFlow)

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/state/MBWayComponentStateExt.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/state/MBWayComponentStateExt.kt
@@ -9,11 +9,9 @@
 package com.adyen.checkout.mbway.internal.ui.state
 
 import com.adyen.checkout.core.components.data.PaymentComponentData
-import com.adyen.checkout.core.components.data.model.Amount
 import com.adyen.checkout.core.components.paymentmethod.MBWayDetails
 
 internal fun MBWayComponentState.toPaymentComponentState(
-    amount: Amount?,
     sdkData: String?,
 ): MBWayPaymentComponentState {
     val sanitizedPhoneNumber = phoneNumber.text.trimStart('0')
@@ -28,7 +26,6 @@ internal fun MBWayComponentState.toPaymentComponentState(
     val paymentComponentData = PaymentComponentData(
         paymentMethod = mbWayDetails,
         order = null,
-        amount = amount,
     )
 
     return MBWayPaymentComponentState(

--- a/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/state/MBWayComponentStateExtTest.kt
+++ b/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/state/MBWayComponentStateExtTest.kt
@@ -1,7 +1,6 @@
 package com.adyen.checkout.mbway.internal.ui.state
 
 import com.adyen.checkout.core.components.data.PaymentComponentData
-import com.adyen.checkout.core.components.data.model.Amount
 import com.adyen.checkout.core.components.internal.data.provider.TestSdkDataProvider
 import com.adyen.checkout.core.components.internal.ui.model.CountryModel
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
@@ -22,7 +21,6 @@ internal class MBWayComponentStateExtTest {
 
     @Test
     fun `when toPaymentComponentState is called, then a valid component state is created`() {
-        val amount = Amount("EUR", 1337)
         val componentState = MBWayComponentState(
             countries = emptyList(),
             selectedCountryCode = CountryModel("PT", "Portugal", "+351"),
@@ -33,7 +31,6 @@ internal class MBWayComponentStateExtTest {
         )
 
         val paymentComponentState = componentState.toPaymentComponentState(
-            amount = amount,
             sdkData = sdkDataProvider.createEncodedSdkData(),
         )
 
@@ -45,7 +42,6 @@ internal class MBWayComponentStateExtTest {
         val expectedPaymentComponentData = PaymentComponentData(
             paymentMethod = expectedMBWayDetails,
             order = null,
-            amount = amount,
         )
         val expectedPaymentComponentState = MBWayPaymentComponentState(
             data = expectedPaymentComponentData,
@@ -67,7 +63,7 @@ internal class MBWayComponentStateExtTest {
             isLoading = false,
         )
 
-        val paymentComponentState = componentState.toPaymentComponentState(null, sdkDataProvider.createEncodedSdkData())
+        val paymentComponentState = componentState.toPaymentComponentState(sdkDataProvider.createEncodedSdkData())
 
         assertEquals(
             "+351123456789",


### PR DESCRIPTION
## Description
This PR removes the amount from the `PaymentComponentData`. Setting this field on the frontend could potentially override whatever amount the payment was initialised with if a merchant does not verify on their backend. Web already doesn't set it on v5, so it makes sense for us to stop setting it as well.

## Ticket Number
COSDK-1088