### PR TITLE
v6 - refactor card brand state in the card component

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/internal/data/api/BinLookupCache.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/data/api/BinLookupCache.kt
@@ -17,9 +17,12 @@ internal class BinLookupCache {
 
     private val cachedBinLookupResults = ConcurrentHashMap<String, BinLookupCacheResult>()
 
-    fun getResult(bin: String): BinLookupCacheResult {
-        val key = hashBin(bin)
-        return cachedBinLookupResults[key] ?: BinLookupCacheResult.Unavailable
+    fun getResult(bin: String?): BinLookupCacheResult {
+        val cachedResult = bin?.let {
+            val key = hashBin(bin)
+            cachedBinLookupResults[key]
+        }
+        return cachedResult ?: BinLookupCacheResult.Unavailable
     }
 
     fun setFetching(bin: String) {

--- a/card/src/main/java/com/adyen/checkout/card/internal/data/api/DefaultDetectCardTypeRepository.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/data/api/DefaultDetectCardTypeRepository.kt
@@ -30,13 +30,7 @@ internal class DefaultDetectCardTypeRepository(
         this@DefaultDetectCardTypeRepository.adyenLog(AdyenLogLevel.VERBOSE) { "detectCardTypes" }
         val bin = getBin(cardNumber)
 
-        val cachedResult = if (bin != null) {
-            binLookupCache.getResult(bin)
-        } else {
-            BinLookupCacheResult.Unavailable
-        }
-
-        when (cachedResult) {
+        when (val cachedResult = binLookupCache.getResult(bin)) {
             is BinLookupCacheResult.Available -> {
                 // found card types in cache, no need to fetch from network or local
                 emit(DetectedCardTypeList(cachedResult.detectedCardTypes, DetectedCardTypeList.Source.NETWORK))

--- a/card/src/main/java/com/adyen/checkout/card/internal/data/api/DefaultDetectCardTypeRepository.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/data/api/DefaultDetectCardTypeRepository.kt
@@ -11,6 +11,7 @@ package com.adyen.checkout.card.internal.data.api
 import androidx.annotation.VisibleForTesting
 import com.adyen.checkout.card.internal.data.model.BinLookupCacheResult
 import com.adyen.checkout.card.internal.data.model.DetectedCardType
+import com.adyen.checkout.card.internal.data.model.DetectedCardTypeList
 import com.adyen.checkout.core.common.AdyenLogLevel
 import com.adyen.checkout.core.common.internal.helper.adyenLog
 import kotlinx.coroutines.flow.Flow
@@ -22,7 +23,7 @@ internal class DefaultDetectCardTypeRepository(
     private val networkCardBrandDetectionService: NetworkCardBrandDetectionService,
 ) : DetectCardTypeRepository {
 
-    override fun detectCardTypes(cardNumber: String): Flow<List<DetectedCardType>> = flow {
+    override fun detectCardTypes(cardNumber: String): Flow<DetectedCardTypeList> = flow {
         // if we remove this@DefaultDetectCardTypeRepository the tag gets resolved as SafeCollector since we're inside
         // a flow block
         // TODO fix logger to resolve the correct tag
@@ -38,7 +39,7 @@ internal class DefaultDetectCardTypeRepository(
         when (cachedResult) {
             is BinLookupCacheResult.Available -> {
                 // found card types in cache, no need to fetch from network or local
-                emit(cachedResult.detectedCardTypes)
+                emit(DetectedCardTypeList(cachedResult.detectedCardTypes, DetectedCardTypeList.Source.NETWORK))
                 this@DefaultDetectCardTypeRepository.adyenLog(AdyenLogLevel.DEBUG) {
                     "card types returned from cache: ${cachedResult.detectedCardTypes.toLogString()}"
                 }
@@ -54,7 +55,7 @@ internal class DefaultDetectCardTypeRepository(
             is BinLookupCacheResult.Unavailable -> {
                 // return local card types first
                 val localDetectedCardTypes = localCardBrandDetectionService.getCardBrands(cardNumber)
-                emit(localDetectedCardTypes)
+                emit(DetectedCardTypeList(localDetectedCardTypes, DetectedCardTypeList.Source.LOCAL))
                 this@DefaultDetectCardTypeRepository.adyenLog(AdyenLogLevel.DEBUG) {
                     "card types detected locally: ${localDetectedCardTypes.toLogString()}"
                 }
@@ -63,7 +64,7 @@ internal class DefaultDetectCardTypeRepository(
                     // fetch from network and cache results
                     val networkDetectedCardTypes = detectCardTypesFromNetwork(bin)
                     if (networkDetectedCardTypes != null) {
-                        emit(networkDetectedCardTypes)
+                        emit(DetectedCardTypeList(networkDetectedCardTypes, DetectedCardTypeList.Source.NETWORK))
                         this@DefaultDetectCardTypeRepository.adyenLog(AdyenLogLevel.DEBUG) {
                             "card types fetched from network: ${networkDetectedCardTypes.toLogString()}"
                         }

--- a/card/src/main/java/com/adyen/checkout/card/internal/data/api/DefaultDetectCardTypeRepository.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/data/api/DefaultDetectCardTypeRepository.kt
@@ -8,16 +8,17 @@
 
 package com.adyen.checkout.card.internal.data.api
 
-import androidx.annotation.VisibleForTesting
 import com.adyen.checkout.card.internal.data.model.BinLookupCacheResult
 import com.adyen.checkout.card.internal.data.model.DetectedCardType
 import com.adyen.checkout.card.internal.data.model.DetectedCardTypeList
+import com.adyen.checkout.card.internal.helper.DetectCardTypeBinHelper
 import com.adyen.checkout.core.common.AdyenLogLevel
 import com.adyen.checkout.core.common.internal.helper.adyenLog
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 internal class DefaultDetectCardTypeRepository(
+    private val detectCardTypeBinHelper: DetectCardTypeBinHelper,
     private val binLookupCache: BinLookupCache,
     private val localCardBrandDetectionService: LocalCardBrandDetectionService,
     private val networkCardBrandDetectionService: NetworkCardBrandDetectionService,
@@ -28,12 +29,18 @@ internal class DefaultDetectCardTypeRepository(
         // a flow block
         // TODO fix logger to resolve the correct tag
         this@DefaultDetectCardTypeRepository.adyenLog(AdyenLogLevel.VERBOSE) { "detectCardTypes" }
-        val bin = getBin(cardNumber)
+        val bin = detectCardTypeBinHelper.getCardDetectionBin(cardNumber)
 
         when (val cachedResult = binLookupCache.getResult(bin)) {
             is BinLookupCacheResult.Available -> {
                 // found card types in cache, no need to fetch from network or local
-                emit(DetectedCardTypeList(cachedResult.detectedCardTypes, DetectedCardTypeList.Source.NETWORK))
+                emit(
+                    DetectedCardTypeList(
+                        detectedCardTypes = cachedResult.detectedCardTypes,
+                        source = DetectedCardTypeList.Source.NETWORK,
+                        cardDetectionBin = bin,
+                    ),
+                )
                 this@DefaultDetectCardTypeRepository.adyenLog(AdyenLogLevel.DEBUG) {
                     "card types returned from cache: ${cachedResult.detectedCardTypes.toLogString()}"
                 }
@@ -49,7 +56,13 @@ internal class DefaultDetectCardTypeRepository(
             is BinLookupCacheResult.Unavailable -> {
                 // return local card types first
                 val localDetectedCardTypes = localCardBrandDetectionService.getCardBrands(cardNumber)
-                emit(DetectedCardTypeList(localDetectedCardTypes, DetectedCardTypeList.Source.LOCAL))
+                emit(
+                    DetectedCardTypeList(
+                        detectedCardTypes = localDetectedCardTypes,
+                        source = DetectedCardTypeList.Source.LOCAL,
+                        cardDetectionBin = bin,
+                    ),
+                )
                 this@DefaultDetectCardTypeRepository.adyenLog(AdyenLogLevel.DEBUG) {
                     "card types detected locally: ${localDetectedCardTypes.toLogString()}"
                 }
@@ -58,7 +71,13 @@ internal class DefaultDetectCardTypeRepository(
                     // fetch from network and cache results
                     val networkDetectedCardTypes = detectCardTypesFromNetwork(bin)
                     if (networkDetectedCardTypes != null) {
-                        emit(DetectedCardTypeList(networkDetectedCardTypes, DetectedCardTypeList.Source.NETWORK))
+                        emit(
+                            DetectedCardTypeList(
+                                detectedCardTypes = networkDetectedCardTypes,
+                                source = DetectedCardTypeList.Source.NETWORK,
+                                cardDetectionBin = bin,
+                            ),
+                        )
                         this@DefaultDetectCardTypeRepository.adyenLog(AdyenLogLevel.DEBUG) {
                             "card types fetched from network: ${networkDetectedCardTypes.toLogString()}"
                         }
@@ -66,14 +85,6 @@ internal class DefaultDetectCardTypeRepository(
                 }
             }
         }
-    }
-
-    /**
-     * Returns the BIN if the card number is equal or longer than the BIN length
-     */
-    @VisibleForTesting
-    internal fun getBin(cardNumber: String): String? {
-        return cardNumber.takeIf { it.length >= BIN_LENGTH }?.take(BIN_LENGTH)
     }
 
     private suspend fun detectCardTypesFromNetwork(bin: String): List<DetectedCardType>? {
@@ -115,9 +126,5 @@ internal class DefaultDetectCardTypeRepository(
             .takeIf { it.isNotEmpty() }
             ?.joinToString(" - ")
             ?: "none"
-    }
-
-    companion object {
-        private const val BIN_LENGTH = 11
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/data/api/DetectCardTypeRepository.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/data/api/DetectCardTypeRepository.kt
@@ -8,9 +8,9 @@
 
 package com.adyen.checkout.card.internal.data.api
 
-import com.adyen.checkout.card.internal.data.model.DetectedCardType
+import com.adyen.checkout.card.internal.data.model.DetectedCardTypeList
 import kotlinx.coroutines.flow.Flow
 
 internal interface DetectCardTypeRepository {
-    fun detectCardTypes(cardNumber: String): Flow<List<DetectedCardType>>
+    fun detectCardTypes(cardNumber: String): Flow<DetectedCardTypeList>
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/data/api/LocalCardBrandDetectionService.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/data/api/LocalCardBrandDetectionService.kt
@@ -38,6 +38,7 @@ internal class LocalCardBrandDetectionService(
             },
             expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
             isSupported = supportedCardBrands.contains(cardBrand),
+            isShopperSelectionAllowedInDualBranded = false,
             panLength = null,
             paymentMethodVariant = null,
             localizedBrand = null,

--- a/card/src/main/java/com/adyen/checkout/card/internal/data/api/LocalCardBrandDetectionService.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/data/api/LocalCardBrandDetectionService.kt
@@ -31,7 +31,6 @@ internal class LocalCardBrandDetectionService(
     private fun mapCardBrands(cardBrand: CardBrand): DetectedCardType {
         return DetectedCardType(
             cardBrand = cardBrand,
-            isReliable = false,
             enableLuhnCheck = true,
             cvcPolicy = when {
                 NO_CVC_BRANDS.contains(cardBrand) -> Brand.FieldPolicy.HIDDEN

--- a/card/src/main/java/com/adyen/checkout/card/internal/data/api/NetworkCardBrandDetectionService.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/data/api/NetworkCardBrandDetectionService.kt
@@ -14,6 +14,7 @@ import com.adyen.checkout.card.internal.data.model.Brand
 import com.adyen.checkout.card.internal.data.model.DetectedCardType
 import com.adyen.checkout.core.common.AdyenLogLevel
 import com.adyen.checkout.core.common.CardBrand
+import com.adyen.checkout.core.common.CardType
 import com.adyen.checkout.core.common.internal.helper.adyenLog
 import com.adyen.checkout.core.common.internal.helper.runSuspendCatching
 import com.adyen.checkout.core.error.internal.GenericError
@@ -68,10 +69,21 @@ internal class NetworkCardBrandDetectionService(
                     brandResponse.expiryDatePolicy ?: Brand.FieldPolicy.REQUIRED.value,
                 ),
                 isSupported = brandResponse.supported != false,
+                // in the future this flag should come directly from the backend
+                isShopperSelectionAllowedInDualBranded = brandResponse.brand
+                    in SUPPORTED_CARD_BRANDS_FOR_DUAL_BRANDED_SELECTION,
                 panLength = brandResponse.panLength,
                 paymentMethodVariant = brandResponse.paymentMethodVariant,
                 localizedBrand = brandResponse.localizedBrand,
             )
         }
+    }
+
+    companion object {
+        private val SUPPORTED_CARD_BRANDS_FOR_DUAL_BRANDED_SELECTION = listOf(
+            CardType.CARTEBANCAIRE,
+            CardType.BCMC,
+            CardType.DANKORT,
+        ).map { it.txVariant }
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/data/api/NetworkCardBrandDetectionService.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/data/api/NetworkCardBrandDetectionService.kt
@@ -60,7 +60,6 @@ internal class NetworkCardBrandDetectionService(
             val cardBrand = CardBrand(txVariant = brandResponse.brand)
             DetectedCardType(
                 cardBrand = cardBrand,
-                isReliable = true,
                 enableLuhnCheck = brandResponse.enableLuhnCheck == true,
                 cvcPolicy = Brand.FieldPolicy.parse(
                     brandResponse.cvcPolicy ?: Brand.FieldPolicy.REQUIRED.value,

--- a/card/src/main/java/com/adyen/checkout/card/internal/data/model/DetectedCardType.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/data/model/DetectedCardType.kt
@@ -16,7 +16,8 @@ internal data class DetectedCardType(
     val cvcPolicy: Brand.FieldPolicy,
     val expiryDatePolicy: Brand.FieldPolicy,
     val isSupported: Boolean,
+    val isShopperSelectionAllowedInDualBranded: Boolean,
     val panLength: Int?,
     val paymentMethodVariant: String?,
-    val localizedBrand: String?
+    val localizedBrand: String?,
 )

--- a/card/src/main/java/com/adyen/checkout/card/internal/data/model/DetectedCardType.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/data/model/DetectedCardType.kt
@@ -12,7 +12,6 @@ import com.adyen.checkout.core.common.CardBrand
 
 internal data class DetectedCardType(
     val cardBrand: CardBrand,
-    val isReliable: Boolean,
     val enableLuhnCheck: Boolean,
     val cvcPolicy: Brand.FieldPolicy,
     val expiryDatePolicy: Brand.FieldPolicy,

--- a/card/src/main/java/com/adyen/checkout/card/internal/data/model/DetectedCardTypeList.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/data/model/DetectedCardTypeList.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 21/4/2026.
+ */
+
+package com.adyen.checkout.card.internal.data.model
+
+internal data class DetectedCardTypeList(
+    val detectedCardTypes: List<DetectedCardType>,
+    val source: Source,
+) {
+    enum class Source {
+        LOCAL,
+        NETWORK,
+    }
+}

--- a/card/src/main/java/com/adyen/checkout/card/internal/data/model/DetectedCardTypeList.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/data/model/DetectedCardTypeList.kt
@@ -11,6 +11,11 @@ package com.adyen.checkout.card.internal.data.model
 internal data class DetectedCardTypeList(
     val detectedCardTypes: List<DetectedCardType>,
     val source: Source,
+    /**
+     * This BIN is only used internally for card brand detection and is different from the actual BIN which is returned
+     * in the public API.
+     */
+    val cardDetectionBin: String?,
 ) {
     enum class Source {
         LOCAL,

--- a/card/src/main/java/com/adyen/checkout/card/internal/helper/CardBrandDataMapper.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/helper/CardBrandDataMapper.kt
@@ -10,8 +10,17 @@ package com.adyen.checkout.card.internal.helper
 
 import com.adyen.checkout.card.BinLookupData
 import com.adyen.checkout.card.internal.data.model.DetectedCardType
+import com.adyen.checkout.card.internal.ui.state.CardBrandData
 
-internal fun DetectedCardType.toBinLookupData() = BinLookupData(
+internal fun DetectedCardType.toCardBrandData() = CardBrandData(
+    cardBrand = cardBrand,
+    enableLuhnCheck = enableLuhnCheck,
+    panLength = panLength,
+    paymentMethodVariant = paymentMethodVariant,
+    localizedBrand = localizedBrand,
+)
+
+internal fun CardBrandData.toBinLookupData() = BinLookupData(
     brand = cardBrand.txVariant,
     paymentMethodVariant = paymentMethodVariant,
 )

--- a/card/src/main/java/com/adyen/checkout/card/internal/helper/CardBrandDataMapper.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/helper/CardBrandDataMapper.kt
@@ -15,6 +15,8 @@ import com.adyen.checkout.card.internal.ui.state.CardBrandData
 internal fun DetectedCardType.toCardBrandData() = CardBrandData(
     cardBrand = cardBrand,
     enableLuhnCheck = enableLuhnCheck,
+    cvcPolicy = cvcPolicy,
+    expiryDatePolicy = expiryDatePolicy,
     panLength = panLength,
     paymentMethodVariant = paymentMethodVariant,
     localizedBrand = localizedBrand,

--- a/card/src/main/java/com/adyen/checkout/card/internal/helper/DetectCardTypeBinHelper.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/helper/DetectCardTypeBinHelper.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 23/4/2026.
+ */
+
+package com.adyen.checkout.card.internal.helper
+
+internal class DetectCardTypeBinHelper {
+
+    /**
+     * Returns the BIN if the card number is equal or longer than the BIN length.
+     *
+     * This BIN is only used internally for card brand detection and is different from the actual BIN which is returned
+     * in the public API.
+     */
+    fun getCardDetectionBin(cardNumber: String): String? {
+        return cardNumber.takeIf { it.length >= BIN_LENGTH }?.take(BIN_LENGTH)
+    }
+
+    companion object {
+        private const val BIN_LENGTH = 11
+    }
+}

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
@@ -170,12 +170,17 @@ internal class CardComponent(
             .launchIn(coroutineScope)
     }
 
+    /**
+     * Only return the reliable card brands in the onBinLookup callback
+     */
     private fun getReliableCardBrandDataList(state: CardComponentState): List<CardBrandData>? {
         return when (val cardBrandState = state.cardBrandState) {
             is CardBrandState.DualBrand -> cardBrandState.cardBrandDataList
             is CardBrandState.DualBrandWithShopperSelection -> cardBrandState.cardBrandDataList
             is CardBrandState.SingleReliableBrand -> listOf(cardBrandState.cardBrandData)
-            else -> null
+            is CardBrandState.NoBrandsDetected,
+            is CardBrandState.SingleUnreliableBrand,
+            is CardBrandState.UnsupportedBrand -> null
         }
     }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
@@ -173,7 +173,8 @@ internal class CardComponent(
     private fun getReliableCardBrandDataList(state: CardComponentState): List<CardBrandData>? {
         return when (val cardBrandState = state.cardBrandState) {
             is CardBrandState.DualBrand -> cardBrandState.cardBrandDataList
-            is CardBrandState.SingleBrand if cardBrandState.isReliable -> listOf(cardBrandState.cardBrandData)
+            is CardBrandState.DualBrandWithShopperSelection -> cardBrandState.cardBrandDataList
+            is CardBrandState.SingleReliableBrand -> listOf(cardBrandState.cardBrandData)
             else -> null
         }
     }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
@@ -15,9 +15,9 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.adyen.checkout.card.OnBinLookupCallback
 import com.adyen.checkout.card.OnBinValueCallback
 import com.adyen.checkout.card.internal.data.api.DetectCardTypeRepository
-import com.adyen.checkout.card.internal.data.model.DetectedCardType
 import com.adyen.checkout.card.internal.helper.toBinLookupData
 import com.adyen.checkout.card.internal.ui.model.CardComponentParams
+import com.adyen.checkout.card.internal.ui.state.CardBrandData
 import com.adyen.checkout.card.internal.ui.state.CardBrandState
 import com.adyen.checkout.card.internal.ui.state.CardComponentState
 import com.adyen.checkout.card.internal.ui.state.CardComponentStateFactory
@@ -87,8 +87,8 @@ internal class CardComponent(
 
     init {
         initializeAnalytics()
-        subscribeToDetectedCardTypesChanges()
-        subscribeToBinChanges()
+        onCardBrandDataChanged()
+        onBinChanged()
     }
 
     private fun initializeAnalytics() {
@@ -153,7 +153,7 @@ internal class CardComponent(
         }.launchIn(coroutineScope)
     }
 
-    private fun subscribeToBinChanges() {
+    private fun onBinChanged() {
         componentState
             .map { it.binValue }
             .distinctUntilChanged()
@@ -162,25 +162,25 @@ internal class CardComponent(
             .launchIn(coroutineScope)
     }
 
-    private fun subscribeToDetectedCardTypesChanges() {
+    private fun onCardBrandDataChanged() {
         componentState
-            .mapNotNull(::getReliableDetectedCardTypes)
+            .mapNotNull(::getReliableCardBrandDataList)
             .distinctUntilChanged()
             .onEach(::updateBinLookupCallback)
             .launchIn(coroutineScope)
     }
 
-    private fun getReliableDetectedCardTypes(state: CardComponentState): List<DetectedCardType>? {
+    private fun getReliableCardBrandDataList(state: CardComponentState): List<CardBrandData>? {
         return when (val cardBrandState = state.cardBrandState) {
-            is CardBrandState.DualBrand -> cardBrandState.detectedCardTypes
-            is CardBrandState.SingleBrand if cardBrandState.isReliable -> listOf(cardBrandState.detectedCardType)
+            is CardBrandState.DualBrand -> cardBrandState.cardBrandDataList
+            is CardBrandState.SingleBrand if cardBrandState.isReliable -> listOf(cardBrandState.cardBrandData)
             else -> null
         }
     }
 
-    private fun updateBinLookupCallback(detectedCardTypes: List<DetectedCardType>) {
+    private fun updateBinLookupCallback(cardBrandDataList: List<CardBrandData>) {
         onBinLookupCallback?.onBinLookup(
-            data = detectedCardTypes.map(DetectedCardType::toBinLookupData),
+            data = cardBrandDataList.map(CardBrandData::toBinLookupData),
         )
     }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
@@ -143,8 +143,8 @@ internal class CardComponent(
     }
 
     private fun onCardNumberChanged(newCardNumber: String) {
-        detectCardTypes(newCardNumber)
         onIntent(CardIntent.UpdateCardNumber(newCardNumber))
+        detectCardTypes(newCardNumber)
     }
 
     private fun detectCardTypes(cardNumber: String) {

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
@@ -18,6 +18,8 @@ import com.adyen.checkout.card.internal.data.api.DetectCardTypeRepository
 import com.adyen.checkout.card.internal.data.model.DetectedCardType
 import com.adyen.checkout.card.internal.helper.toBinLookupData
 import com.adyen.checkout.card.internal.ui.model.CardComponentParams
+import com.adyen.checkout.card.internal.ui.state.CardBrandState
+import com.adyen.checkout.card.internal.ui.state.CardComponentState
 import com.adyen.checkout.card.internal.ui.state.CardComponentStateFactory
 import com.adyen.checkout.card.internal.ui.state.CardComponentStateReducer
 import com.adyen.checkout.card.internal.ui.state.CardComponentStateValidator
@@ -48,6 +50,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 
@@ -161,20 +164,26 @@ internal class CardComponent(
 
     private fun subscribeToDetectedCardTypesChanges() {
         componentState
-            .map { it.detectedCardTypes }
+            .mapNotNull(::getReliableDetectedCardTypes)
             .distinctUntilChanged()
-            .drop(1)
-            .onEach(::onDetectedCardTypesChanged)
+            .onEach(::updateBinLookupCallback)
             .launchIn(coroutineScope)
     }
 
-    private fun onDetectedCardTypesChanged(detectedCardTypes: List<DetectedCardType>) {
-        val isReliable = detectedCardTypes.any { it.isReliable }
-        if (isReliable) {
-            onBinLookupCallback?.onBinLookup(
-                data = detectedCardTypes.map(DetectedCardType::toBinLookupData),
-            )
+    private fun getReliableDetectedCardTypes(state: CardComponentState): List<DetectedCardType>? {
+        return when (val cardBrandState = state.cardBrandState) {
+            is CardBrandState.DualBrand -> cardBrandState.detectedCardTypes
+            is CardBrandState.SingleBrand -> listOf(cardBrandState.detectedCardType)
+            else -> null
+        }.takeIf { detectedCardTypes ->
+            !detectedCardTypes.isNullOrEmpty() && detectedCardTypes.any { it.isReliable }
         }
+    }
+
+    private fun updateBinLookupCallback(detectedCardTypes: List<DetectedCardType>) {
+        onBinLookupCallback?.onBinLookup(
+            data = detectedCardTypes.map(DetectedCardType::toBinLookupData),
+        )
     }
 
     private fun onEncryptionError(e: EncryptionException) {

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
@@ -173,10 +173,8 @@ internal class CardComponent(
     private fun getReliableDetectedCardTypes(state: CardComponentState): List<DetectedCardType>? {
         return when (val cardBrandState = state.cardBrandState) {
             is CardBrandState.DualBrand -> cardBrandState.detectedCardTypes
-            is CardBrandState.SingleBrand -> listOf(cardBrandState.detectedCardType)
+            is CardBrandState.SingleBrand if cardBrandState.isReliable -> listOf(cardBrandState.detectedCardType)
             else -> null
-        }.takeIf { detectedCardTypes ->
-            !detectedCardTypes.isNullOrEmpty() && detectedCardTypes.any { it.isReliable }
         }
     }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardFactory.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardFactory.kt
@@ -27,6 +27,7 @@ import com.adyen.checkout.card.internal.ui.state.StoredCardComponentStateFactory
 import com.adyen.checkout.card.internal.ui.state.StoredCardComponentStateReducer
 import com.adyen.checkout.card.internal.ui.state.StoredCardComponentStateValidator
 import com.adyen.checkout.card.internal.ui.state.StoredCardViewStateProducer
+import com.adyen.checkout.card.internal.ui.state.UpdateDetectedCardTypesIntentHandler
 import com.adyen.checkout.core.analytics.internal.AnalyticsManager
 import com.adyen.checkout.core.common.internal.api.HttpClientFactory
 import com.adyen.checkout.core.components.CheckoutCallbacks
@@ -65,7 +66,8 @@ internal class CardFactory :
         val cardValidationMapper = CardValidationMapper()
         val dualBrandedCardHandler = DualBrandedCardHandler()
         val componentStateFactory = CardComponentStateFactory(cardComponentParams)
-        val componentStateReducer = CardComponentStateReducer(cardComponentParams)
+        val updateDetectedCardTypesIntentHandler = UpdateDetectedCardTypesIntentHandler(cardComponentParams)
+        val componentStateReducer = CardComponentStateReducer(updateDetectedCardTypesIntentHandler)
         val componentStateValidator = CardComponentStateValidator(cardValidationMapper)
         val viewStateProducer = CardViewStateProducer(dualBrandedCardHandler)
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardFactory.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardFactory.kt
@@ -17,6 +17,7 @@ import com.adyen.checkout.card.internal.data.api.DefaultDetectCardTypeRepository
 import com.adyen.checkout.card.internal.data.api.LocalCardBrandDetectionService
 import com.adyen.checkout.card.internal.data.api.NetworkCardBrandDetectionService
 import com.adyen.checkout.card.internal.ui.model.CardComponentParamsMapper
+import com.adyen.checkout.card.internal.ui.state.CardBrandIntentsHandler
 import com.adyen.checkout.card.internal.ui.state.CardComponentStateFactory
 import com.adyen.checkout.card.internal.ui.state.CardComponentStateReducer
 import com.adyen.checkout.card.internal.ui.state.CardComponentStateValidator
@@ -27,7 +28,6 @@ import com.adyen.checkout.card.internal.ui.state.StoredCardComponentStateFactory
 import com.adyen.checkout.card.internal.ui.state.StoredCardComponentStateReducer
 import com.adyen.checkout.card.internal.ui.state.StoredCardComponentStateValidator
 import com.adyen.checkout.card.internal.ui.state.StoredCardViewStateProducer
-import com.adyen.checkout.card.internal.ui.state.UpdateDetectedCardTypesIntentHandler
 import com.adyen.checkout.core.analytics.internal.AnalyticsManager
 import com.adyen.checkout.core.common.internal.api.HttpClientFactory
 import com.adyen.checkout.core.components.CheckoutCallbacks
@@ -66,8 +66,8 @@ internal class CardFactory :
         val cardValidationMapper = CardValidationMapper()
         val dualBrandedCardHandler = DualBrandedCardHandler()
         val componentStateFactory = CardComponentStateFactory(cardComponentParams)
-        val updateDetectedCardTypesIntentHandler = UpdateDetectedCardTypesIntentHandler(cardComponentParams)
-        val componentStateReducer = CardComponentStateReducer(updateDetectedCardTypesIntentHandler)
+        val cardBrandIntentsHandler = CardBrandIntentsHandler(cardComponentParams)
+        val componentStateReducer = CardComponentStateReducer(cardBrandIntentsHandler)
         val componentStateValidator = CardComponentStateValidator(cardValidationMapper)
         val viewStateProducer = CardViewStateProducer(dualBrandedCardHandler)
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardFactory.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardFactory.kt
@@ -16,6 +16,7 @@ import com.adyen.checkout.card.internal.data.api.BinLookupService
 import com.adyen.checkout.card.internal.data.api.DefaultDetectCardTypeRepository
 import com.adyen.checkout.card.internal.data.api.LocalCardBrandDetectionService
 import com.adyen.checkout.card.internal.data.api.NetworkCardBrandDetectionService
+import com.adyen.checkout.card.internal.helper.DetectCardTypeBinHelper
 import com.adyen.checkout.card.internal.ui.model.CardComponentParamsMapper
 import com.adyen.checkout.card.internal.ui.state.CardBrandIntentsHandler
 import com.adyen.checkout.card.internal.ui.state.CardComponentStateFactory
@@ -63,10 +64,12 @@ internal class CardFactory :
             paymentMethod = paymentMethod as? CardPaymentMethod,
         )
 
+        val detectCardTypeBinHelper = DetectCardTypeBinHelper()
+
         val cardValidationMapper = CardValidationMapper()
         val dualBrandedCardHandler = DualBrandedCardHandler()
         val componentStateFactory = CardComponentStateFactory(cardComponentParams)
-        val cardBrandIntentsHandler = CardBrandIntentsHandler(cardComponentParams)
+        val cardBrandIntentsHandler = CardBrandIntentsHandler(cardComponentParams, detectCardTypeBinHelper)
         val componentStateReducer = CardComponentStateReducer(cardBrandIntentsHandler)
         val componentStateValidator = CardComponentStateValidator(cardValidationMapper)
         val viewStateProducer = CardViewStateProducer(dualBrandedCardHandler)
@@ -86,6 +89,7 @@ internal class CardFactory :
             paymentMethodType = CardDetails.PAYMENT_METHOD_TYPE,
         )
         val detectCardTypeRepository = DefaultDetectCardTypeRepository(
+            detectCardTypeBinHelper,
             binLookupCache,
             localCardBrandDetectionService,
             networkCardBrandDetectionService,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/DualBrandedCardHandler.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/DualBrandedCardHandler.kt
@@ -16,13 +16,11 @@ import com.adyen.checkout.card.internal.ui.state.CardBrandState
 internal class DualBrandedCardHandler {
 
     internal fun getDualBrandData(cardBrandState: CardBrandState): DualBrandData? {
-        if (cardBrandState !is CardBrandState.DualBrand || !cardBrandState.shopperSelectionAllowed) return null
+        if (cardBrandState !is CardBrandState.DualBrandWithShopperSelection) return null
 
-        val selectedOrFirstCardBrandData = cardBrandState.shopperSelectedCardBrandData
-            ?: cardBrandState.cardBrandDataList.first()
         val brandOptions = mapToCardBrandItemList(
             cardBrandDataList = cardBrandState.cardBrandDataList,
-            selectedCardBrandData = selectedOrFirstCardBrandData,
+            selectedCardBrandData = cardBrandState.shopperSelectedCardBrandData,
         )
 
         return DualBrandData(

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/DualBrandedCardHandler.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/DualBrandedCardHandler.kt
@@ -16,7 +16,11 @@ import com.adyen.checkout.card.internal.ui.state.CardBrandState
 internal class DualBrandedCardHandler {
 
     internal fun getDualBrandData(cardBrandState: CardBrandState): DualBrandData? {
-        if (cardBrandState !is CardBrandState.DualBrandWithShopperSelection) return null
+        if (cardBrandState !is CardBrandState.DualBrandWithShopperSelection ||
+            cardBrandState.cardBrandDataList.size < 2
+        ) {
+            return null
+        }
 
         val brandOptions = mapToCardBrandItemList(
             cardBrandDataList = cardBrandState.cardBrandDataList,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/DualBrandedCardHandler.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/DualBrandedCardHandler.kt
@@ -8,23 +8,23 @@
 
 package com.adyen.checkout.card.internal.ui
 
-import com.adyen.checkout.card.internal.data.model.DetectedCardType
 import com.adyen.checkout.card.internal.ui.model.CardBrandItem
 import com.adyen.checkout.card.internal.ui.model.DualBrandData
+import com.adyen.checkout.card.internal.ui.state.CardBrandData
 import com.adyen.checkout.card.internal.ui.state.CardBrandState
 import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.common.CardType
 
 internal class DualBrandedCardHandler {
 
-    internal fun processDetectedCardTypes(
+    internal fun getDualBrandData(
         cardBrandState: CardBrandState,
         selectedBrand: CardBrand?,
     ): DualBrandData? {
         if (cardBrandState !is CardBrandState.DualBrand || !isShopperSelectionAllowed(cardBrandState)) return null
 
         val brandOptions = mapToCardBrandItemList(
-            reliableAndSupportedTypes = cardBrandState.detectedCardTypes,
+            cardBrandDataList = cardBrandState.cardBrandDataList,
             selectedBrand = selectedBrand,
         )
 
@@ -35,23 +35,25 @@ internal class DualBrandedCardHandler {
     }
 
     private fun isShopperSelectionAllowed(cardBrandState: CardBrandState.DualBrand): Boolean {
-        return cardBrandState.detectedCardTypes.any { it.cardBrand.txVariant in SUPPORTED_CARD_BRANDS }
+        return cardBrandState.cardBrandDataList.any { it.cardBrand.txVariant in SUPPORTED_CARD_BRANDS }
     }
 
     private fun mapToCardBrandItemList(
-        reliableAndSupportedTypes: List<DetectedCardType>,
+        cardBrandDataList: List<CardBrandData>,
         selectedBrand: CardBrand?,
-    ) = reliableAndSupportedTypes.mapIndexed { index, detectedCardType ->
-        if (selectedBrand == null) {
-            detectedCardType.mapToCardBrandItem(index == 0)
-        } else {
-            detectedCardType.mapToCardBrandItem(
-                detectedCardType.cardBrand.txVariant == selectedBrand.txVariant,
-            )
+    ): List<CardBrandItem> {
+        return cardBrandDataList.mapIndexed { index, cardBrandData ->
+            if (selectedBrand == null) {
+                cardBrandData.mapToCardBrandItem(index == 0)
+            } else {
+                cardBrandData.mapToCardBrandItem(
+                    cardBrandData.cardBrand.txVariant == selectedBrand.txVariant,
+                )
+            }
         }
     }
 
-    private fun DetectedCardType.mapToCardBrandItem(isSelected: Boolean) = CardBrandItem(
+    private fun CardBrandData.mapToCardBrandItem(isSelected: Boolean) = CardBrandItem(
         name = localizedBrand ?: cardBrand.txVariant,
         brand = cardBrand,
         isSelected = isSelected,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/DualBrandedCardHandler.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/DualBrandedCardHandler.kt
@@ -12,20 +12,18 @@ import com.adyen.checkout.card.internal.ui.model.CardBrandItem
 import com.adyen.checkout.card.internal.ui.model.DualBrandData
 import com.adyen.checkout.card.internal.ui.state.CardBrandData
 import com.adyen.checkout.card.internal.ui.state.CardBrandState
-import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.common.CardType
 
 internal class DualBrandedCardHandler {
 
-    internal fun getDualBrandData(
-        cardBrandState: CardBrandState,
-        selectedBrand: CardBrand?,
-    ): DualBrandData? {
+    internal fun getDualBrandData(cardBrandState: CardBrandState): DualBrandData? {
         if (cardBrandState !is CardBrandState.DualBrand || !isShopperSelectionAllowed(cardBrandState)) return null
 
+        val selectedOrFirstCardBrandData = cardBrandState.shopperSelectedCardBrandData
+            ?: cardBrandState.cardBrandDataList.first()
         val brandOptions = mapToCardBrandItemList(
             cardBrandDataList = cardBrandState.cardBrandDataList,
-            selectedBrand = selectedBrand,
+            selectedCardBrandData = selectedOrFirstCardBrandData,
         )
 
         return DualBrandData(
@@ -40,16 +38,12 @@ internal class DualBrandedCardHandler {
 
     private fun mapToCardBrandItemList(
         cardBrandDataList: List<CardBrandData>,
-        selectedBrand: CardBrand?,
+        selectedCardBrandData: CardBrandData,
     ): List<CardBrandItem> {
-        return cardBrandDataList.mapIndexed { index, cardBrandData ->
-            if (selectedBrand == null) {
-                cardBrandData.mapToCardBrandItem(index == 0)
-            } else {
-                cardBrandData.mapToCardBrandItem(
-                    cardBrandData.cardBrand.txVariant == selectedBrand.txVariant,
-                )
-            }
+        return cardBrandDataList.map { cardBrandData ->
+            cardBrandData.mapToCardBrandItem(
+                isSelected = (cardBrandData == selectedCardBrandData),
+            )
         }
     }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/DualBrandedCardHandler.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/DualBrandedCardHandler.kt
@@ -12,12 +12,11 @@ import com.adyen.checkout.card.internal.ui.model.CardBrandItem
 import com.adyen.checkout.card.internal.ui.model.DualBrandData
 import com.adyen.checkout.card.internal.ui.state.CardBrandData
 import com.adyen.checkout.card.internal.ui.state.CardBrandState
-import com.adyen.checkout.core.common.CardType
 
 internal class DualBrandedCardHandler {
 
     internal fun getDualBrandData(cardBrandState: CardBrandState): DualBrandData? {
-        if (cardBrandState !is CardBrandState.DualBrand || !isShopperSelectionAllowed(cardBrandState)) return null
+        if (cardBrandState !is CardBrandState.DualBrand || !cardBrandState.shopperSelectionAllowed) return null
 
         val selectedOrFirstCardBrandData = cardBrandState.shopperSelectedCardBrandData
             ?: cardBrandState.cardBrandDataList.first()
@@ -30,10 +29,6 @@ internal class DualBrandedCardHandler {
             brandOptionFirst = brandOptions[0],
             brandOptionSecond = brandOptions[1],
         )
-    }
-
-    private fun isShopperSelectionAllowed(cardBrandState: CardBrandState.DualBrand): Boolean {
-        return cardBrandState.cardBrandDataList.any { it.cardBrand.txVariant in SUPPORTED_CARD_BRANDS }
     }
 
     private fun mapToCardBrandItemList(
@@ -52,12 +47,4 @@ internal class DualBrandedCardHandler {
         brand = cardBrand,
         isSelected = isSelected,
     )
-
-    companion object {
-        private val SUPPORTED_CARD_BRANDS = listOf(
-            CardType.CARTEBANCAIRE,
-            CardType.BCMC,
-            CardType.DANKORT,
-        ).map { it.txVariant }
-    }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/DualBrandedCardHandler.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/DualBrandedCardHandler.kt
@@ -11,21 +11,20 @@ package com.adyen.checkout.card.internal.ui
 import com.adyen.checkout.card.internal.data.model.DetectedCardType
 import com.adyen.checkout.card.internal.ui.model.CardBrandItem
 import com.adyen.checkout.card.internal.ui.model.DualBrandData
+import com.adyen.checkout.card.internal.ui.state.CardBrandState
 import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.common.CardType
 
 internal class DualBrandedCardHandler {
 
     internal fun processDetectedCardTypes(
-        detectedCardTypes: List<DetectedCardType>,
-        selectedBrand: CardBrand?
+        cardBrandState: CardBrandState,
+        selectedBrand: CardBrand?,
     ): DualBrandData? {
-        val reliableAndSupportedTypes = detectedCardTypes.filter { it.isSupported && it.isReliable }
-
-        if (!isDualBrandedFlow(reliableAndSupportedTypes)) return null
+        if (cardBrandState !is CardBrandState.DualBrand || !isShopperSelectionAllowed(cardBrandState)) return null
 
         val brandOptions = mapToCardBrandItemList(
-            reliableAndSupportedTypes = reliableAndSupportedTypes,
+            reliableAndSupportedTypes = cardBrandState.detectedCardTypes,
             selectedBrand = selectedBrand,
         )
 
@@ -35,11 +34,8 @@ internal class DualBrandedCardHandler {
         )
     }
 
-    private fun isDualBrandedFlow(reliableAndSupportedTypes: List<DetectedCardType>) =
-        reliableAndSupportedTypes.size > 1 && hasSupportedBrands(reliableAndSupportedTypes)
-
-    private fun hasSupportedBrands(reliableAndSupportedTypes: List<DetectedCardType>) = reliableAndSupportedTypes.any {
-        it.cardBrand.txVariant in SUPPORTED_CARD_BRANDS
+    private fun isShopperSelectionAllowed(cardBrandState: CardBrandState.DualBrand): Boolean {
+        return cardBrandState.detectedCardTypes.any { it.cardBrand.txVariant in SUPPORTED_CARD_BRANDS }
     }
 
     private fun mapToCardBrandItemList(

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/StoredCardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/StoredCardComponent.kt
@@ -76,7 +76,6 @@ internal class StoredCardComponent(
 
         val storedDetectedCardType = DetectedCardType(
             cardBrand = cardType,
-            isReliable = true,
             enableLuhnCheck = true,
             cvcPolicy = when {
                 componentParams.storedCVCVisibility == StoredCVCVisibility.HIDE ||

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/StoredCardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/StoredCardComponent.kt
@@ -85,6 +85,7 @@ internal class StoredCardComponent(
             },
             expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
             isSupported = true,
+            isShopperSelectionAllowedInDualBranded = false,
             panLength = null,
             paymentMethodVariant = null,
             localizedBrand = null,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/model/DualBrandData.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/model/DualBrandData.kt
@@ -12,10 +12,3 @@ internal data class DualBrandData(
     val brandOptionFirst: CardBrandItem,
     val brandOptionSecond: CardBrandItem,
 )
-
-internal val DualBrandData.selectedBrand
-    get() = when {
-        brandOptionFirst.isSelected -> brandOptionFirst.brand
-        brandOptionSecond.isSelected -> brandOptionSecond.brand
-        else -> null
-    }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandler.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandler.kt
@@ -25,11 +25,9 @@ internal class CardBrandIntentsHandler(
         val cardBrandState = getCardBrandState(state, intent)
 
         val selectedOrFirstOrReliableCardBrandData = when (cardBrandState) {
-            is CardBrandState.DualBrand -> {
-                cardBrandState.shopperSelectedCardBrandData ?: cardBrandState.cardBrandDataList.firstOrNull()
-            }
-
-            is CardBrandState.SingleBrand if cardBrandState.isReliable -> cardBrandState.cardBrandData
+            is CardBrandState.DualBrandWithShopperSelection -> cardBrandState.shopperSelectedCardBrandData
+            is CardBrandState.DualBrand -> cardBrandState.cardBrandDataList.first()
+            is CardBrandState.SingleReliableBrand -> cardBrandState.cardBrandData
             else -> null
         }
         val cvcPolicy = selectedOrFirstOrReliableCardBrandData?.cvcPolicy
@@ -64,9 +62,8 @@ internal class CardBrandIntentsHandler(
             // local detection + supported brands
             !isDetectedFromNetwork -> {
                 // select the first brand and discard the rest
-                CardBrandState.SingleBrand(
+                CardBrandState.SingleUnreliableBrand(
                     cardBrandData = supportedDetectedCardTypes.first().toCardBrandData(),
-                    isReliable = false,
                 )
             }
 
@@ -83,9 +80,8 @@ internal class CardBrandIntentsHandler(
 
             // network detection + 1 detected brand
             supportedDetectedCardTypes.size == 1 -> {
-                CardBrandState.SingleBrand(
+                CardBrandState.SingleReliableBrand(
                     cardBrandData = supportedDetectedCardTypes.first().toCardBrandData(),
-                    isReliable = true,
                 )
             }
 
@@ -98,25 +94,26 @@ internal class CardBrandIntentsHandler(
                 val shopperSelectionAllowed = firstTwoDetectedCardTypes.any {
                     it.isShopperSelectionAllowedInDualBranded
                 }
-                val currentCardBrandState = currentState.cardBrandState
-                val shopperSelectedCardBrandData = if (
-                    currentCardBrandState is CardBrandState.DualBrand &&
-                    currentCardBrandState.cardBrandDataList == cardBrandDataList
-                ) {
-                    // the list of brands has not changed, keep the previously selected brand
-                    currentCardBrandState.shopperSelectedCardBrandData
-                } else if (shopperSelectionAllowed) {
-                    // auto select the first brand
-                    cardBrandDataList.firstOrNull()
-                } else {
-                    null
-                }
 
-                CardBrandState.DualBrand(
-                    cardBrandDataList = cardBrandDataList,
-                    shopperSelectionAllowed = shopperSelectionAllowed,
-                    shopperSelectedCardBrandData = shopperSelectedCardBrandData,
-                )
+                if (shopperSelectionAllowed) {
+                    val currentCardBrandState = currentState.cardBrandState
+                    val shopperSelectedCardBrandData = if (
+                        currentCardBrandState is CardBrandState.DualBrandWithShopperSelection &&
+                        currentCardBrandState.cardBrandDataList == cardBrandDataList
+                    ) {
+                        // the list of brands has not changed, keep the previously selected brand
+                        currentCardBrandState.shopperSelectedCardBrandData
+                    } else {
+                        // auto select the first brand
+                        cardBrandDataList.first()
+                    }
+                    CardBrandState.DualBrandWithShopperSelection(
+                        cardBrandDataList = cardBrandDataList,
+                        shopperSelectedCardBrandData = shopperSelectedCardBrandData,
+                    )
+                } else {
+                    CardBrandState.DualBrand(cardBrandDataList)
+                }
             }
         }
     }
@@ -154,17 +151,18 @@ internal class CardBrandIntentsHandler(
 
     fun onBrandSelected(state: CardComponentState, intent: CardIntent.SelectBrand): CardComponentState {
         val currentCardBrandState = state.cardBrandState
-        return if (currentCardBrandState is CardBrandState.DualBrand) {
+        if (currentCardBrandState is CardBrandState.DualBrandWithShopperSelection) {
             val selectedCardBrandData = currentCardBrandState.cardBrandDataList.firstOrNull {
                 it.cardBrand == intent.cardBrand
             }
-            state.copy(
-                cardBrandState = currentCardBrandState.copy(
-                    shopperSelectedCardBrandData = selectedCardBrandData,
-                ),
-            )
-        } else {
-            state
+            if (selectedCardBrandData != null) {
+                return state.copy(
+                    cardBrandState = currentCardBrandState.copy(
+                        shopperSelectedCardBrandData = selectedCardBrandData,
+                    ),
+                )
+            }
         }
+        return state
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandler.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandler.kt
@@ -141,11 +141,15 @@ internal class CardBrandIntentsHandler(
         state: CardComponentState,
         cardBrandState: CardBrandState
     ): CardComponentState {
+        // We should only override the default behavior of the CVC / expiry date if the identified brand is reliable
+        // With DualBrand (no shopper selection) we can rely on the first brand
         val selectedOrFirstOrReliableCardBrandData = when (cardBrandState) {
             is CardBrandState.DualBrandWithShopperSelection -> cardBrandState.shopperSelectedCardBrandData
             is CardBrandState.DualBrand -> cardBrandState.cardBrandDataList.first()
             is CardBrandState.SingleReliableBrand -> cardBrandState.cardBrandData
-            else -> null
+            is CardBrandState.NoBrandsDetected,
+            is CardBrandState.SingleUnreliableBrand,
+            is CardBrandState.UnsupportedBrand -> null
         }
         val cvcPolicy = selectedOrFirstOrReliableCardBrandData?.cvcPolicy
         val expiryDatePolicy = selectedOrFirstOrReliableCardBrandData?.expiryDatePolicy

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandler.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandler.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.card.internal.ui.state
 
 import com.adyen.checkout.card.internal.data.model.Brand
 import com.adyen.checkout.card.internal.data.model.DetectedCardTypeList
+import com.adyen.checkout.card.internal.helper.DetectCardTypeBinHelper
 import com.adyen.checkout.card.internal.helper.toCardBrandData
 import com.adyen.checkout.card.internal.ui.model.CVCVisibility
 import com.adyen.checkout.card.internal.ui.model.CardComponentParams
@@ -17,13 +18,29 @@ import com.adyen.checkout.core.components.internal.ui.state.model.RequirementPol
 
 internal class CardBrandIntentsHandler(
     private val componentParams: CardComponentParams,
+    private val detectCardTypeBinHelper: DetectCardTypeBinHelper,
 ) {
     fun onUpdateDetectedCardTypes(
         state: CardComponentState,
         intent: CardIntent.UpdateDetectedCardTypes,
     ): CardComponentState {
-        val cardBrandState = getCardBrandState(state, intent)
-        return getUpdatedCardComponentState(state, cardBrandState)
+        val shouldDiscardIntent = shouldDiscardIntent(
+            currentCardNumber = state.cardNumber.text,
+            intentBin = intent.detectedCardTypeList.cardDetectionBin,
+        )
+        return if (shouldDiscardIntent) {
+            state
+        } else {
+            val newCardBrandState = getCardBrandState(state, intent)
+            getUpdatedCardComponentState(state, newCardBrandState)
+        }
+    }
+
+    private fun shouldDiscardIntent(currentCardNumber: String, intentBin: String?): Boolean {
+        val currentBin = detectCardTypeBinHelper.getCardDetectionBin(currentCardNumber)
+        // result is not relevant anymore and should be discarded
+        // this can happen if network results are returned after a delay and the BIN has already changed
+        return intentBin != currentBin
     }
 
     private fun getCardBrandState(

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandler.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandler.kt
@@ -92,21 +92,29 @@ internal class CardBrandIntentsHandler(
             // network detection + multiple detected brands
             else -> {
                 // select the first 2 brands and discard the rest (should only have 2 brands normally)
-                val cardBrandDataList = supportedDetectedCardTypes.take(2).map { it.toCardBrandData() }
+                val firstTwoDetectedCardTypes = supportedDetectedCardTypes.take(2)
+                val cardBrandDataList = firstTwoDetectedCardTypes.map { it.toCardBrandData() }
 
+                val shopperSelectionAllowed = firstTwoDetectedCardTypes.any {
+                    it.isShopperSelectionAllowedInDualBranded
+                }
                 val currentCardBrandState = currentState.cardBrandState
-                // if the list of brands has not changed, keep the previously selected brand, otherwise reset it
                 val shopperSelectedCardBrandData = if (
                     currentCardBrandState is CardBrandState.DualBrand &&
                     currentCardBrandState.cardBrandDataList == cardBrandDataList
                 ) {
+                    // the list of brands has not changed, keep the previously selected brand
                     currentCardBrandState.shopperSelectedCardBrandData
+                } else if (shopperSelectionAllowed) {
+                    // auto select the first brand
+                    cardBrandDataList.firstOrNull()
                 } else {
                     null
                 }
 
                 CardBrandState.DualBrand(
                     cardBrandDataList = cardBrandDataList,
+                    shopperSelectionAllowed = shopperSelectionAllowed,
                     shopperSelectedCardBrandData = shopperSelectedCardBrandData,
                 )
             }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandler.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandler.kt
@@ -15,10 +15,10 @@ import com.adyen.checkout.card.internal.ui.model.CVCVisibility
 import com.adyen.checkout.card.internal.ui.model.CardComponentParams
 import com.adyen.checkout.core.components.internal.ui.state.model.RequirementPolicy
 
-internal class UpdateDetectedCardTypesIntentHandler(
+internal class CardBrandIntentsHandler(
     private val componentParams: CardComponentParams,
 ) {
-    fun updateCardComponentState(
+    fun onUpdateDetectedCardTypes(
         state: CardComponentState,
         intent: CardIntent.UpdateDetectedCardTypes,
     ): CardComponentState {
@@ -36,7 +36,10 @@ internal class UpdateDetectedCardTypesIntentHandler(
             // local detection + supported brands
             !isDetectedFromNetwork -> {
                 // select the first brand and discard the rest
-                CardBrandState.SingleBrand(supportedDetectedCardTypes.first().toCardBrandData(), false)
+                CardBrandState.SingleBrand(
+                    cardBrandData = supportedDetectedCardTypes.first().toCardBrandData(),
+                    isReliable = false,
+                )
             }
 
             // network detection + no detected brands
@@ -52,26 +55,45 @@ internal class UpdateDetectedCardTypesIntentHandler(
 
             // network detection + 1 detected brand
             supportedDetectedCardTypes.size == 1 -> {
-                CardBrandState.SingleBrand(supportedDetectedCardTypes.first().toCardBrandData(), true)
+                CardBrandState.SingleBrand(
+                    cardBrandData = supportedDetectedCardTypes.first().toCardBrandData(),
+                    isReliable = true,
+                )
             }
 
             // network detection + multiple detected brands
             else -> {
                 // select the first 2 brands and discard the rest (should only have 2 brands normally)
-                CardBrandState.DualBrand(supportedDetectedCardTypes.take(2).map { it.toCardBrandData() })
+                val cardBrandDataList = supportedDetectedCardTypes.take(2).map { it.toCardBrandData() }
+
+                val currentCardBrandState = state.cardBrandState
+                // if the list of brands has not changed, keep the previously selected brand, otherwise reset it
+                val shopperSelectedCardBrandData = if (
+                    currentCardBrandState is CardBrandState.DualBrand &&
+                    currentCardBrandState.cardBrandDataList == cardBrandDataList
+                ) {
+                    currentCardBrandState.shopperSelectedCardBrandData
+                } else {
+                    null
+                }
+
+                CardBrandState.DualBrand(
+                    cardBrandDataList = cardBrandDataList,
+                    shopperSelectedCardBrandData = shopperSelectedCardBrandData,
+                )
             }
         }
 
-        val selectedOrFirstReliableCardType = when {
-            state.selectedCardBrand != null -> {
-                supportedDetectedCardTypes.firstOrNull { it.cardBrand.txVariant == state.selectedCardBrand.txVariant }
+        val selectedOrFirstOrReliableCardBrandData = when (cardBrandState) {
+            is CardBrandState.DualBrand -> {
+                cardBrandState.shopperSelectedCardBrandData ?: cardBrandState.cardBrandDataList.firstOrNull()
             }
 
-            isDetectedFromNetwork -> supportedDetectedCardTypes.firstOrNull()
+            is CardBrandState.SingleBrand if cardBrandState.isReliable -> cardBrandState.cardBrandData
             else -> null
         }
-        val cvcPolicy = selectedOrFirstReliableCardType?.cvcPolicy
-        val expiryDatePolicy = selectedOrFirstReliableCardType?.expiryDatePolicy
+        val cvcPolicy = selectedOrFirstOrReliableCardBrandData?.cvcPolicy
+        val expiryDatePolicy = selectedOrFirstOrReliableCardBrandData?.expiryDatePolicy
 
         return state.copy(
             cardBrandState = cardBrandState,
@@ -112,6 +134,22 @@ internal class UpdateDetectedCardTypesIntentHandler(
                 CVCVisibility.ALWAYS_SHOW -> RequirementPolicy.Required
                 CVCVisibility.HIDE_FIRST, CVCVisibility.ALWAYS_HIDE -> RequirementPolicy.Hidden
             }
+        }
+    }
+
+    fun onBrandSelected(state: CardComponentState, intent: CardIntent.SelectBrand): CardComponentState {
+        val currentCardBrandState = state.cardBrandState
+        return if (currentCardBrandState is CardBrandState.DualBrand) {
+            val selectedCardBrandData = currentCardBrandState.cardBrandDataList.firstOrNull {
+                it.cardBrand == intent.cardBrand
+            }
+            state.copy(
+                cardBrandState = currentCardBrandState.copy(
+                    shopperSelectedCardBrandData = selectedCardBrandData,
+                ),
+            )
+        } else {
+            state
         }
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandler.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandler.kt
@@ -9,6 +9,7 @@
 package com.adyen.checkout.card.internal.ui.state
 
 import com.adyen.checkout.card.internal.data.model.Brand
+import com.adyen.checkout.card.internal.data.model.DetectedCardType
 import com.adyen.checkout.card.internal.data.model.DetectedCardTypeList
 import com.adyen.checkout.card.internal.helper.DetectCardTypeBinHelper
 import com.adyen.checkout.card.internal.helper.toCardBrandData
@@ -48,72 +49,75 @@ internal class CardBrandIntentsHandler(
         intent: CardIntent.UpdateDetectedCardTypes,
     ): CardBrandState {
         val detectedCardTypes = intent.detectedCardTypeList.detectedCardTypes
-        val isDetectedFromNetwork = intent.detectedCardTypeList.source == DetectedCardTypeList.Source.NETWORK
-
         val supportedDetectedCardTypes = detectedCardTypes.filter { it.isSupported }
 
-        return when {
-            // local detection + no supported brands
-            !isDetectedFromNetwork && supportedDetectedCardTypes.isEmpty() -> {
-                CardBrandState.NoBrandsDetected
-            }
-
-            // local detection + supported brands
-            !isDetectedFromNetwork -> {
-                // select the first brand and discard the rest
-                CardBrandState.SingleUnreliableBrand(
-                    cardBrandData = supportedDetectedCardTypes.first().toCardBrandData(),
-                )
-            }
-
-            // network detection + no detected brands
-            detectedCardTypes.isEmpty() -> {
-                // Bin lookup did not return any brands
-                CardBrandState.NoBrandsDetected
-            }
-
-            // network detection + detected brands but no supported brands
-            supportedDetectedCardTypes.isEmpty() -> {
-                CardBrandState.UnsupportedBrand
-            }
-
-            // network detection + 1 detected brand
-            supportedDetectedCardTypes.size == 1 -> {
-                CardBrandState.SingleReliableBrand(
-                    cardBrandData = supportedDetectedCardTypes.first().toCardBrandData(),
-                )
-            }
-
-            // network detection + multiple detected brands
-            else -> {
-                // select the first 2 brands and discard the rest (should only have 2 brands normally)
-                val firstTwoDetectedCardTypes = supportedDetectedCardTypes.take(2)
-                val cardBrandDataList = firstTwoDetectedCardTypes.map { it.toCardBrandData() }
-
-                val shopperSelectionAllowed = firstTwoDetectedCardTypes.any {
-                    it.isShopperSelectionAllowedInDualBranded
-                }
-
-                if (shopperSelectionAllowed) {
-                    val currentCardBrandState = currentState.cardBrandState
-                    val shopperSelectedCardBrandData = if (
-                        currentCardBrandState is CardBrandState.DualBrandWithShopperSelection &&
-                        currentCardBrandState.cardBrandDataList == cardBrandDataList
-                    ) {
-                        // the list of brands has not changed, keep the previously selected brand
-                        currentCardBrandState.shopperSelectedCardBrandData
-                    } else {
-                        // auto select the first brand
-                        cardBrandDataList.first()
-                    }
-                    CardBrandState.DualBrandWithShopperSelection(
-                        cardBrandDataList = cardBrandDataList,
-                        shopperSelectedCardBrandData = shopperSelectedCardBrandData,
-                    )
+        return when (intent.detectedCardTypeList.source) {
+            DetectedCardTypeList.Source.LOCAL -> {
+                if (supportedDetectedCardTypes.isEmpty()) {
+                    // local detection + no supported brands
+                    CardBrandState.NoBrandsDetected
                 } else {
-                    CardBrandState.DualBrand(cardBrandDataList)
+                    // local detection + supported brands
+                    // select the first brand and discard the rest
+                    CardBrandState.SingleUnreliableBrand(
+                        cardBrandData = supportedDetectedCardTypes.first().toCardBrandData(),
+                    )
                 }
             }
+
+            DetectedCardTypeList.Source.NETWORK -> {
+                when {
+                    // network detection + no detected brands
+                    detectedCardTypes.isEmpty() -> CardBrandState.NoBrandsDetected
+
+                    // network detection + detected brands but no supported brands
+                    supportedDetectedCardTypes.isEmpty() -> CardBrandState.UnsupportedBrand
+
+                    // network detection + 1 detected brand
+                    supportedDetectedCardTypes.size == 1 -> {
+                        CardBrandState.SingleReliableBrand(
+                            cardBrandData = supportedDetectedCardTypes.first().toCardBrandData(),
+                        )
+                    }
+
+                    // network detection + multiple detected brands
+                    else -> {
+                        getDualBrandedCardBrandState(currentState.cardBrandState, supportedDetectedCardTypes)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun getDualBrandedCardBrandState(
+        currentCardBrandState: CardBrandState,
+        supportedDetectedCardTypes: List<DetectedCardType>
+    ): CardBrandState {
+        // select the first 2 brands and discard the rest (should only have 2 brands normally)
+        val firstTwoDetectedCardTypes = supportedDetectedCardTypes.take(2)
+        val cardBrandDataList = firstTwoDetectedCardTypes.map { it.toCardBrandData() }
+
+        val shopperSelectionAllowed = firstTwoDetectedCardTypes.any {
+            it.isShopperSelectionAllowedInDualBranded
+        }
+
+        return if (shopperSelectionAllowed) {
+            val shopperSelectedCardBrandData = if (
+                currentCardBrandState is CardBrandState.DualBrandWithShopperSelection &&
+                currentCardBrandState.cardBrandDataList == cardBrandDataList
+            ) {
+                // the list of brands has not changed, keep the previously selected brand
+                currentCardBrandState.shopperSelectedCardBrandData
+            } else {
+                // auto select the first brand
+                cardBrandDataList.first()
+            }
+            CardBrandState.DualBrandWithShopperSelection(
+                cardBrandDataList = cardBrandDataList,
+                shopperSelectedCardBrandData = shopperSelectedCardBrandData,
+            )
+        } else {
+            CardBrandState.DualBrand(cardBrandDataList)
         }
     }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandler.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandler.kt
@@ -23,25 +23,7 @@ internal class CardBrandIntentsHandler(
         intent: CardIntent.UpdateDetectedCardTypes,
     ): CardComponentState {
         val cardBrandState = getCardBrandState(state, intent)
-
-        val selectedOrFirstOrReliableCardBrandData = when (cardBrandState) {
-            is CardBrandState.DualBrandWithShopperSelection -> cardBrandState.shopperSelectedCardBrandData
-            is CardBrandState.DualBrand -> cardBrandState.cardBrandDataList.first()
-            is CardBrandState.SingleReliableBrand -> cardBrandState.cardBrandData
-            else -> null
-        }
-        val cvcPolicy = selectedOrFirstOrReliableCardBrandData?.cvcPolicy
-        val expiryDatePolicy = selectedOrFirstOrReliableCardBrandData?.expiryDatePolicy
-
-        return state.copy(
-            cardBrandState = cardBrandState,
-            securityCode = state.securityCode.copy(
-                requirementPolicy = getSecurityCodeRequirementPolicy(cvcPolicy),
-            ),
-            expiryDate = state.expiryDate.copy(
-                requirementPolicy = getExpiryDateRequirementPolicy(expiryDatePolicy),
-            ),
-        )
+        return getUpdatedCardComponentState(state, cardBrandState)
     }
 
     private fun getCardBrandState(
@@ -118,6 +100,46 @@ internal class CardBrandIntentsHandler(
         }
     }
 
+    fun onBrandSelected(state: CardComponentState, intent: CardIntent.SelectBrand): CardComponentState {
+        val currentCardBrandState = state.cardBrandState
+        if (currentCardBrandState is CardBrandState.DualBrandWithShopperSelection) {
+            val selectedCardBrandData = currentCardBrandState.cardBrandDataList.firstOrNull {
+                it.cardBrand == intent.cardBrand
+            }
+            if (selectedCardBrandData != null) {
+                val cardBrandState = currentCardBrandState.copy(
+                    shopperSelectedCardBrandData = selectedCardBrandData,
+                )
+                return getUpdatedCardComponentState(state, cardBrandState)
+            }
+        }
+        return state
+    }
+
+    private fun getUpdatedCardComponentState(
+        state: CardComponentState,
+        cardBrandState: CardBrandState
+    ): CardComponentState {
+        val selectedOrFirstOrReliableCardBrandData = when (cardBrandState) {
+            is CardBrandState.DualBrandWithShopperSelection -> cardBrandState.shopperSelectedCardBrandData
+            is CardBrandState.DualBrand -> cardBrandState.cardBrandDataList.first()
+            is CardBrandState.SingleReliableBrand -> cardBrandState.cardBrandData
+            else -> null
+        }
+        val cvcPolicy = selectedOrFirstOrReliableCardBrandData?.cvcPolicy
+        val expiryDatePolicy = selectedOrFirstOrReliableCardBrandData?.expiryDatePolicy
+
+        return state.copy(
+            cardBrandState = cardBrandState,
+            securityCode = state.securityCode.copy(
+                requirementPolicy = getSecurityCodeRequirementPolicy(cvcPolicy),
+            ),
+            expiryDate = state.expiryDate.copy(
+                requirementPolicy = getExpiryDateRequirementPolicy(expiryDatePolicy),
+            ),
+        )
+    }
+
     private fun getExpiryDateRequirementPolicy(expiryDatePolicy: Brand.FieldPolicy?): RequirementPolicy {
         if (expiryDatePolicy == null) return RequirementPolicy.Required
 
@@ -147,22 +169,5 @@ internal class CardBrandIntentsHandler(
                 CVCVisibility.HIDE_FIRST, CVCVisibility.ALWAYS_HIDE -> RequirementPolicy.Hidden
             }
         }
-    }
-
-    fun onBrandSelected(state: CardComponentState, intent: CardIntent.SelectBrand): CardComponentState {
-        val currentCardBrandState = state.cardBrandState
-        if (currentCardBrandState is CardBrandState.DualBrandWithShopperSelection) {
-            val selectedCardBrandData = currentCardBrandState.cardBrandDataList.firstOrNull {
-                it.cardBrand == intent.cardBrand
-            }
-            if (selectedCardBrandData != null) {
-                return state.copy(
-                    cardBrandState = currentCardBrandState.copy(
-                        shopperSelectedCardBrandData = selectedCardBrandData,
-                    ),
-                )
-            }
-        }
-        return state
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandler.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandler.kt
@@ -22,12 +22,40 @@ internal class CardBrandIntentsHandler(
         state: CardComponentState,
         intent: CardIntent.UpdateDetectedCardTypes,
     ): CardComponentState {
+        val cardBrandState = getCardBrandState(state, intent)
+
+        val selectedOrFirstOrReliableCardBrandData = when (cardBrandState) {
+            is CardBrandState.DualBrand -> {
+                cardBrandState.shopperSelectedCardBrandData ?: cardBrandState.cardBrandDataList.firstOrNull()
+            }
+
+            is CardBrandState.SingleBrand if cardBrandState.isReliable -> cardBrandState.cardBrandData
+            else -> null
+        }
+        val cvcPolicy = selectedOrFirstOrReliableCardBrandData?.cvcPolicy
+        val expiryDatePolicy = selectedOrFirstOrReliableCardBrandData?.expiryDatePolicy
+
+        return state.copy(
+            cardBrandState = cardBrandState,
+            securityCode = state.securityCode.copy(
+                requirementPolicy = getSecurityCodeRequirementPolicy(cvcPolicy),
+            ),
+            expiryDate = state.expiryDate.copy(
+                requirementPolicy = getExpiryDateRequirementPolicy(expiryDatePolicy),
+            ),
+        )
+    }
+
+    private fun getCardBrandState(
+        currentState: CardComponentState,
+        intent: CardIntent.UpdateDetectedCardTypes,
+    ): CardBrandState {
         val detectedCardTypes = intent.detectedCardTypeList.detectedCardTypes
         val isDetectedFromNetwork = intent.detectedCardTypeList.source == DetectedCardTypeList.Source.NETWORK
 
         val supportedDetectedCardTypes = detectedCardTypes.filter { it.isSupported }
 
-        val cardBrandState = when {
+        return when {
             // local detection + no supported brands
             !isDetectedFromNetwork && supportedDetectedCardTypes.isEmpty() -> {
                 CardBrandState.NoBrandsDetected
@@ -66,7 +94,7 @@ internal class CardBrandIntentsHandler(
                 // select the first 2 brands and discard the rest (should only have 2 brands normally)
                 val cardBrandDataList = supportedDetectedCardTypes.take(2).map { it.toCardBrandData() }
 
-                val currentCardBrandState = state.cardBrandState
+                val currentCardBrandState = currentState.cardBrandState
                 // if the list of brands has not changed, keep the previously selected brand, otherwise reset it
                 val shopperSelectedCardBrandData = if (
                     currentCardBrandState is CardBrandState.DualBrand &&
@@ -83,27 +111,6 @@ internal class CardBrandIntentsHandler(
                 )
             }
         }
-
-        val selectedOrFirstOrReliableCardBrandData = when (cardBrandState) {
-            is CardBrandState.DualBrand -> {
-                cardBrandState.shopperSelectedCardBrandData ?: cardBrandState.cardBrandDataList.firstOrNull()
-            }
-
-            is CardBrandState.SingleBrand if cardBrandState.isReliable -> cardBrandState.cardBrandData
-            else -> null
-        }
-        val cvcPolicy = selectedOrFirstOrReliableCardBrandData?.cvcPolicy
-        val expiryDatePolicy = selectedOrFirstOrReliableCardBrandData?.expiryDatePolicy
-
-        return state.copy(
-            cardBrandState = cardBrandState,
-            securityCode = state.securityCode.copy(
-                requirementPolicy = getSecurityCodeRequirementPolicy(cvcPolicy),
-            ),
-            expiryDate = state.expiryDate.copy(
-                requirementPolicy = getExpiryDateRequirementPolicy(expiryDatePolicy),
-            ),
-        )
     }
 
     private fun getExpiryDateRequirementPolicy(expiryDatePolicy: Brand.FieldPolicy?): RequirementPolicy {

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandler.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandler.kt
@@ -8,6 +8,7 @@
 
 package com.adyen.checkout.card.internal.ui.state
 
+import androidx.annotation.VisibleForTesting
 import com.adyen.checkout.card.internal.data.model.Brand
 import com.adyen.checkout.card.internal.data.model.DetectedCardType
 import com.adyen.checkout.card.internal.data.model.DetectedCardTypeList
@@ -137,7 +138,8 @@ internal class CardBrandIntentsHandler(
         return state
     }
 
-    private fun getUpdatedCardComponentState(
+    @VisibleForTesting
+    internal fun getUpdatedCardComponentState(
         state: CardComponentState,
         cardBrandState: CardBrandState
     ): CardComponentState {

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentState.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentState.kt
@@ -31,9 +31,16 @@ internal data class CardComponentState(
     val isLoading: Boolean,
 
     // Component state
-    val detectedCardTypes: List<DetectedCardType>,
+    val cardBrandState: CardBrandState,
     val selectedCardBrand: CardBrand?,
 ) : ComponentState
+
+internal sealed class CardBrandState {
+    data object NoBrandsDetected : CardBrandState()
+    data object UnsupportedBrand : CardBrandState()
+    data class SingleBrand(val detectedCardType: DetectedCardType) : CardBrandState()
+    data class DualBrand(val detectedCardTypes: List<DetectedCardType>) : CardBrandState()
+}
 
 internal val CardComponentState.binValue: String
     get() = if (cardNumber.isValid && cardNumber.text.length >= EXTENDED_CARD_NUMBER_LENGTH) {

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentState.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentState.kt
@@ -40,6 +40,7 @@ internal sealed class CardBrandState {
     data class SingleBrand(val cardBrandData: CardBrandData, val isReliable: Boolean) : CardBrandState()
     data class DualBrand(
         val cardBrandDataList: List<CardBrandData>,
+        val shopperSelectionAllowed: Boolean,
         val shopperSelectedCardBrandData: CardBrandData?,
     ) : CardBrandState()
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentState.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentState.kt
@@ -9,6 +9,7 @@
 package com.adyen.checkout.card.internal.ui.state
 
 import androidx.annotation.VisibleForTesting
+import com.adyen.checkout.card.internal.data.model.Brand
 import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.components.internal.ui.state.ComponentState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
@@ -31,19 +32,23 @@ internal data class CardComponentState(
 
     // Component state
     val cardBrandState: CardBrandState,
-    val selectedCardBrand: CardBrand?,
 ) : ComponentState
 
 internal sealed class CardBrandState {
     data object NoBrandsDetected : CardBrandState()
     data object UnsupportedBrand : CardBrandState()
     data class SingleBrand(val cardBrandData: CardBrandData, val isReliable: Boolean) : CardBrandState()
-    data class DualBrand(val cardBrandDataList: List<CardBrandData>) : CardBrandState()
+    data class DualBrand(
+        val cardBrandDataList: List<CardBrandData>,
+        val shopperSelectedCardBrandData: CardBrandData?,
+    ) : CardBrandState()
 }
 
 internal data class CardBrandData(
     val cardBrand: CardBrand,
     val enableLuhnCheck: Boolean,
+    val cvcPolicy: Brand.FieldPolicy,
+    val expiryDatePolicy: Brand.FieldPolicy,
     val panLength: Int?,
     val paymentMethodVariant: String?,
     val localizedBrand: String?

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentState.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentState.kt
@@ -38,7 +38,7 @@ internal data class CardComponentState(
 internal sealed class CardBrandState {
     data object NoBrandsDetected : CardBrandState()
     data object UnsupportedBrand : CardBrandState()
-    data class SingleBrand(val detectedCardType: DetectedCardType) : CardBrandState()
+    data class SingleBrand(val detectedCardType: DetectedCardType, val isReliable: Boolean) : CardBrandState()
     data class DualBrand(val detectedCardTypes: List<DetectedCardType>) : CardBrandState()
 }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentState.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentState.kt
@@ -37,11 +37,12 @@ internal data class CardComponentState(
 internal sealed class CardBrandState {
     data object NoBrandsDetected : CardBrandState()
     data object UnsupportedBrand : CardBrandState()
-    data class SingleBrand(val cardBrandData: CardBrandData, val isReliable: Boolean) : CardBrandState()
-    data class DualBrand(
+    data class SingleReliableBrand(val cardBrandData: CardBrandData) : CardBrandState()
+    data class SingleUnreliableBrand(val cardBrandData: CardBrandData) : CardBrandState()
+    data class DualBrand(val cardBrandDataList: List<CardBrandData>) : CardBrandState()
+    data class DualBrandWithShopperSelection(
         val cardBrandDataList: List<CardBrandData>,
-        val shopperSelectionAllowed: Boolean,
-        val shopperSelectedCardBrandData: CardBrandData?,
+        val shopperSelectedCardBrandData: CardBrandData,
     ) : CardBrandState()
 }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentState.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentState.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.card.internal.ui.state
 
 import androidx.annotation.VisibleForTesting
-import com.adyen.checkout.card.internal.data.model.DetectedCardType
 import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.components.internal.ui.state.ComponentState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
@@ -38,9 +37,17 @@ internal data class CardComponentState(
 internal sealed class CardBrandState {
     data object NoBrandsDetected : CardBrandState()
     data object UnsupportedBrand : CardBrandState()
-    data class SingleBrand(val detectedCardType: DetectedCardType, val isReliable: Boolean) : CardBrandState()
-    data class DualBrand(val detectedCardTypes: List<DetectedCardType>) : CardBrandState()
+    data class SingleBrand(val cardBrandData: CardBrandData, val isReliable: Boolean) : CardBrandState()
+    data class DualBrand(val cardBrandDataList: List<CardBrandData>) : CardBrandState()
 }
+
+internal data class CardBrandData(
+    val cardBrand: CardBrand,
+    val enableLuhnCheck: Boolean,
+    val panLength: Int?,
+    val paymentMethodVariant: String?,
+    val localizedBrand: String?
+)
 
 internal val CardComponentState.binValue: String
     get() = if (cardNumber.isValid && cardNumber.text.length >= EXTENDED_CARD_NUMBER_LENGTH) {

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateExt.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateExt.kt
@@ -173,21 +173,12 @@ private fun invalidCardPaymentComponentState() = CardPaymentComponentState(
 )
 
 private fun CardComponentState.cardBrand(): CardBrand? {
-    return when (cardBrandState) {
-        is CardBrandState.SingleBrand if cardBrandState.isReliable -> {
-            cardBrandState.cardBrandData.cardBrand
-        }
-
-        is CardBrandState.DualBrand -> {
-            cardBrandState.cardBrandDataList.firstOrNull {
-                it.cardBrand.txVariant == selectedCardBrand?.txVariant
-            }?.cardBrand
-        }
-
-        else -> {
-            null
-        }
+    val selectedOrReliableCardBrandData = when (cardBrandState) {
+        is CardBrandState.SingleBrand if cardBrandState.isReliable -> cardBrandState.cardBrandData.cardBrand
+        is CardBrandState.DualBrand -> cardBrandState.shopperSelectedCardBrandData?.cardBrand
+        else -> null
     }
+    return selectedOrReliableCardBrandData
 }
 
 private fun CardComponentState.storePaymentMethod(componentParams: CardComponentParams): Boolean? {

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateExt.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateExt.kt
@@ -174,8 +174,8 @@ private fun invalidCardPaymentComponentState() = CardPaymentComponentState(
 
 private fun CardComponentState.cardBrand(): CardBrand? {
     val selectedOrReliableCardBrandData = when (cardBrandState) {
-        is CardBrandState.SingleBrand if cardBrandState.isReliable -> cardBrandState.cardBrandData.cardBrand
-        is CardBrandState.DualBrand -> cardBrandState.shopperSelectedCardBrandData?.cardBrand
+        is CardBrandState.SingleReliableBrand -> cardBrandState.cardBrandData.cardBrand
+        is CardBrandState.DualBrandWithShopperSelection -> cardBrandState.shopperSelectedCardBrandData.cardBrand
         else -> null
     }
     return selectedOrReliableCardBrandData

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateExt.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateExt.kt
@@ -173,11 +173,24 @@ private fun invalidCardPaymentComponentState() = CardPaymentComponentState(
 )
 
 private fun CardComponentState.cardBrand(): CardBrand? {
-    val supportedDetectedCardTypes = detectedCardTypes.filter { it.isSupported && it.isReliable }
-    return if (supportedDetectedCardTypes.size > 1) {
-        selectedCardBrand ?: supportedDetectedCardTypes.firstOrNull()?.cardBrand
-    } else {
-        supportedDetectedCardTypes.firstOrNull()?.cardBrand
+    return when (cardBrandState) {
+        is CardBrandState.SingleBrand -> {
+            if (cardBrandState.detectedCardType.isReliable) {
+                cardBrandState.detectedCardType.cardBrand
+            } else {
+                null
+            }
+        }
+
+        is CardBrandState.DualBrand -> {
+            cardBrandState.detectedCardTypes.firstOrNull {
+                it.cardBrand.txVariant == selectedCardBrand?.txVariant
+            }?.cardBrand
+        }
+
+        else -> {
+            null
+        }
     }
 }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateExt.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateExt.kt
@@ -175,11 +175,11 @@ private fun invalidCardPaymentComponentState() = CardPaymentComponentState(
 private fun CardComponentState.cardBrand(): CardBrand? {
     return when (cardBrandState) {
         is CardBrandState.SingleBrand if cardBrandState.isReliable -> {
-            cardBrandState.detectedCardType.cardBrand
+            cardBrandState.cardBrandData.cardBrand
         }
 
         is CardBrandState.DualBrand -> {
-            cardBrandState.detectedCardTypes.firstOrNull {
+            cardBrandState.cardBrandDataList.firstOrNull {
                 it.cardBrand.txVariant == selectedCardBrand?.txVariant
             }?.cardBrand
         }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateExt.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateExt.kt
@@ -174,12 +174,8 @@ private fun invalidCardPaymentComponentState() = CardPaymentComponentState(
 
 private fun CardComponentState.cardBrand(): CardBrand? {
     return when (cardBrandState) {
-        is CardBrandState.SingleBrand -> {
-            if (cardBrandState.detectedCardType.isReliable) {
-                cardBrandState.detectedCardType.cardBrand
-            } else {
-                null
-            }
+        is CardBrandState.SingleBrand if cardBrandState.isReliable -> {
+            cardBrandState.detectedCardType.cardBrand
         }
 
         is CardBrandState.DualBrand -> {

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateExt.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateExt.kt
@@ -172,11 +172,19 @@ private fun invalidCardPaymentComponentState() = CardPaymentComponentState(
     isValid = false,
 )
 
+/**
+ * We only prefill the card brand in the onSubmit payload if we are sure the card has a single brand identified on the
+ * backend (reliable) or if the shopper manually selected that brand. In all other cases we cannot reliably assume
+ * there is only one possible brand for the /payments call
+ */
 private fun CardComponentState.cardBrand(): CardBrand? {
     val selectedOrReliableCardBrandData = when (cardBrandState) {
         is CardBrandState.SingleReliableBrand -> cardBrandState.cardBrandData.cardBrand
         is CardBrandState.DualBrandWithShopperSelection -> cardBrandState.shopperSelectedCardBrandData.cardBrand
-        else -> null
+        is CardBrandState.DualBrand,
+        is CardBrandState.NoBrandsDetected,
+        is CardBrandState.SingleUnreliableBrand,
+        is CardBrandState.UnsupportedBrand -> null
     }
     return selectedOrReliableCardBrandData
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateFactory.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateFactory.kt
@@ -58,7 +58,7 @@ internal class CardComponentStateFactory(
             isStorePaymentFieldVisible = componentParams.showStorePayment,
             supportedCardBrands = componentParams.supportedCardBrands,
             isLoading = false,
-            detectedCardTypes = emptyList(),
+            cardBrandState = CardBrandState.NoBrandsDetected,
             selectedCardBrand = null,
         )
     }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateFactory.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateFactory.kt
@@ -59,7 +59,6 @@ internal class CardComponentStateFactory(
             supportedCardBrands = componentParams.supportedCardBrands,
             isLoading = false,
             cardBrandState = CardBrandState.NoBrandsDetected,
-            selectedCardBrand = null,
         )
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateReducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateReducer.kt
@@ -8,15 +8,10 @@
 
 package com.adyen.checkout.card.internal.ui.state
 
-import com.adyen.checkout.card.internal.data.model.Brand
-import com.adyen.checkout.card.internal.data.model.DetectedCardType
-import com.adyen.checkout.card.internal.ui.model.CVCVisibility
-import com.adyen.checkout.card.internal.ui.model.CardComponentParams
 import com.adyen.checkout.core.components.internal.ui.state.ComponentStateReducer
-import com.adyen.checkout.core.components.internal.ui.state.model.RequirementPolicy
 
 internal class CardComponentStateReducer(
-    private val componentParams: CardComponentParams,
+    private val updateDetectedCardTypesIntentHandler: UpdateDetectedCardTypesIntentHandler,
 ) : ComponentStateReducer<CardComponentState, CardIntent> {
 
     @Suppress("CyclomaticComplexMethod", "LongMethod")
@@ -87,21 +82,7 @@ internal class CardComponentStateReducer(
             )
 
             is CardIntent.UpdateDetectedCardTypes -> {
-                val cardType = if (state.selectedCardBrand != null) {
-                    intent.detectedCardTypes.firstOrNull { it.cardBrand.txVariant == state.selectedCardBrand.txVariant }
-                } else {
-                    intent.detectedCardTypes.firstOrNull { it.isReliable && it.isSupported }
-                }
-
-                state.copy(
-                    detectedCardTypes = intent.detectedCardTypes,
-                    securityCode = state.securityCode.copy(
-                        requirementPolicy = getSecurityCodeRequirementPolicy(cardType),
-                    ),
-                    expiryDate = state.expiryDate.copy(
-                        requirementPolicy = getExpiryDateRequirementPolicy(cardType),
-                    ),
-                )
+                updateDetectedCardTypesIntentHandler.updateCardComponentState(state, intent)
             }
 
             is CardIntent.UpdateLoading -> state.copy(
@@ -159,35 +140,5 @@ internal class CardComponentStateReducer(
                 isFocused = shouldFocus(hasKcpCardPasswordError),
             ),
         )
-    }
-
-    private fun getExpiryDateRequirementPolicy(cardType: DetectedCardType?): RequirementPolicy {
-        return cardType?.let {
-            when (it.expiryDatePolicy) {
-                Brand.FieldPolicy.REQUIRED -> RequirementPolicy.Required
-                Brand.FieldPolicy.OPTIONAL -> RequirementPolicy.Optional
-                Brand.FieldPolicy.HIDDEN -> RequirementPolicy.Hidden
-            }
-        } ?: RequirementPolicy.Required
-    }
-
-    private fun getSecurityCodeRequirementPolicy(cardType: DetectedCardType?): RequirementPolicy {
-        return cardType?.let {
-            when (componentParams.cvcVisibility) {
-                CVCVisibility.ALWAYS_SHOW,
-                CVCVisibility.HIDE_FIRST -> {
-                    when (it.cvcPolicy) {
-                        Brand.FieldPolicy.REQUIRED -> RequirementPolicy.Required
-                        Brand.FieldPolicy.OPTIONAL -> RequirementPolicy.Optional
-                        Brand.FieldPolicy.HIDDEN -> RequirementPolicy.Hidden
-                    }
-                }
-
-                CVCVisibility.ALWAYS_HIDE -> RequirementPolicy.Hidden
-            }
-        } ?: when (componentParams.cvcVisibility) {
-            CVCVisibility.ALWAYS_SHOW -> RequirementPolicy.Required
-            CVCVisibility.HIDE_FIRST, CVCVisibility.ALWAYS_HIDE -> RequirementPolicy.Hidden
-        }
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateReducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateReducer.kt
@@ -11,7 +11,7 @@ package com.adyen.checkout.card.internal.ui.state
 import com.adyen.checkout.core.components.internal.ui.state.ComponentStateReducer
 
 internal class CardComponentStateReducer(
-    private val updateDetectedCardTypesIntentHandler: UpdateDetectedCardTypesIntentHandler,
+    private val cardBrandIntentsHandler: CardBrandIntentsHandler,
 ) : ComponentStateReducer<CardComponentState, CardIntent> {
 
     @Suppress("CyclomaticComplexMethod", "LongMethod")
@@ -77,12 +77,12 @@ internal class CardComponentStateReducer(
                 storePaymentMethod = intent.isChecked,
             )
 
-            is CardIntent.SelectBrand -> state.copy(
-                selectedCardBrand = intent.cardBrand,
-            )
+            is CardIntent.SelectBrand -> {
+                cardBrandIntentsHandler.onBrandSelected(state, intent)
+            }
 
             is CardIntent.UpdateDetectedCardTypes -> {
-                updateDetectedCardTypesIntentHandler.updateCardComponentState(state, intent)
+                cardBrandIntentsHandler.onUpdateDetectedCardTypes(state, intent)
             }
 
             is CardIntent.UpdateLoading -> state.copy(

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateValidator.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateValidator.kt
@@ -8,7 +8,7 @@
 
 package com.adyen.checkout.card.internal.ui.state
 
-import com.adyen.checkout.card.internal.data.model.DetectedCardType
+import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.components.internal.ui.state.ComponentStateValidator
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
@@ -30,10 +30,13 @@ internal class CardComponentStateValidator(
             else -> null
         }
         val isUnsupportedBrand = state.cardBrandState is CardBrandState.UnsupportedBrand
-
-        val cardNumberError = validateCardNumber(state.cardNumber, selectedOrFirstCardType, isUnsupportedBrand)
-        val expiryDateError = validateExpiryDate(state.expiryDate, selectedOrFirstCardType)
-        val securityCodeError = validateSecurityCode(state.securityCode, selectedOrFirstCardType)
+        val cardNumberError = validateCardNumber(
+            state.cardNumber,
+            selectedOrFirstCardType?.enableLuhnCheck,
+            isUnsupportedBrand,
+        )
+        val expiryDateError = validateExpiryDate(state.expiryDate)
+        val securityCodeError = validateSecurityCode(state.securityCode, selectedOrFirstCardType?.cardBrand)
         val holderNameError = validateHolderName(state.holderName)
         val socialSecurityNumberError = validateSocialSecurityNumber(state.socialSecurityNumber)
         val kcpBirthDateOrTaxNumberError = validateKcpBirthDateOrTaxNumber(state.kcpBirthDateOrTaxNumber)
@@ -62,11 +65,9 @@ internal class CardComponentStateValidator(
 
     private fun validateCardNumber(
         cardNumber: TextInputComponentState,
-        selectedOrFirstCardType: DetectedCardType?,
+        enableLuhnCheck: Boolean?,
         isUnsupportedBrand: Boolean,
     ): CheckoutLocalizationKey? {
-        val enableLuhnCheck = selectedOrFirstCardType?.enableLuhnCheck ?: true
-
         return cardValidationMapper.mapCardNumberValidation(
             validation = CardValidationUtils.validateCardNumber(
                 cardNumber = cardNumber,
@@ -78,24 +79,22 @@ internal class CardComponentStateValidator(
 
     private fun validateExpiryDate(
         expiryDate: TextInputComponentState,
-        selectedOrFirstCardType: DetectedCardType?,
     ): CheckoutLocalizationKey? {
         return cardValidationMapper.mapExpiryDateValidation(
             validation = CardValidationUtils.validateExpiryDate(
                 expiryDate = expiryDate,
-                fieldPolicy = selectedOrFirstCardType?.expiryDatePolicy,
             ),
         )
     }
 
     private fun validateSecurityCode(
         securityCode: TextInputComponentState,
-        selectedOrFirstCardType: DetectedCardType?,
+        cardBrand: CardBrand?,
     ): CheckoutLocalizationKey? {
         return cardValidationMapper.mapSecurityCodeValidation(
             validation = CardValidationUtils.validateSecurityCode(
                 securityCode = securityCode,
-                detectedCardType = selectedOrFirstCardType,
+                cardBrand = cardBrand,
             ),
         )
     }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateValidator.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateValidator.kt
@@ -19,12 +19,10 @@ internal class CardComponentStateValidator(
 
     override fun validate(state: CardComponentState): CardComponentState {
         val selectedOrFirstCardBrandData = when (val cardBrandState = state.cardBrandState) {
-            is CardBrandState.SingleBrand -> cardBrandState.cardBrandData
-
-            is CardBrandState.DualBrand -> {
-                cardBrandState.shopperSelectedCardBrandData ?: cardBrandState.cardBrandDataList.first()
-            }
-
+            is CardBrandState.SingleReliableBrand -> cardBrandState.cardBrandData
+            is CardBrandState.SingleUnreliableBrand -> cardBrandState.cardBrandData
+            is CardBrandState.DualBrandWithShopperSelection -> cardBrandState.shopperSelectedCardBrandData
+            is CardBrandState.DualBrand -> cardBrandState.cardBrandDataList.first()
             else -> null
         }
         val isUnsupportedBrand = state.cardBrandState is CardBrandState.UnsupportedBrand

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateValidator.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateValidator.kt
@@ -18,17 +18,22 @@ internal class CardComponentStateValidator(
 ) : ComponentStateValidator<CardComponentState> {
 
     override fun validate(state: CardComponentState): CardComponentState {
-        val isReliable = state.detectedCardTypes.any { it.isReliable }
-        val supportedDetectedCardTypes = state.detectedCardTypes.filter { it.isSupported }
-        val firstSupportedDetectedCardType = supportedDetectedCardTypes.firstOrNull()
+        val selectedOrFirstCardType = when (val cardBrandState = state.cardBrandState) {
+            is CardBrandState.SingleBrand -> cardBrandState.detectedCardType
 
-        val cardNumberError = validateCardNumber(state.cardNumber, firstSupportedDetectedCardType, isReliable)
-        val expiryDateError = validateExpiryDate(state.expiryDate, firstSupportedDetectedCardType)
-        val securityCodeError =
-            validateSecurityCode(
-                state.securityCode,
-                firstSupportedDetectedCardType,
-            )
+            is CardBrandState.DualBrand -> {
+                cardBrandState.detectedCardTypes.firstOrNull {
+                    it.cardBrand.txVariant == state.selectedCardBrand?.txVariant
+                } ?: cardBrandState.detectedCardTypes.first()
+            }
+
+            else -> null
+        }
+        val isUnsupportedBrand = state.cardBrandState is CardBrandState.UnsupportedBrand
+
+        val cardNumberError = validateCardNumber(state.cardNumber, selectedOrFirstCardType, isUnsupportedBrand)
+        val expiryDateError = validateExpiryDate(state.expiryDate, selectedOrFirstCardType)
+        val securityCodeError = validateSecurityCode(state.securityCode, selectedOrFirstCardType)
         val holderNameError = validateHolderName(state.holderName)
         val socialSecurityNumberError = validateSocialSecurityNumber(state.socialSecurityNumber)
         val kcpBirthDateOrTaxNumberError = validateKcpBirthDateOrTaxNumber(state.kcpBirthDateOrTaxNumber)
@@ -58,16 +63,15 @@ internal class CardComponentStateValidator(
     private fun validateCardNumber(
         cardNumber: TextInputComponentState,
         selectedOrFirstCardType: DetectedCardType?,
-        isReliable: Boolean,
+        isUnsupportedBrand: Boolean,
     ): CheckoutLocalizationKey? {
         val enableLuhnCheck = selectedOrFirstCardType?.enableLuhnCheck ?: true
-        val shouldFailWithUnsupportedBrand = selectedOrFirstCardType == null && isReliable
 
         return cardValidationMapper.mapCardNumberValidation(
             validation = CardValidationUtils.validateCardNumber(
                 cardNumber = cardNumber,
                 enableLuhnCheck = enableLuhnCheck,
-                isBrandSupported = !shouldFailWithUnsupportedBrand,
+                isUnsupportedBrand = isUnsupportedBrand,
             ),
         )
     }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateValidator.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateValidator.kt
@@ -18,13 +18,13 @@ internal class CardComponentStateValidator(
 ) : ComponentStateValidator<CardComponentState> {
 
     override fun validate(state: CardComponentState): CardComponentState {
-        val selectedOrFirstCardType = when (val cardBrandState = state.cardBrandState) {
-            is CardBrandState.SingleBrand -> cardBrandState.detectedCardType
+        val selectedOrFirstCardBrandData = when (val cardBrandState = state.cardBrandState) {
+            is CardBrandState.SingleBrand -> cardBrandState.cardBrandData
 
             is CardBrandState.DualBrand -> {
-                cardBrandState.detectedCardTypes.firstOrNull {
+                cardBrandState.cardBrandDataList.firstOrNull {
                     it.cardBrand.txVariant == state.selectedCardBrand?.txVariant
-                } ?: cardBrandState.detectedCardTypes.first()
+                } ?: cardBrandState.cardBrandDataList.first()
             }
 
             else -> null
@@ -32,11 +32,11 @@ internal class CardComponentStateValidator(
         val isUnsupportedBrand = state.cardBrandState is CardBrandState.UnsupportedBrand
         val cardNumberError = validateCardNumber(
             state.cardNumber,
-            selectedOrFirstCardType?.enableLuhnCheck,
+            selectedOrFirstCardBrandData?.enableLuhnCheck,
             isUnsupportedBrand,
         )
         val expiryDateError = validateExpiryDate(state.expiryDate)
-        val securityCodeError = validateSecurityCode(state.securityCode, selectedOrFirstCardType?.cardBrand)
+        val securityCodeError = validateSecurityCode(state.securityCode, selectedOrFirstCardBrandData?.cardBrand)
         val holderNameError = validateHolderName(state.holderName)
         val socialSecurityNumberError = validateSocialSecurityNumber(state.socialSecurityNumber)
         val kcpBirthDateOrTaxNumberError = validateKcpBirthDateOrTaxNumber(state.kcpBirthDateOrTaxNumber)

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateValidator.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateValidator.kt
@@ -22,9 +22,7 @@ internal class CardComponentStateValidator(
             is CardBrandState.SingleBrand -> cardBrandState.cardBrandData
 
             is CardBrandState.DualBrand -> {
-                cardBrandState.cardBrandDataList.firstOrNull {
-                    it.cardBrand.txVariant == state.selectedCardBrand?.txVariant
-                } ?: cardBrandState.cardBrandDataList.first()
+                cardBrandState.shopperSelectedCardBrandData ?: cardBrandState.cardBrandDataList.first()
             }
 
             else -> null

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateValidator.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateValidator.kt
@@ -18,12 +18,14 @@ internal class CardComponentStateValidator(
 ) : ComponentStateValidator<CardComponentState> {
 
     override fun validate(state: CardComponentState): CardComponentState {
+        // the single / selected / first brand can be used for this validation, regardless whether reliable or not
         val selectedOrFirstCardBrandData = when (val cardBrandState = state.cardBrandState) {
             is CardBrandState.SingleReliableBrand -> cardBrandState.cardBrandData
             is CardBrandState.SingleUnreliableBrand -> cardBrandState.cardBrandData
             is CardBrandState.DualBrandWithShopperSelection -> cardBrandState.shopperSelectedCardBrandData
             is CardBrandState.DualBrand -> cardBrandState.cardBrandDataList.first()
-            else -> null
+            is CardBrandState.NoBrandsDetected,
+            is CardBrandState.UnsupportedBrand -> null
         }
         val isUnsupportedBrand = state.cardBrandState is CardBrandState.UnsupportedBrand
         val cardNumberError = validateCardNumber(

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardIntent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardIntent.kt
@@ -8,7 +8,7 @@
 
 package com.adyen.checkout.card.internal.ui.state
 
-import com.adyen.checkout.card.internal.data.model.DetectedCardType
+import com.adyen.checkout.card.internal.data.model.DetectedCardTypeList
 import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.components.internal.ui.state.ComponentStateIntent
 
@@ -48,7 +48,7 @@ internal sealed interface CardIntent : ComponentStateIntent {
     data class SelectBrand(val cardBrand: CardBrand) : CardIntent
 
     // System intents
-    data class UpdateDetectedCardTypes(val detectedCardTypes: List<DetectedCardType>) : CardIntent
+    data class UpdateDetectedCardTypes(val detectedCardTypeList: DetectedCardTypeList) : CardIntent
 
     data class UpdateLoading(val isLoading: Boolean) : CardIntent
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardValidationMapper.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardValidationMapper.kt
@@ -31,7 +31,6 @@ internal class CardValidationMapper {
     ): CheckoutLocalizationKey? {
         return when (validation) {
             CardExpiryDateValidation.VALID -> null
-            CardExpiryDateValidation.VALID_NOT_REQUIRED -> null
             CardExpiryDateValidation.INVALID_TOO_FAR_IN_THE_FUTURE ->
                 CheckoutLocalizationKey.CARD_EXPIRY_DATE_INVALID_TOO_FAR_IN_THE_FUTURE
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardValidationUtils.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardValidationUtils.kt
@@ -35,17 +35,17 @@ internal object CardValidationUtils {
     internal fun validateCardNumber(
         cardNumber: TextInputComponentState,
         enableLuhnCheck: Boolean,
-        isBrandSupported: Boolean
+        isUnsupportedBrand: Boolean
     ): CardNumberValidation {
         if (!cardNumber.requiresValidation()) return CardNumberValidation.VALID
         val validation = CardNumberValidator.validateCardNumber(cardNumber.text, enableLuhnCheck)
-        return validateCardNumber(validation, isBrandSupported)
+        return validateCardNumber(validation, isUnsupportedBrand)
     }
 
     @VisibleForTesting
     internal fun validateCardNumber(
         validationResult: CardNumberValidationResult,
-        isBrandSupported: Boolean
+        isUnsupportedBrand: Boolean
     ): CardNumberValidation {
         return when (validationResult) {
             is CardNumberValidationResult.Invalid -> {
@@ -63,7 +63,7 @@ internal object CardValidationUtils {
             }
 
             is CardNumberValidationResult.Valid -> when {
-                !isBrandSupported -> CardNumberValidation.INVALID_UNSUPPORTED_BRAND
+                isUnsupportedBrand -> CardNumberValidation.INVALID_UNSUPPORTED_BRAND
                 else -> CardNumberValidation.VALID
             }
         }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardValidationUtils.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardValidationUtils.kt
@@ -10,13 +10,12 @@ package com.adyen.checkout.card.internal.ui.state
 
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
-import com.adyen.checkout.card.internal.data.model.Brand
-import com.adyen.checkout.card.internal.data.model.DetectedCardType
 import com.adyen.checkout.card.internal.helper.ExpiryDateParser
 import com.adyen.checkout.card.internal.ui.properties.KCPBirthDateOrTaxNumberProperties
 import com.adyen.checkout.card.internal.ui.properties.KCPBirthDateOrTaxNumberProperties.KCP_BIRTH_DATE_FORMAT
 import com.adyen.checkout.card.internal.ui.properties.KCPCardPasswordProperties
 import com.adyen.checkout.card.internal.ui.properties.SocialSecurityNumberProperties
+import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.common.helper.CardExpiryDateValidationResult
 import com.adyen.checkout.core.common.helper.CardExpiryDateValidator
 import com.adyen.checkout.core.common.helper.CardNumberValidationResult
@@ -34,11 +33,11 @@ internal object CardValidationUtils {
      */
     internal fun validateCardNumber(
         cardNumber: TextInputComponentState,
-        enableLuhnCheck: Boolean,
+        enableLuhnCheck: Boolean?,
         isUnsupportedBrand: Boolean
     ): CardNumberValidation {
         if (!cardNumber.requiresValidation()) return CardNumberValidation.VALID
-        val validation = CardNumberValidator.validateCardNumber(cardNumber.text, enableLuhnCheck)
+        val validation = CardNumberValidator.validateCardNumber(cardNumber.text, enableLuhnCheck ?: true)
         return validateCardNumber(validation, isUnsupportedBrand)
     }
 
@@ -73,47 +72,27 @@ internal object CardValidationUtils {
      * Validate Expiry Date.
      */
     @Suppress("ReturnCount")
-    internal fun validateExpiryDate(
-        expiryDate: TextInputComponentState,
-        fieldPolicy: Brand.FieldPolicy?,
-    ): CardExpiryDateValidation {
+    internal fun validateExpiryDate(expiryDate: TextInputComponentState): CardExpiryDateValidation {
         if (!expiryDate.requiresValidation()) return CardExpiryDateValidation.VALID
         val (expiryMonth, expiryYear) = ExpiryDateParser.parseToMonthAndYear(expiryDate.text, returnFullYear = false)
             ?: return CardExpiryDateValidation.INVALID_OTHER_REASON
         val result = CardExpiryDateValidator.validateExpiryDate(expiryMonth = expiryMonth, expiryYear = expiryYear)
-        return validateExpiryDate(expiryDate.text, result, fieldPolicy)
-    }
 
-    @VisibleForTesting
-    internal fun validateExpiryDate(
-        expiryDate: String,
-        validationResult: CardExpiryDateValidationResult,
-        fieldPolicy: Brand.FieldPolicy?
-    ): CardExpiryDateValidation {
-        return when (validationResult) {
+        return when (result) {
             is CardExpiryDateValidationResult.Valid -> CardExpiryDateValidation.VALID
 
-            is CardExpiryDateValidationResult.Invalid -> {
-                when (validationResult) {
-                    is CardExpiryDateValidationResult.Invalid.TooFarInTheFuture ->
-                        CardExpiryDateValidation.INVALID_TOO_FAR_IN_THE_FUTURE
+            is CardExpiryDateValidationResult.Invalid.TooFarInTheFuture ->
+                CardExpiryDateValidation.INVALID_TOO_FAR_IN_THE_FUTURE
 
-                    is CardExpiryDateValidationResult.Invalid.TooOld ->
-                        CardExpiryDateValidation.INVALID_TOO_OLD
+            is CardExpiryDateValidationResult.Invalid.TooOld ->
+                CardExpiryDateValidation.INVALID_TOO_OLD
 
-                    is CardExpiryDateValidationResult.Invalid.NonParseableDate -> {
-                        if (expiryDate.isBlank() && fieldPolicy?.isRequired() == false) {
-                            CardExpiryDateValidation.VALID_NOT_REQUIRED
-                        } else {
-                            CardExpiryDateValidation.INVALID_OTHER_REASON
-                        }
-                    }
+            is CardExpiryDateValidationResult.Invalid.NonParseableDate ->
+                CardExpiryDateValidation.INVALID_OTHER_REASON
 
-                    else -> {
-                        // should not happen, due to CardExpiryDateValidationResult being an abstract class
-                        CardExpiryDateValidation.INVALID_OTHER_REASON
-                    }
-                }
+            else -> {
+                // should not happen, due to CardExpiryDateValidationResult being an abstract class
+                CardExpiryDateValidation.INVALID_OTHER_REASON
             }
         }
     }
@@ -137,10 +116,10 @@ internal object CardValidationUtils {
      */
     internal fun validateSecurityCode(
         securityCode: TextInputComponentState,
-        detectedCardType: DetectedCardType?,
+        cardBrand: CardBrand?,
     ): CardSecurityCodeValidation {
         if (!securityCode.requiresValidation()) return CardSecurityCodeValidation.VALID
-        val result = CardSecurityCodeValidator.validateSecurityCode(securityCode.text, detectedCardType?.cardBrand)
+        val result = CardSecurityCodeValidator.validateSecurityCode(securityCode.text, cardBrand)
         return when (result) {
             is CardSecurityCodeValidationResult.Invalid -> CardSecurityCodeValidation.INVALID
             is CardSecurityCodeValidationResult.Valid -> CardSecurityCodeValidation.VALID
@@ -228,7 +207,6 @@ enum class CardNumberValidation {
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 enum class CardExpiryDateValidation {
     VALID,
-    VALID_NOT_REQUIRED,
     INVALID_TOO_FAR_IN_THE_FUTURE,
     INVALID_TOO_OLD,
     INVALID_OTHER_REASON,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
@@ -23,14 +23,10 @@ internal class CardViewStateProducer(
 ) : ViewStateProducer<CardComponentState, CardViewState> {
 
     override fun produce(state: CardComponentState): CardViewState {
-        val dualBrandData = if (state.cardBrandState is CardBrandState.DualBrand) {
-            dualBrandedCardHandler.processDetectedCardTypes(
-                detectedCardTypes = state.cardBrandState.detectedCardTypes,
-                selectedBrand = state.selectedCardBrand,
-            )
-        } else {
-            null
-        }
+        val dualBrandData = dualBrandedCardHandler.processDetectedCardTypes(
+            cardBrandState = state.cardBrandState,
+            selectedBrand = state.selectedCardBrand,
+        )
 
         val isSupportedCardBrandsShown = state.cardBrandState in listOf(
             CardBrandState.NoBrandsDetected,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
@@ -25,8 +25,16 @@ internal class CardViewStateProducer(
     override fun produce(state: CardComponentState): CardViewState {
         val dualBrandData = dualBrandedCardHandler.getDualBrandData(state.cardBrandState)
 
-        val isSupportedCardBrandsShown = state.cardBrandState == CardBrandState.NoBrandsDetected ||
-            state.cardBrandState == CardBrandState.UnsupportedBrand
+        // we only show all supported card brands when we do not detect any brands for this specific card
+        val isSupportedCardBrandsShown = when (state.cardBrandState) {
+            is CardBrandState.UnsupportedBrand,
+            is CardBrandState.NoBrandsDetected -> true
+
+            is CardBrandState.SingleReliableBrand,
+            is CardBrandState.SingleUnreliableBrand,
+            is CardBrandState.DualBrand,
+            is CardBrandState.DualBrandWithShopperSelection -> false
+        }
 
         val detectedCardBrands = getDetectedCardBrands(state.cardBrandState)
 
@@ -54,13 +62,15 @@ internal class CardViewStateProducer(
         )
     }
 
+    // detected card brands are shown on the UI in all flows
     private fun getDetectedCardBrands(cardBrandState: CardBrandState): List<CardBrand> {
         return when (cardBrandState) {
             is CardBrandState.DualBrand -> cardBrandState.cardBrandDataList.map { it.cardBrand }
             is CardBrandState.DualBrandWithShopperSelection -> cardBrandState.cardBrandDataList.map { it.cardBrand }
             is CardBrandState.SingleReliableBrand -> listOf(cardBrandState.cardBrandData.cardBrand)
             is CardBrandState.SingleUnreliableBrand -> listOf(cardBrandState.cardBrandData.cardBrand)
-            else -> emptyList()
+            is CardBrandState.NoBrandsDetected,
+            is CardBrandState.UnsupportedBrand -> emptyList()
         }
     }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
@@ -25,10 +25,8 @@ internal class CardViewStateProducer(
     override fun produce(state: CardComponentState): CardViewState {
         val dualBrandData = dualBrandedCardHandler.getDualBrandData(state.cardBrandState)
 
-        val isSupportedCardBrandsShown = state.cardBrandState in listOf(
-            CardBrandState.NoBrandsDetected,
-            CardBrandState.UnsupportedBrand,
-        )
+        val isSupportedCardBrandsShown = state.cardBrandState == CardBrandState.NoBrandsDetected ||
+            state.cardBrandState == CardBrandState.UnsupportedBrand
 
         val detectedCardBrands = getDetectedCardBrands(state.cardBrandState)
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
@@ -10,7 +10,6 @@ package com.adyen.checkout.card.internal.ui.state
 
 import com.adyen.checkout.card.internal.ui.DualBrandedCardHandler
 import com.adyen.checkout.card.internal.ui.model.CardNumberTrailingIcon
-import com.adyen.checkout.card.internal.ui.model.DualBrandData
 import com.adyen.checkout.card.internal.ui.model.ExpiryDateTrailingIcon
 import com.adyen.checkout.card.internal.ui.model.SecurityCodeTrailingIcon
 import com.adyen.checkout.core.common.CardBrand
@@ -24,14 +23,21 @@ internal class CardViewStateProducer(
 ) : ViewStateProducer<CardComponentState, CardViewState> {
 
     override fun produce(state: CardComponentState): CardViewState {
-        val supportedDetectedCardTypes = state.detectedCardTypes.filter { it.isSupported }
-        val firstSupportedDetectedCardType = supportedDetectedCardTypes.firstOrNull()
+        val dualBrandData = if (state.cardBrandState is CardBrandState.DualBrand) {
+            dualBrandedCardHandler.processDetectedCardTypes(
+                detectedCardTypes = state.cardBrandState.detectedCardTypes,
+                selectedBrand = state.selectedCardBrand,
+            )
+        } else {
+            null
+        }
 
-        val dualBrandData = dualBrandedCardHandler.processDetectedCardTypes(
-            detectedCardTypes = state.detectedCardTypes,
-            selectedBrand = state.selectedCardBrand,
+        val isSupportedCardBrandsShown = state.cardBrandState in listOf(
+            CardBrandState.NoBrandsDetected,
+            CardBrandState.UnsupportedBrand,
         )
-        val detectedCardBrands = getDetectedCardBrands(dualBrandData, firstSupportedDetectedCardType?.cardBrand)
+
+        val detectedCardBrands = getDetectedCardBrands(state.cardBrandState)
 
         return CardViewState(
             cardNumber = state.cardNumber.toViewState(
@@ -50,17 +56,19 @@ internal class CardViewStateProducer(
             storePaymentMethod = state.storePaymentMethod,
             isStorePaymentFieldVisible = state.isStorePaymentFieldVisible,
             supportedCardBrands = state.supportedCardBrands,
-            isSupportedCardBrandsShown = supportedDetectedCardTypes.isEmpty(),
+            isSupportedCardBrandsShown = isSupportedCardBrandsShown,
             detectedCardBrands = detectedCardBrands,
             isLoading = state.isLoading,
             dualBrandData = dualBrandData,
         )
     }
 
-    private fun getDetectedCardBrands(dualBrandData: DualBrandData?, fallbackDetectedCardBrand: CardBrand?) = when {
-        dualBrandData != null -> listOf(dualBrandData.brandOptionFirst.brand, dualBrandData.brandOptionSecond.brand)
-        fallbackDetectedCardBrand != null -> listOf(fallbackDetectedCardBrand)
-        else -> listOf()
+    private fun getDetectedCardBrands(cardBrandState: CardBrandState): List<CardBrand> {
+        return when (cardBrandState) {
+            is CardBrandState.DualBrand -> cardBrandState.detectedCardTypes.map { it.cardBrand }
+            is CardBrandState.SingleBrand -> listOf(cardBrandState.detectedCardType.cardBrand)
+            else -> emptyList()
+        }
     }
 
     private fun getCardNumberTrailingIcon(cardNumber: TextInputComponentState): CardNumberTrailingIcon {

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
@@ -23,10 +23,7 @@ internal class CardViewStateProducer(
 ) : ViewStateProducer<CardComponentState, CardViewState> {
 
     override fun produce(state: CardComponentState): CardViewState {
-        val dualBrandData = dualBrandedCardHandler.getDualBrandData(
-            cardBrandState = state.cardBrandState,
-            selectedBrand = state.selectedCardBrand,
-        )
+        val dualBrandData = dualBrandedCardHandler.getDualBrandData(state.cardBrandState)
 
         val isSupportedCardBrandsShown = state.cardBrandState in listOf(
             CardBrandState.NoBrandsDetected,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
@@ -59,7 +59,9 @@ internal class CardViewStateProducer(
     private fun getDetectedCardBrands(cardBrandState: CardBrandState): List<CardBrand> {
         return when (cardBrandState) {
             is CardBrandState.DualBrand -> cardBrandState.cardBrandDataList.map { it.cardBrand }
-            is CardBrandState.SingleBrand -> listOf(cardBrandState.cardBrandData.cardBrand)
+            is CardBrandState.DualBrandWithShopperSelection -> cardBrandState.cardBrandDataList.map { it.cardBrand }
+            is CardBrandState.SingleReliableBrand -> listOf(cardBrandState.cardBrandData.cardBrand)
+            is CardBrandState.SingleUnreliableBrand -> listOf(cardBrandState.cardBrandData.cardBrand)
             else -> emptyList()
         }
     }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
@@ -23,7 +23,7 @@ internal class CardViewStateProducer(
 ) : ViewStateProducer<CardComponentState, CardViewState> {
 
     override fun produce(state: CardComponentState): CardViewState {
-        val dualBrandData = dualBrandedCardHandler.processDetectedCardTypes(
+        val dualBrandData = dualBrandedCardHandler.getDualBrandData(
             cardBrandState = state.cardBrandState,
             selectedBrand = state.selectedCardBrand,
         )
@@ -61,8 +61,8 @@ internal class CardViewStateProducer(
 
     private fun getDetectedCardBrands(cardBrandState: CardBrandState): List<CardBrand> {
         return when (cardBrandState) {
-            is CardBrandState.DualBrand -> cardBrandState.detectedCardTypes.map { it.cardBrand }
-            is CardBrandState.SingleBrand -> listOf(cardBrandState.detectedCardType.cardBrand)
+            is CardBrandState.DualBrand -> cardBrandState.cardBrandDataList.map { it.cardBrand }
+            is CardBrandState.SingleBrand -> listOf(cardBrandState.cardBrandData.cardBrand)
             else -> emptyList()
         }
     }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardComponentStateValidator.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardComponentStateValidator.kt
@@ -40,7 +40,7 @@ internal class StoredCardComponentStateValidator(
         return cardValidationMapper.mapSecurityCodeValidation(
             validation = CardValidationUtils.validateSecurityCode(
                 securityCode = securityCode,
-                detectedCardType = selectedOrFirstCardType,
+                cardBrand = selectedOrFirstCardType?.cardBrand,
             ),
         )
     }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/UpdateDetectedCardTypesIntentHandler.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/UpdateDetectedCardTypesIntentHandler.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.card.internal.ui.state
 
 import com.adyen.checkout.card.internal.data.model.Brand
 import com.adyen.checkout.card.internal.data.model.DetectedCardTypeList
+import com.adyen.checkout.card.internal.helper.toCardBrandData
 import com.adyen.checkout.card.internal.ui.model.CVCVisibility
 import com.adyen.checkout.card.internal.ui.model.CardComponentParams
 import com.adyen.checkout.core.components.internal.ui.state.model.RequirementPolicy
@@ -35,7 +36,7 @@ internal class UpdateDetectedCardTypesIntentHandler(
             // local detection + supported brands
             !isDetectedFromNetwork -> {
                 // select the first brand and discard the rest
-                CardBrandState.SingleBrand(supportedDetectedCardTypes.first(), false)
+                CardBrandState.SingleBrand(supportedDetectedCardTypes.first().toCardBrandData(), false)
             }
 
             // network detection + no detected brands
@@ -51,13 +52,13 @@ internal class UpdateDetectedCardTypesIntentHandler(
 
             // network detection + 1 detected brand
             supportedDetectedCardTypes.size == 1 -> {
-                CardBrandState.SingleBrand(supportedDetectedCardTypes.first(), true)
+                CardBrandState.SingleBrand(supportedDetectedCardTypes.first().toCardBrandData(), true)
             }
 
             // network detection + multiple detected brands
             else -> {
                 // select the first 2 brands and discard the rest (should only have 2 brands normally)
-                CardBrandState.DualBrand(supportedDetectedCardTypes.take(2))
+                CardBrandState.DualBrand(supportedDetectedCardTypes.take(2).map { it.toCardBrandData() })
             }
         }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/UpdateDetectedCardTypesIntentHandler.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/UpdateDetectedCardTypesIntentHandler.kt
@@ -9,6 +9,7 @@
 package com.adyen.checkout.card.internal.ui.state
 
 import com.adyen.checkout.card.internal.data.model.Brand
+import com.adyen.checkout.card.internal.data.model.DetectedCardTypeList
 import com.adyen.checkout.card.internal.ui.model.CVCVisibility
 import com.adyen.checkout.card.internal.ui.model.CardComponentParams
 import com.adyen.checkout.core.components.internal.ui.state.model.RequirementPolicy
@@ -20,10 +21,10 @@ internal class UpdateDetectedCardTypesIntentHandler(
         state: CardComponentState,
         intent: CardIntent.UpdateDetectedCardTypes,
     ): CardComponentState {
-        val detectedCardTypes = intent.detectedCardTypes
+        val detectedCardTypes = intent.detectedCardTypeList.detectedCardTypes
+        val isDetectedFromNetwork = intent.detectedCardTypeList.source == DetectedCardTypeList.Source.NETWORK
 
         val supportedDetectedCardTypes = detectedCardTypes.filter { it.isSupported }
-        val isDetectedFromNetwork = detectedCardTypes.any { it.isReliable }
 
         val cardBrandState = when {
             // local detection + no supported brands
@@ -34,7 +35,7 @@ internal class UpdateDetectedCardTypesIntentHandler(
             // local detection + supported brands
             !isDetectedFromNetwork -> {
                 // select the first brand and discard the rest
-                CardBrandState.SingleBrand(supportedDetectedCardTypes.first())
+                CardBrandState.SingleBrand(supportedDetectedCardTypes.first(), false)
             }
 
             // network detection + no detected brands
@@ -50,7 +51,7 @@ internal class UpdateDetectedCardTypesIntentHandler(
 
             // network detection + 1 detected brand
             supportedDetectedCardTypes.size == 1 -> {
-                CardBrandState.SingleBrand(supportedDetectedCardTypes.first())
+                CardBrandState.SingleBrand(supportedDetectedCardTypes.first(), true)
             }
 
             // network detection + multiple detected brands

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/UpdateDetectedCardTypesIntentHandler.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/UpdateDetectedCardTypesIntentHandler.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 20/4/2026.
+ */
+
+package com.adyen.checkout.card.internal.ui.state
+
+import com.adyen.checkout.card.internal.data.model.Brand
+import com.adyen.checkout.card.internal.ui.model.CVCVisibility
+import com.adyen.checkout.card.internal.ui.model.CardComponentParams
+import com.adyen.checkout.core.components.internal.ui.state.model.RequirementPolicy
+
+internal class UpdateDetectedCardTypesIntentHandler(
+    private val componentParams: CardComponentParams,
+) {
+    fun updateCardComponentState(
+        state: CardComponentState,
+        intent: CardIntent.UpdateDetectedCardTypes,
+    ): CardComponentState {
+        val detectedCardTypes = intent.detectedCardTypes
+
+        val supportedDetectedCardTypes = detectedCardTypes.filter { it.isSupported }
+        val isDetectedFromNetwork = detectedCardTypes.any { it.isReliable }
+
+        val cardBrandState = when {
+            // local detection + no supported brands
+            !isDetectedFromNetwork && supportedDetectedCardTypes.isEmpty() -> {
+                CardBrandState.NoBrandsDetected
+            }
+
+            // local detection + supported brands
+            !isDetectedFromNetwork -> {
+                // select the first brand and discard the rest
+                CardBrandState.SingleBrand(supportedDetectedCardTypes.first())
+            }
+
+            // network detection + no detected brands
+            detectedCardTypes.isEmpty() -> {
+                // Bin lookup did not return any brands
+                CardBrandState.NoBrandsDetected
+            }
+
+            // network detection + detected brands but no supported brands
+            supportedDetectedCardTypes.isEmpty() -> {
+                CardBrandState.UnsupportedBrand
+            }
+
+            // network detection + 1 detected brand
+            supportedDetectedCardTypes.size == 1 -> {
+                CardBrandState.SingleBrand(supportedDetectedCardTypes.first())
+            }
+
+            // network detection + multiple detected brands
+            else -> {
+                // select the first 2 brands and discard the rest (should only have 2 brands normally)
+                CardBrandState.DualBrand(supportedDetectedCardTypes.take(2))
+            }
+        }
+
+        val selectedOrFirstReliableCardType = when {
+            state.selectedCardBrand != null -> {
+                supportedDetectedCardTypes.firstOrNull { it.cardBrand.txVariant == state.selectedCardBrand.txVariant }
+            }
+
+            isDetectedFromNetwork -> supportedDetectedCardTypes.firstOrNull()
+            else -> null
+        }
+        val cvcPolicy = selectedOrFirstReliableCardType?.cvcPolicy
+        val expiryDatePolicy = selectedOrFirstReliableCardType?.expiryDatePolicy
+
+        return state.copy(
+            cardBrandState = cardBrandState,
+            securityCode = state.securityCode.copy(
+                requirementPolicy = getSecurityCodeRequirementPolicy(cvcPolicy),
+            ),
+            expiryDate = state.expiryDate.copy(
+                requirementPolicy = getExpiryDateRequirementPolicy(expiryDatePolicy),
+            ),
+        )
+    }
+
+    private fun getExpiryDateRequirementPolicy(expiryDatePolicy: Brand.FieldPolicy?): RequirementPolicy {
+        if (expiryDatePolicy == null) return RequirementPolicy.Required
+
+        return when (expiryDatePolicy) {
+            Brand.FieldPolicy.REQUIRED -> RequirementPolicy.Required
+            Brand.FieldPolicy.OPTIONAL -> RequirementPolicy.Optional
+            Brand.FieldPolicy.HIDDEN -> RequirementPolicy.Hidden
+        }
+    }
+
+    private fun getSecurityCodeRequirementPolicy(cvcPolicy: Brand.FieldPolicy?): RequirementPolicy {
+        return if (cvcPolicy != null) {
+            when (componentParams.cvcVisibility) {
+                CVCVisibility.ALWAYS_SHOW, CVCVisibility.HIDE_FIRST -> {
+                    when (cvcPolicy) {
+                        Brand.FieldPolicy.REQUIRED -> RequirementPolicy.Required
+                        Brand.FieldPolicy.OPTIONAL -> RequirementPolicy.Optional
+                        Brand.FieldPolicy.HIDDEN -> RequirementPolicy.Hidden
+                    }
+                }
+
+                CVCVisibility.ALWAYS_HIDE -> RequirementPolicy.Hidden
+            }
+        } else {
+            when (componentParams.cvcVisibility) {
+                CVCVisibility.ALWAYS_SHOW -> RequirementPolicy.Required
+                CVCVisibility.HIDE_FIRST, CVCVisibility.ALWAYS_HIDE -> RequirementPolicy.Hidden
+            }
+        }
+    }
+}

--- a/card/src/test/java/com/adyen/checkout/card/internal/data/api/DefaultDetectCardTypeRepositoryTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/data/api/DefaultDetectCardTypeRepositoryTest.kt
@@ -11,6 +11,8 @@ package com.adyen.checkout.card.internal.data.api
 import com.adyen.checkout.card.internal.data.model.BinLookupCacheResult
 import com.adyen.checkout.card.internal.data.model.BinLookupResponse
 import com.adyen.checkout.card.internal.data.model.Brand
+import com.adyen.checkout.card.internal.data.model.DetectedCardTypeList
+import com.adyen.checkout.card.internal.helper.DetectCardTypeBinHelper
 import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.error.internal.HttpError
 import com.adyen.checkout.cse.internal.TestCardEncryptor
@@ -45,6 +47,7 @@ internal class DefaultDetectCardTypeRepositoryTest(
     private lateinit var networkCardBrandDetectionService: NetworkCardBrandDetectionService
     private lateinit var localCardBrandDetectionService: LocalCardBrandDetectionService
     private lateinit var binLookupCache: BinLookupCache
+    private lateinit var detectCardTypeBinHelper: DetectCardTypeBinHelper
     private lateinit var detectCardTypeRepository: DefaultDetectCardTypeRepository
 
     @BeforeEach
@@ -60,7 +63,12 @@ internal class DefaultDetectCardTypeRepositoryTest(
 
             // assert flow emits only once (local)
             assertEquals(1, flow.values.size)
-            assertEquals(localCardBrandDetectionService.getCardBrands(cardNumber), flow.values[0])
+            val expected = DetectedCardTypeList(
+                detectedCardTypes = localCardBrandDetectionService.getCardBrands(cardNumber),
+                source = DetectedCardTypeList.Source.LOCAL,
+                cardDetectionBin = null,
+            )
+            assertEquals(expected, flow.values[0])
         }
 
     @Nested
@@ -74,13 +82,25 @@ internal class DefaultDetectCardTypeRepositoryTest(
             val cardNumber = "545454545454"
             val flow = detectCardTypeRepository.detectCardTypes(cardNumber).test(testScheduler)
 
-            val bin = detectCardTypeRepository.getBin(cardNumber)
+            val bin = detectCardTypeBinHelper.getCardDetectionBin(cardNumber)
             assertNotNull(bin)
 
             // assert flow emits twice (local + network)
             assertEquals(2, flow.values.size)
-            assertEquals(localCardBrandDetectionService.getCardBrands(cardNumber), flow.values[0])
-            assertEquals(networkCardBrandDetectionService.getCardBrands(bin).getOrNull(), flow.values[1])
+
+            val expectedLocal = DetectedCardTypeList(
+                detectedCardTypes = localCardBrandDetectionService.getCardBrands(cardNumber),
+                source = DetectedCardTypeList.Source.LOCAL,
+                cardDetectionBin = bin,
+            )
+            assertEquals(expectedLocal, flow.values[0])
+
+            val expectedNetwork = DetectedCardTypeList(
+                detectedCardTypes = networkCardBrandDetectionService.getCardBrands(bin).getOrThrow(),
+                source = DetectedCardTypeList.Source.NETWORK,
+                cardDetectionBin = bin,
+            )
+            assertEquals(expectedNetwork, flow.values[1])
         }
 
         @Test
@@ -98,13 +118,18 @@ internal class DefaultDetectCardTypeRepositoryTest(
                 // assert flow emits once (cache)
                 assertEquals(1, secondFlow.values.size)
 
-                val bin = detectCardTypeRepository.getBin(cardNumberWithSameBin)
+                val bin = detectCardTypeBinHelper.getCardDetectionBin(cardNumberWithSameBin)
                 assertNotNull(bin)
 
                 val cachedResult = binLookupCache.getResult(bin)
                 assertInstanceOf<BinLookupCacheResult.Available>(cachedResult)
 
-                assertEquals(cachedResult.detectedCardTypes, secondFlow.values[0])
+                val expected = DetectedCardTypeList(
+                    detectedCardTypes = cachedResult.detectedCardTypes,
+                    source = DetectedCardTypeList.Source.NETWORK,
+                    cardDetectionBin = bin,
+                )
+                assertEquals(expected, secondFlow.values[0])
             }
 
         @Test
@@ -140,13 +165,25 @@ internal class DefaultDetectCardTypeRepositoryTest(
                 .detectCardTypes(cardNumberWithDifferentBin)
                 .test(testScheduler)
 
-            val bin = detectCardTypeRepository.getBin(cardNumberWithDifferentBin)
+            val bin = detectCardTypeBinHelper.getCardDetectionBin(cardNumberWithDifferentBin)
             assertNotNull(bin)
 
             // assert flow emits twice (local + network)
             assertEquals(2, secondFlow.values.size)
-            assertEquals(localCardBrandDetectionService.getCardBrands(cardNumberWithDifferentBin), secondFlow.values[0])
-            assertEquals(networkCardBrandDetectionService.getCardBrands(bin).getOrNull(), secondFlow.values[1])
+
+            val expectedLocal = DetectedCardTypeList(
+                detectedCardTypes = localCardBrandDetectionService.getCardBrands(cardNumberWithDifferentBin),
+                source = DetectedCardTypeList.Source.LOCAL,
+                cardDetectionBin = bin,
+            )
+            assertEquals(expectedLocal, secondFlow.values[0])
+
+            val expectedNetwork = DetectedCardTypeList(
+                detectedCardTypes = networkCardBrandDetectionService.getCardBrands(bin).getOrThrow(),
+                source = DetectedCardTypeList.Source.NETWORK,
+                cardDetectionBin = bin,
+            )
+            assertEquals(expectedNetwork, secondFlow.values[1])
         }
 
         @Test
@@ -167,16 +204,25 @@ internal class DefaultDetectCardTypeRepositoryTest(
 
                 advanceUntilIdle()
 
-                val bin = detectCardTypeRepository.getBin(cardNumberWithDifferentBin)
+                val bin = detectCardTypeBinHelper.getCardDetectionBin(cardNumberWithDifferentBin)
                 assertNotNull(bin)
 
                 // assert flow emits twice (local + network)
                 assertEquals(2, secondFlow.values.size)
-                assertEquals(
-                    localCardBrandDetectionService.getCardBrands(cardNumberWithDifferentBin),
-                    secondFlow.values[0],
+
+                val expectedLocal = DetectedCardTypeList(
+                    detectedCardTypes = localCardBrandDetectionService.getCardBrands(cardNumberWithDifferentBin),
+                    source = DetectedCardTypeList.Source.LOCAL,
+                    cardDetectionBin = bin,
                 )
-                assertEquals(networkCardBrandDetectionService.getCardBrands(bin).getOrNull(), secondFlow.values[1])
+                assertEquals(expectedLocal, secondFlow.values[0])
+
+                val expectedNetwork = DetectedCardTypeList(
+                    detectedCardTypes = networkCardBrandDetectionService.getCardBrands(bin).getOrThrow(),
+                    source = DetectedCardTypeList.Source.NETWORK,
+                    cardDetectionBin = bin,
+                )
+                assertEquals(expectedNetwork, secondFlow.values[1])
             }
 
         @Test
@@ -186,9 +232,9 @@ internal class DefaultDetectCardTypeRepositoryTest(
             val cardNumber = "545454545454"
             val flow = detectCardTypeRepository.detectCardTypes(cardNumber).test(testScheduler)
             // first value emitted is local, second is network, which are the ones that get cached
-            val networkCardTypes = flow.values[1]
+            val networkCardTypes = flow.values[1].detectedCardTypes
 
-            val bin = detectCardTypeRepository.getBin(cardNumber)
+            val bin = detectCardTypeBinHelper.getCardDetectionBin(cardNumber)
             assertNotNull(bin)
 
             val result = binLookupCache.getResult(bin)
@@ -207,7 +253,7 @@ internal class DefaultDetectCardTypeRepositoryTest(
             val cardNumber = "545454545454"
             detectCardTypeRepository.detectCardTypes(cardNumber).test(testScheduler)
 
-            val bin = detectCardTypeRepository.getBin(cardNumber)
+            val bin = detectCardTypeBinHelper.getCardDetectionBin(cardNumber)
             assertNotNull(bin)
 
             val result = binLookupCache.getResult(bin)
@@ -223,7 +269,7 @@ internal class DefaultDetectCardTypeRepositoryTest(
             val cardNumber = "545454545454"
             detectCardTypeRepository.detectCardTypes(cardNumber).test(testScheduler)
 
-            val bin = detectCardTypeRepository.getBin(cardNumber)
+            val bin = detectCardTypeBinHelper.getCardDetectionBin(cardNumber)
             assertNotNull(bin)
 
             val result = binLookupCache.getResult(bin)
@@ -250,6 +296,7 @@ internal class DefaultDetectCardTypeRepositoryTest(
 
     private fun initializeTest(supportedCardBrands: List<CardBrand> = emptyList()) {
         binLookupCache = BinLookupCache()
+        detectCardTypeBinHelper = DetectCardTypeBinHelper()
         localCardBrandDetectionService = LocalCardBrandDetectionService(supportedCardBrands)
         networkCardBrandDetectionService = NetworkCardBrandDetectionService(
             cardEncryptor = TestCardEncryptor(),
@@ -259,6 +306,7 @@ internal class DefaultDetectCardTypeRepositoryTest(
             paymentMethodType = "",
         )
         detectCardTypeRepository = DefaultDetectCardTypeRepository(
+            detectCardTypeBinHelper,
             binLookupCache,
             localCardBrandDetectionService,
             networkCardBrandDetectionService,

--- a/card/src/test/java/com/adyen/checkout/card/internal/data/api/LocalCardBrandDetectionServiceTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/data/api/LocalCardBrandDetectionServiceTest.kt
@@ -44,6 +44,7 @@ internal class LocalCardBrandDetectionServiceTest {
             cvcPolicy = Brand.FieldPolicy.REQUIRED,
             expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
             isSupported = true,
+            isShopperSelectionAllowedInDualBranded = false,
             panLength = null,
             paymentMethodVariant = null,
             localizedBrand = null,

--- a/card/src/test/java/com/adyen/checkout/card/internal/data/api/LocalCardBrandDetectionServiceTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/data/api/LocalCardBrandDetectionServiceTest.kt
@@ -40,7 +40,6 @@ internal class LocalCardBrandDetectionServiceTest {
 
         val expectedDetectedCardType = DetectedCardType(
             cardBrand = cardBrand,
-            isReliable = false,
             enableLuhnCheck = true,
             cvcPolicy = Brand.FieldPolicy.REQUIRED,
             expiryDatePolicy = Brand.FieldPolicy.REQUIRED,

--- a/card/src/test/java/com/adyen/checkout/card/internal/data/api/NetworkCardBrandDetectionServiceTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/data/api/NetworkCardBrandDetectionServiceTest.kt
@@ -242,7 +242,6 @@ internal class NetworkCardBrandDetectionServiceTest(
         @Suppress("LongParameterList")
         private fun mockDetectedCardType(
             cardBrand: CardBrand = CardBrand(CardType.MASTERCARD.txVariant),
-            isReliable: Boolean = true,
             enableLuhnCheck: Boolean = true,
             cvcPolicy: Brand.FieldPolicy = Brand.FieldPolicy.REQUIRED,
             expiryDatePolicy: Brand.FieldPolicy = Brand.FieldPolicy.REQUIRED,
@@ -253,7 +252,6 @@ internal class NetworkCardBrandDetectionServiceTest(
         ): DetectedCardType {
             return DetectedCardType(
                 cardBrand,
-                isReliable,
                 enableLuhnCheck,
                 cvcPolicy,
                 expiryDatePolicy,

--- a/card/src/test/java/com/adyen/checkout/card/internal/data/api/NetworkCardBrandDetectionServiceTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/data/api/NetworkCardBrandDetectionServiceTest.kt
@@ -211,6 +211,27 @@ internal class NetworkCardBrandDetectionServiceTest(
                 ),
             ),
             arguments(
+                listOf(
+                    mockBrand(brand = "cartebancaire"),
+                    mockBrand(brand = "bcmc"),
+                    mockBrand(brand = "dankort"),
+                ),
+                listOf(
+                    mockDetectedCardType(
+                        cardBrand = CardBrand(CardType.CARTEBANCAIRE.txVariant),
+                        isShopperSelectionAllowedInDualBranded = true,
+                    ),
+                    mockDetectedCardType(
+                        cardBrand = CardBrand(CardType.BCMC.txVariant),
+                        isShopperSelectionAllowedInDualBranded = true,
+                    ),
+                    mockDetectedCardType(
+                        cardBrand = CardBrand(CardType.DANKORT.txVariant),
+                        isShopperSelectionAllowedInDualBranded = true,
+                    ),
+                ),
+            ),
+            arguments(
                 null,
                 emptyList<DetectedCardType>(),
             ),
@@ -246,6 +267,7 @@ internal class NetworkCardBrandDetectionServiceTest(
             cvcPolicy: Brand.FieldPolicy = Brand.FieldPolicy.REQUIRED,
             expiryDatePolicy: Brand.FieldPolicy = Brand.FieldPolicy.REQUIRED,
             isSupported: Boolean = true,
+            isShopperSelectionAllowedInDualBranded: Boolean = false,
             panLength: Int? = 16,
             paymentMethodVariant: String? = PaymentMethodTypes.SCHEME,
             localizedBrand: String? = "MasterCard",
@@ -256,6 +278,7 @@ internal class NetworkCardBrandDetectionServiceTest(
                 cvcPolicy,
                 expiryDatePolicy,
                 isSupported,
+                isShopperSelectionAllowedInDualBranded,
                 panLength,
                 paymentMethodVariant,
                 localizedBrand,

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/DualBrandedCardHandlerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/DualBrandedCardHandlerTest.kt
@@ -9,167 +9,153 @@
 package com.adyen.checkout.card.internal.ui
 
 import com.adyen.checkout.card.internal.data.model.Brand
-import com.adyen.checkout.card.internal.data.model.DetectedCardType
-import com.adyen.checkout.card.internal.ui.model.CardBrandItem
-import com.adyen.checkout.card.internal.ui.model.DualBrandData
+import com.adyen.checkout.card.internal.ui.state.CardBrandData
+import com.adyen.checkout.card.internal.ui.state.CardBrandState
 import com.adyen.checkout.core.common.CardBrand
-import com.adyen.checkout.core.common.CardType
+import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments.arguments
-import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.api.assertNotNull
+import org.junit.jupiter.api.assertNull
 
 internal class DualBrandedCardHandlerTest {
 
     private val dualBrandedCardHandler = DualBrandedCardHandler()
 
-    @ParameterizedTest
-    @MethodSource("dualBrandedCardHandlerSource")
-    fun `given detected card types and selected brand, expected dual brand data should be created`(
-        detectedCardTypes: List<DetectedCardType>,
-        selectedBrand: CardBrand?,
-        expectedDualBrandData: DualBrandData?
-    ) {
-        val actual = dualBrandedCardHandler.getDualBrandData(detectedCardTypes, selectedBrand,)
-        assertEquals(expectedDualBrandData, actual)
+    @Test
+    fun `when card brand state is not DualBrandWithShopperSelection then result should be null`() {
+        val cardBrandStates = listOf(
+            CardBrandState.NoBrandsDetected,
+            CardBrandState.UnsupportedBrand,
+            CardBrandState.SingleReliableBrand(getCardBrandData()),
+            CardBrandState.SingleUnreliableBrand(getCardBrandData()),
+            CardBrandState.DualBrand(listOf(getCardBrandData(), getCardBrandData())),
+        )
+
+        cardBrandStates.forEach {
+            val actual = dualBrandedCardHandler.getDualBrandData(it)
+            assertNull(actual)
+        }
     }
 
-    companion object {
+    @Test
+    fun `when detected card types list is empty, then dual brand data is null`() {
+        val cardBrandState = CardBrandState.DualBrandWithShopperSelection(
+            cardBrandDataList = emptyList(),
+            shopperSelectedCardBrandData = getCardBrandData(),
+        )
+        val actual = dualBrandedCardHandler.getDualBrandData(cardBrandState)
+        assertNull(actual)
+    }
 
-        @JvmStatic
-        fun dualBrandedCardHandlerSource() = listOf(
-            // detected card types, selected brand, expected dual brand data
-            arguments(
-                emptyList<DetectedCardType>(),
-                null,
-                null,
-            ),
-            arguments(
-                listOf(
-                    DetectedCardType(
-                        CardBrand(CardType.VISA.txVariant),
-                        enableLuhnCheck = true,
-                        cvcPolicy = Brand.FieldPolicy.REQUIRED,
-                        expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
-                        isSupported = true,
-                        panLength = null,
-                        paymentMethodVariant = null,
-                        localizedBrand = "Visa",
-                    ),
-                    DetectedCardType(
-                        CardBrand(CardType.CARTEBANCAIRE.txVariant),
-                        enableLuhnCheck = true,
-                        cvcPolicy = Brand.FieldPolicy.REQUIRED,
-                        expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
-                        isSupported = true,
-                        panLength = null,
-                        paymentMethodVariant = null,
-                        localizedBrand = "Cartes Bancaire",
-                    ),
-                ),
-                null,
-                null,
-            ),
-            arguments(
-                listOf(
-                    DetectedCardType(
-                        CardBrand(CardType.VISA.txVariant),
-                        enableLuhnCheck = true,
-                        cvcPolicy = Brand.FieldPolicy.REQUIRED,
-                        expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
-                        isSupported = true,
-                        panLength = null,
-                        paymentMethodVariant = null,
-                        localizedBrand = "Visa",
-                    ),
-                    DetectedCardType(
-                        CardBrand(CardType.CARTEBANCAIRE.txVariant),
-                        enableLuhnCheck = true,
-                        cvcPolicy = Brand.FieldPolicy.REQUIRED,
-                        expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
-                        isSupported = true,
-                        panLength = null,
-                        paymentMethodVariant = null,
-                        localizedBrand = "Cartes Bancaire",
-                    ),
-                ),
-                null,
-                DualBrandData(
-                    brandOptionFirst = CardBrandItem(
-                        name = "Visa",
-                        brand = CardBrand(CardType.VISA.txVariant),
-                        isSelected = true,
-                    ),
-                    brandOptionSecond = CardBrandItem(
-                        name = "Cartes Bancaire",
-                        brand = CardBrand(CardType.CARTEBANCAIRE.txVariant),
-                        isSelected = false,
-                    ),
-                ),
-            ),
-            arguments(
-                listOf(
-                    DetectedCardType(
-                        CardBrand(CardType.VISA.txVariant),
-                        enableLuhnCheck = true,
-                        cvcPolicy = Brand.FieldPolicy.REQUIRED,
-                        expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
-                        isSupported = true,
-                        panLength = null,
-                        paymentMethodVariant = null,
-                        localizedBrand = "Visa",
-                    ),
-                    DetectedCardType(
-                        CardBrand(CardType.DANKORT.txVariant),
-                        enableLuhnCheck = true,
-                        cvcPolicy = Brand.FieldPolicy.REQUIRED,
-                        expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
-                        isSupported = true,
-                        panLength = null,
-                        paymentMethodVariant = null,
-                        localizedBrand = "Dankort",
-                    ),
-                ),
-                CardBrand(CardType.DANKORT.txVariant),
-                DualBrandData(
-                    brandOptionFirst = CardBrandItem(
-                        name = "Visa",
-                        brand = CardBrand(CardType.VISA.txVariant),
-                        isSelected = false,
-                    ),
-                    brandOptionSecond = CardBrandItem(
-                        name = "Dankort",
-                        brand = CardBrand(CardType.DANKORT.txVariant),
-                        isSelected = true,
-                    ),
-                ),
-            ),
-            arguments(
-                listOf(
-                    DetectedCardType(
-                        CardBrand(CardType.MASTERCARD.txVariant),
-                        enableLuhnCheck = true,
-                        cvcPolicy = Brand.FieldPolicy.REQUIRED,
-                        expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
-                        isSupported = true,
-                        panLength = null,
-                        paymentMethodVariant = null,
-                        localizedBrand = "Mastercard",
-                    ),
-                    DetectedCardType(
-                        CardBrand("eft_pos"),
-                        enableLuhnCheck = true,
-                        cvcPolicy = Brand.FieldPolicy.REQUIRED,
-                        expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
-                        isSupported = true,
-                        panLength = null,
-                        paymentMethodVariant = null,
-                        localizedBrand = "eftpos_australia",
-                    ),
-                ),
-                null,
-                null,
-            ),
+    @Test
+    fun `when detected card types list has a single item, then dual brand data is null`() {
+        val cardBrandState = CardBrandState.DualBrandWithShopperSelection(
+            cardBrandDataList = listOf(getCardBrandData()),
+            shopperSelectedCardBrandData = getCardBrandData(),
+        )
+        val actual = dualBrandedCardHandler.getDualBrandData(cardBrandState)
+        assertNull(actual)
+    }
+
+    @Test
+    fun `when shopperSelectedCardBrandData is the first item, then brandOptionFirst should be selected`() {
+        val firstCardBrandData = getCardBrandData().copy(cardBrand = CardBrand("first"))
+        val secondCardBrandData = getCardBrandData().copy(cardBrand = CardBrand("second"))
+        val cardBrandState = CardBrandState.DualBrandWithShopperSelection(
+            cardBrandDataList = listOf(firstCardBrandData, secondCardBrandData),
+            shopperSelectedCardBrandData = firstCardBrandData,
+        )
+
+        val actual = dualBrandedCardHandler.getDualBrandData(cardBrandState)
+
+        assertNotNull(actual)
+        assert(actual.brandOptionFirst.isSelected)
+        assert(!actual.brandOptionSecond.isSelected)
+    }
+
+    @Test
+    fun `when shopperSelectedCardBrandData is the second item, then brandOptionSecond should be selected`() {
+        val firstCardBrandData = getCardBrandData().copy(cardBrand = CardBrand("first"))
+        val secondCardBrandData = getCardBrandData().copy(cardBrand = CardBrand("second"))
+        val cardBrandState = CardBrandState.DualBrandWithShopperSelection(
+            cardBrandDataList = listOf(firstCardBrandData, secondCardBrandData),
+            shopperSelectedCardBrandData = secondCardBrandData,
+        )
+        val actual = dualBrandedCardHandler.getDualBrandData(cardBrandState)
+
+        assertNotNull(actual)
+        assert(!actual.brandOptionFirst.isSelected)
+        assert(actual.brandOptionSecond.isSelected)
+    }
+
+    @Test
+    fun `when brand is available, then it should be mapped to CardBrandItem brand`() {
+        val firstCardBrandData = getCardBrandData().copy(
+            cardBrand = CardBrand("first"),
+        )
+        val secondCardBrandData = getCardBrandData().copy(
+            cardBrand = CardBrand("second"),
+        )
+        val cardBrandState = CardBrandState.DualBrandWithShopperSelection(
+            cardBrandDataList = listOf(firstCardBrandData, secondCardBrandData),
+            shopperSelectedCardBrandData = firstCardBrandData,
+        )
+        val actual = dualBrandedCardHandler.getDualBrandData(cardBrandState)
+
+        assertNotNull(actual)
+        assertEquals(CardBrand("first"), actual.brandOptionFirst.brand)
+        assertEquals(CardBrand("second"), actual.brandOptionSecond.brand)
+    }
+
+    @Test
+    fun `when localizedBrand is available, then it should be mapped to CardBrandItem name`() {
+        val firstCardBrandData = getCardBrandData().copy(
+            cardBrand = CardBrand("first"),
+            localizedBrand = "localized first",
+        )
+        val secondCardBrandData = getCardBrandData().copy(
+            cardBrand = CardBrand("second"),
+            localizedBrand = "localized second",
+        )
+        val cardBrandState = CardBrandState.DualBrandWithShopperSelection(
+            cardBrandDataList = listOf(firstCardBrandData, secondCardBrandData),
+            shopperSelectedCardBrandData = firstCardBrandData,
+        )
+        val actual = dualBrandedCardHandler.getDualBrandData(cardBrandState)
+
+        assertNotNull(actual)
+        assertEquals("localized first", actual.brandOptionFirst.name)
+        assertEquals("localized second", actual.brandOptionSecond.name)
+    }
+
+    @Test
+    fun `when localizedBrand is not available, then txVariant should be mapped to CardBrandItem name`() {
+        val firstCardBrandData = getCardBrandData().copy(
+            cardBrand = CardBrand("first"),
+        )
+        val secondCardBrandData = getCardBrandData().copy(
+            cardBrand = CardBrand("second"),
+        )
+        val cardBrandState = CardBrandState.DualBrandWithShopperSelection(
+            cardBrandDataList = listOf(firstCardBrandData, secondCardBrandData),
+            shopperSelectedCardBrandData = firstCardBrandData,
+        )
+        val actual = dualBrandedCardHandler.getDualBrandData(cardBrandState)
+
+        assertNotNull(actual)
+        assertEquals("first", actual.brandOptionFirst.name)
+        assertEquals("second", actual.brandOptionSecond.name)
+    }
+
+    private fun getCardBrandData(): CardBrandData {
+        return CardBrandData(
+            cardBrand = CardBrand(""),
+            enableLuhnCheck = true,
+            cvcPolicy = Brand.FieldPolicy.REQUIRED,
+            expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
+            panLength = null,
+            paymentMethodVariant = null,
+            localizedBrand = null,
         )
     }
 }

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/DualBrandedCardHandlerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/DualBrandedCardHandlerTest.kt
@@ -30,7 +30,7 @@ internal class DualBrandedCardHandlerTest {
         selectedBrand: CardBrand?,
         expectedDualBrandData: DualBrandData?
     ) {
-        val actual = dualBrandedCardHandler.processDetectedCardTypes(detectedCardTypes, selectedBrand)
+        val actual = dualBrandedCardHandler.processDetectedCardTypes(detectedCardTypes, selectedBrand,)
         assertEquals(expectedDualBrandData, actual)
     }
 
@@ -48,7 +48,6 @@ internal class DualBrandedCardHandlerTest {
                 listOf(
                     DetectedCardType(
                         CardBrand(CardType.VISA.txVariant),
-                        isReliable = true,
                         enableLuhnCheck = true,
                         cvcPolicy = Brand.FieldPolicy.REQUIRED,
                         expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
@@ -59,7 +58,6 @@ internal class DualBrandedCardHandlerTest {
                     ),
                     DetectedCardType(
                         CardBrand(CardType.CARTEBANCAIRE.txVariant),
-                        isReliable = false,
                         enableLuhnCheck = true,
                         cvcPolicy = Brand.FieldPolicy.REQUIRED,
                         expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
@@ -76,7 +74,6 @@ internal class DualBrandedCardHandlerTest {
                 listOf(
                     DetectedCardType(
                         CardBrand(CardType.VISA.txVariant),
-                        isReliable = true,
                         enableLuhnCheck = true,
                         cvcPolicy = Brand.FieldPolicy.REQUIRED,
                         expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
@@ -87,7 +84,6 @@ internal class DualBrandedCardHandlerTest {
                     ),
                     DetectedCardType(
                         CardBrand(CardType.CARTEBANCAIRE.txVariant),
-                        isReliable = true,
                         enableLuhnCheck = true,
                         cvcPolicy = Brand.FieldPolicy.REQUIRED,
                         expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
@@ -115,7 +111,6 @@ internal class DualBrandedCardHandlerTest {
                 listOf(
                     DetectedCardType(
                         CardBrand(CardType.VISA.txVariant),
-                        isReliable = true,
                         enableLuhnCheck = true,
                         cvcPolicy = Brand.FieldPolicy.REQUIRED,
                         expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
@@ -126,7 +121,6 @@ internal class DualBrandedCardHandlerTest {
                     ),
                     DetectedCardType(
                         CardBrand(CardType.DANKORT.txVariant),
-                        isReliable = true,
                         enableLuhnCheck = true,
                         cvcPolicy = Brand.FieldPolicy.REQUIRED,
                         expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
@@ -154,7 +148,6 @@ internal class DualBrandedCardHandlerTest {
                 listOf(
                     DetectedCardType(
                         CardBrand(CardType.MASTERCARD.txVariant),
-                        isReliable = true,
                         enableLuhnCheck = true,
                         cvcPolicy = Brand.FieldPolicy.REQUIRED,
                         expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
@@ -165,7 +158,6 @@ internal class DualBrandedCardHandlerTest {
                     ),
                     DetectedCardType(
                         CardBrand("eft_pos"),
-                        isReliable = true,
                         enableLuhnCheck = true,
                         cvcPolicy = Brand.FieldPolicy.REQUIRED,
                         expiryDatePolicy = Brand.FieldPolicy.REQUIRED,

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/DualBrandedCardHandlerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/DualBrandedCardHandlerTest.kt
@@ -30,7 +30,7 @@ internal class DualBrandedCardHandlerTest {
         selectedBrand: CardBrand?,
         expectedDualBrandData: DualBrandData?
     ) {
-        val actual = dualBrandedCardHandler.processDetectedCardTypes(detectedCardTypes, selectedBrand,)
+        val actual = dualBrandedCardHandler.getDualBrandData(detectedCardTypes, selectedBrand,)
         assertEquals(expectedDualBrandData, actual)
     }
 

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandlerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandlerTest.kt
@@ -1,0 +1,691 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 24/4/2026.
+ */
+
+package com.adyen.checkout.card.internal.ui.state
+
+import com.adyen.checkout.card.internal.data.model.Brand
+import com.adyen.checkout.card.internal.data.model.DetectedCardType
+import com.adyen.checkout.card.internal.data.model.DetectedCardTypeList
+import com.adyen.checkout.card.internal.helper.DetectCardTypeBinHelper
+import com.adyen.checkout.card.internal.ui.model.CVCVisibility
+import com.adyen.checkout.card.internal.ui.model.CardComponentParams
+import com.adyen.checkout.core.common.CardBrand
+import com.adyen.checkout.core.components.internal.ui.state.model.RequirementPolicy
+import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertInstanceOf
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+internal class CardBrandIntentsHandlerTest(
+    @Mock private val cardComponentParams: CardComponentParams,
+) {
+
+    private val detectCardTypeBinHelper = DetectCardTypeBinHelper()
+    private lateinit var cardBrandIntentsHandler: CardBrandIntentsHandler
+
+    @BeforeEach
+    fun beforeEach() {
+        whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.ALWAYS_SHOW)
+        cardBrandIntentsHandler = CardBrandIntentsHandler(cardComponentParams, detectCardTypeBinHelper)
+    }
+
+    @Test
+    fun `when intent is UpdateDetectedCardTypes and bin has changed already then intent should be discarded`() {
+        val state = createInitialState().copy(cardNumber = TextInputComponentState(text = "5454545454545454"))
+        val detectedCardTypes = listOf(
+            createDetectedCardType().copy(cardBrand = CardBrand("visa")),
+        )
+        val detectedCardTypeList = DetectedCardTypeList(
+            detectedCardTypes,
+            DetectedCardTypeList.Source.NETWORK,
+            "41111111111",
+        )
+
+        val actual = cardBrandIntentsHandler.onUpdateDetectedCardTypes(
+            state,
+            CardIntent.UpdateDetectedCardTypes(detectedCardTypeList),
+        )
+
+        assertEquals(state, actual)
+    }
+
+    @Nested
+    @DisplayName("when intent is UpdateDetectedCardTypes and detection source is local")
+    inner class UpdateDetectedCardTypesLocalTest {
+
+        @Test
+        fun `and list is empty then state should be no brands detected`() {
+            val state = createInitialState().copy(
+                cardBrandState = CardBrandState.SingleReliableBrand(createCardBrandData()),
+            )
+            val detectedCardTypeList = DetectedCardTypeList(
+                emptyList(),
+                DetectedCardTypeList.Source.LOCAL,
+                null,
+            )
+
+            val actual = cardBrandIntentsHandler.onUpdateDetectedCardTypes(
+                state,
+                CardIntent.UpdateDetectedCardTypes(detectedCardTypeList),
+            )
+
+            assertEquals(CardBrandState.NoBrandsDetected, actual.cardBrandState)
+        }
+
+        @Test
+        fun `and list has only unsupported brands then state should be no brands detected`() {
+            val state = createInitialState().copy(
+                cardBrandState = CardBrandState.SingleReliableBrand(createCardBrandData()),
+            )
+            val detectedCardTypes = listOf(
+                createDetectedCardType().copy(cardBrand = CardBrand("visa"), isSupported = false),
+            )
+            val detectedCardTypeList = DetectedCardTypeList(
+                detectedCardTypes,
+                DetectedCardTypeList.Source.LOCAL,
+                null,
+            )
+
+            val actual = cardBrandIntentsHandler.onUpdateDetectedCardTypes(
+                state,
+                CardIntent.UpdateDetectedCardTypes(detectedCardTypeList),
+            )
+
+            assertEquals(CardBrandState.NoBrandsDetected, actual.cardBrandState)
+        }
+
+        @Test
+        fun `and list has one supported brand then state should be a single unreliable brand`() {
+            val state = createInitialState().copy(
+                cardBrandState = CardBrandState.SingleReliableBrand(createCardBrandData()),
+            )
+            val detectedCardTypes = listOf(
+                createDetectedCardType().copy(cardBrand = CardBrand("visa")),
+            )
+            val detectedCardTypeList = DetectedCardTypeList(
+                detectedCardTypes,
+                DetectedCardTypeList.Source.LOCAL,
+                null,
+            )
+
+            val actual = cardBrandIntentsHandler.onUpdateDetectedCardTypes(
+                state,
+                CardIntent.UpdateDetectedCardTypes(detectedCardTypeList),
+            )
+
+            val expectedState = CardBrandState.SingleUnreliableBrand(
+                createCardBrandData().copy(cardBrand = CardBrand("visa")),
+            )
+
+            assertEquals(expectedState, actual.cardBrandState)
+        }
+
+        @Test
+        fun `and list has one supported brand and unsupported brands then state should be a single unreliable brand`() {
+            val state = createInitialState().copy(
+                cardBrandState = CardBrandState.SingleReliableBrand(createCardBrandData()),
+            )
+            val detectedCardTypes = listOf(
+                createDetectedCardType().copy(cardBrand = CardBrand("amex"), isSupported = false),
+                createDetectedCardType().copy(cardBrand = CardBrand("mc")),
+                createDetectedCardType().copy(cardBrand = CardBrand("visa"), isSupported = false),
+            )
+            val detectedCardTypeList = DetectedCardTypeList(
+                detectedCardTypes,
+                DetectedCardTypeList.Source.LOCAL,
+                null,
+            )
+
+            val actual = cardBrandIntentsHandler.onUpdateDetectedCardTypes(
+                state,
+                CardIntent.UpdateDetectedCardTypes(detectedCardTypeList),
+            )
+
+            val expectedState = CardBrandState.SingleUnreliableBrand(
+                createCardBrandData().copy(cardBrand = CardBrand("mc")),
+            )
+
+            assertEquals(expectedState, actual.cardBrandState)
+        }
+
+        @Test
+        fun `and list has multiple supported brands then state should be a single unreliable brand with first brand in the list`() {
+            val state = createInitialState().copy(
+                cardBrandState = CardBrandState.SingleReliableBrand(createCardBrandData()),
+            )
+            val detectedCardTypes = listOf(
+                createDetectedCardType().copy(cardBrand = CardBrand("amex")),
+                createDetectedCardType().copy(cardBrand = CardBrand("mc")),
+                createDetectedCardType().copy(cardBrand = CardBrand("visa")),
+            )
+            val detectedCardTypeList = DetectedCardTypeList(
+                detectedCardTypes,
+                DetectedCardTypeList.Source.LOCAL,
+                null,
+            )
+
+            val actual = cardBrandIntentsHandler.onUpdateDetectedCardTypes(
+                state,
+                CardIntent.UpdateDetectedCardTypes(detectedCardTypeList),
+            )
+
+            val expectedState = CardBrandState.SingleUnreliableBrand(
+                createCardBrandData().copy(cardBrand = CardBrand("amex")),
+            )
+
+            assertEquals(expectedState, actual.cardBrandState)
+        }
+    }
+
+    @Nested
+    @DisplayName("when intent is UpdateDetectedCardTypes and detection source is network")
+    inner class UpdateDetectedCardTypesNetworkTest {
+
+        @Test
+        fun `and list is empty then state should be no brands detected`() {
+            val state = createInitialState().copy(
+                cardBrandState = CardBrandState.SingleReliableBrand(createCardBrandData()),
+            )
+            val detectedCardTypeList = DetectedCardTypeList(
+                emptyList(),
+                DetectedCardTypeList.Source.NETWORK,
+                null,
+            )
+
+            val actual = cardBrandIntentsHandler.onUpdateDetectedCardTypes(
+                state,
+                CardIntent.UpdateDetectedCardTypes(detectedCardTypeList),
+            )
+
+            assertEquals(CardBrandState.NoBrandsDetected, actual.cardBrandState)
+        }
+
+        @Test
+        fun `and list has only unsupported brands then state should be unsupported brand`() {
+            val state = createInitialState().copy(
+                cardBrandState = CardBrandState.SingleReliableBrand(createCardBrandData()),
+            )
+            val detectedCardTypes = listOf(
+                createDetectedCardType().copy(cardBrand = CardBrand("visa"), isSupported = false),
+            )
+            val detectedCardTypeList = DetectedCardTypeList(
+                detectedCardTypes,
+                DetectedCardTypeList.Source.NETWORK,
+                null,
+            )
+
+            val actual = cardBrandIntentsHandler.onUpdateDetectedCardTypes(
+                state,
+                CardIntent.UpdateDetectedCardTypes(detectedCardTypeList),
+            )
+
+            assertEquals(CardBrandState.UnsupportedBrand, actual.cardBrandState)
+        }
+
+        @Test
+        fun `and list has one supported brand then state should be a single reliable brand`() {
+            val state = createInitialState().copy(
+                cardBrandState = CardBrandState.SingleReliableBrand(createCardBrandData()),
+            )
+            val detectedCardTypes = listOf(
+                createDetectedCardType().copy(cardBrand = CardBrand("visa")),
+            )
+            val detectedCardTypeList = DetectedCardTypeList(
+                detectedCardTypes,
+                DetectedCardTypeList.Source.NETWORK,
+                null,
+            )
+
+            val actual = cardBrandIntentsHandler.onUpdateDetectedCardTypes(
+                state,
+                CardIntent.UpdateDetectedCardTypes(detectedCardTypeList),
+            )
+
+            val expectedState = CardBrandState.SingleReliableBrand(
+                createCardBrandData().copy(cardBrand = CardBrand("visa")),
+            )
+
+            assertEquals(expectedState, actual.cardBrandState)
+        }
+
+        @Test
+        fun `and list has one supported brand and unsupported brands then state should be a single reliable brand`() {
+            val state = createInitialState().copy(
+                cardBrandState = CardBrandState.SingleReliableBrand(createCardBrandData()),
+            )
+            val detectedCardTypes = listOf(
+                createDetectedCardType().copy(cardBrand = CardBrand("amex"), isSupported = false),
+                createDetectedCardType().copy(cardBrand = CardBrand("mc")),
+                createDetectedCardType().copy(cardBrand = CardBrand("visa"), isSupported = false),
+            )
+            val detectedCardTypeList = DetectedCardTypeList(
+                detectedCardTypes,
+                DetectedCardTypeList.Source.NETWORK,
+                null,
+            )
+
+            val actual = cardBrandIntentsHandler.onUpdateDetectedCardTypes(
+                state,
+                CardIntent.UpdateDetectedCardTypes(detectedCardTypeList),
+            )
+
+            val expectedState = CardBrandState.SingleReliableBrand(
+                createCardBrandData().copy(cardBrand = CardBrand("mc")),
+            )
+
+            assertEquals(expectedState, actual.cardBrandState)
+        }
+
+        @Test
+        fun `and list has two supported brands with no shopper selection allowed then state should be a dual branded`() {
+            val state = createInitialState().copy(
+                cardBrandState = CardBrandState.SingleReliableBrand(createCardBrandData()),
+            )
+            val detectedCardTypes = listOf(
+                createDetectedCardType().copy(cardBrand = CardBrand("amex")),
+                createDetectedCardType().copy(cardBrand = CardBrand("mc")),
+            )
+            val detectedCardTypeList = DetectedCardTypeList(
+                detectedCardTypes,
+                DetectedCardTypeList.Source.NETWORK,
+                null,
+            )
+
+            val actual = cardBrandIntentsHandler.onUpdateDetectedCardTypes(
+                state,
+                CardIntent.UpdateDetectedCardTypes(detectedCardTypeList),
+            )
+
+            val expectedState = CardBrandState.DualBrand(
+                listOf(
+                    createCardBrandData().copy(cardBrand = CardBrand("amex")),
+                    createCardBrandData().copy(cardBrand = CardBrand("mc")),
+                ),
+            )
+
+            assertEquals(expectedState, actual.cardBrandState)
+        }
+
+        @Test
+        fun `and list has more than two supported brands with no shopper selection allowed then state should be a dual branded with first two brands only`() {
+            val state = createInitialState().copy(
+                cardBrandState = CardBrandState.SingleReliableBrand(createCardBrandData()),
+            )
+            val detectedCardTypes = listOf(
+                createDetectedCardType().copy(cardBrand = CardBrand("visa")),
+                createDetectedCardType().copy(cardBrand = CardBrand("mc")),
+                createDetectedCardType().copy(cardBrand = CardBrand("amex")),
+            )
+            val detectedCardTypeList = DetectedCardTypeList(
+                detectedCardTypes,
+                DetectedCardTypeList.Source.NETWORK,
+                null,
+            )
+
+            val actual = cardBrandIntentsHandler.onUpdateDetectedCardTypes(
+                state,
+                CardIntent.UpdateDetectedCardTypes(detectedCardTypeList),
+            )
+
+            val expectedState = CardBrandState.DualBrand(
+                listOf(
+                    createCardBrandData().copy(cardBrand = CardBrand("visa")),
+                    createCardBrandData().copy(cardBrand = CardBrand("mc")),
+                ),
+            )
+
+            assertEquals(expectedState, actual.cardBrandState)
+        }
+
+        @Test
+        fun `and list has two supported brands with shopper selection allowed then state should be a dual branded with shopper selection allowed`() {
+            val state = createInitialState().copy(
+                cardBrandState = CardBrandState.SingleReliableBrand(createCardBrandData()),
+            )
+            val detectedCardTypes = listOf(
+                createDetectedCardType().copy(cardBrand = CardBrand("amex")),
+                createDetectedCardType().copy(
+                    cardBrand = CardBrand("mc"),
+                    isShopperSelectionAllowedInDualBranded = true,
+                ),
+            )
+            val detectedCardTypeList = DetectedCardTypeList(
+                detectedCardTypes,
+                DetectedCardTypeList.Source.NETWORK,
+                null,
+            )
+
+            val actual = cardBrandIntentsHandler.onUpdateDetectedCardTypes(
+                state,
+                CardIntent.UpdateDetectedCardTypes(detectedCardTypeList),
+            )
+
+            val expectedState = CardBrandState.DualBrandWithShopperSelection(
+                cardBrandDataList = listOf(
+                    createCardBrandData().copy(cardBrand = CardBrand("amex")),
+                    createCardBrandData().copy(cardBrand = CardBrand("mc")),
+                ),
+                shopperSelectedCardBrandData = createCardBrandData().copy(cardBrand = CardBrand("amex")),
+            )
+
+            assertEquals(expectedState, actual.cardBrandState)
+        }
+
+        @Test
+        fun `and flow is dual branded with shopper selection and card brand list has not changed then selected brand is preserved`() {
+            val state = createInitialState().copy(
+                cardBrandState = CardBrandState.DualBrandWithShopperSelection(
+                    cardBrandDataList = listOf(
+                        createCardBrandData().copy(cardBrand = CardBrand("visa")),
+                        createCardBrandData().copy(cardBrand = CardBrand("amex")),
+                    ),
+                    shopperSelectedCardBrandData = createCardBrandData().copy(cardBrand = CardBrand("amex")),
+                ),
+            )
+            val detectedCardTypes = listOf(
+                createDetectedCardType().copy(
+                    cardBrand = CardBrand("visa"),
+                    isShopperSelectionAllowedInDualBranded = true,
+                ),
+                createDetectedCardType().copy(cardBrand = CardBrand("amex")),
+            )
+            val detectedCardTypeList = DetectedCardTypeList(
+                detectedCardTypes,
+                DetectedCardTypeList.Source.NETWORK,
+                null,
+            )
+
+            val actual = cardBrandIntentsHandler.onUpdateDetectedCardTypes(
+                state,
+                CardIntent.UpdateDetectedCardTypes(detectedCardTypeList),
+            )
+
+            // whole state should not change
+            assertEquals(state, actual)
+        }
+
+        @Test
+        fun `and flow is dual branded with shopper selection and card brand list has changed then selected brand is first one`() {
+            val state = createInitialState().copy(
+                cardBrandState = CardBrandState.DualBrandWithShopperSelection(
+                    cardBrandDataList = listOf(
+                        createCardBrandData().copy(cardBrand = CardBrand("visa")),
+                        createCardBrandData().copy(cardBrand = CardBrand("amex")),
+                    ),
+                    shopperSelectedCardBrandData = createCardBrandData().copy(cardBrand = CardBrand("amex")),
+                ),
+            )
+            val detectedCardTypes = listOf(
+                createDetectedCardType().copy(
+                    cardBrand = CardBrand("visa"),
+                    isShopperSelectionAllowedInDualBranded = true,
+                ),
+                createDetectedCardType().copy(cardBrand = CardBrand("mc")),
+            )
+            val detectedCardTypeList = DetectedCardTypeList(
+                detectedCardTypes,
+                DetectedCardTypeList.Source.NETWORK,
+                null,
+            )
+
+            val actual = cardBrandIntentsHandler.onUpdateDetectedCardTypes(
+                state,
+                CardIntent.UpdateDetectedCardTypes(detectedCardTypeList),
+            )
+
+            val expectedState = CardBrandState.DualBrandWithShopperSelection(
+                cardBrandDataList = listOf(
+                    createCardBrandData().copy(cardBrand = CardBrand("visa")),
+                    createCardBrandData().copy(cardBrand = CardBrand("mc")),
+                ),
+                shopperSelectedCardBrandData = createCardBrandData().copy(cardBrand = CardBrand("visa")),
+            )
+
+            assertEquals(expectedState, actual.cardBrandState)
+        }
+    }
+
+    // CVC / expiry date policy tests
+
+    @Test
+    fun `when card brand has expiryDatePolicy REQUIRED, then expiryDate requirementPolicy is Required`() {
+        val cardBrandState = CardBrandState.SingleReliableBrand(
+            createCardBrandData().copy(expiryDatePolicy = Brand.FieldPolicy.REQUIRED),
+        )
+
+        val actual = cardBrandIntentsHandler.getUpdatedCardComponentState(createInitialState(), cardBrandState)
+
+        assertEquals(RequirementPolicy.Required, actual.expiryDate.requirementPolicy)
+    }
+
+    @Test
+    fun `when card brand has expiryDatePolicy OPTIONAL, then expiryDate requirementPolicy is Optional`() {
+        val cardBrandState = CardBrandState.SingleReliableBrand(
+            createCardBrandData().copy(expiryDatePolicy = Brand.FieldPolicy.OPTIONAL),
+        )
+
+        val actual = cardBrandIntentsHandler.getUpdatedCardComponentState(createInitialState(), cardBrandState)
+
+        assertEquals(RequirementPolicy.Optional, actual.expiryDate.requirementPolicy)
+    }
+
+    @Test
+    fun `when card brand has expiryDatePolicy HIDDEN, then expiryDate requirementPolicy is Hidden`() {
+        val cardBrandState = CardBrandState.SingleReliableBrand(
+            createCardBrandData().copy(expiryDatePolicy = Brand.FieldPolicy.HIDDEN),
+        )
+
+        val actual = cardBrandIntentsHandler.getUpdatedCardComponentState(createInitialState(), cardBrandState)
+
+        assertEquals(RequirementPolicy.Hidden, actual.expiryDate.requirementPolicy)
+    }
+
+    @Test
+    fun `when no card brand is detected then expiryDate requirementPolicy defaults to Required`() {
+        val cardBrandState = CardBrandState.NoBrandsDetected
+
+        val actual = cardBrandIntentsHandler.getUpdatedCardComponentState(createInitialState(), cardBrandState)
+
+        assertEquals(RequirementPolicy.Required, actual.expiryDate.requirementPolicy)
+    }
+
+    @Test
+    fun `when cvcVisibility is ALWAYS_SHOW and detected card type has cvcPolicy REQUIRED, then securityCode requirementPolicy is Required`() {
+        whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.ALWAYS_SHOW)
+        val cardBrandState = CardBrandState.SingleReliableBrand(
+            createCardBrandData().copy(cvcPolicy = Brand.FieldPolicy.REQUIRED),
+        )
+
+        val actual = cardBrandIntentsHandler.getUpdatedCardComponentState(createInitialState(), cardBrandState)
+
+        assertEquals(RequirementPolicy.Required, actual.securityCode.requirementPolicy)
+    }
+
+    @Test
+    fun `when cvcVisibility is ALWAYS_SHOW and detected card type has cvcPolicy OPTIONAL, then securityCode requirementPolicy is Optional`() {
+        whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.ALWAYS_SHOW)
+        val cardBrandState = CardBrandState.SingleReliableBrand(
+            createCardBrandData().copy(cvcPolicy = Brand.FieldPolicy.OPTIONAL),
+        )
+
+        val actual = cardBrandIntentsHandler.getUpdatedCardComponentState(createInitialState(), cardBrandState)
+
+        assertEquals(RequirementPolicy.Optional, actual.securityCode.requirementPolicy)
+    }
+
+    @Test
+    fun `when cvcVisibility is ALWAYS_SHOW and detected card type has cvcPolicy HIDDEN, then securityCode requirementPolicy is Hidden`() {
+        whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.ALWAYS_SHOW)
+        val cardBrandState = CardBrandState.SingleReliableBrand(
+            createCardBrandData().copy(cvcPolicy = Brand.FieldPolicy.HIDDEN),
+        )
+
+        val actual = cardBrandIntentsHandler.getUpdatedCardComponentState(createInitialState(), cardBrandState)
+
+        assertEquals(RequirementPolicy.Hidden, actual.securityCode.requirementPolicy)
+    }
+
+    @Test
+    fun `when cvcVisibility is HIDE_FIRST and detected card type has cvcPolicy REQUIRED, then securityCode requirementPolicy is Required`() {
+        whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.HIDE_FIRST)
+        val cardBrandState = CardBrandState.SingleReliableBrand(
+            createCardBrandData().copy(cvcPolicy = Brand.FieldPolicy.REQUIRED),
+        )
+
+        val actual = cardBrandIntentsHandler.getUpdatedCardComponentState(createInitialState(), cardBrandState)
+
+        assertEquals(RequirementPolicy.Required, actual.securityCode.requirementPolicy)
+    }
+
+    @Test
+    fun `when cvcVisibility is HIDE_FIRST and detected card type has cvcPolicy OPTIONAL, then securityCode requirementPolicy is Optional`() {
+        whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.HIDE_FIRST)
+        val cardBrandState = CardBrandState.SingleReliableBrand(
+            createCardBrandData().copy(cvcPolicy = Brand.FieldPolicy.OPTIONAL),
+        )
+
+        val actual = cardBrandIntentsHandler.getUpdatedCardComponentState(createInitialState(), cardBrandState)
+
+        assertEquals(RequirementPolicy.Optional, actual.securityCode.requirementPolicy)
+    }
+
+    @Test
+    fun `when cvcVisibility is HIDE_FIRST and detected card type has cvcPolicy HIDDEN, then securityCode requirementPolicy is Hidden`() {
+        whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.HIDE_FIRST)
+        val cardBrandState = CardBrandState.SingleReliableBrand(
+            createCardBrandData().copy(cvcPolicy = Brand.FieldPolicy.HIDDEN),
+        )
+
+        val actual = cardBrandIntentsHandler.getUpdatedCardComponentState(createInitialState(), cardBrandState)
+
+        assertEquals(RequirementPolicy.Hidden, actual.securityCode.requirementPolicy)
+    }
+
+    @Test
+    fun `when cvcVisibility is ALWAYS_HIDE and detected card type has cvcPolicy REQUIRED, then securityCode requirementPolicy is Hidden`() {
+        whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.ALWAYS_HIDE)
+        val cardBrandState = CardBrandState.SingleReliableBrand(
+            createCardBrandData().copy(cvcPolicy = Brand.FieldPolicy.REQUIRED),
+        )
+
+        val actual = cardBrandIntentsHandler.getUpdatedCardComponentState(createInitialState(), cardBrandState)
+
+        assertEquals(RequirementPolicy.Hidden, actual.securityCode.requirementPolicy)
+    }
+
+    @Test
+    fun `when cvcVisibility is ALWAYS_HIDE and detected card type has cvcPolicy OPTIONAL, then securityCode requirementPolicy is Hidden`() {
+        whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.ALWAYS_HIDE)
+        val cardBrandState = CardBrandState.SingleReliableBrand(
+            createCardBrandData().copy(cvcPolicy = Brand.FieldPolicy.OPTIONAL),
+        )
+
+        val actual = cardBrandIntentsHandler.getUpdatedCardComponentState(createInitialState(), cardBrandState)
+
+        assertEquals(RequirementPolicy.Hidden, actual.securityCode.requirementPolicy)
+    }
+
+    @Test
+    fun `when no card brand is detected and cvcVisibility is ALWAYS_SHOW, then securityCode requirementPolicy defaults to Required`() {
+        whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.ALWAYS_SHOW)
+        val cardBrandState = CardBrandState.NoBrandsDetected
+
+        val actual = cardBrandIntentsHandler.getUpdatedCardComponentState(createInitialState(), cardBrandState)
+
+        assertEquals(RequirementPolicy.Required, actual.securityCode.requirementPolicy)
+    }
+
+    @Test
+    fun `when no card brand is detected  and cvcVisibility is HIDE_FIRST, then securityCode requirementPolicy defaults to Hidden`() {
+        whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.HIDE_FIRST)
+        val cardBrandState = CardBrandState.NoBrandsDetected
+
+        val actual = cardBrandIntentsHandler.getUpdatedCardComponentState(createInitialState(), cardBrandState)
+
+        assertEquals(RequirementPolicy.Hidden, actual.securityCode.requirementPolicy)
+    }
+
+    @Test
+    fun `when no card brand is detected  and cvcVisibility is ALWAYS_HIDE, then securityCode requirementPolicy defaults to Hidden`() {
+        whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.ALWAYS_HIDE)
+        val cardBrandState = CardBrandState.NoBrandsDetected
+
+        val actual = cardBrandIntentsHandler.getUpdatedCardComponentState(createInitialState(), cardBrandState)
+
+        assertEquals(RequirementPolicy.Hidden, actual.securityCode.requirementPolicy)
+    }
+
+    @Nested
+    @DisplayName("when intent is SelectBrand")
+    inner class SelectBrandTest {
+        @Test
+        fun `then selectedCardBrand is updated`() {
+            val visaCardBrandData = createCardBrandData().copy(cardBrand = CardBrand("visa"))
+            val carteBancaireCardBrandData = createCardBrandData().copy(cardBrand = CardBrand("cartebancaire"))
+            val state = createInitialState().copy(
+                cardBrandState = CardBrandState.DualBrandWithShopperSelection(
+                    cardBrandDataList = listOf(visaCardBrandData, carteBancaireCardBrandData),
+                    shopperSelectedCardBrandData = visaCardBrandData,
+                ),
+            )
+
+            val actual =
+                cardBrandIntentsHandler.onBrandSelected(state, CardIntent.SelectBrand(CardBrand("cartebancaire")))
+
+            assertInstanceOf<CardBrandState.DualBrandWithShopperSelection>(actual.cardBrandState)
+            assertEquals(carteBancaireCardBrandData, actual.cardBrandState.shopperSelectedCardBrandData)
+        }
+    }
+
+    private fun createDetectedCardType(): DetectedCardType {
+        return DetectedCardType(
+            cardBrand = CardBrand("visa"),
+            enableLuhnCheck = true,
+            cvcPolicy = Brand.FieldPolicy.REQUIRED,
+            expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
+            isSupported = true,
+            isShopperSelectionAllowedInDualBranded = false,
+            panLength = null,
+            paymentMethodVariant = null,
+            localizedBrand = null,
+        )
+    }
+
+    private fun createInitialState() = CardComponentState(
+        cardNumber = TextInputComponentState(),
+        expiryDate = TextInputComponentState(),
+        securityCode = TextInputComponentState(),
+        holderName = TextInputComponentState(),
+        socialSecurityNumber = TextInputComponentState(),
+        kcpCardPassword = TextInputComponentState(),
+        kcpBirthDateOrTaxNumber = TextInputComponentState(),
+        storePaymentMethod = false,
+        isStorePaymentFieldVisible = false,
+        supportedCardBrands = emptyList(),
+        isLoading = false,
+        cardBrandState = CardBrandState.NoBrandsDetected,
+    )
+
+    private fun createCardBrandData() = CardBrandData(
+        cardBrand = CardBrand(""),
+        enableLuhnCheck = true,
+        cvcPolicy = Brand.FieldPolicy.REQUIRED,
+        expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
+        panLength = null,
+        paymentMethodVariant = null,
+        localizedBrand = null,
+    )
+}

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateReducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateReducerTest.kt
@@ -8,36 +8,30 @@
 
 package com.adyen.checkout.card.internal.ui.state
 
-import com.adyen.checkout.card.internal.data.model.Brand
-import com.adyen.checkout.card.internal.data.model.DetectedCardType
-import com.adyen.checkout.card.internal.ui.model.CVCVisibility
+import com.adyen.checkout.card.internal.helper.DetectCardTypeBinHelper
 import com.adyen.checkout.card.internal.ui.model.CardComponentParams
-import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
-import com.adyen.checkout.core.components.internal.ui.state.model.RequirementPolicy
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.whenever
+import org.mockito.kotlin.mock
 
 @ExtendWith(MockitoExtension::class)
-internal class CardComponentStateReducerTest(
-    @Mock private val cardComponentParams: CardComponentParams,
-) {
+internal class CardComponentStateReducerTest {
 
     private lateinit var reducer: CardComponentStateReducer
 
     @BeforeEach
     fun beforeEach() {
-        reducer = CardComponentStateReducer(cardComponentParams)
+        val detectCardTypeBinHelper = DetectCardTypeBinHelper()
+        val cardComponentParams = mock<CardComponentParams>()
+        val cardBrandIntentsHandler = CardBrandIntentsHandler(cardComponentParams, detectCardTypeBinHelper)
+        reducer = CardComponentStateReducer(cardBrandIntentsHandler)
     }
 
     @Test
@@ -176,292 +170,6 @@ internal class CardComponentStateReducerTest(
     }
 
     @Test
-    fun `when intent is SelectBrand, then selectedCardBrand is updated`() {
-        val state = createInitialState()
-        val cardBrand = CardBrand("visa")
-
-        val actual = reducer.reduce(state, CardIntent.SelectBrand(cardBrand))
-
-        assertEquals(cardBrand, actual.selectedCardBrand)
-    }
-
-    @Nested
-    @DisplayName("when intent is UpdateDetectedCardTypes")
-    inner class UpdateDetectedCardTypesTest {
-
-        @Test
-        fun `when intent is UpdateDetectedCardTypes, then detectedCardTypes state is updated with new list`() {
-            whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.ALWAYS_SHOW)
-            val state = createInitialState()
-            val detectedCardTypes = listOf(
-                createDetectedCardType(cardBrand = CardBrand("visa")),
-            )
-
-            val actual = reducer.reduce(state, CardIntent.UpdateDetectedCardTypes(detectedCardTypes))
-
-            assertEquals(detectedCardTypes, actual.detectedCardTypes)
-        }
-
-        @Test
-        fun `when selectedCardBrand is set, then card type matching selectedCardBrand txVariant is used for policies`() {
-            whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.ALWAYS_SHOW)
-            val selectedBrand = CardBrand("mc")
-            val state = createInitialState().copy(selectedCardBrand = selectedBrand)
-            val detectedCardTypes = listOf(
-                createDetectedCardType(
-                    cardBrand = CardBrand("visa"),
-                    cvcPolicy = Brand.FieldPolicy.REQUIRED,
-                ),
-                createDetectedCardType(
-                    cardBrand = CardBrand("mc"),
-                    cvcPolicy = Brand.FieldPolicy.OPTIONAL,
-                ),
-            )
-
-            val actual = reducer.reduce(state, CardIntent.UpdateDetectedCardTypes(detectedCardTypes))
-
-            assertEquals(RequirementPolicy.Optional, actual.securityCode.requirementPolicy)
-        }
-
-        @Test
-        fun `when selectedCardBrand is null, then first reliable and supported card type is used for policies`() {
-            whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.ALWAYS_SHOW)
-            val state = createInitialState()
-            val detectedCardTypes = listOf(
-                createDetectedCardType(
-                    cardBrand = CardBrand("visa"),
-                    isReliable = false,
-                    isSupported = true,
-                    cvcPolicy = Brand.FieldPolicy.REQUIRED,
-                ),
-                createDetectedCardType(
-                    cardBrand = CardBrand("mc"),
-                    isReliable = true,
-                    isSupported = true,
-                    cvcPolicy = Brand.FieldPolicy.OPTIONAL,
-                ),
-            )
-
-            val actual = reducer.reduce(state, CardIntent.UpdateDetectedCardTypes(detectedCardTypes))
-
-            assertEquals(RequirementPolicy.Optional, actual.securityCode.requirementPolicy)
-        }
-
-        @Test
-        fun `when no card type is both reliable and supported, then default policies are applied`() {
-            whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.ALWAYS_SHOW)
-            val state = createInitialState()
-            val detectedCardTypes = listOf(
-                createDetectedCardType(
-                    cardBrand = CardBrand("visa"),
-                    isReliable = false,
-                    isSupported = true,
-                ),
-                createDetectedCardType(
-                    cardBrand = CardBrand("mc"),
-                    isReliable = true,
-                    isSupported = false,
-                ),
-            )
-
-            val actual = reducer.reduce(state, CardIntent.UpdateDetectedCardTypes(detectedCardTypes))
-
-            assertEquals(RequirementPolicy.Required, actual.securityCode.requirementPolicy)
-            assertEquals(RequirementPolicy.Required, actual.expiryDate.requirementPolicy)
-        }
-
-        @Test
-        fun `when detected card type has expiryDatePolicy REQUIRED, then expiryDate requirementPolicy is Required`() {
-            whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.ALWAYS_SHOW)
-            val state = createInitialState()
-            val detectedCardTypes = listOf(
-                createDetectedCardType(expiryDatePolicy = Brand.FieldPolicy.REQUIRED),
-            )
-
-            val actual = reducer.reduce(state, CardIntent.UpdateDetectedCardTypes(detectedCardTypes))
-
-            assertEquals(RequirementPolicy.Required, actual.expiryDate.requirementPolicy)
-        }
-
-        @Test
-        fun `when detected card type has expiryDatePolicy OPTIONAL, then expiryDate requirementPolicy is Optional`() {
-            whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.ALWAYS_SHOW)
-            val state = createInitialState()
-            val detectedCardTypes = listOf(
-                createDetectedCardType(expiryDatePolicy = Brand.FieldPolicy.OPTIONAL),
-            )
-
-            val actual = reducer.reduce(state, CardIntent.UpdateDetectedCardTypes(detectedCardTypes))
-
-            assertEquals(RequirementPolicy.Optional, actual.expiryDate.requirementPolicy)
-        }
-
-        @Test
-        fun `when detected card type has expiryDatePolicy HIDDEN, then expiryDate requirementPolicy is Hidden`() {
-            whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.ALWAYS_SHOW)
-            val state = createInitialState()
-            val detectedCardTypes = listOf(
-                createDetectedCardType(expiryDatePolicy = Brand.FieldPolicy.HIDDEN),
-            )
-
-            val actual = reducer.reduce(state, CardIntent.UpdateDetectedCardTypes(detectedCardTypes))
-
-            assertEquals(RequirementPolicy.Hidden, actual.expiryDate.requirementPolicy)
-        }
-
-        @Test
-        fun `when detected card types list is empty, then expiryDate requirementPolicy defaults to Required`() {
-            whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.ALWAYS_SHOW)
-            val state = createInitialState()
-            val detectedCardTypes = emptyList<DetectedCardType>()
-
-            val actual = reducer.reduce(state, CardIntent.UpdateDetectedCardTypes(detectedCardTypes))
-
-            assertEquals(RequirementPolicy.Required, actual.expiryDate.requirementPolicy)
-        }
-
-        @Test
-        fun `when cvcVisibility is ALWAYS_SHOW and detected card type has cvcPolicy REQUIRED, then securityCode requirementPolicy is Required`() {
-            whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.ALWAYS_SHOW)
-            val state = createInitialState()
-            val detectedCardTypes = listOf(
-                createDetectedCardType(cvcPolicy = Brand.FieldPolicy.REQUIRED),
-            )
-
-            val actual = reducer.reduce(state, CardIntent.UpdateDetectedCardTypes(detectedCardTypes))
-
-            assertEquals(RequirementPolicy.Required, actual.securityCode.requirementPolicy)
-        }
-
-        @Test
-        fun `when cvcVisibility is ALWAYS_SHOW and detected card type has cvcPolicy OPTIONAL, then securityCode requirementPolicy is Optional`() {
-            whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.ALWAYS_SHOW)
-            val state = createInitialState()
-            val detectedCardTypes = listOf(
-                createDetectedCardType(cvcPolicy = Brand.FieldPolicy.OPTIONAL),
-            )
-
-            val actual = reducer.reduce(state, CardIntent.UpdateDetectedCardTypes(detectedCardTypes))
-
-            assertEquals(RequirementPolicy.Optional, actual.securityCode.requirementPolicy)
-        }
-
-        @Test
-        fun `when cvcVisibility is ALWAYS_SHOW and detected card type has cvcPolicy HIDDEN, then securityCode requirementPolicy is Hidden`() {
-            whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.ALWAYS_SHOW)
-            val state = createInitialState()
-            val detectedCardTypes = listOf(
-                createDetectedCardType(cvcPolicy = Brand.FieldPolicy.HIDDEN),
-            )
-
-            val actual = reducer.reduce(state, CardIntent.UpdateDetectedCardTypes(detectedCardTypes))
-
-            assertEquals(RequirementPolicy.Hidden, actual.securityCode.requirementPolicy)
-        }
-
-        @Test
-        fun `when cvcVisibility is HIDE_FIRST and detected card type has cvcPolicy REQUIRED, then securityCode requirementPolicy is Required`() {
-            whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.HIDE_FIRST)
-            val state = createInitialState()
-            val detectedCardTypes = listOf(
-                createDetectedCardType(cvcPolicy = Brand.FieldPolicy.REQUIRED),
-            )
-
-            val actual = reducer.reduce(state, CardIntent.UpdateDetectedCardTypes(detectedCardTypes))
-
-            assertEquals(RequirementPolicy.Required, actual.securityCode.requirementPolicy)
-        }
-
-        @Test
-        fun `when cvcVisibility is HIDE_FIRST and detected card type has cvcPolicy OPTIONAL, then securityCode requirementPolicy is Optional`() {
-            whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.HIDE_FIRST)
-            val state = createInitialState()
-            val detectedCardTypes = listOf(
-                createDetectedCardType(cvcPolicy = Brand.FieldPolicy.OPTIONAL),
-            )
-
-            val actual = reducer.reduce(state, CardIntent.UpdateDetectedCardTypes(detectedCardTypes))
-
-            assertEquals(RequirementPolicy.Optional, actual.securityCode.requirementPolicy)
-        }
-
-        @Test
-        fun `when cvcVisibility is HIDE_FIRST and detected card type has cvcPolicy HIDDEN, then securityCode requirementPolicy is Hidden`() {
-            whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.HIDE_FIRST)
-            val state = createInitialState()
-            val detectedCardTypes = listOf(
-                createDetectedCardType(cvcPolicy = Brand.FieldPolicy.HIDDEN),
-            )
-
-            val actual = reducer.reduce(state, CardIntent.UpdateDetectedCardTypes(detectedCardTypes))
-
-            assertEquals(RequirementPolicy.Hidden, actual.securityCode.requirementPolicy)
-        }
-
-        @Test
-        fun `when cvcVisibility is ALWAYS_HIDE, then securityCode requirementPolicy is Hidden regardless of detected card type cvcPolicy`() {
-            whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.ALWAYS_HIDE)
-            val state = createInitialState()
-            val detectedCardTypes = listOf(
-                createDetectedCardType(cvcPolicy = Brand.FieldPolicy.REQUIRED),
-            )
-
-            val actual = reducer.reduce(state, CardIntent.UpdateDetectedCardTypes(detectedCardTypes))
-
-            assertEquals(RequirementPolicy.Hidden, actual.securityCode.requirementPolicy)
-        }
-
-        @Test
-        fun `when detected card types list is empty and cvcVisibility is ALWAYS_SHOW, then securityCode requirementPolicy defaults to Required`() {
-            whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.ALWAYS_SHOW)
-            val state = createInitialState()
-            val detectedCardTypes = emptyList<DetectedCardType>()
-
-            val actual = reducer.reduce(state, CardIntent.UpdateDetectedCardTypes(detectedCardTypes))
-
-            assertEquals(RequirementPolicy.Required, actual.securityCode.requirementPolicy)
-        }
-
-        @Test
-        fun `when detected card types list is empty and cvcVisibility is HIDE_FIRST, then securityCode requirementPolicy defaults to Hidden`() {
-            whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.HIDE_FIRST)
-            val state = createInitialState()
-            val detectedCardTypes = emptyList<DetectedCardType>()
-
-            val actual = reducer.reduce(state, CardIntent.UpdateDetectedCardTypes(detectedCardTypes))
-
-            assertEquals(RequirementPolicy.Hidden, actual.securityCode.requirementPolicy)
-        }
-
-        @Test
-        fun `when detected card types list is empty and cvcVisibility is ALWAYS_HIDE, then securityCode requirementPolicy defaults to Hidden`() {
-            whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.ALWAYS_HIDE)
-            val state = createInitialState()
-            val detectedCardTypes = emptyList<DetectedCardType>()
-
-            val actual = reducer.reduce(state, CardIntent.UpdateDetectedCardTypes(detectedCardTypes))
-
-            assertEquals(RequirementPolicy.Hidden, actual.securityCode.requirementPolicy)
-        }
-
-        private fun createDetectedCardType(
-            cardBrand: CardBrand = CardBrand("visa"),
-            isSupported: Boolean = true,
-            cvcPolicy: Brand.FieldPolicy = Brand.FieldPolicy.REQUIRED,
-            expiryDatePolicy: Brand.FieldPolicy = Brand.FieldPolicy.REQUIRED,
-        ) = DetectedCardType(
-            cardBrand = cardBrand,
-            enableLuhnCheck = true,
-            cvcPolicy = cvcPolicy,
-            expiryDatePolicy = expiryDatePolicy,
-            isSupported = isSupported,
-            panLength = 16,
-            paymentMethodVariant = null,
-            localizedBrand = null,
-        )
-    }
-
-    @Test
     fun `when intent is UpdateLoading, then isLoading is updated`() {
         val state = createInitialState()
 
@@ -526,7 +234,6 @@ internal class CardComponentStateReducerTest(
         isStorePaymentFieldVisible = false,
         supportedCardBrands = emptyList(),
         isLoading = false,
-        detectedCardTypes = emptyList(),
-        selectedCardBrand = null,
+        cardBrandState = CardBrandState.NoBrandsDetected,
     )
 }

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateReducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateReducerTest.kt
@@ -446,13 +446,11 @@ internal class CardComponentStateReducerTest(
 
         private fun createDetectedCardType(
             cardBrand: CardBrand = CardBrand("visa"),
-            isReliable: Boolean = true,
             isSupported: Boolean = true,
             cvcPolicy: Brand.FieldPolicy = Brand.FieldPolicy.REQUIRED,
             expiryDatePolicy: Brand.FieldPolicy = Brand.FieldPolicy.REQUIRED,
         ) = DetectedCardType(
             cardBrand = cardBrand,
-            isReliable = isReliable,
             enableLuhnCheck = true,
             cvcPolicy = cvcPolicy,
             expiryDatePolicy = expiryDatePolicy,

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateValidatorTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateValidatorTest.kt
@@ -8,9 +8,6 @@
 
 package com.adyen.checkout.card.internal.ui.state
 
-import com.adyen.checkout.card.internal.data.model.Brand
-import com.adyen.checkout.card.internal.data.model.DetectedCardType
-import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.components.internal.ui.state.model.RequirementPolicy
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -235,11 +232,9 @@ internal class CardComponentStateValidatorTest {
     }
 
     @Test
-    fun `when card brand is unsupported and reliable, then card number has error`() {
+    fun `when card brand is unsupported, then card number has error`() {
         val state = createValidState().copy(
-            detectedCardTypes = listOf(
-                createDetectedCardType(isSupported = false, isReliable = true),
-            ),
+            cardBrandState = CardBrandState.UnsupportedBrand,
         )
 
         val validatedState = validator.validate(state)
@@ -262,20 +257,6 @@ internal class CardComponentStateValidatorTest {
         isStorePaymentFieldVisible = false,
         supportedCardBrands = emptyList(),
         isLoading = false,
-        detectedCardTypes = listOf(createDetectedCardType()),
-        selectedCardBrand = null,
-    )
-
-    private fun createDetectedCardType(
-        isSupported: Boolean = true,
-    ) = DetectedCardType(
-        cardBrand = CardBrand("visa"),
-        enableLuhnCheck = true,
-        cvcPolicy = Brand.FieldPolicy.REQUIRED,
-        expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
-        isSupported = isSupported,
-        panLength = 16,
-        paymentMethodVariant = null,
-        localizedBrand = null,
+        cardBrandState = CardBrandState.NoBrandsDetected,
     )
 }

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateValidatorTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateValidatorTest.kt
@@ -268,10 +268,8 @@ internal class CardComponentStateValidatorTest {
 
     private fun createDetectedCardType(
         isSupported: Boolean = true,
-        isReliable: Boolean = true,
     ) = DetectedCardType(
         cardBrand = CardBrand("visa"),
-        isReliable = isReliable,
         enableLuhnCheck = true,
         cvcPolicy = Brand.FieldPolicy.REQUIRED,
         expiryDatePolicy = Brand.FieldPolicy.REQUIRED,

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
@@ -265,7 +265,6 @@ internal class CardViewStateProducerTest {
         isSupported: Boolean = true,
     ) = DetectedCardType(
         cardBrand = cardBrand,
-        isReliable = true,
         enableLuhnCheck = true,
         cvcPolicy = Brand.FieldPolicy.REQUIRED,
         expiryDatePolicy = Brand.FieldPolicy.REQUIRED,

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.card.internal.ui.state
 
 import com.adyen.checkout.card.internal.data.model.Brand
-import com.adyen.checkout.card.internal.data.model.DetectedCardType
 import com.adyen.checkout.card.internal.ui.DualBrandedCardHandler
 import com.adyen.checkout.card.internal.ui.model.CardNumberTrailingIcon
 import com.adyen.checkout.core.common.CardBrand
@@ -37,7 +36,7 @@ internal class CardViewStateProducerTest {
     fun `when no card brand is detected, then supported card brands should be shown`() {
         // GIVEN
         val componentState = createComponentState(
-            detectedCardTypes = emptyList(),
+            cardBrandState = CardBrandState.NoBrandsDetected,
         )
 
         // WHEN
@@ -52,12 +51,7 @@ internal class CardViewStateProducerTest {
     fun `when supported card brand is detected, then supported card brands should be hidden`() {
         // GIVEN
         val componentState = createComponentState(
-            detectedCardTypes = listOf(
-                createDetectedCardType(
-                    cardBrand = CardBrand("visa"),
-                    isSupported = true,
-                ),
-            ),
+            cardBrandState = CardBrandState.SingleReliableBrand(getCardBrandData()),
         )
 
         // WHEN
@@ -72,12 +66,7 @@ internal class CardViewStateProducerTest {
     fun `when unsupported card brand is detected, then supported card brands should be shown`() {
         // GIVEN
         val componentState = createComponentState(
-            detectedCardTypes = listOf(
-                createDetectedCardType(
-                    cardBrand = CardBrand("unknown"),
-                    isSupported = false,
-                ),
-            ),
+            cardBrandState = CardBrandState.UnsupportedBrand,
         )
 
         // WHEN
@@ -97,12 +86,7 @@ internal class CardViewStateProducerTest {
                 errorMessage = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
                 showError = true,
             ),
-            detectedCardTypes = listOf(
-                createDetectedCardType(
-                    cardBrand = CardBrand("visa"),
-                    isSupported = true,
-                ),
-            ),
+            cardBrandState = CardBrandState.SingleReliableBrand(getCardBrandData()),
         )
 
         // WHEN
@@ -127,12 +111,7 @@ internal class CardViewStateProducerTest {
                 isFocused = true,
                 showError = false, // Focus gain clears showError
             ),
-            detectedCardTypes = listOf(
-                createDetectedCardType(
-                    cardBrand = CardBrand("visa"),
-                    isSupported = true,
-                ),
-            ),
+            cardBrandState = CardBrandState.SingleReliableBrand(getCardBrandData()),
         )
 
         // WHEN
@@ -154,7 +133,7 @@ internal class CardViewStateProducerTest {
                 isFocused = true,
                 showError = false, // Focus gain clears showError
             ),
-            detectedCardTypes = emptyList(),
+            cardBrandState = CardBrandState.NoBrandsDetected,
         )
 
         // WHEN
@@ -175,12 +154,7 @@ internal class CardViewStateProducerTest {
                 errorMessage = null,
                 showError = false,
             ),
-            detectedCardTypes = listOf(
-                createDetectedCardType(
-                    cardBrand = CardBrand("visa"),
-                    isSupported = true,
-                ),
-            ),
+            cardBrandState = CardBrandState.SingleReliableBrand(getCardBrandData()),
         )
 
         // WHEN
@@ -206,12 +180,7 @@ internal class CardViewStateProducerTest {
                 isFocused = true,
                 showError = false, // Text change sets showError to false
             ),
-            detectedCardTypes = listOf(
-                createDetectedCardType(
-                    cardBrand = CardBrand("visa"),
-                    isSupported = true,
-                ),
-            ),
+            cardBrandState = CardBrandState.SingleReliableBrand(getCardBrandData()),
         )
         val componentStateWithoutError = createComponentState(
             cardNumber = TextInputComponentState(
@@ -219,12 +188,7 @@ internal class CardViewStateProducerTest {
                 isFocused = true,
                 showError = false,
             ),
-            detectedCardTypes = listOf(
-                createDetectedCardType(
-                    cardBrand = CardBrand("visa"),
-                    isSupported = true,
-                ),
-            ),
+            cardBrandState = CardBrandState.SingleReliableBrand(getCardBrandData()),
         )
 
         listOf(componentStateWithHiddenError, componentStateWithoutError).forEach { componentState ->
@@ -243,7 +207,7 @@ internal class CardViewStateProducerTest {
 
     private fun createComponentState(
         cardNumber: TextInputComponentState = TextInputComponentState(),
-        detectedCardTypes: List<DetectedCardType> = emptyList(),
+        cardBrandState: CardBrandState = CardBrandState.NoBrandsDetected,
     ) = CardComponentState(
         cardNumber = cardNumber,
         expiryDate = TextInputComponentState(),
@@ -256,21 +220,18 @@ internal class CardViewStateProducerTest {
         isStorePaymentFieldVisible = false,
         supportedCardBrands = emptyList(),
         isLoading = false,
-        detectedCardTypes = detectedCardTypes,
-        selectedCardBrand = null,
+        cardBrandState = cardBrandState,
     )
 
-    private fun createDetectedCardType(
-        cardBrand: CardBrand = CardBrand("visa"),
-        isSupported: Boolean = true,
-    ) = DetectedCardType(
-        cardBrand = cardBrand,
-        enableLuhnCheck = true,
-        cvcPolicy = Brand.FieldPolicy.REQUIRED,
-        expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
-        isSupported = isSupported,
-        panLength = 16,
-        paymentMethodVariant = null,
-        localizedBrand = null,
-    )
+    private fun getCardBrandData(): CardBrandData {
+        return CardBrandData(
+            cardBrand = CardBrand(""),
+            enableLuhnCheck = true,
+            cvcPolicy = Brand.FieldPolicy.REQUIRED,
+            expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
+            panLength = null,
+            paymentMethodVariant = null,
+            localizedBrand = null,
+        )
+    }
 }

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/StoredCardComponentStateReducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/StoredCardComponentStateReducerTest.kt
@@ -120,7 +120,6 @@ internal class StoredCardComponentStateReducerTest {
 
     private fun createDetectedCardType() = DetectedCardType(
         cardBrand = CardBrand("visa"),
-        isReliable = true,
         enableLuhnCheck = true,
         cvcPolicy = Brand.FieldPolicy.REQUIRED,
         expiryDatePolicy = Brand.FieldPolicy.REQUIRED,

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/StoredCardComponentStateReducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/StoredCardComponentStateReducerTest.kt
@@ -124,6 +124,7 @@ internal class StoredCardComponentStateReducerTest {
         cvcPolicy = Brand.FieldPolicy.REQUIRED,
         expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
         isSupported = true,
+        isShopperSelectionAllowedInDualBranded = false,
         panLength = 16,
         paymentMethodVariant = null,
         localizedBrand = null,

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/StoredCardComponentStateValidatorTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/StoredCardComponentStateValidatorTest.kt
@@ -107,6 +107,7 @@ internal class StoredCardComponentStateValidatorTest {
         cvcPolicy = Brand.FieldPolicy.REQUIRED,
         expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
         isSupported = true,
+        isShopperSelectionAllowedInDualBranded = false,
         panLength = 16,
         paymentMethodVariant = null,
         localizedBrand = null,

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/StoredCardComponentStateValidatorTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/StoredCardComponentStateValidatorTest.kt
@@ -103,7 +103,6 @@ internal class StoredCardComponentStateValidatorTest {
         cardBrand: CardBrand = CardBrand("visa"),
     ) = DetectedCardType(
         cardBrand = cardBrand,
-        isReliable = true,
         enableLuhnCheck = true,
         cvcPolicy = Brand.FieldPolicy.REQUIRED,
         expiryDatePolicy = Brand.FieldPolicy.REQUIRED,


### PR DESCRIPTION
## Description
This is the second part of a major refactor to how we handle card brand detection ([see first PR](https://github.com/Adyen/adyen-android/pull/2696)). This PR focuses on being more explicit in the `CardComponentState` on which flow are we currently in (local vs network - single vs dual branded - etc). The main changes are:
- Replace `DetectedCardType` list with a sealed class in the card component state. 
- Handle the selected card brand with co-badged cards within the same logic as the previous point.
- Ensure BIN lookup results are displayed on the UI only if they are still relevant.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

## Ticket Number
COSDK-921