### PR TITLE
v6 - Deprecate old public classes - await

### DIFF
--- a/await/src/main/java/com/adyen/checkout/await/old/AwaitComponent.kt
+++ b/await/src/main/java/com/adyen/checkout/await/old/AwaitComponent.kt
@@ -28,6 +28,10 @@ import kotlinx.coroutines.flow.Flow
 /**
  * An [ActionComponent] that is able to handle the 'await' action.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class AwaitComponent internal constructor(
     override val delegate: AwaitDelegate,
     internal val actionComponentEventHandler: ActionComponentEventHandler,

--- a/await/src/main/java/com/adyen/checkout/await/old/AwaitConfiguration.kt
+++ b/await/src/main/java/com/adyen/checkout/await/old/AwaitConfiguration.kt
@@ -22,6 +22,10 @@ import java.util.Locale
 /**
  * Configuration class for the [AwaitComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class AwaitConfiguration private constructor(
     override val shopperLocale: Locale?,
@@ -34,6 +38,10 @@ class AwaitConfiguration private constructor(
     /**
      * Builder to create an [AwaitConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : BaseConfigurationBuilder<AwaitConfiguration, Builder> {
 
         /**
@@ -91,6 +99,10 @@ class AwaitConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.await(
     configuration: @CheckoutConfigurationMarker AwaitConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/await/src/test/java/com/adyen/checkout/await/old/AwaitComponentTest.kt
+++ b/await/src/test/java/com/adyen/checkout/await/old/AwaitComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 19/12/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.await.old
 
 import android.app.Activity

--- a/await/src/test/java/com/adyen/checkout/await/old/AwaitConfigurationTest.kt
+++ b/await/src/test/java/com/adyen/checkout/await/old/AwaitConfigurationTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 11/7/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.await.old
 
 import com.adyen.checkout.components.core.Amount

--- a/await/src/test/java/com/adyen/checkout/await/old/internal/ui/DefaultAwaitDelegateTest.kt
+++ b/await/src/test/java/com/adyen/checkout/await/old/internal/ui/DefaultAwaitDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 14/7/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.await.old.internal.ui
 
 import android.app.Activity


### PR DESCRIPTION
## Description

Deprecate all v5 public classes with `@Deprecated` annotations to prepare for the v6 release.
Deprecated code will be removed before the v6 production release.

### Progress

✅ Phase 1 — [checkout-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2707)
✅ Phase 2 — [ui-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2708)
✅ Phase 3 — [card (.old packages)](https://github.com/Adyen/adyen-android/pull/2709)
✅ Phase 4 — [googlepay (.old packages)](https://github.com/Adyen/adyen-android/pull/2711)
✅ Phase 5 — [drop-in (.old packages)](https://github.com/Adyen/adyen-android/pull/2712)
✅ Phase 6 — [3ds2 (.old packages)](https://github.com/Adyen/adyen-android/pull/2713)
✅ Phase 7 — [mbway (.old packages)](https://github.com/Adyen/adyen-android/pull/2714)
✅ Phase 8 — [blik (.old packages)](https://github.com/Adyen/adyen-android/pull/2715)
➡️ **Phase 9 — await (.old packages)**
Phase 10 — redirect (.old packages)
Phase 11 — components-core (entire v5 module)
Phase 12 — action-core (entire v5 module)
Phase 13 — sessions-core (entire v5 module)
Phase 14 — action, components-compose, drop-in-compose (v5 utility modules)
Phase 15 — 34 v5-only payment method modules

## Ticket Number
COSDK-1121
