### PR TITLE
v6 - Deprecate old public classes - action-core

### DIFF
--- a/action-core/src/main/java/com/adyen/checkout/action/core/GenericActionComponent.kt
+++ b/action-core/src/main/java/com/adyen/checkout/action/core/GenericActionComponent.kt
@@ -31,6 +31,10 @@ import kotlinx.coroutines.flow.Flow
 /**
  * An [ActionComponent] that is able to handle every action.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class GenericActionComponent internal constructor(
     private val genericActionDelegate: GenericActionDelegate,
     internal val actionComponentEventHandler: ActionComponentEventHandler,

--- a/action-core/src/main/java/com/adyen/checkout/action/core/GenericActionConfiguration.kt
+++ b/action-core/src/main/java/com/adyen/checkout/action/core/GenericActionConfiguration.kt
@@ -35,6 +35,10 @@ import java.util.Locale
  * customize their behavior.
  * If you don't specify anything, a default configuration will be used.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class GenericActionConfiguration private constructor(
     override val shopperLocale: Locale?,
@@ -53,6 +57,10 @@ class GenericActionConfiguration private constructor(
      * component.
      */
     @Suppress("unused")
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder :
         BaseConfigurationBuilder<GenericActionConfiguration, Builder>,
         ActionHandlingConfigurationBuilder<Builder> {

--- a/action-core/src/test/java/com/adyen/checkout/action/core/GenericActionComponentTest.kt
+++ b/action-core/src/test/java/com/adyen/checkout/action/core/GenericActionComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 19/12/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.action.core
 
 import android.app.Activity

--- a/action-core/src/test/java/com/adyen/checkout/action/core/GenericActionConfigurationTest.kt
+++ b/action-core/src/test/java/com/adyen/checkout/action/core/GenericActionConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.action.core
 
 import com.adyen.checkout.await.old.AwaitConfiguration

--- a/action-core/src/test/java/com/adyen/checkout/action/core/TestActionDelegate.kt
+++ b/action-core/src/test/java/com/adyen/checkout/action/core/TestActionDelegate.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 21/9/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.action.core
 
 import android.app.Activity

--- a/action-core/src/test/java/com/adyen/checkout/action/core/internal/DefaultActionHandlingComponentTest.kt
+++ b/action-core/src/test/java/com/adyen/checkout/action/core/internal/DefaultActionHandlingComponentTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.action.core.internal
 
 import android.app.Activity

--- a/action-core/src/test/java/com/adyen/checkout/action/core/internal/ui/ActionDelegateProviderTest.kt
+++ b/action-core/src/test/java/com/adyen/checkout/action/core/internal/ui/ActionDelegateProviderTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.action.core.internal.ui
 
 import android.app.Application

--- a/action-core/src/test/java/com/adyen/checkout/action/core/ui/DefaultGenericActionDelegateTest.kt
+++ b/action-core/src/test/java/com/adyen/checkout/action/core/ui/DefaultGenericActionDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 20/9/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.action.core.ui
 
 import android.app.Activity


### PR DESCRIPTION
## Description

Deprecate all v5 public classes with `@Deprecated` annotations to prepare for the v6 release.
Deprecated code will be removed before the v6 production release.

### Progress

✅ Phase 1 — [checkout-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2707)
✅ Phase 2 — [ui-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2708)
✅ Phase 3 — [card (.old packages)](https://github.com/Adyen/adyen-android/pull/2709)
✅ Phase 4 — [googlepay (.old packages)](https://github.com/Adyen/adyen-android/pull/2711)
✅ Phase 5 — [drop-in (.old packages)](https://github.com/Adyen/adyen-android/pull/2712)
✅ Phase 6 — [3ds2 (.old packages)](https://github.com/Adyen/adyen-android/pull/2713)
✅ Phase 7 — [mbway (.old packages)](https://github.com/Adyen/adyen-android/pull/2714)
✅ Phase 8 — [blik (.old packages)](https://github.com/Adyen/adyen-android/pull/2715)
✅ Phase 9 — [await (.old packages)](https://github.com/Adyen/adyen-android/pull/2716)
✅ Phase 10 — [redirect (.old packages)](https://github.com/Adyen/adyen-android/pull/2726)
✅ Phase 11 — [components-core (entire v5 module)](https://github.com/Adyen/adyen-android/pull/2727)
➡️ **Phase 12 — action-core (entire v5 module)**
Phase 13 — sessions-core (entire v5 module)
Phase 14 — action, components-compose, drop-in-compose (v5 utility modules)
Phase 15 — 34 v5-only payment method modules

## Ticket Number
COSDK-1121