### PR TITLE
v5 - Co-badged cards - Bin lookup fix

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegate.kt
@@ -870,9 +870,7 @@ class DefaultCardDelegate(
         return if (dualBrandData != null) {
             dualBrandData.selectedBrand?.txVariant
         } else {
-            val reliableCardBrand = detectedCardTypes.firstOrNull { it.isReliable }
-            val firstDetectedBrand = detectedCardTypes.firstOrNull()
-            val cardType = reliableCardBrand ?: firstDetectedBrand
+            val cardType = detectedCardTypes.firstOrNull { it.isReliable }
             cardType?.cardBrand?.txVariant
         }
     }

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegateTest.kt
@@ -856,7 +856,7 @@ internal class DefaultCardDelegateTest(
                     assertEquals(TEST_EXPIRY_YEAR.trimStart('0'), encryptedExpiryYear)
                     assertEquals(TEST_SECURITY_CODE, encryptedSecurityCode)
                     assertEquals(PaymentMethodTypes.SCHEME, type)
-                    assertEquals(CardType.VISA.txVariant, brand)
+                    assertNull(brand)
                     assertNull(holderName)
                     assertNull(taxNumber)
                     assertNull(encryptedPassword)
@@ -1062,6 +1062,160 @@ internal class DefaultCardDelegateTest(
                     expiryDate = TEST_EXPIRY_DATE
                 }
                 assertEquals(expectedComponentStateValue, expectMostRecentItem().data.amount)
+            }
+        }
+
+        @Test
+        fun `when detected card types only contain unreliable brands, then brand should be null`() = runTest {
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+
+            delegate.componentStateFlow.test {
+                val unreliableDetectedCards = listOf(
+                    createDetectedCardType(
+                        cardBrand = CardBrand(cardType = CardType.VISA),
+                        isReliable = false,
+                    ),
+                )
+
+                delegate.updateComponentState(
+                    createOutputData(detectedCardTypes = unreliableDetectedCards),
+                )
+
+                val componentState = expectMostRecentItem()
+
+                assertNull(componentState.data.paymentMethod?.brand)
+            }
+        }
+
+        @Test
+        fun `when detected card types contain a reliable brand, then brand should be that brand`() = runTest {
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+
+            delegate.componentStateFlow.test {
+                val reliableDetectedCards = listOf(
+                    createDetectedCardType(
+                        cardBrand = CardBrand(cardType = CardType.MASTERCARD),
+                        isReliable = true,
+                    ),
+                )
+
+                delegate.updateComponentState(
+                    createOutputData(detectedCardTypes = reliableDetectedCards),
+                )
+
+                val componentState = expectMostRecentItem()
+
+                assertEquals(CardType.MASTERCARD.txVariant, componentState.data.paymentMethod?.brand)
+            }
+        }
+
+        @Test
+        fun `when detected card types contain both unreliable and reliable brands, then brand should be the first reliable`() =
+            runTest {
+                delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+
+                delegate.componentStateFlow.test {
+                    val mixedDetectedCards = listOf(
+                        createDetectedCardType(
+                            cardBrand = CardBrand(cardType = CardType.VISA),
+                            isReliable = false,
+                        ),
+                        createDetectedCardType(
+                            cardBrand = CardBrand(cardType = CardType.MASTERCARD),
+                            isReliable = true,
+                        ),
+                    )
+
+                    delegate.updateComponentState(
+                        createOutputData(detectedCardTypes = mixedDetectedCards),
+                    )
+
+                    val componentState = expectMostRecentItem()
+
+                    assertEquals(CardType.MASTERCARD.txVariant, componentState.data.paymentMethod?.brand)
+                }
+            }
+
+        @Test
+        fun `when detected card types is empty, then brand should be null`() = runTest {
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+
+            delegate.componentStateFlow.test {
+                delegate.updateComponentState(
+                    createOutputData(detectedCardTypes = emptyList()),
+                )
+
+                val componentState = expectMostRecentItem()
+
+                assertNull(componentState.data.paymentMethod?.brand)
+            }
+        }
+
+        @Test
+        fun `when dual brand data has no selected brand, then brand should be null`() = runTest {
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+
+            delegate.componentStateFlow.test {
+                delegate.updateComponentState(
+                    createOutputData(
+                        dualBrandData = DualBrandData(
+                            selectedBrand = null,
+                            brandOptions = listOf(
+                                CardBrandItem(
+                                    name = "Visa",
+                                    brand = CardBrand(cardType = CardType.VISA),
+                                    isSelected = false,
+                                    environment = Environment.TEST,
+                                ),
+                                CardBrandItem(
+                                    name = "MasterCard",
+                                    brand = CardBrand(cardType = CardType.MASTERCARD),
+                                    isSelected = false,
+                                    environment = Environment.TEST,
+                                ),
+                            ),
+                            selectable = true,
+                        ),
+                    ),
+                )
+
+                val componentState = expectMostRecentItem()
+
+                assertNull(componentState.data.paymentMethod?.brand)
+            }
+        }
+
+        @Test
+        fun `when dual brand data has selected brand, then brand should be the selected brand`() = runTest {
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+
+            delegate.componentStateFlow.test {
+                delegate.updateComponentState(
+                    createOutputData(
+                        dualBrandData = DualBrandData(
+                            selectedBrand = CardBrand(cardType = CardType.MASTERCARD),
+                            brandOptions = listOf(
+                                CardBrandItem(
+                                    name = "Visa",
+                                    brand = CardBrand(cardType = CardType.VISA),
+                                    isSelected = false,
+                                    environment = Environment.TEST,
+                                ),
+                                CardBrandItem(
+                                    name = "MasterCard",
+                                    brand = CardBrand(cardType = CardType.MASTERCARD),
+                                    isSelected = true,
+                                    environment = Environment.TEST,
+                                ),
+                            ),
+                            selectable = true,
+                        ),
+                    ),
+                )
+
+                val componentState = expectMostRecentItem()
+
+                assertEquals(CardType.MASTERCARD.txVariant, componentState.data.paymentMethod?.brand)
             }
         }
     }


### PR DESCRIPTION
## Description
If bin lookup fails or it is slow, we send the locally detected brand in the CardPaymentMethod object, which in some cases fails the payments call.
With this change we make sure to only send brands which are reliable (which we got from bin lookup).

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

## Ticket Number
COSDK-1062