### PR TITLE
v6 - Deprecate old public classes - sessions-core

### DIFF
--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/CheckoutSession.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/CheckoutSession.kt
@@ -18,6 +18,10 @@ import com.adyen.checkout.core.old.Environment
  * A class holding the data required to launch Drop-in or a component with the sessions flow.
  * Use [CheckoutSessionProvider.createSession] to create this class.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class CheckoutSession(
     val sessionSetupResponse: SessionSetupResponse,
     val order: Order?,

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/CheckoutSessionProvider.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/CheckoutSessionProvider.kt
@@ -14,6 +14,10 @@ import com.adyen.checkout.core.old.Environment
 import com.adyen.checkout.core.old.exception.CheckoutException
 import com.adyen.checkout.sessions.core.internal.CheckoutSessionInitializer
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 object CheckoutSessionProvider {
 
     /**

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/CheckoutSessionResult.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/CheckoutSessionResult.kt
@@ -13,7 +13,20 @@ import com.adyen.checkout.core.old.exception.CheckoutException
 /**
  * The result of the API call to fetch a [CheckoutSession].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 sealed class CheckoutSessionResult {
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Success(val checkoutSession: CheckoutSession) : CheckoutSessionResult()
+
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Error(val exception: CheckoutException) : CheckoutSessionResult()
 }

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/SessionComponentCallback.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/SessionComponentCallback.kt
@@ -22,6 +22,10 @@ import org.json.JSONObject
 /**
  * Implement this callback to interact with a [PaymentComponent] initialized with a session.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 interface SessionComponentCallback<T : PaymentComponentState<*>> : BaseComponentCallback {
     // Generic events
     /**

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/SessionModel.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/SessionModel.kt
@@ -19,6 +19,10 @@ import org.json.JSONObject
  * Object that parses and holds the response data from the /sessions endpoint.
  * Use [PaymentMethodsApiResponse.SERIALIZER] to deserialize this class from your JSON response.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class SessionModel(
     val id: String,

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/SessionPaymentResult.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/SessionPaymentResult.kt
@@ -22,6 +22,10 @@ import kotlinx.parcelize.Parcelize
  * [Result codes](https://docs.adyen.com/online-payments/build-your-integration/payment-result-codes/).
  * @param order An order, only applicable in case of an ongoing partial payment flow.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class SessionPaymentResult(
     val sessionId: String?,

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/SessionSetupConfiguration.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/SessionSetupConfiguration.kt
@@ -16,6 +16,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class SessionSetupConfiguration(
     val enableStoreDetails: Boolean? = null,

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/SessionSetupInstallmentOptions.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/SessionSetupInstallmentOptions.kt
@@ -18,6 +18,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class SessionSetupInstallmentOptions(
     val plans: List<String>?,

--- a/sessions-core/src/main/java/com/adyen/checkout/sessions/core/SessionSetupResponse.kt
+++ b/sessions-core/src/main/java/com/adyen/checkout/sessions/core/SessionSetupResponse.kt
@@ -18,6 +18,10 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONException
 import org.json.JSONObject
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class SessionSetupResponse(
     val id: String,

--- a/sessions-core/src/test/java/com/adyen/checkout/sessions/core/SessionComponentCallbackTest.kt
+++ b/sessions-core/src/test/java/com/adyen/checkout/sessions/core/SessionComponentCallbackTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 2/2/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.sessions.core
 
 import com.adyen.checkout.core.old.PermissionHandlerCallback

--- a/sessions-core/src/test/java/com/adyen/checkout/sessions/core/TestComponentState.kt
+++ b/sessions-core/src/test/java/com/adyen/checkout/sessions/core/TestComponentState.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 2/2/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.sessions.core
 
 import com.adyen.checkout.components.core.PaymentComponentData

--- a/sessions-core/src/test/java/com/adyen/checkout/sessions/core/TestPaymentMethod.kt
+++ b/sessions-core/src/test/java/com/adyen/checkout/sessions/core/TestPaymentMethod.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 2/2/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.sessions.core
 
 import android.os.Parcel

--- a/sessions-core/src/test/java/com/adyen/checkout/sessions/core/TestSessionComponentCallback.kt
+++ b/sessions-core/src/test/java/com/adyen/checkout/sessions/core/TestSessionComponentCallback.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 2/2/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.sessions.core
 
 import com.adyen.checkout.components.core.ComponentError

--- a/sessions-core/src/test/java/com/adyen/checkout/sessions/core/internal/SessionComponentEventHandlerTest.kt
+++ b/sessions-core/src/test/java/com/adyen/checkout/sessions/core/internal/SessionComponentEventHandlerTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 6/2/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.sessions.core.internal
 
 import android.os.Parcel

--- a/sessions-core/src/test/java/com/adyen/checkout/sessions/core/internal/SessionInteractorTest.kt
+++ b/sessions-core/src/test/java/com/adyen/checkout/sessions/core/internal/SessionInteractorTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 2/2/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.sessions.core.internal
 
 import app.cash.turbine.test


### PR DESCRIPTION
## Description

Deprecate all v5 public classes with `@Deprecated` annotations to prepare for the v6 release.
Deprecated code will be removed before the v6 production release.

### Progress

✅ Phase 1 — [checkout-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2707)
✅ Phase 2 — [ui-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2708)
✅ Phase 3 — [card (.old packages)](https://github.com/Adyen/adyen-android/pull/2709)
✅ Phase 4 — [googlepay (.old packages)](https://github.com/Adyen/adyen-android/pull/2711)
✅ Phase 5 — [drop-in (.old packages)](https://github.com/Adyen/adyen-android/pull/2712)
✅ Phase 6 — [3ds2 (.old packages)](https://github.com/Adyen/adyen-android/pull/2713)
✅ Phase 7 — [mbway (.old packages)](https://github.com/Adyen/adyen-android/pull/2714)
✅ Phase 8 — [blik (.old packages)](https://github.com/Adyen/adyen-android/pull/2715)
✅ Phase 9 — [await (.old packages)](https://github.com/Adyen/adyen-android/pull/2716)
✅ Phase 10 — [redirect (.old packages)](https://github.com/Adyen/adyen-android/pull/2726)
✅ Phase 11 — [components-core (entire v5 module)](https://github.com/Adyen/adyen-android/pull/2727)
✅ Phase 12 — [action-core (entire v5 module)](https://github.com/Adyen/adyen-android/pull/2729)
➡️ **Phase 13 — sessions-core (entire v5 module)**
Phase 14 — action, components-compose, drop-in-compose (v5 utility modules)
Phase 15 — 34 v5-only payment method modules

## Ticket Number
COSDK-1121