### PR TITLE
[DO NOT MERGE] Test - validate_public_api workflow - add scenario

### DIFF
--- a/await/src/main/java/com/adyen/checkout/await/old/AwaitApiTestStub.kt
+++ b/await/src/main/java/com/adyen/checkout/await/old/AwaitApiTestStub.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Temporary stub used to exercise the validate_public_api workflow (COSDK-1121).
+ * To be removed before merge.
+ */
+
+package com.adyen.checkout.await.old
+
+/** Dummy public API used to verify the public-API change detection flow. */
+fun awaitApiTestStub(): String = "await"

--- a/blik/src/main/java/com/adyen/checkout/blik/old/BlikApiTestStub.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/old/BlikApiTestStub.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Temporary stub used to exercise the validate_public_api workflow (COSDK-1121).
+ * To be removed before merge.
+ */
+
+package com.adyen.checkout.blik.old
+
+/** Dummy public API used to verify the public-API change detection flow. */
+fun blikApiTestStub(): String = "blik"


### PR DESCRIPTION
Scratch PR used to exercise the updated `validate_public_api` workflow end-to-end on CI. **Do not merge.**

### Scenario
Add new public top-level functions in two existing modules (`await`, `blik`) _without_ running `./gradlew apiDump`. The workflow should post a PR comment with 🚫 and two module sections, each showing the new public symbol as an addition hunk.

Related test PRs:
- Add scenario (this PR)
- Remove scenario: TBD
- New module scenario: TBD
- Green path (apiDump) scenario: TBD

Linked to #2719.