### PR TITLE
v5 - Co-badged cards - Fix tracking for dual branded selector visibility

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegate.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegate.kt
@@ -89,6 +89,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -306,14 +307,16 @@ class DefaultCardDelegate(
             }
             .launchIn(coroutineScope)
 
-        outputDataFlow.map { it.dualBrandData?.brandOptions?.map { it.brand.txVariant } }
-            .distinctUntilChanged()
+        outputDataFlow
+            .map { it.dualBrandData?.takeIf { data -> data.selectable } }
+            .distinctUntilChangedBy { it?.brandOptions?.map { option -> option.brand.txVariant } }
             .filterNotNull()
-            .map { brandOptions ->
+            .onEach { dualBrandData ->
+                val brandOptions = dualBrandData.brandOptions.map { it.brand.txVariant }
                 val event = GenericEvents.displayed(
                     component = paymentMethod.type.orEmpty(),
                     target = DUAL_BRAND_ANALYTICS_TARGET,
-                    brand = outputData.dualBrandData?.selectedBrand?.txVariant.orEmpty(),
+                    brand = dualBrandData.selectedBrand?.txVariant.orEmpty(),
                     configData = cardConfigDataGenerator.generateDualBrandConfigData(brandOptions),
                 )
                 analyticsManager.trackEvent(event)

--- a/card/src/test/java/com/adyen/checkout/card/internal/data/api/TestDetectCardTypeRepository.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/data/api/TestDetectCardTypeRepository.kt
@@ -41,6 +41,9 @@ internal class TestDetectCardTypeRepository : DetectCardTypeRepository {
             TestDetectedCardType.DETECTED_LOCALLY -> getDetectedCardTypesLocal(supportedCardBrands)
             TestDetectedCardType.FETCHED_FROM_NETWORK -> getDetectedCardTypesNetwork(supportedCardBrands)
             TestDetectedCardType.DUAL_BRANDED -> getDetectedCardTypesDualBranded(supportedCardBrands)
+            TestDetectedCardType.DUAL_BRANDED_UNSELECTABLE ->
+                getDetectedCardTypesDualBranded(supportedCardBrands)
+
             TestDetectedCardType.EMPTY -> emptyList()
         } ?: return
 
@@ -116,5 +119,6 @@ internal enum class TestDetectedCardType {
     DETECTED_LOCALLY,
     FETCHED_FROM_NETWORK,
     DUAL_BRANDED,
+    DUAL_BRANDED_UNSELECTABLE,
     EMPTY,
 }

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegateTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/DefaultCardDelegateTest.kt
@@ -1368,6 +1368,72 @@ internal class DefaultCardDelegateTest(
 
             analyticsManager.assertIsCleared()
         }
+
+        @Test
+        fun `when selectable dual brand is shown, then displayed event is tracked`() = runTest {
+            delegate = createCardDelegate(configuration = createDualBrandSelectableConfiguration())
+            detectCardTypeRepository.detectionResult = TestDetectedCardType.DUAL_BRANDED
+            whenever(cardConfigDataGenerator.generateDualBrandConfigData(any())) doReturn emptyMap()
+
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+            delegate.updateInputData { cardNumber = "4" }
+
+            analyticsManager.assertEventCountEquals(createExpectedDualBrandDisplayedEvent(), 1)
+        }
+
+        @Test
+        fun `when dual brand is not selectable, then displayed event is not tracked`() = runTest {
+            detectCardTypeRepository.detectionResult = TestDetectedCardType.DUAL_BRANDED_UNSELECTABLE
+
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+            delegate.updateInputData { cardNumber = "4" }
+
+            analyticsManager.assertEventCountEquals(createExpectedDualBrandDisplayedEvent(), 0)
+        }
+
+        @Test
+        fun `when dual brand data is null, then displayed event is not tracked`() = runTest {
+            detectCardTypeRepository.detectionResult = TestDetectedCardType.DETECTED_LOCALLY
+
+            delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+            delegate.updateInputData { cardNumber = "4" }
+
+            analyticsManager.assertEventCountEquals(createExpectedDualBrandDisplayedEvent(), 0)
+        }
+
+        @Test
+        fun `when same selectable dual brand is emitted consecutively, then displayed event is tracked only once`() =
+            runTest {
+                delegate = createCardDelegate(configuration = createDualBrandSelectableConfiguration())
+                detectCardTypeRepository.detectionResult = TestDetectedCardType.DUAL_BRANDED
+                whenever(cardConfigDataGenerator.generateDualBrandConfigData(any())) doReturn emptyMap()
+
+                delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+                delegate.updateInputData { cardNumber = "4" }
+                delegate.updateInputData { cardNumber = "42" }
+
+                analyticsManager.assertEventCountEquals(createExpectedDualBrandDisplayedEvent(), 1)
+            }
+
+        @Test
+        fun `when dual brand transitions through null and back to selectable, then displayed event is tracked each time`() =
+            runTest {
+                delegate = createCardDelegate(configuration = createDualBrandSelectableConfiguration())
+                whenever(cardConfigDataGenerator.generateDualBrandConfigData(any())) doReturn emptyMap()
+
+                delegate.initialize(CoroutineScope(UnconfinedTestDispatcher()))
+
+                detectCardTypeRepository.detectionResult = TestDetectedCardType.DUAL_BRANDED
+                delegate.updateInputData { cardNumber = "4" }
+
+                detectCardTypeRepository.detectionResult = TestDetectedCardType.DETECTED_LOCALLY
+                delegate.updateInputData { cardNumber = "42" }
+
+                detectCardTypeRepository.detectionResult = TestDetectedCardType.DUAL_BRANDED
+                delegate.updateInputData { cardNumber = "421" }
+
+                analyticsManager.assertEventCountEquals(createExpectedDualBrandDisplayedEvent(), 2)
+            }
     }
 
     @Nested
@@ -1774,6 +1840,20 @@ internal class DefaultCardDelegateTest(
             isCardScanningVisible = isCardScanningVisible,
         )
     }
+
+    private fun createDualBrandSelectableConfiguration() = createCheckoutConfiguration {
+        supportedCardBrands = listOf(
+            CardBrand(cardType = CardType.BCMC),
+            CardBrand(cardType = CardType.MAESTRO),
+        )
+    }
+
+    private fun createExpectedDualBrandDisplayedEvent() = GenericEvents.displayed(
+        component = PaymentMethodTypes.SCHEME,
+        target = "dual_brand_button",
+        brand = "bcmc",
+        configData = emptyMap(),
+    )
 
     @Suppress("LongParameterList")
     private fun createDetectedCardType(

--- a/components-core/src/testFixtures/java/com/adyen/checkout/components/core/internal/analytics/TestAnalyticsManager.kt
+++ b/components-core/src/testFixtures/java/com/adyen/checkout/components/core/internal/analytics/TestAnalyticsManager.kt
@@ -9,6 +9,7 @@
 package com.adyen.checkout.components.core.internal.analytics
 
 import kotlinx.coroutines.CoroutineScope
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.fail
@@ -46,6 +47,11 @@ class TestAnalyticsManager : AnalyticsManager {
     fun assertLastEventNotEquals(expected: AnalyticsEvent) {
         if (events.isEmpty()) return
         assertFalse(areEventsEqual(expected, events.last()))
+    }
+
+    fun assertEventCountEquals(expected: AnalyticsEvent, count: Int) {
+        val actual = events.count { areEventsEqual(expected, it) }
+        assertEquals(count, actual, "Expected $count events matching $expected but got $actual")
     }
 
     private fun areEventsEqual(expected: AnalyticsEvent, actual: AnalyticsEvent): Boolean {


### PR DESCRIPTION
## Description
Fixes the analytics `displayed` event for the dual brand button so it is only tracked when the dual brand UI is actually user-selectable.

Previously the event fired whenever `dualBrandData` had any `brandOptions`, including the non-selectable display-only case. The flow now:
- Maps `dualBrandData` to `null` when `selectable == false` so only selectable states propagate downstream.
- Uses a custom `distinctUntilChanged` comparator on `brandOptions` so `null → selectable` transitions reset the de-duplication (the event re-fires correctly after a brand sequence clears and reappears).
- Reads `selectedBrand` from the emitted `dualBrandData` instead of the stale `outputData` snapshot, so the tracked `brand` always matches the emission being recorded.

## Checklist
- [x] Code is unit tested
- [x] Changes are tested manually

## Ticket number
COSDK-1062
