### PR TITLE
[DO NOT MERGE] Test - validate_public_api workflow - green path scenario

### DIFF
--- a/await/api/await.api
+++ b/await/api/await.api
@@ -6,6 +6,10 @@ public final class com/adyen/checkout/await/BuildConfig {
 	public fun <init> ()V
 }
 
+public final class com/adyen/checkout/await/old/AwaitApiTestStubGreenKt {
+	public static final fun awaitApiTestStubGreen ()Ljava/lang/String;
+}
+
 public final class com/adyen/checkout/await/old/AwaitComponent : androidx/lifecycle/ViewModel, com/adyen/checkout/components/core/RedirectableActionComponent, com/adyen/checkout/components/core/internal/ActionComponent, com/adyen/checkout/ui/core/old/internal/ui/ViewableComponent {
 	public static final field $stable I
 	public static final field Companion Lcom/adyen/checkout/await/old/AwaitComponent$Companion;

--- a/await/src/main/java/com/adyen/checkout/await/old/AwaitApiTestStubGreen.kt
+++ b/await/src/main/java/com/adyen/checkout/await/old/AwaitApiTestStubGreen.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Temporary stub used to exercise the validate_public_api workflow (COSDK-1121).
+ * To be removed before merge.
+ */
+
+package com.adyen.checkout.await.old
+
+/** Dummy public API used to verify the public-API change detection flow. */
+fun awaitApiTestStubGreen(): String = "await-green"


### PR DESCRIPTION
Scratch PR used to exercise the updated `validate_public_api` workflow end-to-end on CI. **Do not merge.**

### Scenario
Add a public stub function in `await` **and** commit the matching `await.api` entry in the same commit (i.e. the developer ran `./gradlew apiDump` before pushing).

CI should detect no .api drift: the workflow should post a PR comment with ✅ "No public API changes" and the job should pass.

Linked to #2719.