### PR TITLE
v6 - Deprecate old public classes - checkout-core (fix)

### DIFF
--- a/checkout-core/src/main/java/com/adyen/checkout/core/old/ui/validation/CardExpiryDateValidationResult.kt
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/old/ui/validation/CardExpiryDateValidationResult.kt
@@ -16,10 +16,35 @@ package com.adyen.checkout.core.old.ui.validation
     level = DeprecationLevel.WARNING,
 )
 sealed interface CardExpiryDateValidationResult {
+
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Valid : CardExpiryDateValidationResult
+
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     interface Invalid : CardExpiryDateValidationResult {
+
+        @Deprecated(
+            message = "Deprecated. This will be removed in a future release.",
+            level = DeprecationLevel.WARNING,
+        )
         class TooFarInTheFuture : Invalid
+
+        @Deprecated(
+            message = "Deprecated. This will be removed in a future release.",
+            level = DeprecationLevel.WARNING,
+        )
         class TooOld : Invalid
+
+        @Deprecated(
+            message = "Deprecated. This will be removed in a future release.",
+            level = DeprecationLevel.WARNING,
+        )
         class NonParseableDate : Invalid
     }
 }

--- a/checkout-core/src/main/java/com/adyen/checkout/core/old/ui/validation/CardNumberValidationResult.kt
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/old/ui/validation/CardNumberValidationResult.kt
@@ -16,11 +16,41 @@ package com.adyen.checkout.core.old.ui.validation
     level = DeprecationLevel.WARNING,
 )
 sealed interface CardNumberValidationResult {
+
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Valid : CardNumberValidationResult
+
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     interface Invalid : CardNumberValidationResult {
+
+        @Deprecated(
+            message = "Deprecated. This will be removed in a future release.",
+            level = DeprecationLevel.WARNING,
+        )
         class IllegalCharacters : Invalid
+
+        @Deprecated(
+            message = "Deprecated. This will be removed in a future release.",
+            level = DeprecationLevel.WARNING,
+        )
         class TooLong : Invalid
+
+        @Deprecated(
+            message = "Deprecated. This will be removed in a future release.",
+            level = DeprecationLevel.WARNING,
+        )
         class TooShort : Invalid
+
+        @Deprecated(
+            message = "Deprecated. This will be removed in a future release.",
+            level = DeprecationLevel.WARNING,
+        )
         class LuhnCheck : Invalid
     }
 }

--- a/checkout-core/src/main/java/com/adyen/checkout/core/old/ui/validation/CardSecurityCodeValidationResult.kt
+++ b/checkout-core/src/main/java/com/adyen/checkout/core/old/ui/validation/CardSecurityCodeValidationResult.kt
@@ -16,6 +16,16 @@ package com.adyen.checkout.core.old.ui.validation
     level = DeprecationLevel.WARNING,
 )
 sealed interface CardSecurityCodeValidationResult {
+
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Valid : CardSecurityCodeValidationResult
+
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Invalid : CardSecurityCodeValidationResult
 }


### PR DESCRIPTION
## Description

Deprecate all v5 public classes with `@Deprecated` annotations to prepare for the v6 release.
Deprecated code will be removed before the v6 production release.

**Fix**: Added explicit `@Deprecated` to nested subclasses of validation result interfaces (`CardExpiryDateValidationResult`, `CardNumberValidationResult`, `CardSecurityCodeValidationResult`). Deprecation does not reliably propagate to `class` subclasses used via `is` checks — each must be explicitly deprecated.

### Progress

➡️ Phase 1 — [checkout-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2707)
Phase 2 — ui-core (.old packages)
Phase 3 — card (.old packages)
Phase 4 — googlepay (.old packages)
Phase 5 — drop-in (.old packages)
Phase 6 — 3ds2 (.old packages)
Phase 7 — mbway (.old packages)
Phase 8 — blik (.old packages)
Phase 9 — await (.old packages)
Phase 10 — redirect (.old packages)
Phase 11 — components-core (entire v5 module)
Phase 12 — action-core (entire v5 module)
Phase 13 — sessions-core (entire v5 module)
Phase 14 — action, components-compose, drop-in-compose (v5 utility modules)
Phase 15 — 34 v5-only payment method modules

## Ticket Number
COSDK-1121