### PR TITLE
[DO NOT MERGE] Test - validate_public_api workflow - remove scenario

### DIFF
--- a/await/api/await.api
+++ b/await/api/await.api
@@ -6,6 +6,10 @@ public final class com/adyen/checkout/await/BuildConfig {
 	public fun <init> ()V
 }
 
+public final class com/adyen/checkout/await/old/AwaitApiTestStubRemoveKt {
+	public static final fun awaitApiTestStubRemove ()Ljava/lang/String;
+}
+
 public final class com/adyen/checkout/await/old/AwaitComponent : androidx/lifecycle/ViewModel, com/adyen/checkout/components/core/RedirectableActionComponent, com/adyen/checkout/components/core/internal/ActionComponent, com/adyen/checkout/ui/core/old/internal/ui/ViewableComponent {
 	public static final field $stable I
 	public static final field Companion Lcom/adyen/checkout/await/old/AwaitComponent$Companion;


### PR DESCRIPTION
Scratch PR used to exercise the updated `validate_public_api` workflow end-to-end on CI. **Do not merge.**

### Scenario
Single commit that inserts an orphan entry into `await/api/await.api` — it claims a public function (`awaitApiTestStubRemove`) that does not exist in source. This reproduces the state that results when a developer removes a public API and forgets to run `./gradlew apiDump`.

CI's `./gradlew apiDump` should regenerate `await.api` without the orphan entry. The workflow should then post a PR comment with 🚫 and one `## await` section showing the entry as a `-` hunk.

Linked to #2719.