### PR TITLE
v6 - Deprecate old public classes - utility modules

### DIFF
--- a/components-compose/src/main/java/com/adyen/checkout/components/compose/ComposeExtensions.kt
+++ b/components-compose/src/main/java/com/adyen/checkout/components/compose/ComposeExtensions.kt
@@ -53,6 +53,10 @@ import com.adyen.checkout.ui.core.old.internal.ui.ViewableComponent
  *
  * @return The Component
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Composable
 fun <
     ComponentT : PaymentComponent,
@@ -94,6 +98,10 @@ fun <
  *
  * @return The Component
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Composable
 fun <
     ComponentT : PaymentComponent,
@@ -136,6 +144,10 @@ fun <
  *
  * @return The Component
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Composable
 fun <
     ComponentT : PaymentComponent,
@@ -177,6 +189,10 @@ fun <
  *
  * @return The Component
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Composable
 fun <
     ComponentT : PaymentComponent,
@@ -214,6 +230,10 @@ fun <
  *
  * @return The Component
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Composable
 fun <
     ComponentT : PaymentComponent,
@@ -256,6 +276,10 @@ fun <
  *
  * @return The Component
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Composable
 fun <
     ComponentT : PaymentComponent,
@@ -295,6 +319,10 @@ fun <
  *
  * @return The Component
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Composable
 fun <
     ComponentT : PaymentComponent,
@@ -336,6 +364,10 @@ fun <
  *
  * @return The Component
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Composable
 fun <
     ComponentT : PaymentComponent,
@@ -378,6 +410,10 @@ fun <
  *
  * @return The Component
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Composable
 fun <
     ComponentT : PaymentComponent,
@@ -421,6 +457,10 @@ fun <
  *
  * @return The Component
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Composable
 fun <
     ComponentT : PaymentComponent,
@@ -453,6 +493,10 @@ fun <
 /**
  * A [Composable] that can display input and fill in details for a [Component].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("unused")
 @Composable
 fun <T> AdyenComponent(

--- a/drop-in-compose/src/main/java/com/adyen/checkout/dropin/compose/ComposeExtensions.kt
+++ b/drop-in-compose/src/main/java/com/adyen/checkout/dropin/compose/ComposeExtensions.kt
@@ -45,6 +45,10 @@ import com.adyen.checkout.sessions.core.CheckoutSessionProvider
  *
  * @return The [ActivityResultLauncher] required to receive the result of Drop-in.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("unused")
 @Composable
 fun rememberLauncherForDropInResult(
@@ -73,6 +77,10 @@ fun rememberLauncherForDropInResult(
  * @param dropInConfiguration Additional required configuration data.
  * @param serviceClass Service that extends from [SessionDropInService] to optionally take over the checkout flow.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @SuppressLint("ComposableNaming")
 @Suppress("unused")
 @Composable
@@ -111,6 +119,10 @@ fun DropIn.startPayment(
  * @param checkoutConfiguration Additional required configuration data.
  * @param serviceClass Service that extends from [SessionDropInService] to optionally take over the checkout flow.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @SuppressLint("ComposableNaming")
 @Suppress("unused")
 @Composable
@@ -145,6 +157,10 @@ fun DropIn.startPayment(
  *
  * @return The [ActivityResultLauncher] required to receive the result of Drop-in.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("unused")
 @Composable
 fun rememberLauncherForDropInResult(
@@ -172,6 +188,10 @@ fun rememberLauncherForDropInResult(
  * @param dropInConfiguration Additional required configuration data.
  * @param serviceClass Service that extends from [DropInService] to interact with Drop-in during the checkout flow.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @SuppressLint("ComposableNaming")
 @Suppress("unused")
 @Composable
@@ -209,6 +229,10 @@ fun DropIn.startPayment(
  * @param checkoutConfiguration Additional required configuration data.
  * @param serviceClass Service that extends from [DropInService] to interact with Drop-in during the checkout flow.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @SuppressLint("ComposableNaming")
 @Suppress("unused")
 @Composable


### PR DESCRIPTION
## Description

Deprecate all v5 public classes with `@Deprecated` annotations to prepare for the v6 release.
Deprecated code will be removed before the v6 production release.

Note: The `action` module only contains an auto-generated `BuildConfig` class, so there is nothing to deprecate there.

### Progress

✅ Phase 1 — [checkout-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2707)
✅ Phase 2 — [ui-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2708)
✅ Phase 3 — [card (.old packages)](https://github.com/Adyen/adyen-android/pull/2709)
✅ Phase 4 — [googlepay (.old packages)](https://github.com/Adyen/adyen-android/pull/2711)
✅ Phase 5 — [drop-in (.old packages)](https://github.com/Adyen/adyen-android/pull/2712)
✅ Phase 6 — [3ds2 (.old packages)](https://github.com/Adyen/adyen-android/pull/2713)
✅ Phase 7 — [mbway (.old packages)](https://github.com/Adyen/adyen-android/pull/2714)
✅ Phase 8 — [blik (.old packages)](https://github.com/Adyen/adyen-android/pull/2715)
✅ Phase 9 — [await (.old packages)](https://github.com/Adyen/adyen-android/pull/2716)
✅ Phase 10 — [redirect (.old packages)](https://github.com/Adyen/adyen-android/pull/2726)
✅ Phase 11 — [components-core (entire v5 module)](https://github.com/Adyen/adyen-android/pull/2727)
✅ Phase 12 — [action-core (entire v5 module)](https://github.com/Adyen/adyen-android/pull/2729)
✅ Phase 13 — [sessions-core (entire v5 module)](https://github.com/Adyen/adyen-android/pull/2730)
➡️ **Phase 14 — action, components-compose, drop-in-compose (v5 utility modules)**
Phase 15 — 34 v5-only payment method modules

## Ticket Number
COSDK-1121