### PR TITLE
Debug: print api_changes.txt on validate_public_api failure

### DIFF
--- a/.github/workflows/validate_public_api.yml
+++ b/.github/workflows/validate_public_api.yml
@@ -50,6 +50,10 @@ jobs:
         run: |
           if [ -s api_changes.txt ]
           then
+            # DEBUG: print api_changes.txt content to diagnose false positives
+            echo "::group::api_changes.txt content"
+            cat api_changes.txt
+            echo "::endgroup::"
             # Fail workflow if there are API changes
             exit 1
           fi


### PR DESCRIPTION
## Description

Temporary debug line added to `validate_public_api.yml` to print the content of `api_changes.txt` when the check fails.

## Context

PR #2708 (Phase 2 — ui-core deprecation) is flagged with "🚫 Public API changes" despite:
- `.api` files being unchanged
- Local `./gradlew apiCheck` passing with exit code 0 and 0 bytes on stderr
- The generated PR comment having an empty body below the header (diff loop in `process_api_changes.sh` finds no diffs)

The workflow fails because `[ -s api_changes.txt ]` returns true — something on CI writes to stderr during `./gradlew apiCheck` that does not happen locally. This PR adds a `cat api_changes.txt` inside a GitHub Actions log group so the next failed run reveals the actual content.

Once we know what's there, this PR can be replaced with a proper fix that bases the failure signal on actual `.api` diff (e.g. `apiDump` + `git diff --exit-code '**/*.api'`) instead of stderr presence.

## Ticket Number
COSDK-1121
