### PR TITLE
v6 - Deprecate old public classes - blik

### DIFF
--- a/blik/src/main/java/com/adyen/checkout/blik/old/BlikComponent.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/old/BlikComponent.kt
@@ -33,6 +33,10 @@ import kotlinx.coroutines.flow.Flow
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.BLIK] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class BlikComponent internal constructor(
     private val blikDelegate: BlikDelegate,
     private val genericActionDelegate: GenericActionDelegate,

--- a/blik/src/main/java/com/adyen/checkout/blik/old/BlikComponentState.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/old/BlikComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.BlikPaymentMethod
 /**
  * Represents the state of [BlikComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class BlikComponentState(
     override val data: PaymentComponentData<BlikPaymentMethod>,
     override val isInputValid: Boolean,

--- a/blik/src/main/java/com/adyen/checkout/blik/old/BlikConfiguration.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/old/BlikConfiguration.kt
@@ -25,6 +25,10 @@ import java.util.Locale
 /**
  * Configuration class for the [BlikConfiguration].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class BlikConfiguration private constructor(
@@ -40,6 +44,10 @@ class BlikConfiguration private constructor(
     /**
      * Builder to create a [BlikConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder :
         ActionHandlingPaymentMethodConfigurationBuilder<BlikConfiguration, Builder>,
         ButtonConfigurationBuilder {
@@ -115,6 +123,10 @@ class BlikConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.blik(
     configuration: @CheckoutConfigurationMarker BlikConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/blik/src/test/java/com/adyen/checkout/blik/old/BlikComponentTest.kt
+++ b/blik/src/test/java/com/adyen/checkout/blik/old/BlikComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 17/12/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.blik.old
 
 import androidx.lifecycle.LifecycleOwner

--- a/blik/src/test/java/com/adyen/checkout/blik/old/BlikConfigurationTest.kt
+++ b/blik/src/test/java/com/adyen/checkout/blik/old/BlikConfigurationTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 17/12/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.blik.old
 
 import com.adyen.checkout.components.core.Amount

--- a/blik/src/test/java/com/adyen/checkout/blik/old/internal/ui/DefaultBlikDelegateTest.kt
+++ b/blik/src/test/java/com/adyen/checkout/blik/old/internal/ui/DefaultBlikDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 17/12/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.blik.old.internal.ui
 
 import app.cash.turbine.test

--- a/blik/src/test/java/com/adyen/checkout/blik/old/internal/ui/StoredBlikDelegateTest.kt
+++ b/blik/src/test/java/com/adyen/checkout/blik/old/internal/ui/StoredBlikDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 17/12/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.blik.old.internal.ui
 
 import app.cash.turbine.test


### PR DESCRIPTION
## Description

Deprecate all v5 public classes with `@Deprecated` annotations to prepare for the v6 release.
Deprecated code will be removed before the v6 production release.

### Progress

✅ Phase 1 — [checkout-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2707)
✅ Phase 2 — [ui-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2708)
✅ Phase 3 — [card (.old packages)](https://github.com/Adyen/adyen-android/pull/2709)
✅ Phase 4 — [googlepay (.old packages)](https://github.com/Adyen/adyen-android/pull/2711)
✅ Phase 5 — [drop-in (.old packages)](https://github.com/Adyen/adyen-android/pull/2712)
✅ Phase 6 — [3ds2 (.old packages)](https://github.com/Adyen/adyen-android/pull/2713)
✅ Phase 7 — [mbway (.old packages)](https://github.com/Adyen/adyen-android/pull/2714)
➡️ **Phase 8 — blik (.old packages)**
Phase 9 — await (.old packages)
Phase 10 — redirect (.old packages)
Phase 11 — components-core (entire v5 module)
Phase 12 — action-core (entire v5 module)
Phase 13 — sessions-core (entire v5 module)
Phase 14 — action, components-compose, drop-in-compose (v5 utility modules)
Phase 15 — 34 v5-only payment method modules

## Ticket Number
COSDK-1121
