### PR TITLE
v6 - Deprecate old public classes - card

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/old/AddressConfiguration.kt
+++ b/card/src/main/java/com/adyen/checkout/card/old/AddressConfiguration.kt
@@ -8,11 +8,19 @@ import kotlinx.parcelize.Parcelize
  * Configuration class for Address Form in Card Component. This class can be used define the
  * visibility of the address form.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 sealed class AddressConfiguration : Parcelable {
 
     /**
      * Address Form will be hidden.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     @SuppressLint("ObjectInPublicSealedClass")
     @Parcelize
     object None : AddressConfiguration()
@@ -20,6 +28,10 @@ sealed class AddressConfiguration : Parcelable {
     /**
      * Only postal code will be shown as part of the card component.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     @Parcelize
     data class PostalCode(
         val addressFieldPolicy: CardAddressFieldPolicy = CardAddressFieldPolicy.Required()
@@ -32,6 +44,10 @@ sealed class AddressConfiguration : Parcelable {
      * @param supportedCountryCodes Supported country codes to be filtered from the available country
      * options.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     @Parcelize
     data class FullAddress(
         val defaultCountryCode: String? = null,
@@ -42,29 +58,49 @@ sealed class AddressConfiguration : Parcelable {
     /**
      * Address Lookup option will be shown as part of card component.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     @Parcelize
     class Lookup : AddressConfiguration()
 
     /**
      * Configuration for requirement of the address fields.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     sealed class CardAddressFieldPolicy : Parcelable {
 
         /**
          * Address form fields will be required.
          */
+        @Deprecated(
+            message = "Deprecated. This will be removed in a future release.",
+            level = DeprecationLevel.WARNING,
+        )
         @Parcelize
         class Required : CardAddressFieldPolicy()
 
         /**
          * Address form fields will be optional.
          */
+        @Deprecated(
+            message = "Deprecated. This will be removed in a future release.",
+            level = DeprecationLevel.WARNING,
+        )
         @Parcelize
         class Optional : CardAddressFieldPolicy()
 
         /**
          * Address form fields will be optional for given [brands] and required for the other brands.
          */
+        @Deprecated(
+            message = "Deprecated. This will be removed in a future release.",
+            level = DeprecationLevel.WARNING,
+        )
         @Parcelize
         data class OptionalForCardTypes(val brands: List<String>) : CardAddressFieldPolicy()
     }

--- a/card/src/main/java/com/adyen/checkout/card/old/BinLookupData.kt
+++ b/card/src/main/java/com/adyen/checkout/card/old/BinLookupData.kt
@@ -9,6 +9,10 @@ package com.adyen.checkout.card.old
  * @param isReliable Indicates whether the data is reliable. If true, the card number is checked with Adyen systems.
  * If false, the data is provided by a local detection algorithm.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class BinLookupData(
     val brand: String,
     val paymentMethodVariant: String?,

--- a/card/src/main/java/com/adyen/checkout/card/old/CardBrand.kt
+++ b/card/src/main/java/com/adyen/checkout/card/old/CardBrand.kt
@@ -10,4 +10,8 @@ package com.adyen.checkout.card.old
 
 import com.adyen.checkout.core.old.CardBrand
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 typealias CardBrand = CardBrand

--- a/card/src/main/java/com/adyen/checkout/card/old/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/old/CardComponent.kt
@@ -39,6 +39,10 @@ import kotlinx.coroutines.flow.Flow
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.SCHEME] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("TooManyFunctions")
 open class CardComponent
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/card/src/main/java/com/adyen/checkout/card/old/CardComponentState.kt
+++ b/card/src/main/java/com/adyen/checkout/card/old/CardComponentState.kt
@@ -14,6 +14,10 @@ import com.adyen.checkout.components.core.paymentmethod.CardPaymentMethod
 /**
  * Represents the state of [CardComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class CardComponentState(
     override val data: PaymentComponentData<CardPaymentMethod>,
     override val isInputValid: Boolean,

--- a/card/src/main/java/com/adyen/checkout/card/old/CardConfiguration.kt
+++ b/card/src/main/java/com/adyen/checkout/card/old/CardConfiguration.kt
@@ -27,6 +27,10 @@ import java.util.Locale
 /**
  * Configuration class for the [CardComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class CardConfiguration private constructor(
@@ -52,6 +56,10 @@ class CardConfiguration private constructor(
     /**
      * Builder to create a [CardConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     @Suppress("TooManyFunctions")
     class Builder :
         ActionHandlingPaymentMethodConfigurationBuilder<CardConfiguration, Builder>,
@@ -315,6 +323,10 @@ class CardConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.card(
     configuration: @CheckoutConfigurationMarker CardConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/card/src/main/java/com/adyen/checkout/card/old/CardType.kt
+++ b/card/src/main/java/com/adyen/checkout/card/old/CardType.kt
@@ -10,4 +10,8 @@ package com.adyen.checkout.card.old
 
 import com.adyen.checkout.core.old.CardType
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 typealias CardType = CardType

--- a/card/src/main/java/com/adyen/checkout/card/old/InstallmentConfiguration.kt
+++ b/card/src/main/java/com/adyen/checkout/card/old/InstallmentConfiguration.kt
@@ -26,6 +26,10 @@ import kotlinx.parcelize.Parcelize
  * @param cardBasedOptions Installment Options to be used for specific card types.
  * @param showInstallmentAmount A flag to show the installment amount.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class InstallmentConfiguration(
     val defaultOptions: InstallmentOptions.DefaultInstallmentOptions? = null,
@@ -50,6 +54,10 @@ data class InstallmentConfiguration(
  *
  * Note: All values specified in [values] must be greater than 1.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 sealed class InstallmentOptions : Parcelable {
 
     abstract val values: List<Int>
@@ -64,6 +72,10 @@ sealed class InstallmentOptions : Parcelable {
      * @param includeRevolving see [InstallmentOptions.includeRevolving]
      * @param cardBrand a [CardBrand] to apply the given options
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     @Parcelize
     data class CardBasedInstallmentOptions(
         override val values: List<Int>,
@@ -84,6 +96,10 @@ sealed class InstallmentOptions : Parcelable {
      * @param values see [InstallmentOptions.values]
      * @param includeRevolving see [InstallmentOptions.includeRevolving]
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     @Parcelize
     data class DefaultInstallmentOptions(
         override val values: List<Int>,

--- a/card/src/main/java/com/adyen/checkout/card/old/KCPAuthVisibility.kt
+++ b/card/src/main/java/com/adyen/checkout/card/old/KCPAuthVisibility.kt
@@ -3,6 +3,10 @@ package com.adyen.checkout.card.old
 /**
  * Used in [CardConfiguration.Builder.kcpAuthVisibility] to show or hide the KCP authentication input field.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 enum class KCPAuthVisibility {
     SHOW,
     HIDE,

--- a/card/src/main/java/com/adyen/checkout/card/old/SocialSecurityNumberVisibility.kt
+++ b/card/src/main/java/com/adyen/checkout/card/old/SocialSecurityNumberVisibility.kt
@@ -4,6 +4,10 @@ package com.adyen.checkout.card.old
  * Used in [CardConfiguration.Builder.socialSecurityNumberVisibility] to show or hide the social security number input
  * field.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 enum class SocialSecurityNumberVisibility {
     SHOW,
     HIDE,

--- a/card/src/test/java/com/adyen/checkout/card/CardComponentTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/CardComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 7/12/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.card
 
 import androidx.lifecycle.LifecycleOwner

--- a/card/src/test/java/com/adyen/checkout/card/internal/data/api/TestDetectCardTypeRepository.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/data/api/TestDetectCardTypeRepository.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 8/8/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.card.internal.data.api
 
 import com.adyen.checkout.card.old.internal.data.api.DetectCardTypeRepository

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/CardConfigDataGeneratorTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/CardConfigDataGeneratorTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 19/8/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.card.internal.ui
 
 import com.adyen.checkout.card.old.KCPAuthVisibility

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/CardValidationMapperTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/CardValidationMapperTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 4/10/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.card.internal.ui
 
 import com.adyen.checkout.card.R

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 9/8/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.card.internal.ui
 
 import android.app.Activity

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/StoredCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/StoredCardDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 12/8/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.card.internal.ui
 
 import app.cash.turbine.test

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapperTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapperTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 16/11/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.card.internal.ui.model
 
 import com.adyen.checkout.card.old.AddressConfiguration

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/model/InstallmentParamsMapperTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/model/InstallmentParamsMapperTest.kt
@@ -6,6 +6,8 @@
  * Created by atef on 24/2/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.card.internal.ui.model
 
 import com.adyen.checkout.card.old.InstallmentConfiguration

--- a/card/src/test/java/com/adyen/checkout/card/internal/util/CardAddressValidationUtilsTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/util/CardAddressValidationUtilsTest.kt
@@ -6,6 +6,8 @@
  * Created by onurk on 11/1/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.card.internal.util
 
 import com.adyen.checkout.card.old.internal.ui.model.AddressFieldPolicyParams

--- a/card/src/test/java/com/adyen/checkout/card/internal/util/CardNumberUtilsTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/util/CardNumberUtilsTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 31/1/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.card.internal.util
 
 import com.adyen.checkout.card.old.internal.util.CardNumberUtils

--- a/card/src/test/java/com/adyen/checkout/card/internal/util/CardValidationUtilsTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/util/CardValidationUtilsTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 5/10/2021.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.card.internal.util
 
 import com.adyen.checkout.card.old.internal.data.model.Brand

--- a/card/src/test/java/com/adyen/checkout/card/internal/util/DualBrandedCardHandlerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/util/DualBrandedCardHandlerTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 4/7/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.card.internal.util
 
 import com.adyen.checkout.card.old.internal.data.model.Brand

--- a/card/src/test/java/com/adyen/checkout/card/internal/util/InstallmentUtilsTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/util/InstallmentUtilsTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 17/11/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.card.internal.util
 
 import android.content.Context


### PR DESCRIPTION
## Description

Deprecate all v5 public classes with `@Deprecated` annotations to prepare for the v6 release.
Deprecated code will be removed before the v6 production release.

### Progress

✅ Phase 1 — [checkout-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2707)
✅ Phase 2 — [ui-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2708)
➡️ **Phase 3 — card (.old packages)**
Phase 4 — googlepay (.old packages)
Phase 5 — drop-in (.old packages)
Phase 6 — 3ds2 (.old packages)
Phase 7 — mbway (.old packages)
Phase 8 — blik (.old packages)
Phase 9 — await (.old packages)
Phase 10 — redirect (.old packages)
Phase 11 — components-core (entire v5 module)
Phase 12 — action-core (entire v5 module)
Phase 13 — sessions-core (entire v5 module)
Phase 14 — action, components-compose, drop-in-compose (v5 utility modules)
Phase 15 — 34 v5-only payment method modules

## Ticket Number
COSDK-1121