### PR TITLE
v6 - Deprecate old public classes - components-core

### DIFF
--- a/components-core/src/main/java/com/adyen/checkout/components/core/ActionComponentCallback.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/ActionComponentCallback.kt
@@ -15,6 +15,10 @@ import org.json.JSONObject
 /**
  * Implement this callback to interact with an [ActionComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 interface ActionComponentCallback {
 
     /**

--- a/components-core/src/main/java/com/adyen/checkout/components/core/ActionComponentData.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/ActionComponentData.kt
@@ -20,6 +20,10 @@ import org.json.JSONObject
  * Class containing the whole request data expected by the /payments/details endpoint. Use
  * [ActionComponentData.SERIALIZER] to serialize it to a [JSONObject].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class ActionComponentData(
     var paymentData: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/ActionHandlingMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/ActionHandlingMethod.kt
@@ -11,6 +11,10 @@ package com.adyen.checkout.components.core
 /**
  * Used to configure the method used to handle actions.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 enum class ActionHandlingMethod {
     /**
      * The action will be handled in a native way (e.g. using a SDK). **If** there is no way to handle the action

--- a/components-core/src/main/java/com/adyen/checkout/components/core/Address.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/Address.kt
@@ -14,6 +14,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class Address(
     var city: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/AddressData.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/AddressData.kt
@@ -11,6 +11,10 @@ package com.adyen.checkout.components.core
 import androidx.annotation.RestrictTo
 import com.adyen.checkout.components.core.internal.ui.model.AddressInputModel
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class AddressData(
     val postalCode: String,
     val street: String,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/AddressLookupCallback.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/AddressLookupCallback.kt
@@ -11,6 +11,10 @@ package com.adyen.checkout.components.core
 /**
  * Implement this callback to be able to use Address Lookup functionality.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 interface AddressLookupCallback {
 
     /**

--- a/components-core/src/main/java/com/adyen/checkout/components/core/AddressLookupResult.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/AddressLookupResult.kt
@@ -11,12 +11,20 @@ package com.adyen.checkout.components.core
 /**
  * A class that contains the result of address lookup completion call.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 sealed class AddressLookupResult {
     /**
      * An error occurred while making of the call.
      *
      * @param message Error message to be shown to shopper.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     data class Error(val message: String? = null) : AddressLookupResult()
 
     /**
@@ -24,5 +32,9 @@ sealed class AddressLookupResult {
      *
      * @param lookupAddress The complete address details.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     data class Completed(val lookupAddress: LookupAddress) : AddressLookupResult()
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/Amount.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/Amount.kt
@@ -16,6 +16,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class Amount(
     var currency: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/AnalyticsConfiguration.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/AnalyticsConfiguration.kt
@@ -14,6 +14,10 @@ import kotlinx.parcelize.Parcelize
 /**
  * Class that allows configuring internal analytics.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class AnalyticsConfiguration(
     /**
@@ -28,6 +32,10 @@ data class AnalyticsConfiguration(
  * The different configurable levels of analytics. Learn more about the
  * [data we are collecting](https://docs.adyen.com/online-payments/analytics-and-data-tracking/#data-we-are-collecting).
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 enum class AnalyticsLevel {
     /**
      * All analytics events, logs and errors are sent from the library.

--- a/components-core/src/main/java/com/adyen/checkout/components/core/AppData.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/AppData.kt
@@ -15,6 +15,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class AppData(
     val id: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/BalanceResult.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/BalanceResult.kt
@@ -15,6 +15,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class BalanceResult(
     val balance: Amount?,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/CheckoutConfiguration.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/CheckoutConfiguration.kt
@@ -53,6 +53,10 @@ import java.util.Locale
  * @param analyticsConfiguration A configuration for the internal analytics of the library.
  * @param configurationBlock A block that allows adding drop-in or payment method specific configurations.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @CheckoutConfigurationMarker
 class CheckoutConfiguration(
     override val environment: Environment,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/CheckoutCurrency.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/CheckoutCurrency.kt
@@ -15,6 +15,10 @@ import java.util.Collections
  * Utility class holding currency information.
  * @see [Adyen currency codes](https://docs.adyen.com/developers/currency-codes)
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("MagicNumber")
 enum class CheckoutCurrency(val fractionDigits: Int) {
     AED(2),

--- a/components-core/src/main/java/com/adyen/checkout/components/core/ComponentAvailableCallback.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/ComponentAvailableCallback.kt
@@ -7,6 +7,10 @@
  */
 package com.adyen.checkout.components.core
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun interface ComponentAvailableCallback {
     fun onAvailabilityResult(isAvailable: Boolean, paymentMethod: PaymentMethod)
 }

--- a/components-core/src/main/java/com/adyen/checkout/components/core/ComponentCallback.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/ComponentCallback.kt
@@ -16,6 +16,10 @@ import org.json.JSONObject
 /**
  * Implement this callback to interact with a [PaymentComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 interface ComponentCallback<T : PaymentComponentState<*>> : BaseComponentCallback {
 
     /**

--- a/components-core/src/main/java/com/adyen/checkout/components/core/ComponentError.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/ComponentError.kt
@@ -12,6 +12,10 @@ import com.adyen.checkout.core.old.exception.CheckoutException
 /**
  * Data about an error that happened inside a component.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class ComponentError(
     /**
      * Can be used to try to identify the root cause of the issue.

--- a/components-core/src/main/java/com/adyen/checkout/components/core/Configuration.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/Configuration.kt
@@ -14,6 +14,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class Configuration(
     var merchantId: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/InputDetail.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/InputDetail.kt
@@ -15,6 +15,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class InputDetail(
     var items: List<Item>? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/Installments.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/Installments.kt
@@ -15,6 +15,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class Installments(
     val plan: String?,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/Issuer.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/Issuer.kt
@@ -15,6 +15,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class Issuer(
     var id: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/Item.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/Item.kt
@@ -14,6 +14,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class Item(
     var id: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/LookupAddress.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/LookupAddress.kt
@@ -8,6 +8,10 @@
 
 package com.adyen.checkout.components.core
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class LookupAddress(
     val id: String,
     val address: AddressData

--- a/components-core/src/main/java/com/adyen/checkout/components/core/OrderRequest.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/OrderRequest.kt
@@ -14,6 +14,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class OrderRequest constructor(
     val pspReference: String,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/OrderRequest.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/OrderRequest.kt
@@ -51,4 +51,8 @@ data class OrderRequest constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 typealias Order = OrderRequest

--- a/components-core/src/main/java/com/adyen/checkout/components/core/OrderResponse.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/OrderResponse.kt
@@ -15,6 +15,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class OrderResponse(
     val pspReference: String,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/PaymentComponentData.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/PaymentComponentData.kt
@@ -24,6 +24,10 @@ import org.json.JSONObject
  * [JSONObject]. The rest of the /payments call request data should be filled in, on your server, according to your
  * needs.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class PaymentComponentData<PaymentMethodDetailsT : PaymentMethodDetails>(
     var paymentMethod: PaymentMethodDetailsT?,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/PaymentComponentState.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/PaymentComponentState.kt
@@ -12,6 +12,10 @@ import com.adyen.checkout.components.core.paymentmethod.PaymentMethodDetails
 /**
  * The current state of a PaymentComponent.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 interface PaymentComponentState<PaymentMethodDetailsT : PaymentMethodDetails> {
 
     /**

--- a/components-core/src/main/java/com/adyen/checkout/components/core/PaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/PaymentMethod.kt
@@ -20,6 +20,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class PaymentMethod(
     var type: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/PaymentMethodTypes.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/PaymentMethodTypes.kt
@@ -10,6 +10,10 @@ package com.adyen.checkout.components.core
 /**
  * Helper class with a list of all the currently supported Payment Methods on Components and Drop-In.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 object PaymentMethodTypes {
 
     // Placeholder value if the type is not found.

--- a/components-core/src/main/java/com/adyen/checkout/components/core/PaymentMethodUnavailableException.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/PaymentMethodUnavailableException.kt
@@ -10,6 +10,10 @@ package com.adyen.checkout.components.core
 
 import com.adyen.checkout.core.old.exception.CheckoutException
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 open class PaymentMethodUnavailableException(
     message: String,
     cause: Throwable? = null

--- a/components-core/src/main/java/com/adyen/checkout/components/core/PaymentMethodsApiResponse.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/PaymentMethodsApiResponse.kt
@@ -19,6 +19,10 @@ import org.json.JSONObject
  * Object that parses and holds the response data from the /paymentMethods endpoint.
  * Use [PaymentMethodsApiResponse.SERIALIZER] to deserialize this class from your JSON response.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class PaymentMethodsApiResponse(
     var storedPaymentMethods: List<StoredPaymentMethod>? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/RedirectableActionComponent.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/RedirectableActionComponent.kt
@@ -8,6 +8,10 @@
 
 package com.adyen.checkout.components.core
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 interface RedirectableActionComponent {
 
     /**

--- a/components-core/src/main/java/com/adyen/checkout/components/core/ShopperName.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/ShopperName.kt
@@ -14,6 +14,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class ShopperName(
     var firstName: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/StoredPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/StoredPaymentMethod.kt
@@ -16,6 +16,10 @@ import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class StoredPaymentMethod(
     var type: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/action/Action.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/action/Action.kt
@@ -21,6 +21,10 @@ import org.json.JSONObject
  * [Action.SERIALIZER] can be used to serialize and deserialize the subclasses of [Action] without having to know the
  * exact type of the subclass.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 abstract class Action : ModelObject() {
     abstract var type: String?
     abstract var paymentData: String?

--- a/components-core/src/main/java/com/adyen/checkout/components/core/action/ActionTypes.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/action/ActionTypes.kt
@@ -10,6 +10,10 @@ package com.adyen.checkout.components.core.action
 /**
  * Helper class with a list of all the currently supported Actions on Components and Drop-In.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 object ActionTypes {
     const val AWAIT = "await"
     const val QR_CODE = "qrCode"

--- a/components-core/src/main/java/com/adyen/checkout/components/core/action/AwaitAction.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/action/AwaitAction.kt
@@ -13,6 +13,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class AwaitAction(
     override var type: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/action/BaseThreeds2Action.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/action/BaseThreeds2Action.kt
@@ -8,5 +8,9 @@
 
 package com.adyen.checkout.components.core.action
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("UnnecessaryAbstractClass")
 abstract class BaseThreeds2Action : Action()

--- a/components-core/src/main/java/com/adyen/checkout/components/core/action/QrCodeAction.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/action/QrCodeAction.kt
@@ -13,6 +13,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class QrCodeAction(
     override var type: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/action/RedirectAction.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/action/RedirectAction.kt
@@ -13,6 +13,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class RedirectAction(
     override var type: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/action/SdkAction.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/action/SdkAction.kt
@@ -17,6 +17,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class SdkAction<SdkDataT : SdkData>(
     override var type: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/action/SdkData.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/action/SdkData.kt
@@ -9,5 +9,9 @@ package com.adyen.checkout.components.core.action
 
 import com.adyen.checkout.core.old.internal.data.model.ModelObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("UnnecessaryAbstractClass")
 abstract class SdkData : ModelObject()

--- a/components-core/src/main/java/com/adyen/checkout/components/core/action/Threeds2Action.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/action/Threeds2Action.kt
@@ -13,6 +13,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class Threeds2Action(
     override var type: String? = null,
@@ -64,6 +68,10 @@ class Threeds2Action(
         }
     }
 
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     enum class SubType(val value: String) {
         FINGERPRINT("fingerprint"),
         CHALLENGE("challenge");

--- a/components-core/src/main/java/com/adyen/checkout/components/core/action/Threeds2ChallengeAction.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/action/Threeds2ChallengeAction.kt
@@ -13,6 +13,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class Threeds2ChallengeAction(
     override var type: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/action/Threeds2FingerprintAction.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/action/Threeds2FingerprintAction.kt
@@ -13,6 +13,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class Threeds2FingerprintAction(
     override var type: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/action/TwintSdkData.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/action/TwintSdkData.kt
@@ -14,6 +14,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class TwintSdkData(
     val token: String,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/action/VoucherAction.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/action/VoucherAction.kt
@@ -16,6 +16,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class VoucherAction(
     override var type: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/action/WeChatPaySdkData.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/action/WeChatPaySdkData.kt
@@ -13,6 +13,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class WeChatPaySdkData(
     var appid: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/ACHDirectDebitPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/ACHDirectDebitPaymentMethod.kt
@@ -15,6 +15,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class ACHDirectDebitPaymentMethod(
     override var type: String?,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/BacsDirectDebitPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/BacsDirectDebitPaymentMethod.kt
@@ -14,6 +14,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class BacsDirectDebitPaymentMethod(
     override var type: String?,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/BlikPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/BlikPaymentMethod.kt
@@ -14,6 +14,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class BlikPaymentMethod(
     override var type: String?,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/CardPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/CardPaymentMethod.kt
@@ -14,6 +14,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class CardPaymentMethod(
     override var type: String?,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/CashAppPayPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/CashAppPayPaymentMethod.kt
@@ -7,6 +7,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class CashAppPayPaymentMethod(
     override var type: String?,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/ConvenienceStoresJPPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/ConvenienceStoresJPPaymentMethod.kt
@@ -15,6 +15,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class ConvenienceStoresJPPaymentMethod(
     override var type: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/DotpayPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/DotpayPaymentMethod.kt
@@ -14,6 +14,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class DotpayPaymentMethod(
     override var type: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/EContextPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/EContextPaymentMethod.kt
@@ -8,6 +8,10 @@
 
 package com.adyen.checkout.components.core.paymentmethod
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 abstract class EContextPaymentMethod : PaymentMethodDetails() {
 
     abstract var firstName: String?

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/EPSPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/EPSPaymentMethod.kt
@@ -14,6 +14,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class EPSPaymentMethod(
     override var type: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/EntercashPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/EntercashPaymentMethod.kt
@@ -14,6 +14,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class EntercashPaymentMethod(
     override var type: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/GenericPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/GenericPaymentMethod.kt
@@ -13,6 +13,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class GenericPaymentMethod(
     override var type: String?,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/GiftCardPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/GiftCardPaymentMethod.kt
@@ -14,6 +14,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class GiftCardPaymentMethod(

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/GooglePayPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/GooglePayPaymentMethod.kt
@@ -13,6 +13,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class GooglePayPaymentMethod(
     override var type: String?,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/IdealPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/IdealPaymentMethod.kt
@@ -14,6 +14,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class IdealPaymentMethod(
     override var type: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/IssuerListPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/IssuerListPaymentMethod.kt
@@ -7,6 +7,10 @@
  */
 package com.adyen.checkout.components.core.paymentmethod
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 abstract class IssuerListPaymentMethod : PaymentMethodDetails() {
     abstract var issuer: String?
 

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/MBWayPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/MBWayPaymentMethod.kt
@@ -14,6 +14,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class MBWayPaymentMethod(
     override var type: String?,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/MolpayPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/MolpayPaymentMethod.kt
@@ -13,6 +13,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class MolpayPaymentMethod(
     override var type: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OnlineBankingCZPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OnlineBankingCZPaymentMethod.kt
@@ -15,6 +15,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class OnlineBankingCZPaymentMethod(
     override var type: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OnlineBankingJPPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OnlineBankingJPPaymentMethod.kt
@@ -15,6 +15,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class OnlineBankingJPPaymentMethod(
     override var type: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OnlineBankingPLPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OnlineBankingPLPaymentMethod.kt
@@ -15,6 +15,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class OnlineBankingPLPaymentMethod(
     override var type: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OnlineBankingSKPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OnlineBankingSKPaymentMethod.kt
@@ -15,6 +15,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class OnlineBankingSKPaymentMethod(
     override var type: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OpenBankingPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/OpenBankingPaymentMethod.kt
@@ -14,6 +14,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class OpenBankingPaymentMethod(
     override var type: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/PayByBankPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/PayByBankPaymentMethod.kt
@@ -15,6 +15,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class PayByBankPaymentMethod(
     override var type: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/PayByBankUSPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/PayByBankUSPaymentMethod.kt
@@ -14,6 +14,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class PayByBankUSPaymentMethod(
     override var type: String?,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/PayEasyPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/PayEasyPaymentMethod.kt
@@ -15,6 +15,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class PayEasyPaymentMethod(
     override var type: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/PayToPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/PayToPaymentMethod.kt
@@ -15,6 +15,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class PayToPaymentMethod(
     override var type: String?,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/PaymentMethodDetails.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/PaymentMethodDetails.kt
@@ -20,6 +20,10 @@ import org.json.JSONObject
  * [PaymentMethodDetails.SERIALIZER] can be used to serialize and deserialize the subclasses of [PaymentMethodDetails]
  * without having to know the exact type of the subclass.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 abstract class PaymentMethodDetails : ModelObject() {
 
     abstract var type: String?

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/SepaPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/SepaPaymentMethod.kt
@@ -14,6 +14,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class SepaPaymentMethod(
     override var type: String?,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/SevenElevenPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/SevenElevenPaymentMethod.kt
@@ -15,6 +15,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class SevenElevenPaymentMethod(
     override var type: String? = null,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/TwintPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/TwintPaymentMethod.kt
@@ -14,6 +14,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class TwintPaymentMethod(
     override var type: String?,

--- a/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/UPIPaymentMethod.kt
+++ b/components-core/src/main/java/com/adyen/checkout/components/core/paymentmethod/UPIPaymentMethod.kt
@@ -14,6 +14,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class UPIPaymentMethod(
     override var type: String?,

--- a/components-core/src/test/java/com/adyen/checkout/components/core/ActionComponentCallbackTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/ActionComponentCallbackTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 2/2/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core
 
 import com.adyen.checkout.core.old.PermissionHandlerCallback

--- a/components-core/src/test/java/com/adyen/checkout/components/core/AddressInputModelTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/AddressInputModelTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 31/1/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core
 
 import com.adyen.checkout.components.core.internal.ui.model.AddressInputModel

--- a/components-core/src/test/java/com/adyen/checkout/components/core/ButtonTestConfiguration.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/ButtonTestConfiguration.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core
 
 import com.adyen.checkout.components.core.internal.BaseConfigurationBuilder

--- a/components-core/src/test/java/com/adyen/checkout/components/core/CheckoutConfigurationTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/CheckoutConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core
 
 import android.os.Parcel

--- a/components-core/src/test/java/com/adyen/checkout/components/core/ComponentCallbackTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/ComponentCallbackTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 2/2/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core
 
 import com.adyen.checkout.core.old.PermissionHandlerCallback

--- a/components-core/src/test/java/com/adyen/checkout/components/core/PaymentComponentDataTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/PaymentComponentDataTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core
 
 import com.adyen.checkout.components.core.paymentmethod.GenericPaymentMethod

--- a/components-core/src/test/java/com/adyen/checkout/components/core/TestActionComponentCallback.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/TestActionComponentCallback.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 2/2/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core
 
 internal class TestActionComponentCallback : ActionComponentCallback {

--- a/components-core/src/test/java/com/adyen/checkout/components/core/TestComponentCallback.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/TestComponentCallback.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 2/2/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core
 
 internal class TestComponentCallback : ComponentCallback<TestComponentState> {

--- a/components-core/src/test/java/com/adyen/checkout/components/core/TestComponentState.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/TestComponentState.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 27/2/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core
 
 import com.adyen.checkout.components.core.paymentmethod.PaymentMethodDetails

--- a/components-core/src/test/java/com/adyen/checkout/components/core/TestConfiguration.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/TestConfiguration.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 18/11/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core
 
 import com.adyen.checkout.components.core.internal.BaseConfigurationBuilder

--- a/components-core/src/test/java/com/adyen/checkout/components/core/action/RedirectActionTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/action/RedirectActionTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core.action
 
 import org.json.JSONObject

--- a/components-core/src/test/java/com/adyen/checkout/components/core/action/TwintSdkDataTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/action/TwintSdkDataTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core.action
 
 import com.adyen.checkout.core.old.exception.ModelSerializationException

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/DefaultComponentEventHandlerTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/DefaultComponentEventHandlerTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 6/2/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core.internal
 
 import com.adyen.checkout.components.core.ActionComponentData

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/analytics/AnalyticsPlatformParamsTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/analytics/AnalyticsPlatformParamsTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core.internal.analytics
 
 import com.adyen.checkout.components.core.BuildConfig

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/analytics/DefaultAnalyticsManagerTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/analytics/DefaultAnalyticsManagerTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core.internal.analytics
 
 import com.adyen.checkout.components.core.internal.analytics.data.AnalyticsRepository

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/analytics/data/DefaultAnalyticsRepositoryTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/analytics/data/DefaultAnalyticsRepositoryTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core.internal.analytics.data
 
 import com.adyen.checkout.components.core.internal.analytics.AnalyticsEvent

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/analytics/data/remote/AnalyticsTrackRequestProviderTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/analytics/data/remote/AnalyticsTrackRequestProviderTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core.internal.analytics.data.remote
 
 import com.adyen.checkout.components.core.internal.analytics.AnalyticsEvent

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/analytics/data/remote/DefaultAnalyticsSetupProviderTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/analytics/data/remote/DefaultAnalyticsSetupProviderTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core.internal.analytics.data.remote
 
 import android.app.Application

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsServiceTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/api/AnalyticsServiceTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core.internal.data.api
 
 import com.adyen.checkout.components.core.internal.data.model.AnalyticsTrackRequest

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/api/DefaultStatusRepositoryTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/api/DefaultStatusRepositoryTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 8/8/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core.internal.data.api
 
 import com.adyen.checkout.components.core.internal.data.model.StatusResponse

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/model/AnalyticsSetupRequestTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/model/AnalyticsSetupRequestTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core.internal.data.model
 
 import com.adyen.checkout.components.core.Amount

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/model/AnalyticsSetupResponseTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/model/AnalyticsSetupResponseTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core.internal.data.model
 
 import org.json.JSONObject

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/model/AnalyticsTrackInfoTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/model/AnalyticsTrackInfoTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core.internal.data.model
 
 import com.adyen.checkout.core.old.exception.ModelSerializationException

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/model/AnalyticsTrackLogTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/model/AnalyticsTrackLogTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core.internal.data.model
 
 import com.adyen.checkout.core.old.exception.ModelSerializationException

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/model/AnalyticsTrackRequestTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/data/model/AnalyticsTrackRequestTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core.internal.data.model
 
 import com.adyen.checkout.core.old.internal.data.model.ModelUtils

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/ui/model/ButtonComponentParamsMapperTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/ui/model/ButtonComponentParamsMapperTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core.internal.ui.model
 
 import com.adyen.checkout.components.core.Amount

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/ui/model/GenericComponentParamsMapperTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/ui/model/GenericComponentParamsMapperTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 18/11/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core.internal.ui.model
 
 import com.adyen.checkout.components.core.Amount

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/util/CountryUtilsTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/util/CountryUtilsTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core.internal.util
 
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/util/CurrencyUtilsTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/util/CurrencyUtilsTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 21/11/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core.internal.util
 
 import com.adyen.checkout.components.core.Amount

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/util/DateUtilsTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/util/DateUtilsTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 22/1/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core.internal.util
 
 import com.adyen.checkout.test.LoggingExtension

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/util/NumberExtensionTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/util/NumberExtensionTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 21/11/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core.internal.util
 
 import org.junit.Assert.assertEquals

--- a/components-core/src/test/java/com/adyen/checkout/components/core/internal/util/ValidationUtilsTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/internal/util/ValidationUtilsTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 7/7/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core.internal.util
 
 import com.adyen.checkout.core.old.Environment

--- a/components-core/src/test/java/com/adyen/checkout/components/core/paymentmethod/TwintPaymentMethodTest.kt
+++ b/components-core/src/test/java/com/adyen/checkout/components/core/paymentmethod/TwintPaymentMethodTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core.paymentmethod
 
 import org.json.JSONObject

--- a/components-core/src/testFixtures/java/com/adyen/checkout/components/core/internal/analytics/TestAnalyticsManager.kt
+++ b/components-core/src/testFixtures/java/com/adyen/checkout/components/core/internal/analytics/TestAnalyticsManager.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 19/7/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core.internal.analytics
 
 import kotlinx.coroutines.CoroutineScope

--- a/components-core/src/testFixtures/java/com/adyen/checkout/components/core/internal/data/api/TestPublicKeyRepository.kt
+++ b/components-core/src/testFixtures/java/com/adyen/checkout/components/core/internal/data/api/TestPublicKeyRepository.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 19/7/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core.internal.data.api
 
 import com.adyen.checkout.core.old.Environment

--- a/components-core/src/testFixtures/java/com/adyen/checkout/components/core/internal/data/api/TestStatusRepository.kt
+++ b/components-core/src/testFixtures/java/com/adyen/checkout/components/core/internal/data/api/TestStatusRepository.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 19/7/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.components.core.internal.data.api
 
 import com.adyen.checkout.components.core.internal.data.model.StatusResponse


### PR DESCRIPTION
## Description

Deprecate all v5 public classes with `@Deprecated` annotations to prepare for the v6 release.
Deprecated code will be removed before the v6 production release.

### Progress

✅ Phase 1 — [checkout-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2707)
✅ Phase 2 — [ui-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2708)
✅ Phase 3 — [card (.old packages)](https://github.com/Adyen/adyen-android/pull/2709)
✅ Phase 4 — [googlepay (.old packages)](https://github.com/Adyen/adyen-android/pull/2711)
✅ Phase 5 — [drop-in (.old packages)](https://github.com/Adyen/adyen-android/pull/2712)
✅ Phase 6 — [3ds2 (.old packages)](https://github.com/Adyen/adyen-android/pull/2713)
✅ Phase 7 — [mbway (.old packages)](https://github.com/Adyen/adyen-android/pull/2714)
✅ Phase 8 — [blik (.old packages)](https://github.com/Adyen/adyen-android/pull/2715)
✅ Phase 9 — [await (.old packages)](https://github.com/Adyen/adyen-android/pull/2716)
✅ Phase 10 — [redirect (.old packages)](https://github.com/Adyen/adyen-android/pull/2726)
➡️ **Phase 11 — components-core (entire v5 module)**
Phase 12 — action-core (entire v5 module)
Phase 13 — sessions-core (entire v5 module)
Phase 14 — action, components-compose, drop-in-compose (v5 utility modules)
Phase 15 — 34 v5-only payment method modules

## Ticket Number
COSDK-1121