### PR TITLE
v6 - Deprecate old public classes - drop-in

### DIFF
--- a/drop-in/src/main/java/com/adyen/checkout/dropin/old/BaseDropInServiceContract.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/old/BaseDropInServiceContract.kt
@@ -14,6 +14,10 @@ import com.adyen.checkout.components.core.LookupAddress
 import com.adyen.checkout.components.core.StoredPaymentMethod
 import com.adyen.checkout.core.old.exception.MethodNotImplementedException
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("TooManyFunctions")
 interface BaseDropInServiceContract {
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/old/DialogData.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/old/DialogData.kt
@@ -14,6 +14,10 @@ package com.adyen.checkout.dropin.old
  * @param title The title displayed in the dialog. If not provided a generic error title will be shown.
  * @param message The message displayed in the dialog. If not provided a generic error message will be shown.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class ErrorDialog(
     val title: String? = null,
     val message: String? = null,
@@ -25,6 +29,10 @@ data class ErrorDialog(
  * @param title The title displayed in the dialog.
  * @param message The message displayed in the dialog.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class FinishedDialog(
     val title: String,
     val message: String,

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/old/DropIn.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/old/DropIn.kt
@@ -38,6 +38,10 @@ import java.util.Locale
  * To start the checkout flow, register you activity or fragment using [registerForDropInResult] to receive the result
  * of Drop-in. Then call one of the [startPayment] methods.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 object DropIn {
 
     internal const val RESULT_KEY = "payment_result"

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/old/DropInCallback.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/old/DropInCallback.kt
@@ -11,6 +11,10 @@ package com.adyen.checkout.dropin.old
 /**
  * A class that defines the callbacks from Drop-in to the Activity or Fragment that launched it.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun interface DropInCallback {
 
     /**

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/old/DropInConfiguration.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/old/DropInConfiguration.kt
@@ -62,6 +62,10 @@ import kotlin.collections.set
  * their behavior.
  * If you don't specify anything, a default configuration will be used.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class DropInConfiguration private constructor(
@@ -102,6 +106,10 @@ class DropInConfiguration private constructor(
     /**
      * Builder for creating a [DropInConfiguration] where you can set specific Configurations for a Payment Method
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     @Suppress("unused", "TooManyFunctions")
     class Builder :
         ActionHandlingPaymentMethodConfigurationBuilder<DropInConfiguration, Builder> {
@@ -512,6 +520,10 @@ class DropInConfiguration private constructor(
 
 private const val DROP_IN_CONFIG_KEY = "DROP_IN_CONFIG_KEY"
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.dropIn(
     configuration: @CheckoutConfigurationMarker Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/old/DropInRedirectHandlingActivity.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/old/DropInRedirectHandlingActivity.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.core.old.AdyenLogLevel
 import com.adyen.checkout.core.old.internal.util.adyenLog
 import com.adyen.checkout.dropin.old.internal.ui.DropInActivity
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class DropInRedirectHandlingActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/old/DropInResult.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/old/DropInResult.kt
@@ -11,11 +11,19 @@ package com.adyen.checkout.dropin.old
 /**
  * A class that contains the final result of Drop-in.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 sealed class DropInResult {
 
     /**
      * Drop-in was dismissed by the user before it has completed.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class CancelledByUser : DropInResult()
 
     /**
@@ -28,6 +36,10 @@ sealed class DropInResult {
      *
      * @param reason The reason of the error.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Error(val reason: String?) : DropInResult()
 
     /**
@@ -36,5 +48,9 @@ sealed class DropInResult {
      *
      * @param result The result of Drop-in, mirrors the value of [DropInServiceResult.Finished.result].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Finished(val result: String) : DropInResult()
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/old/DropInResultContract.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/old/DropInResultContract.kt
@@ -16,6 +16,10 @@ import androidx.activity.result.contract.ActivityResultContract
 import com.adyen.checkout.dropin.old.internal.ui.DropInActivity
 import com.adyen.checkout.dropin.old.internal.ui.model.DropInResultContractParams
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class DropInResultContract : ActivityResultContract<DropInResultContractParams, DropInResult?>() {
     override fun createIntent(context: Context, input: DropInResultContractParams): Intent {
         return DropInActivity.createIntent(

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/old/DropInService.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/old/DropInService.kt
@@ -24,6 +24,10 @@ import com.adyen.checkout.dropin.old.internal.service.BaseDropInService
  * You need to implement the [onSubmit] and [onAdditionalDetails] with this service. The rest of the methods are
  * optional.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 abstract class DropInService : BaseDropInService(), DropInServiceContract {
 
     final override fun requestPaymentsCall(paymentComponentState: PaymentComponentState<*>) {

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/old/DropInServiceContract.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/old/DropInServiceContract.kt
@@ -16,6 +16,10 @@ import com.adyen.checkout.components.core.paymentmethod.PaymentMethodDetails
 import com.adyen.checkout.core.old.exception.MethodNotImplementedException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 interface DropInServiceContract {
 
     /**

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/old/DropInServiceResult.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/old/DropInServiceResult.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.PaymentMethodsApiResponse
 import com.adyen.checkout.sessions.core.SessionPaymentResult
 import com.adyen.checkout.components.core.action.Action as ActionResponse
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 sealed class BaseDropInServiceResult
 
 internal interface DropInServiceResultError {
@@ -26,6 +30,10 @@ internal interface DropInServiceResultError {
 /**
  * The result of a network call to be sent to [DropInService] or [SessionDropInService].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 sealed class DropInServiceResult : BaseDropInServiceResult() {
 
     /**
@@ -38,6 +46,10 @@ sealed class DropInServiceResult : BaseDropInServiceResult() {
      * @param finishedDialog If set, a dialog will be shown with the data passed in [FinishedDialog]. If null, no
      * dialog will be displayed.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Finished(
         val result: String,
         val finishedDialog: FinishedDialog? = null,
@@ -50,6 +62,10 @@ sealed class DropInServiceResult : BaseDropInServiceResult() {
      *
      * @param action the action object to be handled by Drop-in.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Action(val action: ActionResponse) : DropInServiceResult()
 
     /**
@@ -68,6 +84,10 @@ sealed class DropInServiceResult : BaseDropInServiceResult() {
      * @param paymentMethodsApiResponse the updated payment methods list.
      * @param order the order object returned from the backend, or null if an order was cancelled.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Update(
         val paymentMethodsApiResponse: PaymentMethodsApiResponse,
         val order: OrderResponse?
@@ -82,6 +102,10 @@ sealed class DropInServiceResult : BaseDropInServiceResult() {
      * value is not used internally by Drop-in.
      * @param dismissDropIn whether Drop-in should be dismissed after presenting the Alert Dialog.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Error(
         override val errorDialog: ErrorDialog?,
         override val reason: String? = null,
@@ -94,11 +118,19 @@ sealed class DropInServiceResult : BaseDropInServiceResult() {
      *
      * @param paymentMethodsApiResponse Optionally pass this to refresh the displayed payment methods.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class ToPaymentMethodsList(
         val paymentMethodsApiResponse: PaymentMethodsApiResponse? = null,
     ) : DropInServiceResult()
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 sealed class BalanceDropInServiceResult : BaseDropInServiceResult() {
 
     /**
@@ -108,6 +140,10 @@ sealed class BalanceDropInServiceResult : BaseDropInServiceResult() {
      *
      * Use [BalanceResult.SERIALIZER] to deserialize your JSON response string.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Balance(val balance: BalanceResult) : BalanceDropInServiceResult()
 
     /**
@@ -121,6 +157,10 @@ sealed class BalanceDropInServiceResult : BaseDropInServiceResult() {
      * value is not used internally by Drop-in.
      * @param dismissDropIn whether Drop-in should be dismissed after presenting the Alert Dialog.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Error(
         override val errorDialog: ErrorDialog?,
         override val reason: String? = null,
@@ -128,6 +168,10 @@ sealed class BalanceDropInServiceResult : BaseDropInServiceResult() {
     ) : BalanceDropInServiceResult(), DropInServiceResultError
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 sealed class OrderDropInServiceResult : BaseDropInServiceResult() {
 
     /**
@@ -137,6 +181,10 @@ sealed class OrderDropInServiceResult : BaseDropInServiceResult() {
      *
      * Use [OrderResponse.SERIALIZER] to deserialize your JSON response string.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class OrderCreated(val order: OrderResponse) : OrderDropInServiceResult()
 
     /**
@@ -150,6 +198,10 @@ sealed class OrderDropInServiceResult : BaseDropInServiceResult() {
      * value is not used internally by Drop-in.
      * @param dismissDropIn whether Drop-in should be dismissed after presenting the Alert Dialog.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Error(
         override val errorDialog: ErrorDialog?,
         override val reason: String? = null,
@@ -157,6 +209,10 @@ sealed class OrderDropInServiceResult : BaseDropInServiceResult() {
     ) : OrderDropInServiceResult(), DropInServiceResultError
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 sealed class RecurringDropInServiceResult : BaseDropInServiceResult() {
 
     /**
@@ -166,6 +222,10 @@ sealed class RecurringDropInServiceResult : BaseDropInServiceResult() {
      *
      * @param id Id of the stored payment method.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class PaymentMethodRemoved(val id: String) : RecurringDropInServiceResult()
 
     /**
@@ -179,6 +239,10 @@ sealed class RecurringDropInServiceResult : BaseDropInServiceResult() {
      * value is not used internally by Drop-in.
      * @param dismissDropIn whether Drop-in should be dismissed after presenting the Alert Dialog.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Error(
         override val errorDialog: ErrorDialog?,
         override val reason: String? = null,
@@ -186,6 +250,10 @@ sealed class RecurringDropInServiceResult : BaseDropInServiceResult() {
     ) : RecurringDropInServiceResult(), DropInServiceResultError
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 sealed class AddressLookupDropInServiceResult : BaseDropInServiceResult() {
 
     /**
@@ -195,6 +263,10 @@ sealed class AddressLookupDropInServiceResult : BaseDropInServiceResult() {
      *
      * @param options Address options to be displayed to the shopper.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class LookupResult(
         val options: List<LookupAddress>
     ) : AddressLookupDropInServiceResult()
@@ -206,6 +278,10 @@ sealed class AddressLookupDropInServiceResult : BaseDropInServiceResult() {
      *
      * @param lookupAddress Complete address details.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class LookupComplete(
         val lookupAddress: LookupAddress
     ) : AddressLookupDropInServiceResult()
@@ -221,6 +297,10 @@ sealed class AddressLookupDropInServiceResult : BaseDropInServiceResult() {
      * value is not used internally by Drop-in.
      * @param dismissDropIn whether Drop-in should be dismissed after presenting the Alert Dialog.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Error(
         override val errorDialog: ErrorDialog?,
         override val reason: String? = null,

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/old/SessionDropInCallback.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/old/SessionDropInCallback.kt
@@ -11,6 +11,10 @@ package com.adyen.checkout.dropin.old
 /**
  * A class that defines the callbacks from Drop-in to the Activity or Fragment that launched it.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun interface SessionDropInCallback {
 
     /**

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/old/SessionDropInResult.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/old/SessionDropInResult.kt
@@ -13,11 +13,19 @@ import com.adyen.checkout.sessions.core.SessionPaymentResult
 /**
  * A class that contains the final result of Drop-in.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 sealed class SessionDropInResult {
 
     /**
      * Drop-in was dismissed by the user before it has completed.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class CancelledByUser : SessionDropInResult()
 
     /**
@@ -30,6 +38,10 @@ sealed class SessionDropInResult {
      *
      * @param reason The reason of the error.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Error(val reason: String?) : SessionDropInResult()
 
     /**
@@ -38,5 +50,9 @@ sealed class SessionDropInResult {
      *
      * @param result The result of the payment.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Finished(val result: SessionPaymentResult) : SessionDropInResult()
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/old/SessionDropInResultContract.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/old/SessionDropInResultContract.kt
@@ -17,6 +17,10 @@ import com.adyen.checkout.dropin.old.internal.ui.DropInActivity
 import com.adyen.checkout.dropin.old.internal.ui.model.SessionDropInResultContractParams
 import com.adyen.checkout.sessions.core.SessionPaymentResult
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class SessionDropInResultContract :
     ActivityResultContract<SessionDropInResultContractParams, SessionDropInResult?>() {
     override fun createIntent(context: Context, input: SessionDropInResultContractParams): Intent {

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/old/SessionDropInService.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/old/SessionDropInService.kt
@@ -36,6 +36,10 @@ import kotlinx.coroutines.launch
  *
  * Make sure you define add your subclass of this [SessionDropInService] in your manifest file.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 open class SessionDropInService : BaseDropInService(), SessionDropInServiceInterface, SessionDropInServiceContract {
 
     private lateinit var sessionInteractor: SessionInteractor

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/old/SessionDropInServiceContract.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/old/SessionDropInServiceContract.kt
@@ -16,6 +16,10 @@ import com.adyen.checkout.components.core.paymentmethod.PaymentMethodDetails
 import com.adyen.checkout.core.old.exception.MethodNotImplementedException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 interface SessionDropInServiceContract {
 
     /**

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/old/DropInConfigurationTest.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/old/DropInConfigurationTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 5/11/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.dropin.old
 
 import com.adyen.checkout.card.old.CardConfiguration

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/old/internal/ConfigurationProvider.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/old/internal/ConfigurationProvider.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 5/11/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.dropin.old.internal
 
 import com.adyen.checkout.bcmc.bcmc

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/old/internal/DataProvider.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/old/internal/DataProvider.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 5/11/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.dropin.old.internal
 
 import com.adyen.checkout.components.core.PaymentMethod

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/old/internal/Helpers.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/old/internal/Helpers.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 5/11/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.dropin.old.internal
 
 import com.adyen.checkout.components.core.PaymentMethod

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/old/internal/ui/DropInConfigDataGeneratorTest.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/old/internal/ui/DropInConfigDataGeneratorTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 5/11/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.dropin.old.internal.ui
 
 import com.adyen.checkout.components.core.internal.ui.model.AnalyticsParams

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/old/internal/ui/DropInViewModelFactoryTest.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/old/internal/ui/DropInViewModelFactoryTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 5/11/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.dropin.old.internal.ui
 
 import com.adyen.checkout.components.core.PaymentMethod

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/old/internal/ui/DropInViewModelTest.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/old/internal/ui/DropInViewModelTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 5/11/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.dropin.old.internal.ui
 
 import com.adyen.checkout.components.core.Amount

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/old/internal/ui/PaymentMethodsListViewModelTest.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/old/internal/ui/PaymentMethodsListViewModelTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 5/11/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.dropin.old.internal.ui
 
 import android.app.Application

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/old/internal/ui/PreselectedStoredPaymentViewModelTest.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/old/internal/ui/PreselectedStoredPaymentViewModelTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 5/11/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.dropin.old.internal.ui
 
 import app.cash.turbine.test

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/old/internal/ui/TestComponentState.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/old/internal/ui/TestComponentState.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 22/2/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.dropin.old.internal.ui
 
 import com.adyen.checkout.components.core.PaymentComponentData

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/old/internal/ui/model/DropInParamsMapperTest.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/old/internal/ui/model/DropInParamsMapperTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 5/11/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.dropin.old.internal.ui.model
 
 import android.os.Bundle


### PR DESCRIPTION
## Description

Deprecate all v5 public classes with `@Deprecated` annotations to prepare for the v6 release.
Deprecated code will be removed before the v6 production release.

### Progress

✅ Phase 1 — [checkout-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2707)
✅ Phase 2 — [ui-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2708)
✅ Phase 3 — [card (.old packages)](https://github.com/Adyen/adyen-android/pull/2709)
✅ Phase 4 — [googlepay (.old packages)](https://github.com/Adyen/adyen-android/pull/2711)
➡️ **Phase 5 — drop-in (.old packages)**
Phase 6 — 3ds2 (.old packages)
Phase 7 — mbway (.old packages)
Phase 8 — blik (.old packages)
Phase 9 — await (.old packages)
Phase 10 — redirect (.old packages)
Phase 11 — components-core (entire v5 module)
Phase 12 — action-core (entire v5 module)
Phase 13 — sessions-core (entire v5 module)
Phase 14 — action, components-compose, drop-in-compose (v5 utility modules)
Phase 15 — 34 v5-only payment method modules

## Ticket Number
COSDK-1121