### PR TITLE
v6 - Deprecate old public classes - googlepay

### DIFF
--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/old/AllowedAuthMethods.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/old/AllowedAuthMethods.kt
@@ -10,6 +10,10 @@ package com.adyen.checkout.googlepay.old
 /**
  * The authentication methods accepted by Google Pay.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("MemberVisibilityCanBePrivate")
 object AllowedAuthMethods {
 

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/old/AllowedCardNetworks.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/old/AllowedCardNetworks.kt
@@ -10,6 +10,10 @@ package com.adyen.checkout.googlepay.old
 /**
  * The card networks accepted by Google Pay.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("MemberVisibilityCanBePrivate")
 object AllowedCardNetworks {
 

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/old/BillingAddressParameters.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/old/BillingAddressParameters.kt
@@ -24,6 +24,10 @@ import org.json.JSONObject
  * @param format The format of the billing address. Check the Google Pay SDK documentation for the possible values.
  * @param isPhoneNumberRequired Set to true if a phone number is required for the billing address.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("MaxLineLength")
 @Parcelize
 data class BillingAddressParameters(

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/old/GooglePayButtonParameters.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/old/GooglePayButtonParameters.kt
@@ -11,6 +11,10 @@ package com.adyen.checkout.googlepay.old
 /**
  * Class containing some of the parameters required to initialize the Google Pay button.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class GooglePayButtonParameters(
     val allowedPaymentMethods: String,
 )

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/old/GooglePayButtonStyling.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/old/GooglePayButtonStyling.kt
@@ -20,6 +20,10 @@ import kotlinx.parcelize.Parcelize
  * @param buttonType Changes the text displayed inside of the button.
  * @param cornerRadius Sets the corner radius of the button. For example, passing 16 means the radius will be 16 dp.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("MaxLineLength")
 @Parcelize
 data class GooglePayButtonStyling(
@@ -28,6 +32,10 @@ data class GooglePayButtonStyling(
     @Dimension(Dimension.DP) val cornerRadius: Int? = null,
 ) : Parcelable
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 enum class GooglePayButtonTheme(
     val value: Int,
 ) {
@@ -35,6 +43,10 @@ enum class GooglePayButtonTheme(
     DARK(ButtonConstants.ButtonTheme.DARK),
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 enum class GooglePayButtonType(
     val value: Int,
 ) {

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/old/GooglePayCancellationException.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/old/GooglePayCancellationException.kt
@@ -13,4 +13,8 @@ import com.adyen.checkout.core.old.exception.CancellationException
 /**
  * This exception indicates that the payment flow was manually cancelled by the user.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class GooglePayCancellationException(errorMessage: String) : CancellationException(errorMessage)

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/old/GooglePayComponent.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/old/GooglePayComponent.kt
@@ -38,6 +38,10 @@ import kotlinx.coroutines.flow.Flow
  * A [PaymentComponent] that supports the [PaymentMethodTypes.GOOGLE_PAY] and [PaymentMethodTypes.GOOGLE_PAY_LEGACY]
  * payment methods.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class GooglePayComponent internal constructor(
     private val googlePayDelegate: GooglePayDelegate,
     private val genericActionDelegate: GenericActionDelegate,

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/old/GooglePayComponentState.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/old/GooglePayComponentState.kt
@@ -15,6 +15,10 @@ import com.google.android.gms.wallet.PaymentData
 /**
  * Represents the state of [GooglePayComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class GooglePayComponentState(
     override val data: PaymentComponentData<GooglePayPaymentMethod>,
     override val isInputValid: Boolean,

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/old/GooglePayConfiguration.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/old/GooglePayConfiguration.kt
@@ -29,6 +29,10 @@ import java.util.Locale
 /**
  * Configuration class for the [GooglePayComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class GooglePayConfiguration private constructor(
@@ -62,6 +66,10 @@ class GooglePayConfiguration private constructor(
     /**
      * Builder to create a [GooglePayConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     @Suppress("TooManyFunctions")
     class Builder :
         ActionHandlingPaymentMethodConfigurationBuilder<GooglePayConfiguration, Builder>,
@@ -453,6 +461,10 @@ class GooglePayConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.googlePay(
     configuration: @CheckoutConfigurationMarker GooglePayConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/old/GooglePayUnavailableException.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/old/GooglePayUnavailableException.kt
@@ -10,6 +10,10 @@ package com.adyen.checkout.googlepay.old
 
 import com.adyen.checkout.components.core.PaymentMethodUnavailableException
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class GooglePayUnavailableException(
     cause: Throwable? = null,
 ) : PaymentMethodUnavailableException(

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/old/MerchantInfo.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/old/MerchantInfo.kt
@@ -23,6 +23,10 @@ import org.json.JSONObject
  * @param merchantId The id of the merchant.
  * @param softwareInfo Information associated with the caller of the request.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class MerchantInfo(
     var merchantName: String? = null,

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/old/ShippingAddressParameters.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/old/ShippingAddressParameters.kt
@@ -25,6 +25,10 @@ import org.json.JSONObject
  * @param allowedCountryCodes A list of ISO 3166-1 alpha-2 country code values where shipping is allowed.
  * @param isPhoneNumberRequired Set to true if a phone number is required for the shipping address.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("MaxLineLength")
 @Parcelize
 data class ShippingAddressParameters(

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/old/SoftwareInfo.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/old/SoftwareInfo.kt
@@ -20,6 +20,10 @@ import org.json.JSONObject
  * @param id The id of the client / library making the call.
  * @param version The version of the caller
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class SoftwareInfo(
     val id: String,

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/old/GooglePayComponentTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/old/GooglePayComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 3/2/2026.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.googlepay.old
 
 import android.app.Activity

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/old/GooglePayConfigurationTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/old/GooglePayConfigurationTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 3/2/2026.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.googlepay.old
 
 import com.adyen.checkout.components.core.Amount

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/old/internal/ui/DefaultGooglePayDelegateTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/old/internal/ui/DefaultGooglePayDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 3/2/2026.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.googlepay.old.internal.ui
 
 import android.app.Activity

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/old/internal/ui/model/GooglePayComponentParamsMapperTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/old/internal/ui/model/GooglePayComponentParamsMapperTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 18/11/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.googlepay.old.internal.ui.model
 
 import com.adyen.checkout.components.core.Amount

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/old/internal/util/GooglePayUtilsTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/old/internal/util/GooglePayUtilsTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 3/2/2026.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.googlepay.old.internal.util
 
 import com.adyen.checkout.components.core.Amount


### PR DESCRIPTION
## Description

Deprecate all v5 public classes with `@Deprecated` annotations to prepare for the v6 release.
Deprecated code will be removed before the v6 production release.

### Progress

✅ Phase 1 — [checkout-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2707)
✅ Phase 2 — [ui-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2708)
✅ Phase 3 — [card (.old packages)](https://github.com/Adyen/adyen-android/pull/2709)
➡️ **Phase 4 — googlepay (.old packages)**
Phase 5 — drop-in (.old packages)
Phase 6 — 3ds2 (.old packages)
Phase 7 — mbway (.old packages)
Phase 8 — blik (.old packages)
Phase 9 — await (.old packages)
Phase 10 — redirect (.old packages)
Phase 11 — components-core (entire v5 module)
Phase 12 — action-core (entire v5 module)
Phase 13 — sessions-core (entire v5 module)
Phase 14 — action, components-compose, drop-in-compose (v5 utility modules)
Phase 15 — 34 v5-only payment method modules

## Ticket Number
COSDK-1121