### PR TITLE
v6 - move properties classes to their corresponding modules

### DIFF
--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/properties/BlikCodeProperties.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/properties/BlikCodeProperties.kt
@@ -6,16 +6,14 @@
  * Created by josephj on 13/3/2026.
  */
 
-package com.adyen.checkout.core.common.internal.properties
+package com.adyen.checkout.blik.internal.ui.properties
 
-import androidx.annotation.RestrictTo
 import com.adyen.checkout.ui.internal.element.input.TextFieldSeparator
 
 /**
  * This field is formatted as such 123 456
  */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-object BlikCodeProperties {
+internal object BlikCodeProperties {
     const val BLIK_CODE_MAX_LENGTH = 6
     const val BLIK_CODE_SEPARATOR = ' '
 

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/BlikCodeField.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/BlikCodeField.kt
@@ -15,10 +15,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.adyen.checkout.blik.internal.ui.properties.BlikCodeProperties.BLIK_CODE_MAX_LENGTH
+import com.adyen.checkout.blik.internal.ui.properties.BlikCodeProperties.BLIK_CODE_SEPARATOR
+import com.adyen.checkout.blik.internal.ui.properties.BlikCodeProperties.BLIK_CODE_SEPARATORS
 import com.adyen.checkout.blik.internal.ui.state.BlikIntent
-import com.adyen.checkout.core.common.internal.properties.BlikCodeProperties.BLIK_CODE_MAX_LENGTH
-import com.adyen.checkout.core.common.internal.properties.BlikCodeProperties.BLIK_CODE_SEPARATOR
-import com.adyen.checkout.core.common.internal.properties.BlikCodeProperties.BLIK_CODE_SEPARATORS
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/properties/KCPBirthDateOrTaxNumberProperties.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/properties/KCPBirthDateOrTaxNumberProperties.kt
@@ -6,17 +6,14 @@
  * Created by josephj on 23/3/2026.
  */
 
-package com.adyen.checkout.core.common.internal.properties
-
-import androidx.annotation.RestrictTo
+package com.adyen.checkout.card.internal.ui.properties
 
 /**
  * This field has two valid formats:
  * - Birth date: 6 digits, following the "yyMMdd" format e.g 230704 for 4 July 2023
  * - Tax number: 10 digits, no special format
  */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-object KCPBirthDateOrTaxNumberProperties {
+internal object KCPBirthDateOrTaxNumberProperties {
 
     const val KCP_BIRTH_DATE_VALID_LENGTH = 6
     const val KCP_TAX_NUMBER_VALID_LENGTH = 10

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/properties/KCPCardPasswordProperties.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/properties/KCPCardPasswordProperties.kt
@@ -6,15 +6,12 @@
  * Created by josephj on 23/3/2026.
  */
 
-package com.adyen.checkout.core.common.internal.properties
-
-import androidx.annotation.RestrictTo
+package com.adyen.checkout.card.internal.ui.properties
 
 /**
  * This field is a two-digit number
  */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-object KCPCardPasswordProperties {
+internal object KCPCardPasswordProperties {
 
     const val KCP_CARD_PASSWORD_MAX_LENGTH = 2
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/properties/SocialSecurityNumberProperties.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/properties/SocialSecurityNumberProperties.kt
@@ -6,9 +6,8 @@
  * Created by josephj on 13/3/2026.
  */
 
-package com.adyen.checkout.core.common.internal.properties
+package com.adyen.checkout.card.internal.ui.properties
 
-import androidx.annotation.RestrictTo
 import com.adyen.checkout.ui.internal.element.input.TextFieldSeparator
 
 /**
@@ -19,8 +18,7 @@ import com.adyen.checkout.ui.internal.element.input.TextFieldSeparator
  * The formatting follows the CPF format as long as the length is less than 11 digits. Then between 12 and 14 digits,
  * the CNPJ format is used.
  */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-object SocialSecurityNumberProperties {
+internal object SocialSecurityNumberProperties {
 
     const val CPF_VALID_LENGTH = 11
     const val CNPJ_VALID_LENGTH = 14

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardValidationUtils.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardValidationUtils.kt
@@ -13,6 +13,10 @@ import androidx.annotation.VisibleForTesting
 import com.adyen.checkout.card.internal.data.model.Brand
 import com.adyen.checkout.card.internal.data.model.DetectedCardType
 import com.adyen.checkout.card.internal.helper.ExpiryDateParser
+import com.adyen.checkout.card.internal.ui.properties.KCPBirthDateOrTaxNumberProperties
+import com.adyen.checkout.card.internal.ui.properties.KCPBirthDateOrTaxNumberProperties.KCP_BIRTH_DATE_FORMAT
+import com.adyen.checkout.card.internal.ui.properties.KCPCardPasswordProperties
+import com.adyen.checkout.card.internal.ui.properties.SocialSecurityNumberProperties
 import com.adyen.checkout.core.common.helper.CardExpiryDateValidationResult
 import com.adyen.checkout.core.common.helper.CardExpiryDateValidator
 import com.adyen.checkout.core.common.helper.CardNumberValidationResult
@@ -21,10 +25,6 @@ import com.adyen.checkout.core.common.helper.CardSecurityCodeValidationResult
 import com.adyen.checkout.core.common.helper.CardSecurityCodeValidator
 import com.adyen.checkout.core.common.internal.helper.DateUtils
 import com.adyen.checkout.core.common.internal.helper.StringUtil
-import com.adyen.checkout.core.common.internal.properties.KCPBirthDateOrTaxNumberProperties
-import com.adyen.checkout.core.common.internal.properties.KCPBirthDateOrTaxNumberProperties.KCP_BIRTH_DATE_FORMAT
-import com.adyen.checkout.core.common.internal.properties.KCPCardPasswordProperties
-import com.adyen.checkout.core.common.internal.properties.SocialSecurityNumberProperties
 import com.adyen.checkout.core.components.internal.ui.state.model.RequirementPolicy
 
 internal object CardValidationUtils {

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPBirthDateOrTaxNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPBirthDateOrTaxNumberField.kt
@@ -15,9 +15,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.adyen.checkout.card.internal.ui.properties.KCPBirthDateOrTaxNumberProperties.KCP_BIRTH_DATE_OR_TAX_NUMBER_MAX_LENGTH
+import com.adyen.checkout.card.internal.ui.properties.KCPBirthDateOrTaxNumberProperties.KCP_BIRTH_DATE_VALID_LENGTH
 import com.adyen.checkout.card.internal.ui.state.CardIntent
-import com.adyen.checkout.core.common.internal.properties.KCPBirthDateOrTaxNumberProperties.KCP_BIRTH_DATE_OR_TAX_NUMBER_MAX_LENGTH
-import com.adyen.checkout.core.common.internal.properties.KCPBirthDateOrTaxNumberProperties.KCP_BIRTH_DATE_VALID_LENGTH
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPCardPasswordField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPCardPasswordField.kt
@@ -15,8 +15,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.adyen.checkout.card.internal.ui.properties.KCPCardPasswordProperties.KCP_CARD_PASSWORD_MAX_LENGTH
 import com.adyen.checkout.card.internal.ui.state.CardIntent
-import com.adyen.checkout.core.common.internal.properties.KCPCardPasswordProperties.KCP_CARD_PASSWORD_MAX_LENGTH
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SocialSecurityNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SocialSecurityNumberField.kt
@@ -15,9 +15,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.adyen.checkout.card.internal.ui.properties.SocialSecurityNumberProperties.SOCIAL_SECURITY_MAX_LENGTH
+import com.adyen.checkout.card.internal.ui.properties.SocialSecurityNumberProperties.SOCIAL_SECURITY_SEPARATORS
 import com.adyen.checkout.card.internal.ui.state.CardIntent
-import com.adyen.checkout.core.common.internal.properties.SocialSecurityNumberProperties.SOCIAL_SECURITY_MAX_LENGTH
-import com.adyen.checkout.core.common.internal.properties.SocialSecurityNumberProperties.SOCIAL_SECURITY_SEPARATORS
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SocialSecurityNumberOutputTransformation.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SocialSecurityNumberOutputTransformation.kt
@@ -10,9 +10,9 @@ package com.adyen.checkout.card.internal.ui.view
 
 import androidx.compose.foundation.text.input.OutputTransformation
 import androidx.compose.foundation.text.input.TextFieldBuffer
-import com.adyen.checkout.core.common.internal.properties.SocialSecurityNumberProperties.CNPJ_SEPARATORS
-import com.adyen.checkout.core.common.internal.properties.SocialSecurityNumberProperties.CPF_SEPARATORS
-import com.adyen.checkout.core.common.internal.properties.SocialSecurityNumberProperties.CPF_VALID_LENGTH
+import com.adyen.checkout.card.internal.ui.properties.SocialSecurityNumberProperties.CNPJ_SEPARATORS
+import com.adyen.checkout.card.internal.ui.properties.SocialSecurityNumberProperties.CPF_SEPARATORS
+import com.adyen.checkout.card.internal.ui.properties.SocialSecurityNumberProperties.CPF_VALID_LENGTH
 import com.adyen.checkout.ui.internal.element.input.SeparatorsTextFieldBufferTransformation
 
 internal class SocialSecurityNumberOutputTransformation : OutputTransformation {


### PR DESCRIPTION
## Description
These classes correspond to fields that are only used inside cards, there is no need to have them in the `core` module.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

## Ticket Number
COSDK-921
