### PR TITLE
v6 - Deprecate old public classes - redirect

### DIFF
--- a/redirect/src/main/java/com/adyen/checkout/redirect/old/RedirectComponent.kt
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/old/RedirectComponent.kt
@@ -32,6 +32,10 @@ import kotlinx.coroutines.flow.Flow
 /**
  * An [ActionComponent] that is able to handle the 'redirect' action.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class RedirectComponent internal constructor(
     override val delegate: RedirectDelegate,
     internal val actionComponentEventHandler: ActionComponentEventHandler,
@@ -83,6 +87,10 @@ class RedirectComponent internal constructor(
         delegate.onCleared()
     }
 
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     companion object {
 
         @JvmField

--- a/redirect/src/main/java/com/adyen/checkout/redirect/old/RedirectConfiguration.kt
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/old/RedirectConfiguration.kt
@@ -21,6 +21,10 @@ import java.util.Locale
 /**
  * Configuration class for the [RedirectComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class RedirectConfiguration private constructor(
     override val shopperLocale: Locale?,
@@ -33,6 +37,10 @@ class RedirectConfiguration private constructor(
     /**
      * Builder to create a [RedirectConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : BaseConfigurationBuilder<RedirectConfiguration, Builder> {
 
         /**
@@ -90,6 +98,10 @@ class RedirectConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.redirect(
     configuration: @CheckoutConfigurationMarker RedirectConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/redirect/src/test/java/com/adyen/checkout/redirect/RedirectComponentTest.kt
+++ b/redirect/src/test/java/com/adyen/checkout/redirect/RedirectComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 19/12/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.redirect
 
 import android.app.Activity

--- a/redirect/src/test/java/com/adyen/checkout/redirect/RedirectConfigurationTest.kt
+++ b/redirect/src/test/java/com/adyen/checkout/redirect/RedirectConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.redirect
 
 import com.adyen.checkout.components.core.Amount

--- a/redirect/src/test/java/com/adyen/checkout/redirect/internal/ui/DefaultRedirectDelegateTest.kt
+++ b/redirect/src/test/java/com/adyen/checkout/redirect/internal/ui/DefaultRedirectDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 18/8/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.redirect.internal.ui
 
 import android.app.Activity


### PR DESCRIPTION
## Description

Deprecate all v5 public classes with `@Deprecated` annotations to prepare for the v6 release.
Deprecated code will be removed before the v6 production release.

### Progress

✅ Phase 1 — [checkout-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2707)
✅ Phase 2 — [ui-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2708)
✅ Phase 3 — [card (.old packages)](https://github.com/Adyen/adyen-android/pull/2709)
✅ Phase 4 — [googlepay (.old packages)](https://github.com/Adyen/adyen-android/pull/2711)
✅ Phase 5 — [drop-in (.old packages)](https://github.com/Adyen/adyen-android/pull/2712)
✅ Phase 6 — [3ds2 (.old packages)](https://github.com/Adyen/adyen-android/pull/2713)
✅ Phase 7 — [mbway (.old packages)](https://github.com/Adyen/adyen-android/pull/2714)
✅ Phase 8 — [blik (.old packages)](https://github.com/Adyen/adyen-android/pull/2715)
✅ Phase 9 — [await (.old packages)](https://github.com/Adyen/adyen-android/pull/2716)
➡️ **Phase 10 — redirect (.old packages)**
Phase 11 — components-core (entire v5 module)
Phase 12 — action-core (entire v5 module)
Phase 13 — sessions-core (entire v5 module)
Phase 14 — action, components-compose, drop-in-compose (v5 utility modules)
Phase 15 — 34 v5-only payment method modules

## Ticket Number
COSDK-1121