### PR TITLE
v6 - Fix public api validation false positives

### DIFF
--- a/.github/workflows/validate_public_api.yml
+++ b/.github/workflows/validate_public_api.yml
@@ -32,7 +32,15 @@ jobs:
 
       - name: Check public API
         run: |
-          ( ./gradlew apiCheck --continue 2> "${{ github.workspace }}/api_changes.txt" ) || true
+          # Regenerate all .api files from the current source.
+          ./gradlew apiDump --quiet
+          # Mark any newly-created .api files (e.g. from a new module) as
+          # intent-to-add so they show up in `git diff` even though untracked.
+          git add --intent-to-add -- '**/*.api'
+          # Capture only actual changes to .api files. This ignores unrelated
+          # stderr output from the build (e.g. javac "uses deprecated API" notes,
+          # Gradle deprecation warnings) that previously caused false positives.
+          git diff --no-color -- '**/*.api' > "${{ github.workspace }}/api_changes.txt"
           bash ./scripts/process_api_changes.sh
 
       - name: Comment on PR

--- a/.github/workflows/validate_public_api.yml
+++ b/.github/workflows/validate_public_api.yml
@@ -37,11 +37,7 @@ jobs:
           # Mark any newly-created .api files (e.g. from a new module) as
           # intent-to-add so they show up in `git diff` even though untracked.
           git add --intent-to-add -- '**/*.api'
-          # Capture only actual changes to .api files. This ignores unrelated
-          # stderr output from the build (e.g. javac "uses deprecated API" notes,
-          # Gradle deprecation warnings) that previously caused false positives.
-          git diff --no-color -- '**/*.api' > "${{ github.workspace }}/api_changes.txt"
-          bash ./scripts/process_api_changes.sh
+          git diff --no-color -- '**/*.api' | bash ./scripts/process_api_changes.sh
 
       - name: Comment on PR
         # This step will only run on pull_request events.
@@ -56,8 +52,5 @@ jobs:
 
       - name: Check if successful
         run: |
-          if [ -s api_changes.txt ]
-          then
-            # Fail workflow if there are API changes
-            exit 1
-          fi
+          # Fail the workflow if any `.api` file has uncommitted changes.
+          git diff --quiet -- '**/*.api'

--- a/scripts/process_api_changes.sh
+++ b/scripts/process_api_changes.sh
@@ -33,20 +33,28 @@ fi
         in_block = 0
       }
 
-      # Derive the module name from the b-path (`diff --git a/<path> b/<path>`).
-      match($0, / b\/[^ ]+/)
-      b_path = substr($0, RSTART + 3, RLENGTH - 3)
+      # Derive the module name from the b-path. Match both ` b/...` and
+      # ` "b/..."` (git quotes paths that contain spaces), and only call
+      # `substr` on a successful match.
+      if (match($0, / "?b\//)) {
+        b_path = substr($0, RSTART + RLENGTH)
+        gsub(/"/, "", b_path)
 
-      # Strip `/api/<name>.api` to leave just the module folder
-      # (e.g. `ui-core/api/ui-core.api` → `ui-core`).
-      module = b_path
-      sub(/\/api\/.*/, "", module)
+        # Strip `/api/<name>.api` to leave just the module folder (e.g.
+        # `ui-core/api/ui-core.api` → `ui-core`). Fall back to dropping the
+        # `.api` suffix for paths without a `/api/` segment.
+        module = b_path
+        if (!sub(/\/api\/.*/, "", module)) {
+          sub(/\.api$/, "", module)
+        }
+        if (module == "") module = "root"
 
-      print ""
-      print "## " module
-      print "```diff"
-      in_block = 1
-      skip_header = 1
+        print ""
+        print "## " module
+        print "```diff"
+        in_block = 1
+        skip_header = 1
+      }
       next
     }
     # Skip the remaining git-diff header lines (`index ...`, `new file mode`,

--- a/scripts/process_api_changes.sh
+++ b/scripts/process_api_changes.sh
@@ -8,65 +8,57 @@
 # Created by oscars on 14/6/2024.
 #
 
+# Input is the raw `git diff` output for `.api` files produced by the workflow
+# (see .github/workflows/validate_public_api.yml).
 input_file="api_changes.txt"
 output_file="api_changes.md"
 
-touch "$output_file"
-
-if [ -s $input_file ]
+if [ ! -s "$input_file" ]
 then
-  echo "# 🚫 Public API changes" >> "$output_file"
-else
-  echo "# ✅ No public API changes" >> "$output_file"
+  echo "# ✅ No public API changes" > "$output_file"
   exit 0
 fi
 
-# Find all .api files to loop over later
-api_files=($(find . -name '*.api'))
-api_files_size=${#api_files[@]}
+echo "# 🚫 Public API changes" > "$output_file"
 
-for ((i = 0 ; i < $api_files_size ; i+= 2 )); do
-  git_diff=$(git diff --no-index "${api_files[i]}" "${api_files[i + 1]}")
-  if [ -n "$git_diff" ]
-  then
-    # Add module name as title
-    file_name=${api_files[i]}
-    words=(${file_name//\// })
-    words_size=${#words[@]}
-    last_index=$(( words_size-1))
-    title=${words[$last_index]}
-    title=${title%????}
-    echo "## $title" >> "$output_file"
+# The input is one or more consecutive git-diff sections, one per changed file.
+# Split it into per-file sections, render each as its own fenced diff block
+# with a heading derived from the module name (parent folder of the .api file).
+awk '
+  /^diff --git / {
+    # Close previous block if any.
+    if (in_block) {
+      print "```"
+      in_block = 0
+    }
 
-    diff_index=0
-    is_block_open=false
-    # Dump git diff output
-    while read -r line; do
-      # Skip first 4 lines as they are verbose
-      if (( $diff_index > 3 ))
-      then
+    # Extract the b-path (post-image) to derive the module name.
+    # Line format: `diff --git a/<path> b/<path>`
+    match($0, / b\/[^ ]+/)
+    b_path = substr($0, RSTART + 3, RLENGTH - 3)
 
-        if [[ "$line" == "@@"* ]]
-        then
-          if $is_block_open
-          then
-            # Close code block
-            echo "\`\`\`" >> "$output_file"
-            is_block_open=false
-          fi
+    # Module name = segment before `/api/` (e.g. `ui-core/api/ui-core.api` → `ui-core`).
+    module = b_path
+    sub(/\/api\/.*/, "", module)
 
-          # Open code block
-          echo "\`\`\`diff" >> "$output_file"
-          is_block_open=true
-        fi
-        echo "$line" >> "$output_file"
-      fi
-      ((diff_index++))
-    done <<< "$git_diff"
+    print ""
+    print "## " module
+    print "```diff"
+    in_block = 1
+    skip_header = 1
+    next
+  }
+  # Skip the remaining git-diff header lines (`index ...`, `new file mode ...`,
+  # `deleted file mode ...`, `--- a/...`, `+++ b/...`). These duplicate info
+  # already shown in the `## <module>` heading. Passthrough begins at the first
+  # `@@` hunk header.
+  skip_header && !/^@@/ { next }
+  /^@@/ { skip_header = 0 }
+  { if (in_block) print }
+  END {
+    if (in_block) print "```"
+  }
+' "$input_file" >> "$output_file"
 
-    # Always close last code block
-    echo "\`\`\`" >> "$output_file"
-  fi
-done
-
+echo "" >> "$output_file"
 echo "If these changes are intentional run \`./gradlew apiDump\` and commit the changes." >> "$output_file"

--- a/scripts/process_api_changes.sh
+++ b/scripts/process_api_changes.sh
@@ -8,57 +8,57 @@
 # Created by oscars on 14/6/2024.
 #
 
-# Input is the raw `git diff` output for `.api` files produced by the workflow
-# (see .github/workflows/validate_public_api.yml).
-input_file="api_changes.txt"
+# Reads `git diff` output for `.api` files from stdin and renders a Markdown
+# report to `api_changes.md`. Intended to be piped from the workflow:
+#
+#   git diff --no-color -- '**/*.api' | bash scripts/process_api_changes.sh
 output_file="api_changes.md"
 
-if [ ! -s "$input_file" ]
+diff_output="$(cat)"
+
+if [ -z "$diff_output" ]
 then
   echo "# ✅ No public API changes" > "$output_file"
   exit 0
 fi
 
-echo "# 🚫 Public API changes" > "$output_file"
+{
+  echo "# 🚫 Public API changes"
+  # Split the concatenated git-diff sections (one per changed file) into
+  # per-module fenced diff blocks, headed by the module name.
+  printf '%s\n' "$diff_output" | awk '
+    /^diff --git / {
+      if (in_block) {
+        print "```"
+        in_block = 0
+      }
 
-# The input is one or more consecutive git-diff sections, one per changed file.
-# Split it into per-file sections, render each as its own fenced diff block
-# with a heading derived from the module name (parent folder of the .api file).
-awk '
-  /^diff --git / {
-    # Close previous block if any.
-    if (in_block) {
-      print "```"
-      in_block = 0
+      # Derive the module name from the b-path (`diff --git a/<path> b/<path>`).
+      match($0, / b\/[^ ]+/)
+      b_path = substr($0, RSTART + 3, RLENGTH - 3)
+
+      # Strip `/api/<name>.api` to leave just the module folder
+      # (e.g. `ui-core/api/ui-core.api` → `ui-core`).
+      module = b_path
+      sub(/\/api\/.*/, "", module)
+
+      print ""
+      print "## " module
+      print "```diff"
+      in_block = 1
+      skip_header = 1
+      next
     }
-
-    # Extract the b-path (post-image) to derive the module name.
-    # Line format: `diff --git a/<path> b/<path>`
-    match($0, / b\/[^ ]+/)
-    b_path = substr($0, RSTART + 3, RLENGTH - 3)
-
-    # Module name = segment before `/api/` (e.g. `ui-core/api/ui-core.api` → `ui-core`).
-    module = b_path
-    sub(/\/api\/.*/, "", module)
-
-    print ""
-    print "## " module
-    print "```diff"
-    in_block = 1
-    skip_header = 1
-    next
-  }
-  # Skip the remaining git-diff header lines (`index ...`, `new file mode ...`,
-  # `deleted file mode ...`, `--- a/...`, `+++ b/...`). These duplicate info
-  # already shown in the `## <module>` heading. Passthrough begins at the first
-  # `@@` hunk header.
-  skip_header && !/^@@/ { next }
-  /^@@/ { skip_header = 0 }
-  { if (in_block) print }
-  END {
-    if (in_block) print "```"
-  }
-' "$input_file" >> "$output_file"
-
-echo "" >> "$output_file"
-echo "If these changes are intentional run \`./gradlew apiDump\` and commit the changes." >> "$output_file"
+    # Skip the remaining git-diff header lines (`index ...`, `new file mode`,
+    # `deleted file mode`, `--- a/...`, `+++ b/...`); passthrough starts at
+    # the first `@@` hunk header.
+    skip_header && !/^@@/ { next }
+    /^@@/ { skip_header = 0 }
+    { if (in_block) print }
+    END {
+      if (in_block) print "```"
+    }
+  '
+  echo ""
+  echo 'If these changes are intentional run `./gradlew apiDump` and commit the changes.'
+} > "$output_file"


### PR DESCRIPTION
## Description

The `Validate public API` workflow used Gradle stderr as the API-change signal:

```bash
( ./gradlew apiCheck --continue 2> api_changes.txt ) || true
...
if [ -s api_changes.txt ]; then exit 1; fi
```

Any stderr output from the build failed the check, regardless of whether `.api`
files actually differ. When Kotlin classes annotated with `@Deprecated` are
referenced from Java sources (e.g. generated DataBinding / ViewBinding /
`R.java`), `javac` emits:

```
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
```

These notes go to stderr and caused false positives on recent deprecation PRs
(e.g. #2708).

### Fix

- Run `./gradlew apiDump --quiet` to regenerate all `.api` files from source,
  then use `git diff` against the committed `.api` files as the failure signal.
  This is robust to any stderr noise from the build.
- Add `git add --intent-to-add -- '**/*.api'` so newly-created `.api` files for
  a new module (previously a silent false negative) are now detected.
- Rewrite `scripts/process_api_changes.sh` to render the `git diff` output as
  per-module fenced diff blocks. The previous implementation had a latent bug
  where it pairwise-diffed unrelated modules' `.api` files.

## Manual end-to-end testing

Each scenario was a scratch PR targeting this branch so the workflow comment is
preserved on-PR for review:

- #2720 — **add** scenario: new public functions added in `await` and `blik` without running `apiDump`. CI posted 🚫 with two `## <module>` sections as expected; job failed as intended.
- #2721 — **remove** scenario: orphan entry added to `await.api` that does not exist in source. CI posted 🚫 with a single `## await` removal hunk as expected; job failed as intended.
- #2722 — **new file (intent-to-add)** scenario: committed `sepa/api/sepa.api` removed so CI must regenerate it. CI posted 🚫 with a `## sepa` new-file addition hunk as expected; job failed as intended.
- #2723 — **green path** scenario: public API added together with the matching `apiDump` output. CI posted ✅ "No public API changes" and the job passed.

## Checklist
- [x] Changes are tested manually
- [x] Related issues are linked

## Ticket Number
COSDK-1121
