### PR TITLE
v6 - Deprecate old public classes - 3ds2

### DIFF
--- a/3ds2/src/main/java/com/adyen/checkout/threeds2/old/Adyen3DS2Component.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/threeds2/old/Adyen3DS2Component.kt
@@ -30,6 +30,10 @@ import kotlinx.coroutines.flow.Flow
 /**
  * An [ActionComponent] that is able to handle 3DS2 related actions.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class Adyen3DS2Component internal constructor(
     override val delegate: Adyen3DS2Delegate,
     internal val actionComponentEventHandler: ActionComponentEventHandler,

--- a/3ds2/src/main/java/com/adyen/checkout/threeds2/old/Adyen3DS2Configuration.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/threeds2/old/Adyen3DS2Configuration.kt
@@ -24,6 +24,10 @@ import java.util.Locale
 /**
  * Configuration class for the [Adyen3DS2Component].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("LongParameterList")
 @Parcelize
 class Adyen3DS2Configuration private constructor(
@@ -39,6 +43,10 @@ class Adyen3DS2Configuration private constructor(
     /**
      * Builder to create an [Adyen3DS2Configuration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : BaseConfigurationBuilder<Adyen3DS2Configuration, Builder> {
 
         private var uiCustomization: UiCustomization? = null
@@ -126,6 +134,10 @@ class Adyen3DS2Configuration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.adyen3DS2(
     configuration: @CheckoutConfigurationMarker Adyen3DS2Configuration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/3ds2/src/main/java/com/adyen/checkout/threeds2/old/Authentication3DS2Exception.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/threeds2/old/Authentication3DS2Exception.kt
@@ -13,6 +13,10 @@ import com.adyen.checkout.core.old.exception.ComponentException
  * This exception is just an indication that the 3DS2 Authentication did not finish as expected.
  * Can be caused by an actual error, like a timeout or a runtime exception.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class Authentication3DS2Exception(errorMessage: String) : ComponentException(errorMessage) {
     companion object {
         private const val serialVersionUID = 7142998120028361912L

--- a/3ds2/src/main/java/com/adyen/checkout/threeds2/old/Cancelled3DS2Exception.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/threeds2/old/Cancelled3DS2Exception.kt
@@ -12,7 +12,10 @@ import com.adyen.checkout.core.old.exception.ComponentException
 /**
  * This exception is an indication that the 3DS2 Authentication was cancelled by the user.
  */
-@Deprecated("This exception is no longer in use")
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class Cancelled3DS2Exception(errorMessage: String) : ComponentException(errorMessage) {
     companion object {
         private const val serialVersionUID = 3858008275644429050L

--- a/3ds2/src/test/java/com/adyen/checkout/threeds2/old/Adyen3DS2ComponentTest.kt
+++ b/3ds2/src/test/java/com/adyen/checkout/threeds2/old/Adyen3DS2ComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 3/12/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.threeds2.old
 
 import android.app.Activity

--- a/3ds2/src/test/java/com/adyen/checkout/threeds2/old/Adyen3DS2ConfigurationTest.kt
+++ b/3ds2/src/test/java/com/adyen/checkout/threeds2/old/Adyen3DS2ConfigurationTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 3/12/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.threeds2.old
 
 import com.adyen.checkout.components.core.Amount

--- a/3ds2/src/test/java/com/adyen/checkout/threeds2/old/internal/ui/DefaultAdyen3DS2DelegateTest.kt
+++ b/3ds2/src/test/java/com/adyen/checkout/threeds2/old/internal/ui/DefaultAdyen3DS2DelegateTest.kt
@@ -7,6 +7,7 @@
  */
 
 @file:OptIn(ExperimentalEncodingApi::class)
+@file:Suppress("DEPRECATION")
 
 package com.adyen.checkout.threeds2.old.internal.ui
 

--- a/3ds2/src/test/java/com/adyen/checkout/threeds2/old/internal/ui/model/Adyen3DS2ComponentParamsMapperTest.kt
+++ b/3ds2/src/test/java/com/adyen/checkout/threeds2/old/internal/ui/model/Adyen3DS2ComponentParamsMapperTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 30/10/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.threeds2.old.internal.ui.model
 
 import com.adyen.checkout.components.core.Amount


### PR DESCRIPTION
## Description

Deprecate all v5 public classes with `@Deprecated` annotations to prepare for the v6 release.
Deprecated code will be removed before the v6 production release.

### Progress

✅ Phase 1 — [checkout-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2707)
✅ Phase 2 — [ui-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2708)
✅ Phase 3 — [card (.old packages)](https://github.com/Adyen/adyen-android/pull/2709)
✅ Phase 4 — [googlepay (.old packages)](https://github.com/Adyen/adyen-android/pull/2711)
✅ Phase 5 — [drop-in (.old packages)](https://github.com/Adyen/adyen-android/pull/2712)
➡️ **Phase 6 — 3ds2 (.old packages)**
Phase 7 — mbway (.old packages)
Phase 8 — blik (.old packages)
Phase 9 — await (.old packages)
Phase 10 — redirect (.old packages)
Phase 11 — components-core (entire v5 module)
Phase 12 — action-core (entire v5 module)
Phase 13 — sessions-core (entire v5 module)
Phase 14 — action, components-compose, drop-in-compose (v5 utility modules)
Phase 15 — 34 v5-only payment method modules

## Ticket Number
COSDK-1121
