### PR TITLE
v5 - Add new SDK data fields

### DIFF
--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/model/sdkData/PaymentMethodBehavior.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/model/sdkData/PaymentMethodBehavior.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 25/3/2026.
+ */
+
+package com.adyen.checkout.components.core.internal.data.model.sdkData
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+enum class PaymentMethodBehavior(val value: String) {
+    /**
+     * Indicates that the SDK does not have native component support for this payment method and will handle it
+     * through the Instant Payment Component.
+     */
+    GENERIC("genericComponent"),
+
+    /**
+     * Indicates that the SDK has a specific component for this payment method.
+     */
+    NATIVE("nativeComponent"),
+}

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/model/sdkData/SdkData.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/model/sdkData/SdkData.kt
@@ -17,6 +17,9 @@ internal data class SdkData(
     val authentication: Authentication? = null,
     val createdAt: Long? = null,
     val supportNativeRedirect: Boolean? = null,
+    val sdkVersion: String,
+    val platform: String,
+    val channel: String,
 ) {
 
     @Throws(JSONException::class)
@@ -26,6 +29,9 @@ internal data class SdkData(
         putOpt(AUTHENTICATION, authentication?.serialize())
         putOpt(CREATED_AT, createdAt)
         putOpt(SUPPORT_NATIVE_REDIRECT, supportNativeRedirect)
+        putOpt(SDK_VERSION, sdkVersion)
+        putOpt(SDK_PLATFORM, platform)
+        putOpt(SDK_CHANNEL, channel)
     }
 
     companion object {
@@ -34,5 +40,8 @@ internal data class SdkData(
         private const val AUTHENTICATION = "authentication"
         private const val CREATED_AT = "createdAt"
         private const val SUPPORT_NATIVE_REDIRECT = "supportNativeRedirect"
+        private const val SDK_VERSION = "sdkVersion"
+        private const val SDK_PLATFORM = "platform"
+        private const val SDK_CHANNEL = "channel"
     }
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/model/sdkData/SdkData.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/model/sdkData/SdkData.kt
@@ -13,10 +13,10 @@ import org.json.JSONObject
 
 internal data class SdkData(
     val schemaVersion: Int,
-    val analytics: Analytics? = null,
-    val authentication: Authentication? = null,
-    val createdAt: Long? = null,
-    val supportNativeRedirect: Boolean? = null,
+    val analytics: Analytics?,
+    val authentication: Authentication?,
+    val createdAt: Long?,
+    val supportNativeRedirect: Boolean?,
     val sdkVersion: String,
     val platform: String,
     val channel: String,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/model/sdkData/SdkData.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/data/model/sdkData/SdkData.kt
@@ -20,6 +20,7 @@ internal data class SdkData(
     val sdkVersion: String,
     val platform: String,
     val channel: String,
+    val paymentMethodBehavior: PaymentMethodBehavior,
 ) {
 
     @Throws(JSONException::class)
@@ -32,6 +33,7 @@ internal data class SdkData(
         putOpt(SDK_VERSION, sdkVersion)
         putOpt(SDK_PLATFORM, platform)
         putOpt(SDK_CHANNEL, channel)
+        putOpt(PAYMENT_METHOD_BEHAVIOR, paymentMethodBehavior.value)
     }
 
     companion object {
@@ -43,5 +45,6 @@ internal data class SdkData(
         private const val SDK_VERSION = "sdkVersion"
         private const val SDK_PLATFORM = "platform"
         private const val SDK_CHANNEL = "channel"
+        private const val PAYMENT_METHOD_BEHAVIOR = "paymentMethodBehavior"
     }
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/provider/DefaultSdkDataProvider.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/provider/DefaultSdkDataProvider.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.components.core.internal.provider
 
 import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.core.internal.analytics.AnalyticsManager
+import com.adyen.checkout.components.core.internal.analytics.AnalyticsPlatformParams
 import com.adyen.checkout.components.core.internal.data.model.sdkData.Analytics
 import com.adyen.checkout.components.core.internal.data.model.sdkData.Authentication
 import com.adyen.checkout.components.core.internal.data.model.sdkData.DirectSdkDataCreation
@@ -58,6 +59,9 @@ class DefaultSdkDataProvider(
             authentication = authentication,
             createdAt = Date().time,
             supportNativeRedirect = true,
+            sdkVersion = AnalyticsPlatformParams.version,
+            platform = AnalyticsPlatformParams.platform,
+            channel = AnalyticsPlatformParams.channel,
         )
     }
 

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/provider/DefaultSdkDataProvider.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/provider/DefaultSdkDataProvider.kt
@@ -14,6 +14,7 @@ import com.adyen.checkout.components.core.internal.analytics.AnalyticsPlatformPa
 import com.adyen.checkout.components.core.internal.data.model.sdkData.Analytics
 import com.adyen.checkout.components.core.internal.data.model.sdkData.Authentication
 import com.adyen.checkout.components.core.internal.data.model.sdkData.DirectSdkDataCreation
+import com.adyen.checkout.components.core.internal.data.model.sdkData.PaymentMethodBehavior
 import com.adyen.checkout.components.core.internal.data.model.sdkData.SdkData
 import com.adyen.checkout.core.AdyenLogLevel
 import com.adyen.checkout.core.internal.util.adyenLog
@@ -32,8 +33,11 @@ class DefaultSdkDataProvider(
 ) : SdkDataProvider {
 
     @OptIn(ExperimentalEncodingApi::class)
-    override fun createEncodedSdkData(threeDS2SdkVersion: String?): String? {
-        val sdkData = createSdkData(threeDS2SdkVersion)
+    override fun createEncodedSdkData(
+        threeDS2SdkVersion: String?,
+        paymentMethodBehavior: PaymentMethodBehavior,
+    ): String? {
+        val sdkData = createSdkData(threeDS2SdkVersion, paymentMethodBehavior)
 
         try {
             val jsonObject = sdkData.serialize()
@@ -44,7 +48,10 @@ class DefaultSdkDataProvider(
         }
     }
 
-    private fun createSdkData(threeDS2SdkVersion: String? = null): SdkData {
+    private fun createSdkData(
+        threeDS2SdkVersion: String?,
+        paymentMethodBehavior: PaymentMethodBehavior,
+    ): SdkData {
         val authentication = threeDS2SdkVersion?.let {
             Authentication(
                 threeDS2SdkVersion = it,
@@ -62,6 +69,7 @@ class DefaultSdkDataProvider(
             sdkVersion = AnalyticsPlatformParams.version,
             platform = AnalyticsPlatformParams.platform,
             channel = AnalyticsPlatformParams.channel,
+            paymentMethodBehavior = paymentMethodBehavior,
         )
     }
 

--- a/components-core/src/main/java/com/adyen/checkout/components/core/internal/provider/SdkDataProvider.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/internal/provider/SdkDataProvider.kt
@@ -9,6 +9,7 @@
 package com.adyen.checkout.components.core.internal.provider
 
 import androidx.annotation.RestrictTo
+import com.adyen.checkout.components.core.internal.data.model.sdkData.PaymentMethodBehavior
 
 /**
  * A provider that creates SDK data with the necessary information.
@@ -20,7 +21,12 @@ interface SdkDataProvider {
      * Creates the encoded SDK data.
      *
      * @param threeDS2SdkVersion The version of the 3DS2 SDK.
+     * @param paymentMethodBehavior indicates the behavior in which the SDK handles the given payment method.
+     *
      * @return The created encoded [String] from SDK data object.
      */
-    fun createEncodedSdkData(threeDS2SdkVersion: String? = null): String?
+    fun createEncodedSdkData(
+        threeDS2SdkVersion: String? = null,
+        paymentMethodBehavior: PaymentMethodBehavior = PaymentMethodBehavior.NATIVE,
+    ): String?
 }

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/provider/DefaultSdkDataProviderTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/provider/DefaultSdkDataProviderTest.kt
@@ -8,7 +8,9 @@
 
 package com.adyen.checkout.components.core.internal.provider
 
+import com.adyen.checkout.components.core.internal.analytics.AnalyticsPlatformParams
 import com.adyen.checkout.components.core.internal.analytics.TestAnalyticsManager
+import com.adyen.checkout.components.core.internal.data.model.sdkData.PaymentMethodBehavior
 import com.adyen.checkout.core.internal.data.model.getBooleanOrNull
 import com.adyen.checkout.core.internal.data.model.getLongOrNull
 import com.adyen.checkout.core.internal.data.model.getStringOrNull
@@ -53,6 +55,10 @@ internal class DefaultSdkDataProviderTest {
         )
         assertNotNull(jsonObject.getLongOrNull("createdAt"))
         assertEquals(true, jsonObject.getBooleanOrNull("supportNativeRedirect"))
+        assertEquals(AnalyticsPlatformParams.version, jsonObject.getStringOrNull("sdkVersion"))
+        assertEquals(AnalyticsPlatformParams.platform, jsonObject.getStringOrNull("platform"))
+        assertEquals(AnalyticsPlatformParams.channel, jsonObject.getStringOrNull("channel"))
+        assertEquals("nativeComponent", jsonObject.getStringOrNull("paymentMethodBehavior"))
     }
 
     @Test
@@ -64,6 +70,17 @@ internal class DefaultSdkDataProviderTest {
         assertNotNull(encodedSdkData)
         val jsonObject = decodeJsonObject(encodedSdkData!!)
         assertNull(jsonObject.optJSONObject("authentication")?.getStringOrNull("threeDS2SdkVersion"))
+    }
+
+    @Test
+    fun `when createEncodedSdkData is called with a payment method support value, then it is correctly set`() {
+        analyticsManager.setCheckoutAttemptId("test_checkout_attempt_id")
+
+        val encodedSdkData = sdkDataProvider.createEncodedSdkData(paymentMethodBehavior = PaymentMethodBehavior.GENERIC)
+
+        assertNotNull(encodedSdkData)
+        val jsonObject = decodeJsonObject(encodedSdkData!!)
+        assertEquals("genericComponent", jsonObject.getStringOrNull("paymentMethodBehavior"))
     }
 
     private fun decodeJsonObject(encodedString: String): JSONObject {

--- a/components-core/src/testFixtures/java/com/adyen/checkout/components/core/internal/provider/TestSdkDataProvider.kt
+++ b/components-core/src/testFixtures/java/com/adyen/checkout/components/core/internal/provider/TestSdkDataProvider.kt
@@ -8,6 +8,7 @@
 
 package com.adyen.checkout.components.core.internal.provider
 
+import com.adyen.checkout.components.core.internal.data.model.sdkData.PaymentMethodBehavior
 import org.junit.jupiter.api.Assertions.assertEquals
 
 /**
@@ -18,9 +19,14 @@ class TestSdkDataProvider : SdkDataProvider {
 
     private var sdkData: String? = TEST_SDK_DATA
     private var lastThreeDS2SdkVersion: String? = null
+    private var lastPaymentMethodBehavior: PaymentMethodBehavior? = null
 
-    override fun createEncodedSdkData(threeDS2SdkVersion: String?): String? {
+    override fun createEncodedSdkData(
+        threeDS2SdkVersion: String?,
+        paymentMethodBehavior: PaymentMethodBehavior
+    ): String? {
         lastThreeDS2SdkVersion = threeDS2SdkVersion
+        lastPaymentMethodBehavior = paymentMethodBehavior
         return sdkData
     }
 
@@ -29,6 +35,13 @@ class TestSdkDataProvider : SdkDataProvider {
      */
     fun assertThreeDS2SdkVersionEquals(expected: String?) {
         assertEquals(expected, lastThreeDS2SdkVersion)
+    }
+
+    /**
+     * Asserts that the last call to [createEncodedSdkData] was made with the expected paymentMethodBehavior.
+     */
+    fun assertPaymentMethodBehaviorEquals(expected: PaymentMethodBehavior?) {
+        assertEquals(expected, lastPaymentMethodBehavior)
     }
 
     companion object {

--- a/example-app/src/main/java/com/adyen/checkout/example/data/storage/IntegrationRegion.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/data/storage/IntegrationRegion.kt
@@ -23,6 +23,7 @@ enum class IntegrationRegion(val countryCode: String, val currency: String) {
     FI("FI", "EUR"),
     FR("FR", "EUR"),
     DE("DE", "EUR"),
+    GR("GR", "EUR"),
     HK("HK", "HKD"),
     IN("IN", "INR"),
     ID("ID", "IDR"),

--- a/instant/src/main/java/com/adyen/checkout/instant/internal/ui/DefaultInstantPaymentDelegate.kt
+++ b/instant/src/main/java/com/adyen/checkout/instant/internal/ui/DefaultInstantPaymentDelegate.kt
@@ -18,6 +18,7 @@ import com.adyen.checkout.components.core.internal.PaymentComponentEvent
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.analytics.AnalyticsManager
 import com.adyen.checkout.components.core.internal.analytics.GenericEvents
+import com.adyen.checkout.components.core.internal.data.model.sdkData.PaymentMethodBehavior
 import com.adyen.checkout.components.core.internal.provider.SdkDataProvider
 import com.adyen.checkout.components.core.internal.util.bufferedChannel
 import com.adyen.checkout.components.core.paymentmethod.GenericPaymentMethod
@@ -63,7 +64,7 @@ internal class DefaultInstantPaymentDelegate(
             paymentMethod = GenericPaymentMethod(
                 type = paymentMethod.type,
                 checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
-                sdkData = sdkDataProvider.createEncodedSdkData(),
+                sdkData = sdkDataProvider.createEncodedSdkData(paymentMethodBehavior = PaymentMethodBehavior.GENERIC),
                 subtype = getSubtype(paymentMethod),
             ),
             order = order,

--- a/instant/src/test/java/com/adyen/checkout/instant/internal/ui/DefaultInstantPaymentDelegateTest.kt
+++ b/instant/src/test/java/com/adyen/checkout/instant/internal/ui/DefaultInstantPaymentDelegateTest.kt
@@ -16,6 +16,7 @@ import com.adyen.checkout.components.core.PaymentMethod
 import com.adyen.checkout.components.core.internal.PaymentObserverRepository
 import com.adyen.checkout.components.core.internal.analytics.GenericEvents
 import com.adyen.checkout.components.core.internal.analytics.TestAnalyticsManager
+import com.adyen.checkout.components.core.internal.data.model.sdkData.PaymentMethodBehavior
 import com.adyen.checkout.components.core.internal.provider.TestSdkDataProvider
 import com.adyen.checkout.components.core.internal.ui.model.CommonComponentParamsMapper
 import com.adyen.checkout.core.Environment
@@ -124,6 +125,7 @@ class DefaultInstantPaymentDelegateTest {
 
             delegate.componentStateFlow.test {
                 assertEquals(TestSdkDataProvider.TEST_SDK_DATA, expectMostRecentItem().data.paymentMethod?.sdkData)
+                sdkDataProvider.assertPaymentMethodBehaviorEquals(PaymentMethodBehavior.GENERIC)
             }
         }
 


### PR DESCRIPTION
## Description
Add 4 new fields to `sdkData`: `channel` / `platform` / `sdkVersion` / `paymentMethodBehavior`.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

## Ticket Number
COSDK-1148

## Release notes
### Changed
- The payload returned in the `onSubmit` callback has increased in size, because of changes to the included `sdkData` field.