### PR TITLE
v6 - Deprecate old public classes - ui-core

### DIFF
--- a/checkout-core/src/main/java/com/adyen/checkout/core/old/ui/validation/CardExpiryDateValidationResult.kt
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/old/ui/validation/CardExpiryDateValidationResult.kt
@@ -16,10 +16,35 @@ package com.adyen.checkout.core.old.ui.validation
     level = DeprecationLevel.WARNING,
 )
 sealed interface CardExpiryDateValidationResult {
+
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Valid : CardExpiryDateValidationResult
+
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     interface Invalid : CardExpiryDateValidationResult {
+
+        @Deprecated(
+            message = "Deprecated. This will be removed in a future release.",
+            level = DeprecationLevel.WARNING,
+        )
         class TooFarInTheFuture : Invalid
+
+        @Deprecated(
+            message = "Deprecated. This will be removed in a future release.",
+            level = DeprecationLevel.WARNING,
+        )
         class TooOld : Invalid
+
+        @Deprecated(
+            message = "Deprecated. This will be removed in a future release.",
+            level = DeprecationLevel.WARNING,
+        )
         class NonParseableDate : Invalid
     }
 }

--- a/checkout-core/src/main/java/com/adyen/checkout/core/old/ui/validation/CardNumberValidationResult.kt
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/old/ui/validation/CardNumberValidationResult.kt
@@ -16,11 +16,41 @@ package com.adyen.checkout.core.old.ui.validation
     level = DeprecationLevel.WARNING,
 )
 sealed interface CardNumberValidationResult {
+
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Valid : CardNumberValidationResult
+
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     interface Invalid : CardNumberValidationResult {
+
+        @Deprecated(
+            message = "Deprecated. This will be removed in a future release.",
+            level = DeprecationLevel.WARNING,
+        )
         class IllegalCharacters : Invalid
+
+        @Deprecated(
+            message = "Deprecated. This will be removed in a future release.",
+            level = DeprecationLevel.WARNING,
+        )
         class TooLong : Invalid
+
+        @Deprecated(
+            message = "Deprecated. This will be removed in a future release.",
+            level = DeprecationLevel.WARNING,
+        )
         class TooShort : Invalid
+
+        @Deprecated(
+            message = "Deprecated. This will be removed in a future release.",
+            level = DeprecationLevel.WARNING,
+        )
         class LuhnCheck : Invalid
     }
 }

--- a/checkout-core/src/main/java/com/adyen/checkout/core/old/ui/validation/CardSecurityCodeValidationResult.kt
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/old/ui/validation/CardSecurityCodeValidationResult.kt
@@ -16,6 +16,16 @@ package com.adyen.checkout.core.old.ui.validation
     level = DeprecationLevel.WARNING,
 )
 sealed interface CardSecurityCodeValidationResult {
+
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Valid : CardSecurityCodeValidationResult
+
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Invalid : CardSecurityCodeValidationResult
 }

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/old/AdyenComponentView.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/old/AdyenComponentView.kt
@@ -48,6 +48,10 @@ import java.lang.ref.WeakReference
  * A View that can display input and fill in details for a Component.
  * Declare this view in your xml layout file and call [attach] to bind it to a component.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class AdyenComponentView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,

--- a/ui-core/src/test/java/com/adyen/checkout/ui/core/old/TestComponentState.kt
+++ b/ui-core/src/test/java/com/adyen/checkout/ui/core/old/TestComponentState.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 22/2/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.ui.core.old
 
 import com.adyen.checkout.components.core.PaymentComponentData

--- a/ui-core/src/test/java/com/adyen/checkout/ui/core/old/TestPermissionHandler.kt
+++ b/ui-core/src/test/java/com/adyen/checkout/ui/core/old/TestPermissionHandler.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 22/1/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.ui.core.old
 
 import android.content.Context

--- a/ui-core/src/test/java/com/adyen/checkout/ui/core/old/internal/DefaultRedirectHandlerTest.kt
+++ b/ui-core/src/test/java/com/adyen/checkout/ui/core/old/internal/DefaultRedirectHandlerTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 15/7/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.ui.core.old.internal
 
 import android.net.Uri

--- a/ui-core/src/test/java/com/adyen/checkout/ui/core/old/internal/ui/AddressFormUIStateTest.kt
+++ b/ui-core/src/test/java/com/adyen/checkout/ui/core/old/internal/ui/AddressFormUIStateTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 15/7/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.ui.core.old.internal.ui
 
 import com.adyen.checkout.ui.core.old.internal.ui.model.AddressParams

--- a/ui-core/src/test/java/com/adyen/checkout/ui/core/old/internal/ui/DefaultAddressLookupDelegateTest.kt
+++ b/ui-core/src/test/java/com/adyen/checkout/ui/core/old/internal/ui/DefaultAddressLookupDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 15/7/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.ui.core.old.internal.ui
 
 import com.adyen.checkout.components.core.AddressData

--- a/ui-core/src/test/java/com/adyen/checkout/ui/core/old/internal/ui/SubmitHandlerTest.kt
+++ b/ui-core/src/test/java/com/adyen/checkout/ui/core/old/internal/ui/SubmitHandlerTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 15/7/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.ui.core.old.internal.ui
 
 import androidx.lifecycle.SavedStateHandle

--- a/ui-core/src/test/java/com/adyen/checkout/ui/core/old/internal/ui/model/AddressOutputDataTest.kt
+++ b/ui-core/src/test/java/com/adyen/checkout/ui/core/old/internal/ui/model/AddressOutputDataTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 15/7/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.ui.core.old.internal.ui.model
 
 import com.adyen.checkout.components.core.internal.ui.model.FieldState

--- a/ui-core/src/test/java/com/adyen/checkout/ui/core/old/internal/ui/model/Required.kt
+++ b/ui-core/src/test/java/com/adyen/checkout/ui/core/old/internal/ui/model/Required.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 15/7/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.ui.core.old.internal.ui.model
 
 internal class Required : AddressFieldPolicy

--- a/ui-core/src/test/java/com/adyen/checkout/ui/core/old/internal/ui/view/LookupOptionTest.kt
+++ b/ui-core/src/test/java/com/adyen/checkout/ui/core/old/internal/ui/view/LookupOptionTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 15/7/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.ui.core.old.internal.ui.view
 
 import com.adyen.checkout.components.core.AddressData

--- a/ui-core/src/test/java/com/adyen/checkout/ui/core/old/internal/util/AddressFormUtilsTest.kt
+++ b/ui-core/src/test/java/com/adyen/checkout/ui/core/old/internal/util/AddressFormUtilsTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 15/7/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.ui.core.old.internal.util
 
 import com.adyen.checkout.components.core.Address

--- a/ui-core/src/test/java/com/adyen/checkout/ui/core/old/internal/util/CountryUtilsTest.kt
+++ b/ui-core/src/test/java/com/adyen/checkout/ui/core/old/internal/util/CountryUtilsTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 15/7/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.ui.core.old.internal.util
 
 import com.adyen.checkout.ui.core.old.internal.ui.model.CountryModel

--- a/ui-core/src/test/java/com/adyen/checkout/ui/core/old/internal/util/FlowExtensionsTest.kt
+++ b/ui-core/src/test/java/com/adyen/checkout/ui/core/old/internal/util/FlowExtensionsTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 15/7/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.ui.core.old.internal.util
 
 import app.cash.turbine.test

--- a/ui-core/src/test/java/com/adyen/checkout/ui/core/old/internal/util/PermissionHandlerExtensionTest.kt
+++ b/ui-core/src/test/java/com/adyen/checkout/ui/core/old/internal/util/PermissionHandlerExtensionTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 15/7/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.ui.core.old.internal.util
 
 import android.content.Context

--- a/ui-core/src/testFixtures/java/com/adyen/checkout/ui/core/old/internal/TestRedirectHandler.kt
+++ b/ui-core/src/testFixtures/java/com/adyen/checkout/ui/core/old/internal/TestRedirectHandler.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 15/7/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.ui.core.old.internal
 
 import android.content.Context

--- a/ui-core/src/testFixtures/java/com/adyen/checkout/ui/core/old/internal/data/api/TestAddressRepository.kt
+++ b/ui-core/src/testFixtures/java/com/adyen/checkout/ui/core/old/internal/data/api/TestAddressRepository.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 15/7/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.ui.core.old.internal.data.api
 
 import com.adyen.checkout.ui.core.old.internal.data.model.AddressItem

--- a/ui-core/src/testFixtures/java/com/adyen/checkout/ui/core/old/internal/ui/TestComponentViewType.kt
+++ b/ui-core/src/testFixtures/java/com/adyen/checkout/ui/core/old/internal/ui/TestComponentViewType.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 15/7/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.ui.core.old.internal.ui
 
 /**


### PR DESCRIPTION
## Description

Deprecate all v5 public classes with `@Deprecated` annotations to prepare for the v6 release.
Deprecated code will be removed before the v6 production release.

### Progress

✅ Phase 1 — [checkout-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2707)
➡️ **Phase 2 — ui-core (.old packages)**
Phase 3 — card (.old packages)
Phase 4 — googlepay (.old packages)
Phase 5 — drop-in (.old packages)
Phase 6 — 3ds2 (.old packages)
Phase 7 — mbway (.old packages)
Phase 8 — blik (.old packages)
Phase 9 — await (.old packages)
Phase 10 — redirect (.old packages)
Phase 11 — components-core (entire v5 module)
Phase 12 — action-core (entire v5 module)
Phase 13 — sessions-core (entire v5 module)
Phase 14 — action, components-compose, drop-in-compose (v5 utility modules)
Phase 15 — 34 v5-only payment method modules

## Ticket Number
COSDK-1121