### PR TITLE
v5 - Co-badged cards - Track displayed event

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegate.kt
@@ -307,8 +307,8 @@ class DefaultCardDelegate(
             .launchIn(coroutineScope)
 
         outputDataFlow.map { it.dualBrandData?.brandOptions?.map { it.brand.txVariant } }
-            .filterNotNull()
             .distinctUntilChanged()
+            .filterNotNull()
             .map { brandOptions ->
                 val event = GenericEvents.displayed(
                     component = paymentMethod.type.orEmpty(),


### PR DESCRIPTION
## Description
Track displayed event every time the dual branded view is shown, instead of only once. Before it would be tracked only once for each unique dual branded card combination.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

## Ticket Number
COSDK-1062
