### PR TITLE
v6 - Deprecate old public classes - mbway

### DIFF
--- a/mbway/src/main/java/com/adyen/checkout/mbway/old/MBWayComponent.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/old/MBWayComponent.kt
@@ -33,6 +33,10 @@ import kotlinx.coroutines.flow.Flow
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.MB_WAY] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class MBWayComponent internal constructor(
     private val mbWayDelegate: MBWayDelegate,
     private val genericActionDelegate: GenericActionDelegate,

--- a/mbway/src/main/java/com/adyen/checkout/mbway/old/MBWayComponentState.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/old/MBWayComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.MBWayPaymentMethod
 /**
  * Represents the state of [MBWayComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class MBWayComponentState(
     override val data: PaymentComponentData<MBWayPaymentMethod>,
     override val isInputValid: Boolean,

--- a/mbway/src/main/java/com/adyen/checkout/mbway/old/MBWayConfiguration.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/old/MBWayConfiguration.kt
@@ -25,6 +25,10 @@ import java.util.Locale
 /**
  * Configuration class for the [MBWayComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class MBWayConfiguration private constructor(
@@ -40,6 +44,10 @@ class MBWayConfiguration private constructor(
     /**
      * Builder to create an [MBWayConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder :
         ActionHandlingPaymentMethodConfigurationBuilder<MBWayConfiguration, Builder>,
         ButtonConfigurationBuilder {
@@ -115,6 +123,10 @@ class MBWayConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.mbWay(
     configuration: @CheckoutConfigurationMarker MBWayConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/mbway/src/test/java/com/adyen/checkout/mbway/old/MBWayComponentTest.kt
+++ b/mbway/src/test/java/com/adyen/checkout/mbway/old/MBWayComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 8/7/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.mbway.old
 
 import androidx.lifecycle.LifecycleOwner

--- a/mbway/src/test/java/com/adyen/checkout/mbway/old/MBWayConfigurationTest.kt
+++ b/mbway/src/test/java/com/adyen/checkout/mbway/old/MBWayConfigurationTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 8/7/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.mbway.old
 
 import com.adyen.checkout.components.core.Amount

--- a/mbway/src/test/java/com/adyen/checkout/mbway/old/internal/ui/DefaultMBWayDelegateTest.kt
+++ b/mbway/src/test/java/com/adyen/checkout/mbway/old/internal/ui/DefaultMBWayDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 8/7/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.mbway.old.internal.ui
 
 import app.cash.turbine.test


### PR DESCRIPTION
## Description

Deprecate all v5 public classes with `@Deprecated` annotations to prepare for the v6 release.
Deprecated code will be removed before the v6 production release.

### Progress

✅ Phase 1 — [checkout-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2707)
✅ Phase 2 — [ui-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2708)
✅ Phase 3 — [card (.old packages)](https://github.com/Adyen/adyen-android/pull/2709)
✅ Phase 4 — [googlepay (.old packages)](https://github.com/Adyen/adyen-android/pull/2711)
✅ Phase 5 — [drop-in (.old packages)](https://github.com/Adyen/adyen-android/pull/2712)
✅ Phase 6 — [3ds2 (.old packages)](https://github.com/Adyen/adyen-android/pull/2713)
➡️ **Phase 7 — mbway (.old packages)**
Phase 8 — blik (.old packages)
Phase 9 — await (.old packages)
Phase 10 — redirect (.old packages)
Phase 11 — components-core (entire v5 module)
Phase 12 — action-core (entire v5 module)
Phase 13 — sessions-core (entire v5 module)
Phase 14 — action, components-compose, drop-in-compose (v5 utility modules)
Phase 15 — 34 v5-only payment method modules

## Ticket Number
COSDK-1121
