### PR TITLE
v6 - Deprecate old public classes - 34 payment method modules

### DIFF
--- a/ach/src/main/java/com/adyen/checkout/ach/ACHDirectDebitAddressConfiguration.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/ACHDirectDebitAddressConfiguration.kt
@@ -16,11 +16,19 @@ import kotlinx.parcelize.Parcelize
  * Configuration class for Address Form in ACH Component. This class can be used define the
  * visibility of the address form.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 sealed class ACHDirectDebitAddressConfiguration : Parcelable {
     /**
      * Address Form will be hidden.
      */
     @SuppressLint("ObjectInPublicSealedClass")
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     @Parcelize
     object None : ACHDirectDebitAddressConfiguration()
 
@@ -29,6 +37,10 @@ sealed class ACHDirectDebitAddressConfiguration : Parcelable {
      * @param supportedCountryCodes Supported country codes to be filtered from the available country
      * options.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     @Parcelize
     data class FullAddress(
         val supportedCountryCodes: List<String>,

--- a/ach/src/main/java/com/adyen/checkout/ach/ACHDirectDebitComponent.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/ACHDirectDebitComponent.kt
@@ -35,6 +35,10 @@ import kotlinx.coroutines.flow.Flow
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.ACH] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class ACHDirectDebitComponent internal constructor(
     private val achDirectDebitDelegate: ACHDirectDebitDelegate,
     private val genericActionDelegate: GenericActionDelegate,

--- a/ach/src/main/java/com/adyen/checkout/ach/ACHDirectDebitComponentState.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/ACHDirectDebitComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.ACHDirectDebitPaymentMet
 /**
  * Represents the state of [ACHDirectDebitComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class ACHDirectDebitComponentState(
     override val data: PaymentComponentData<ACHDirectDebitPaymentMethod>,
     override val isInputValid: Boolean,

--- a/ach/src/main/java/com/adyen/checkout/ach/ACHDirectDebitConfiguration.kt
+++ b/ach/src/main/java/com/adyen/checkout/ach/ACHDirectDebitConfiguration.kt
@@ -26,6 +26,10 @@ import java.util.Locale
 /**
  * Configuration class for the [ACHDirectDebitComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class ACHDirectDebitConfiguration private constructor(
@@ -43,6 +47,10 @@ class ACHDirectDebitConfiguration private constructor(
     /**
      * Builder to create an [ACHDirectDebitConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder :
         ActionHandlingPaymentMethodConfigurationBuilder<ACHDirectDebitConfiguration, Builder>,
         ButtonConfigurationBuilder {
@@ -152,6 +160,10 @@ class ACHDirectDebitConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.achDirectDebit(
     configuration: @CheckoutConfigurationMarker ACHDirectDebitConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/ach/src/test/java/com/adyen/checkout/ach/ACHDirectDebitComponentTest.kt
+++ b/ach/src/test/java/com/adyen/checkout/ach/ACHDirectDebitComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by onurk on 31/1/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.ach
 
 import androidx.lifecycle.LifecycleOwner

--- a/ach/src/test/java/com/adyen/checkout/ach/ACHDirectDebitConfigurationTest.kt
+++ b/ach/src/test/java/com/adyen/checkout/ach/ACHDirectDebitConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.ach
 
 import com.adyen.checkout.components.core.Amount

--- a/ach/src/test/java/com/adyen/checkout/ach/internal/ui/DefaultACHDirectDebitDelegateTest.kt
+++ b/ach/src/test/java/com/adyen/checkout/ach/internal/ui/DefaultACHDirectDebitDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by onurk on 16/2/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.ach.internal.ui
 
 import app.cash.turbine.test

--- a/ach/src/test/java/com/adyen/checkout/ach/internal/ui/StoredACHDirectDebitDelegateTest.kt
+++ b/ach/src/test/java/com/adyen/checkout/ach/internal/ui/StoredACHDirectDebitDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by onurk on 28/2/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.ach.internal.ui
 
 import app.cash.turbine.test

--- a/ach/src/test/java/com/adyen/checkout/ach/internal/ui/model/ACHDirectDebitComponentParamsMapperTest.kt
+++ b/ach/src/test/java/com/adyen/checkout/ach/internal/ui/model/ACHDirectDebitComponentParamsMapperTest.kt
@@ -6,6 +6,8 @@
  * Created by onurk on 16/2/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.ach.internal.ui.model
 
 import com.adyen.checkout.ach.ACHDirectDebitAddressConfiguration

--- a/ach/src/test/java/com/adyen/checkout/ach/internal/util/ACHDirectDebitValidationUtilsTest.kt
+++ b/ach/src/test/java/com/adyen/checkout/ach/internal/util/ACHDirectDebitValidationUtilsTest.kt
@@ -6,6 +6,8 @@
  * Created by onurk on 16/2/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.ach.internal.util
 
 import com.adyen.checkout.ach.R

--- a/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponent.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponent.kt
@@ -34,6 +34,10 @@ import kotlinx.coroutines.flow.Flow
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.BACS] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class BacsDirectDebitComponent internal constructor(
     private val bacsDelegate: BacsDirectDebitDelegate,
     private val genericActionDelegate: GenericActionDelegate,

--- a/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponentState.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.BacsDirectDebitPaymentMe
 /**
  * Represents the state of [BacsDirectDebitComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class BacsDirectDebitComponentState(
     override val data: PaymentComponentData<BacsDirectDebitPaymentMethod>,
     override val isInputValid: Boolean,

--- a/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitConfiguration.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitConfiguration.kt
@@ -26,6 +26,10 @@ import java.util.Locale
 /**
  * Configuration class for the [BacsDirectDebitComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class BacsDirectDebitConfiguration private constructor(
@@ -41,6 +45,10 @@ class BacsDirectDebitConfiguration private constructor(
     /**
      * Builder to create an [BacsDirectDebitConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder :
         ActionHandlingPaymentMethodConfigurationBuilder<BacsDirectDebitConfiguration, Builder>,
         ButtonConfigurationBuilder {
@@ -116,6 +124,10 @@ class BacsDirectDebitConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.bacsDirectDebit(
     configuration: @CheckoutConfigurationMarker BacsDirectDebitConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitMode.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/BacsDirectDebitMode.kt
@@ -11,6 +11,10 @@ package com.adyen.checkout.bacs
 /**
  * The different modes [BacsDirectDebitComponent] can be in.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 enum class BacsDirectDebitMode {
     INPUT,
     CONFIRMATION

--- a/bacs/src/test/java/com/adyen/checkout/bacs/BacsDirectDebitComponentTest.kt
+++ b/bacs/src/test/java/com/adyen/checkout/bacs/BacsDirectDebitComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 12/12/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.bacs
 
 import androidx.lifecycle.LifecycleOwner

--- a/bacs/src/test/java/com/adyen/checkout/bacs/BacsDirectDebitConfigurationTest.kt
+++ b/bacs/src/test/java/com/adyen/checkout/bacs/BacsDirectDebitConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.bacs
 
 import com.adyen.checkout.components.core.Amount

--- a/bacs/src/test/java/com/adyen/checkout/bacs/internal/DefaultBacsDirectDebitDelegateTest.kt
+++ b/bacs/src/test/java/com/adyen/checkout/bacs/internal/DefaultBacsDirectDebitDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by atef on 18/8/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.bacs.internal
 
 import app.cash.turbine.test

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcComponent.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcComponent.kt
@@ -20,6 +20,10 @@ import com.adyen.checkout.components.core.internal.PaymentComponent
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.BCMC] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class BcmcComponent internal constructor(
     cardDelegate: CardDelegate,
     genericActionDelegate: GenericActionDelegate,

--- a/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcConfiguration.kt
+++ b/bcmc/src/main/java/com/adyen/checkout/bcmc/BcmcConfiguration.kt
@@ -26,6 +26,10 @@ import java.util.Locale
 /**
  * Configuration class for the [BcmcComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class BcmcConfiguration private constructor(
@@ -44,6 +48,10 @@ class BcmcConfiguration private constructor(
     /**
      * Builder to create a [BcmcConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder :
         ActionHandlingPaymentMethodConfigurationBuilder<BcmcConfiguration, Builder>,
         ButtonConfigurationBuilder {
@@ -172,6 +180,10 @@ class BcmcConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.bcmc(
     configuration: @CheckoutConfigurationMarker BcmcConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/bcmc/src/test/java/com/adyen/checkout/bcmc/BcmcComponentTest.kt
+++ b/bcmc/src/test/java/com/adyen/checkout/bcmc/BcmcComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 13/12/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.bcmc
 
 import androidx.lifecycle.LifecycleOwner

--- a/bcmc/src/test/java/com/adyen/checkout/bcmc/BcmcConfigurationTest.kt
+++ b/bcmc/src/test/java/com/adyen/checkout/bcmc/BcmcConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.bcmc
 
 import com.adyen.checkout.components.core.Amount

--- a/bcmc/src/test/java/com/adyen/checkout/bcmc/internal/ui/model/BcmcComponentParamsMapperTest.kt
+++ b/bcmc/src/test/java/com/adyen/checkout/bcmc/internal/ui/model/BcmcComponentParamsMapperTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 17/11/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.bcmc.internal.ui.model
 
 import com.adyen.checkout.bcmc.BcmcConfiguration

--- a/boleto/src/main/java/com/adyen/checkout/boleto/BoletoComponent.kt
+++ b/boleto/src/main/java/com/adyen/checkout/boleto/BoletoComponent.kt
@@ -37,6 +37,10 @@ import kotlinx.coroutines.flow.Flow
  * [PaymentMethodTypes.BOLETOBANCARIO_HSBC], [PaymentMethodTypes.BOLETOBANCARIO_ITAU],
  * [PaymentMethodTypes.BOLETOBANCARIO_SANTANDER] and [PaymentMethodTypes.BOLETO_PRIMEIRO_PAY] payment methods.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class BoletoComponent internal constructor(
     private val boletoDelegate: BoletoDelegate,
     private val genericActionDelegate: GenericActionDelegate,

--- a/boleto/src/main/java/com/adyen/checkout/boleto/BoletoComponentState.kt
+++ b/boleto/src/main/java/com/adyen/checkout/boleto/BoletoComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.GenericPaymentMethod
 /**
  * Represents the state of [BoletoComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class BoletoComponentState(
     override val data: PaymentComponentData<GenericPaymentMethod>,
     override val isInputValid: Boolean,

--- a/boleto/src/main/java/com/adyen/checkout/boleto/BoletoConfiguration.kt
+++ b/boleto/src/main/java/com/adyen/checkout/boleto/BoletoConfiguration.kt
@@ -25,6 +25,10 @@ import java.util.Locale
 /**
  * Configuration class for the [BoletoComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class BoletoConfiguration private constructor(
@@ -41,6 +45,10 @@ class BoletoConfiguration private constructor(
     /**
      * Builder to create a [BoletoConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder :
         ActionHandlingPaymentMethodConfigurationBuilder<BoletoConfiguration, Builder>,
         ButtonConfigurationBuilder {
@@ -126,6 +134,10 @@ class BoletoConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.boleto(
     configuration: @CheckoutConfigurationMarker BoletoConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/boleto/src/test/java/com/adyen/checkout/boleto/BoletoComponentTest.kt
+++ b/boleto/src/test/java/com/adyen/checkout/boleto/BoletoComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by atef on 31/3/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.boleto
 
 import androidx.lifecycle.LifecycleOwner

--- a/boleto/src/test/java/com/adyen/checkout/boleto/BoletoConfigurationTest.kt
+++ b/boleto/src/test/java/com/adyen/checkout/boleto/BoletoConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.boleto
 
 import com.adyen.checkout.components.core.Amount

--- a/boleto/src/test/java/com/adyen/checkout/boleto/internal/ui/DefaultBoletoDelegateTest.kt
+++ b/boleto/src/test/java/com/adyen/checkout/boleto/internal/ui/DefaultBoletoDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by atef on 31/3/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.boleto.internal.ui
 
 import app.cash.turbine.test

--- a/boleto/src/test/java/com/adyen/checkout/boleto/internal/ui/model/BoletoComponentParamsMapperTest.kt
+++ b/boleto/src/test/java/com/adyen/checkout/boleto/internal/ui/model/BoletoComponentParamsMapperTest.kt
@@ -6,6 +6,8 @@
  * Created by atef on 31/3/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.boleto.internal.ui.model
 
 import com.adyen.checkout.boleto.BoletoConfiguration

--- a/boleto/src/test/java/com/adyen/checkout/boleto/internal/util/BoletoValidationUtilsTest.kt
+++ b/boleto/src/test/java/com/adyen/checkout/boleto/internal/util/BoletoValidationUtilsTest.kt
@@ -6,6 +6,8 @@
  * Created by atef on 4/4/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.boleto.internal.util
 
 import com.adyen.checkout.boleto.R

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/CashAppPayComponent.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/CashAppPayComponent.kt
@@ -36,6 +36,10 @@ import kotlinx.coroutines.flow.Flow
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.CASH_APP_PAY] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class CashAppPayComponent internal constructor(
     private val cashAppPayDelegate: CashAppPayDelegate,
     private val genericActionDelegate: GenericActionDelegate,

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/CashAppPayComponentState.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/CashAppPayComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.CashAppPayPaymentMethod
 /**
  * Represents the state of [CashAppPayComponent]
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class CashAppPayComponentState(
     override val data: PaymentComponentData<CashAppPayPaymentMethod>,
     override val isInputValid: Boolean,

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/CashAppPayConfiguration.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/CashAppPayConfiguration.kt
@@ -26,6 +26,10 @@ import java.util.Locale
 /**
  * Configuration class for the [CashAppPayComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class CashAppPayConfiguration
 @Suppress("LongParameterList")
@@ -43,6 +47,10 @@ private constructor(
     val storePaymentMethod: Boolean?,
 ) : Configuration, ButtonConfiguration {
 
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder :
         ActionHandlingPaymentMethodConfigurationBuilder<CashAppPayConfiguration, Builder>,
         ButtonConfigurationBuilder {
@@ -184,6 +192,10 @@ private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.cashAppPay(
     configuration: @CheckoutConfigurationMarker CashAppPayConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/CashAppPayEnvironment.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/CashAppPayEnvironment.kt
@@ -8,6 +8,10 @@
 
 package com.adyen.checkout.cashapppay
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 enum class CashAppPayEnvironment {
     SANDBOX,
     PRODUCTION,

--- a/cashapppay/src/test/java/com/adyen/checkout/cashapppay/CashAppPayComponentTest.kt
+++ b/cashapppay/src/test/java/com/adyen/checkout/cashapppay/CashAppPayComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 4/7/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.cashapppay
 
 import androidx.lifecycle.LifecycleOwner

--- a/cashapppay/src/test/java/com/adyen/checkout/cashapppay/CashAppPayConfigurationTest.kt
+++ b/cashapppay/src/test/java/com/adyen/checkout/cashapppay/CashAppPayConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.cashapppay
 
 import com.adyen.checkout.components.core.Amount

--- a/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/DefaultCashAppPayDelegateTest.kt
+++ b/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/DefaultCashAppPayDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 5/7/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.cashapppay.internal.ui
 
 import android.app.Application

--- a/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/StoredCashAppPayDelegateTest.kt
+++ b/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/StoredCashAppPayDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 4/7/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.cashapppay.internal.ui
 
 import android.app.Application

--- a/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/model/CashAppPayComponentParamsMapperTest.kt
+++ b/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/model/CashAppPayComponentParamsMapperTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 4/7/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.cashapppay.internal.ui.model
 
 import android.app.Application

--- a/convenience-stores-jp/src/main/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPComponent.kt
+++ b/convenience-stores-jp/src/main/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPComponent.kt
@@ -21,6 +21,10 @@ import com.adyen.checkout.econtext.internal.ui.EContextDelegate
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.ECONTEXT_STORES] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class ConvenienceStoresJPComponent internal constructor(
     delegate: EContextDelegate<ConvenienceStoresJPPaymentMethod, ConvenienceStoresJPComponentState>,
     genericActionDelegate: GenericActionDelegate,

--- a/convenience-stores-jp/src/main/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPComponentState.kt
+++ b/convenience-stores-jp/src/main/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.ConvenienceStoresJPPayme
 /**
  * Represents the state of [ConvenienceStoresJPComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class ConvenienceStoresJPComponentState(
     override val data: PaymentComponentData<ConvenienceStoresJPPaymentMethod>,
     override val isInputValid: Boolean,

--- a/convenience-stores-jp/src/main/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPConfiguration.kt
+++ b/convenience-stores-jp/src/main/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPConfiguration.kt
@@ -23,6 +23,10 @@ import java.util.Locale
 /**
  * Configuration class for the [ConvenienceStoresJPComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("LongParameterList")
 @Parcelize
 class ConvenienceStoresJPConfiguration private constructor(
@@ -38,6 +42,10 @@ class ConvenienceStoresJPConfiguration private constructor(
     /**
      * Builder to create a [ConvenienceStoresJPConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : EContextConfiguration.Builder<ConvenienceStoresJPConfiguration, Builder> {
 
         /**
@@ -97,6 +105,10 @@ class ConvenienceStoresJPConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.convenienceStoresJP(
     configuration: @CheckoutConfigurationMarker ConvenienceStoresJPConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/convenience-stores-jp/src/test/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPConfigurationTest.kt
+++ b/convenience-stores-jp/src/test/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.conveniencestoresjp
 
 import com.adyen.checkout.components.core.Amount

--- a/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayComponent.kt
+++ b/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayComponent.kt
@@ -20,6 +20,10 @@ import com.adyen.checkout.issuerlist.internal.ui.IssuerListDelegate
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.DOTPAY] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class DotpayComponent internal constructor(
     delegate: IssuerListDelegate<DotpayPaymentMethod, DotpayComponentState>,
     genericActionDelegate: GenericActionDelegate,

--- a/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayComponentState.kt
+++ b/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.DotpayPaymentMethod
 /**
  * Represents the state of [DotpayComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class DotpayComponentState(
     override val data: PaymentComponentData<DotpayPaymentMethod>,
     override val isInputValid: Boolean,

--- a/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayConfiguration.kt
+++ b/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayConfiguration.kt
@@ -23,6 +23,10 @@ import java.util.Locale
 /**
  * Configuration class for the [DotpayComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class DotpayConfiguration private constructor(
@@ -40,6 +44,10 @@ class DotpayConfiguration private constructor(
     /**
      * Builder to create a [DotpayConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : IssuerListBuilder<DotpayConfiguration, Builder> {
 
         /**
@@ -101,6 +109,10 @@ class DotpayConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.dotpay(
     configuration: @CheckoutConfigurationMarker DotpayConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/dotpay/src/test/java/com/adyen/checkout/dotpay/DotpayConfigurationTest.kt
+++ b/dotpay/src/test/java/com/adyen/checkout/dotpay/DotpayConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.dotpay
 
 import com.adyen.checkout.components.core.Amount

--- a/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextComponent.kt
+++ b/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextComponent.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 13/2/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.econtext
 
 import com.adyen.checkout.action.core.internal.DefaultActionHandlingComponent

--- a/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextComponentState.kt
+++ b/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextComponentState.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 21/2/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.econtext
 
 import com.adyen.checkout.components.core.PaymentComponentData

--- a/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextConfiguration.kt
+++ b/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextConfiguration.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 25/1/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.econtext
 
 import com.adyen.checkout.action.core.GenericActionConfiguration

--- a/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextPaymentMethod.kt
+++ b/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextPaymentMethod.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 25/1/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.econtext
 
 import android.os.Parcel

--- a/econtext/src/test/java/com/adyen/checkout/econtext/internal/EContextComponentTest.kt
+++ b/econtext/src/test/java/com/adyen/checkout/econtext/internal/EContextComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 13/2/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.econtext.internal
 
 import androidx.lifecycle.LifecycleOwner

--- a/econtext/src/test/java/com/adyen/checkout/econtext/internal/ui/DefaultEContextDelegateTest.kt
+++ b/econtext/src/test/java/com/adyen/checkout/econtext/internal/ui/DefaultEContextDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 25/1/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.econtext.internal.ui
 
 import app.cash.turbine.test

--- a/entercash/src/main/java/com/adyen/checkout/entercash/EntercashComponent.kt
+++ b/entercash/src/main/java/com/adyen/checkout/entercash/EntercashComponent.kt
@@ -20,6 +20,10 @@ import com.adyen.checkout.issuerlist.internal.ui.IssuerListDelegate
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.ENTERCASH] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class EntercashComponent internal constructor(
     delegate: IssuerListDelegate<EntercashPaymentMethod, EntercashComponentState>,
     genericActionDelegate: GenericActionDelegate,

--- a/entercash/src/main/java/com/adyen/checkout/entercash/EntercashComponentState.kt
+++ b/entercash/src/main/java/com/adyen/checkout/entercash/EntercashComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.EntercashPaymentMethod
 /**
  * Represents the state of [EntercashComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class EntercashComponentState(
     override val data: PaymentComponentData<EntercashPaymentMethod>,
     override val isInputValid: Boolean,

--- a/entercash/src/main/java/com/adyen/checkout/entercash/EntercashConfiguration.kt
+++ b/entercash/src/main/java/com/adyen/checkout/entercash/EntercashConfiguration.kt
@@ -23,6 +23,10 @@ import java.util.Locale
 /**
  * Configuration class for the [EntercashComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class EntercashConfiguration private constructor(
@@ -40,6 +44,10 @@ class EntercashConfiguration private constructor(
     /**
      * Builder to create an [EntercashConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : IssuerListBuilder<EntercashConfiguration, Builder> {
 
         /**
@@ -101,6 +109,10 @@ class EntercashConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.entercash(
     configuration: @CheckoutConfigurationMarker EntercashConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/entercash/src/test/java/com/adyen/checkout/entercash/EntercashConfigurationTest.kt
+++ b/entercash/src/test/java/com/adyen/checkout/entercash/EntercashConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.entercash
 
 import com.adyen.checkout.components.core.Amount

--- a/eps/src/main/java/com/adyen/checkout/eps/EPSComponent.kt
+++ b/eps/src/main/java/com/adyen/checkout/eps/EPSComponent.kt
@@ -20,6 +20,10 @@ import com.adyen.checkout.issuerlist.internal.ui.IssuerListDelegate
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.EPS] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class EPSComponent internal constructor(
     delegate: IssuerListDelegate<EPSPaymentMethod, EPSComponentState>,
     genericActionDelegate: GenericActionDelegate,

--- a/eps/src/main/java/com/adyen/checkout/eps/EPSComponentState.kt
+++ b/eps/src/main/java/com/adyen/checkout/eps/EPSComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.EPSPaymentMethod
 /**
  * Represents the state of [EPSComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class EPSComponentState(
     override val data: PaymentComponentData<EPSPaymentMethod>,
     override val isInputValid: Boolean,

--- a/eps/src/main/java/com/adyen/checkout/eps/EPSConfiguration.kt
+++ b/eps/src/main/java/com/adyen/checkout/eps/EPSConfiguration.kt
@@ -23,6 +23,10 @@ import java.util.Locale
 /**
  * Configuration class for the [EPSComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class EPSConfiguration private constructor(
@@ -40,6 +44,10 @@ class EPSConfiguration private constructor(
     /**
      * Builder to create an [EPSConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : IssuerListBuilder<EPSConfiguration, Builder> {
 
         /**
@@ -112,6 +120,10 @@ class EPSConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.eps(
     configuration: @CheckoutConfigurationMarker EPSConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/eps/src/test/java/com/adyen/checkout/eps/EPSConfigurationTest.kt
+++ b/eps/src/test/java/com/adyen/checkout/eps/EPSConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.eps
 
 import com.adyen.checkout.components.core.Amount

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardAction.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardAction.kt
@@ -10,6 +10,10 @@ import kotlinx.parcelize.Parcelize
  * in partial payments flow. This class is used to distinguish separate actions that can be taken when submit button
  * is clicked.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @SuppressLint("ObjectInPublicSealedClass")
 @Parcelize
 sealed class GiftCardAction : Parcelable {
@@ -17,20 +21,36 @@ sealed class GiftCardAction : Parcelable {
     /**
      * No action to be taken.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     object Idle : GiftCardAction()
 
     /**
      * Check balance of the partial payment method.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     object CheckBalance : GiftCardAction()
 
     /**
      * Submit the payment.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     object SendPayment : GiftCardAction()
 
     /**
      * Create an order.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     object CreateOrder : GiftCardAction()
 }

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardComponent.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardComponent.kt
@@ -36,6 +36,10 @@ import kotlinx.coroutines.flow.Flow
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.GIFTCARD] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 open class GiftCardComponent
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardComponentCallback.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardComponentCallback.kt
@@ -17,6 +17,10 @@ import org.json.JSONObject
 /**
  * Implement this callback to interact with a GiftCardComponent.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 interface GiftCardComponentCallback : ComponentCallback<GiftCardComponentState> {
     /**
      * In this method you should make a network call to the /orders endpoint of the Checkout API through your server.

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardComponentState.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardComponentState.kt
@@ -16,6 +16,10 @@ import kotlinx.parcelize.Parcelize
 /**
  * Represents the state of [GiftCardComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class GiftCardComponentState(
     override val data: PaymentComponentData<GiftCardPaymentMethod>,

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardConfiguration.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardConfiguration.kt
@@ -25,6 +25,10 @@ import java.util.Locale
 /**
  * Configuration class for the [GiftCardComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class GiftCardConfiguration private constructor(
@@ -41,6 +45,10 @@ class GiftCardConfiguration private constructor(
     /**
      * Builder to create a [GiftCardConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder :
         ActionHandlingPaymentMethodConfigurationBuilder<GiftCardConfiguration, Builder>,
         ButtonConfigurationBuilder {
@@ -131,6 +139,10 @@ class GiftCardConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.giftCard(
     configuration: @CheckoutConfigurationMarker GiftCardConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardException.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardException.kt
@@ -13,4 +13,8 @@ import com.adyen.checkout.core.old.exception.CheckoutException
 /**
  * Exception thrown when an error occurs during a payment flow using Gift Cards.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class GiftCardException(errorMessage: String) : CheckoutException(errorMessage)

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/SessionsGiftCardComponentCallback.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/SessionsGiftCardComponentCallback.kt
@@ -22,6 +22,10 @@ import org.json.JSONObject
 /**
  * Implement this callback to interact with a [GiftCardComponent] initialized with a session.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 interface SessionsGiftCardComponentCallback : SessionComponentCallback<GiftCardComponentState> {
 
     /**

--- a/giftcard/src/test/java/com/adyen/checkout/giftcard/GiftCardComponentTest.kt
+++ b/giftcard/src/test/java/com/adyen/checkout/giftcard/GiftCardComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 13/12/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.giftcard
 
 import androidx.lifecycle.LifecycleOwner

--- a/giftcard/src/test/java/com/adyen/checkout/giftcard/GiftCardConfigurationTest.kt
+++ b/giftcard/src/test/java/com/adyen/checkout/giftcard/GiftCardConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.giftcard
 
 import com.adyen.checkout.components.core.Amount

--- a/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/ui/DefaultGiftCardDelegateTest.kt
+++ b/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/ui/DefaultGiftCardDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 18/7/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.giftcard.internal.ui
 
 import app.cash.turbine.test

--- a/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/ui/model/GiftCardComponentParamsMapperTest.kt
+++ b/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/ui/model/GiftCardComponentParamsMapperTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.giftcard.internal.ui.model
 
 import com.adyen.checkout.components.core.Amount

--- a/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/util/GiftCardBalanceUtilsTest.kt
+++ b/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/util/GiftCardBalanceUtilsTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.giftcard.internal.util
 
 import com.adyen.checkout.components.core.Amount

--- a/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/util/GiftCardNumberUtilsTest.kt
+++ b/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/util/GiftCardNumberUtilsTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.giftcard.internal.util
 
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/util/GiftCardPinUtilsTest.kt
+++ b/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/util/GiftCardPinUtilsTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 20/8/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.giftcard.internal.util
 
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/ideal/src/main/java/com/adyen/checkout/ideal/IdealComponent.kt
+++ b/ideal/src/main/java/com/adyen/checkout/ideal/IdealComponent.kt
@@ -32,6 +32,10 @@ import kotlinx.coroutines.flow.Flow
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.IDEAL] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class IdealComponent internal constructor(
     private val idealDelegate: IdealDelegate,
     private val genericActionDelegate: GenericActionDelegate,

--- a/ideal/src/main/java/com/adyen/checkout/ideal/IdealComponentState.kt
+++ b/ideal/src/main/java/com/adyen/checkout/ideal/IdealComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.IdealPaymentMethod
 /**
  * Represents the state of [IdealComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class IdealComponentState(
     override val data: PaymentComponentData<IdealPaymentMethod>,
     override val isInputValid: Boolean,

--- a/ideal/src/main/java/com/adyen/checkout/ideal/IdealConfiguration.kt
+++ b/ideal/src/main/java/com/adyen/checkout/ideal/IdealConfiguration.kt
@@ -23,6 +23,10 @@ import java.util.Locale
 /**
  * Configuration class for the [IdealComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class IdealConfiguration private constructor(
@@ -122,6 +126,10 @@ class IdealConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.ideal(
     configuration: @CheckoutConfigurationMarker IdealConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/ideal/src/test/java/com/adyen/checkout/ideal/IdealComponentTest.kt
+++ b/ideal/src/test/java/com/adyen/checkout/ideal/IdealComponentTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.ideal
 
 import androidx.lifecycle.LifecycleOwner

--- a/ideal/src/test/java/com/adyen/checkout/ideal/IdealConfigurationTest.kt
+++ b/ideal/src/test/java/com/adyen/checkout/ideal/IdealConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.ideal
 
 import com.adyen.checkout.components.core.Amount

--- a/ideal/src/test/java/com/adyen/checkout/ideal/internal/ui/DefaultIdealDelegateTest.kt
+++ b/ideal/src/test/java/com/adyen/checkout/ideal/internal/ui/DefaultIdealDelegateTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.ideal.internal.ui
 
 import com.adyen.checkout.components.core.Amount

--- a/instant/src/main/java/com/adyen/checkout/instant/InstantComponentState.kt
+++ b/instant/src/main/java/com/adyen/checkout/instant/InstantComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.PaymentMethodDetails
 /**
  * Represents the state of [InstantPaymentComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class InstantComponentState(
     override val data: PaymentComponentData<PaymentMethodDetails>,
     override val isInputValid: Boolean,

--- a/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentComponent.kt
+++ b/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentComponent.kt
@@ -23,6 +23,10 @@ import kotlinx.coroutines.flow.Flow
 /**
  * A [PaymentComponent] used for handling payment methods that do not require any input from the shopper.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class InstantPaymentComponent internal constructor(
     private val instantPaymentDelegate: InstantPaymentDelegate,
     private val genericActionDelegate: GenericActionDelegate,

--- a/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentConfiguration.kt
+++ b/instant/src/main/java/com/adyen/checkout/instant/InstantPaymentConfiguration.kt
@@ -25,6 +25,10 @@ import java.util.Locale
 /**
  * Configuration class for the [InstantPaymentComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class InstantPaymentConfiguration
 @Suppress("LongParameterList")
@@ -41,6 +45,10 @@ private constructor(
     /**
      * Builder to create an [InstantPaymentConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : ActionHandlingPaymentMethodConfigurationBuilder<InstantPaymentConfiguration, Builder> {
 
         private var actionHandlingMethod: ActionHandlingMethod? = null
@@ -115,6 +123,10 @@ private constructor(
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 const val GLOBAL_INSTANT_CONFIG_KEY = "GLOBAL_INSTANT_CONFIG_KEY"
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.instantPayment(
     paymentMethod: String = GLOBAL_INSTANT_CONFIG_KEY,
     configuration: @CheckoutConfigurationMarker InstantPaymentConfiguration.Builder.() -> Unit = {},

--- a/instant/src/test/java/com/adyen/checkout/instant/InstantPaymentComponentTest.kt
+++ b/instant/src/test/java/com/adyen/checkout/instant/InstantPaymentComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 14/12/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.instant
 
 import androidx.lifecycle.LifecycleOwner

--- a/instant/src/test/java/com/adyen/checkout/instant/InstantPaymentConfigurationTest.kt
+++ b/instant/src/test/java/com/adyen/checkout/instant/InstantPaymentConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.instant
 
 import com.adyen.checkout.components.core.ActionHandlingMethod

--- a/instant/src/test/java/com/adyen/checkout/instant/internal/provider/InstantPaymentComponentProviderTest.kt
+++ b/instant/src/test/java/com/adyen/checkout/instant/internal/provider/InstantPaymentComponentProviderTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.instant.internal.provider
 
 import com.adyen.checkout.components.core.PaymentMethod

--- a/instant/src/test/java/com/adyen/checkout/instant/internal/ui/DefaultInstantPaymentDelegateTest.kt
+++ b/instant/src/test/java/com/adyen/checkout/instant/internal/ui/DefaultInstantPaymentDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 9/11/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.instant.internal.ui
 
 import app.cash.turbine.test

--- a/instant/src/test/java/com/adyen/checkout/instant/internal/ui/model/InstantComponentParamsMapperTest.kt
+++ b/instant/src/test/java/com/adyen/checkout/instant/internal/ui/model/InstantComponentParamsMapperTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 28/11/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.instant.internal.ui.model
 
 import com.adyen.checkout.components.core.ActionHandlingMethod

--- a/issuer-list/src/main/java/com/adyen/checkout/issuerlist/IssuerListViewType.kt
+++ b/issuer-list/src/main/java/com/adyen/checkout/issuerlist/IssuerListViewType.kt
@@ -11,6 +11,10 @@ package com.adyen.checkout.issuerlist
 /**
  * Represents the multiple view types the can be displayed with an issuer list component.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 enum class IssuerListViewType {
     /**
      * A simple list of issuers inside a recycler view.

--- a/issuer-list/src/test/java/com/adyen/checkout/issuerlist/TestIssuerComponentState.kt
+++ b/issuer-list/src/test/java/com/adyen/checkout/issuerlist/TestIssuerComponentState.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 20/2/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.issuerlist
 
 import com.adyen.checkout.components.core.PaymentComponentData

--- a/issuer-list/src/test/java/com/adyen/checkout/issuerlist/internal/IssuerListComponentTest.kt
+++ b/issuer-list/src/test/java/com/adyen/checkout/issuerlist/internal/IssuerListComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 13/12/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.issuerlist.internal
 
 import androidx.lifecycle.LifecycleOwner

--- a/issuer-list/src/test/java/com/adyen/checkout/issuerlist/internal/ui/DefaultIssuerListDelegateTest.kt
+++ b/issuer-list/src/test/java/com/adyen/checkout/issuerlist/internal/ui/DefaultIssuerListDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by atef on 17/8/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.issuerlist.internal.ui
 
 import app.cash.turbine.test

--- a/issuer-list/src/test/java/com/adyen/checkout/issuerlist/internal/ui/model/IssuerListComponentParamsMapperTest.kt
+++ b/issuer-list/src/test/java/com/adyen/checkout/issuerlist/internal/ui/model/IssuerListComponentParamsMapperTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 17/11/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.issuerlist.internal.ui.model
 
 import com.adyen.checkout.components.core.Amount

--- a/issuer-list/src/test/java/com/adyen/checkout/issuerlist/utils/TestIssuerListComponent.kt
+++ b/issuer-list/src/test/java/com/adyen/checkout/issuerlist/utils/TestIssuerListComponent.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 13/12/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.issuerlist.utils
 
 import com.adyen.checkout.action.core.internal.DefaultActionHandlingComponent

--- a/issuer-list/src/test/java/com/adyen/checkout/issuerlist/utils/TestIssuerListConfiguration.kt
+++ b/issuer-list/src/test/java/com/adyen/checkout/issuerlist/utils/TestIssuerListConfiguration.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 17/11/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.issuerlist.utils
 
 import com.adyen.checkout.action.core.GenericActionConfiguration

--- a/issuer-list/src/test/java/com/adyen/checkout/issuerlist/utils/TestIssuerPaymentMethod.kt
+++ b/issuer-list/src/test/java/com/adyen/checkout/issuerlist/utils/TestIssuerPaymentMethod.kt
@@ -6,6 +6,8 @@
  * Created by atef on 17/8/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.issuerlist.utils
 
 import android.os.Parcel

--- a/meal-voucher-fr/src/main/java/com/adyen/checkout/mealvoucherfr/MealVoucherFRComponent.kt
+++ b/meal-voucher-fr/src/main/java/com/adyen/checkout/mealvoucherfr/MealVoucherFRComponent.kt
@@ -16,6 +16,10 @@ import com.adyen.checkout.giftcard.GiftCardComponent
 import com.adyen.checkout.giftcard.internal.ui.GiftCardDelegate
 import com.adyen.checkout.mealvoucherfr.internal.provider.MealVoucherFRComponentProvider
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class MealVoucherFRComponent internal constructor(
     giftCardDelegate: GiftCardDelegate,
     genericActionDelegate: GenericActionDelegate,

--- a/meal-voucher-fr/src/main/java/com/adyen/checkout/mealvoucherfr/MealVoucherFRConfiguration.kt
+++ b/meal-voucher-fr/src/main/java/com/adyen/checkout/mealvoucherfr/MealVoucherFRConfiguration.kt
@@ -25,6 +25,10 @@ import java.util.Locale
 /**
  * Configuration class for the [MealVoucherFRComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class MealVoucherFRConfiguration private constructor(
@@ -41,6 +45,10 @@ class MealVoucherFRConfiguration private constructor(
     /**
      * Builder to create a [MealVoucherFRConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder :
         ActionHandlingPaymentMethodConfigurationBuilder<MealVoucherFRConfiguration, Builder>,
         ButtonConfigurationBuilder {
@@ -131,6 +139,10 @@ class MealVoucherFRConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.mealVoucherFR(
     configuration: @CheckoutConfigurationMarker MealVoucherFRConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/meal-voucher-fr/src/test/java/com/adyen/checkout/mealvoucherfr/MealVoucherFRComponentTest.kt
+++ b/meal-voucher-fr/src/test/java/com/adyen/checkout/mealvoucherfr/MealVoucherFRComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 27/8/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.mealvoucherfr
 
 import androidx.lifecycle.LifecycleOwner

--- a/meal-voucher-fr/src/test/java/com/adyen/checkout/mealvoucherfr/MealVoucherFRConfigurationTest.kt
+++ b/meal-voucher-fr/src/test/java/com/adyen/checkout/mealvoucherfr/MealVoucherFRConfigurationTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 28/8/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.mealvoucherfr
 
 import com.adyen.checkout.components.core.Amount

--- a/meal-voucher-fr/src/test/java/com/adyen/checkout/mealvoucherfr/internal/ui/model/MealVoucherFRComponentParamsMapperTest.kt
+++ b/meal-voucher-fr/src/test/java/com/adyen/checkout/mealvoucherfr/internal/ui/model/MealVoucherFRComponentParamsMapperTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 27/8/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.mealvoucherfr.internal.ui.model
 
 import com.adyen.checkout.components.core.Amount

--- a/molpay/src/main/java/com/adyen/checkout/molpay/MolpayComponent.kt
+++ b/molpay/src/main/java/com/adyen/checkout/molpay/MolpayComponent.kt
@@ -21,6 +21,10 @@ import com.adyen.checkout.molpay.internal.provider.MolpayComponentProvider
  * A [PaymentComponent] that supports the [PaymentMethodTypes.MOLPAY_MALAYSIA], [PaymentMethodTypes.MOLPAY_THAILAND]
  * and [PaymentMethodTypes.MOLPAY_VIETNAM] payment methods.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class MolpayComponent internal constructor(
     delegate: IssuerListDelegate<MolpayPaymentMethod, MolpayComponentState>,
     genericActionDelegate: GenericActionDelegate,

--- a/molpay/src/main/java/com/adyen/checkout/molpay/MolpayComponentState.kt
+++ b/molpay/src/main/java/com/adyen/checkout/molpay/MolpayComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.MolpayPaymentMethod
 /**
  * Represents the state of [MolpayComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class MolpayComponentState(
     override val data: PaymentComponentData<MolpayPaymentMethod>,
     override val isInputValid: Boolean,

--- a/molpay/src/main/java/com/adyen/checkout/molpay/MolpayConfiguration.kt
+++ b/molpay/src/main/java/com/adyen/checkout/molpay/MolpayConfiguration.kt
@@ -22,6 +22,10 @@ import java.util.Locale
 /**
  * Configuration class for the [MolpayComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class MolpayConfiguration private constructor(
@@ -39,6 +43,10 @@ class MolpayConfiguration private constructor(
     /**
      * Builder to create a [MolpayConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : IssuerListBuilder<MolpayConfiguration, Builder> {
 
         /**
@@ -100,6 +108,10 @@ class MolpayConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.molpay(
     configuration: @CheckoutConfigurationMarker MolpayConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/molpay/src/test/java/com/adyen/checkout/molpay/MolpayConfigurationTest.kt
+++ b/molpay/src/test/java/com/adyen/checkout/molpay/MolpayConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.molpay
 
 import com.adyen.checkout.components.core.Amount

--- a/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/internal/OnlineBankingComponentTest.kt
+++ b/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/internal/OnlineBankingComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 13/12/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.onlinebankingcore.internal
 
 import androidx.lifecycle.LifecycleOwner

--- a/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/internal/ui/DefaultOnlineBankingDelegateTest.kt
+++ b/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/internal/ui/DefaultOnlineBankingDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by atef on 15/2/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.onlinebankingcore.internal.ui
 
 import android.content.Context

--- a/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/utils/TestOnlineBankingComponent.kt
+++ b/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/utils/TestOnlineBankingComponent.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 13/12/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.onlinebankingcore.utils
 
 import com.adyen.checkout.action.core.internal.DefaultActionHandlingComponent

--- a/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/utils/TestOnlineBankingComponentState.kt
+++ b/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/utils/TestOnlineBankingComponentState.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 21/2/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.onlinebankingcore.utils
 
 import com.adyen.checkout.components.core.PaymentComponentData

--- a/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/utils/TestOnlineBankingConfiguration.kt
+++ b/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/utils/TestOnlineBankingConfiguration.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 21/11/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.onlinebankingcore.utils
 
 import com.adyen.checkout.components.core.Amount

--- a/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/utils/TestOnlineBankingPaymentMethod.kt
+++ b/online-banking-core/src/test/java/com/adyen/checkout/onlinebankingcore/utils/TestOnlineBankingPaymentMethod.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 13/12/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.onlinebankingcore.utils
 
 import android.os.Parcel

--- a/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZComponent.kt
+++ b/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZComponent.kt
@@ -21,6 +21,10 @@ import com.adyen.checkout.onlinebankingcz.internal.provider.OnlineBankingCZCompo
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.ONLINE_BANKING_CZ] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class OnlineBankingCZComponent internal constructor(
     delegate: OnlineBankingDelegate<OnlineBankingCZPaymentMethod, OnlineBankingCZComponentState>,
     genericActionDelegate: GenericActionDelegate,

--- a/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZComponentState.kt
+++ b/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.OnlineBankingCZPaymentMe
 /**
  * Represents the state of [OnlineBankingCZComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class OnlineBankingCZComponentState(
     override val data: PaymentComponentData<OnlineBankingCZPaymentMethod>,
     override val isInputValid: Boolean,

--- a/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZConfiguration.kt
+++ b/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZConfiguration.kt
@@ -23,6 +23,10 @@ import java.util.Locale
 /**
  * Configuration class for the [OnlineBankingCZComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("LongParameterList")
 @Parcelize
 class OnlineBankingCZConfiguration private constructor(
@@ -38,6 +42,10 @@ class OnlineBankingCZConfiguration private constructor(
     /**
      * Builder to create an [OnlineBankingCZConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : OnlineBankingConfigurationBuilder<OnlineBankingCZConfiguration, Builder> {
 
         /**
@@ -97,6 +105,10 @@ class OnlineBankingCZConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.onlineBankingCZ(
     configuration: @CheckoutConfigurationMarker OnlineBankingCZConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/online-banking-cz/src/test/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZConfigurationTest.kt
+++ b/online-banking-cz/src/test/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.onlinebankingcz
 
 import com.adyen.checkout.components.core.Amount

--- a/online-banking-jp/src/main/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPComponent.kt
+++ b/online-banking-jp/src/main/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPComponent.kt
@@ -21,6 +21,10 @@ import com.adyen.checkout.onlinebankingjp.internal.provider.OnlineBankingJPCompo
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.ECONTEXT_ONLINE] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class OnlineBankingJPComponent internal constructor(
     delegate: EContextDelegate<OnlineBankingJPPaymentMethod, OnlineBankingJPComponentState>,
     genericActionDelegate: GenericActionDelegate,

--- a/online-banking-jp/src/main/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPComponentState.kt
+++ b/online-banking-jp/src/main/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.OnlineBankingJPPaymentMe
 /**
  * Represents the state of [OnlineBankingJPComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class OnlineBankingJPComponentState(
     override val data: PaymentComponentData<OnlineBankingJPPaymentMethod>,
     override val isInputValid: Boolean,

--- a/online-banking-jp/src/main/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPConfiguration.kt
+++ b/online-banking-jp/src/main/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPConfiguration.kt
@@ -23,6 +23,10 @@ import java.util.Locale
 /**
  * Configuration class for the [OnlineBankingJPComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("LongParameterList")
 @Parcelize
 class OnlineBankingJPConfiguration private constructor(
@@ -38,6 +42,10 @@ class OnlineBankingJPConfiguration private constructor(
     /**
      * Builder to create an [OnlineBankingJPConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : EContextConfiguration.Builder<OnlineBankingJPConfiguration, Builder> {
 
         /**
@@ -97,6 +105,10 @@ class OnlineBankingJPConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.onlineBankingJP(
     configuration: @CheckoutConfigurationMarker OnlineBankingJPConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/online-banking-jp/src/test/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPConfigurationTest.kt
+++ b/online-banking-jp/src/test/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.onlinebankingjp
 
 import com.adyen.checkout.components.core.Amount

--- a/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLComponent.kt
+++ b/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLComponent.kt
@@ -21,6 +21,10 @@ import com.adyen.checkout.onlinebankingpl.internal.provider.OnlineBankingPLCompo
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.ONLINE_BANKING_PL] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class OnlineBankingPLComponent internal constructor(
     delegate: IssuerListDelegate<OnlineBankingPLPaymentMethod, OnlineBankingPLComponentState>,
     genericActionDelegate: GenericActionDelegate,

--- a/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLComponentState.kt
+++ b/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.OnlineBankingPLPaymentMe
 /**
  * Represents the state of [OnlineBankingPLComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class OnlineBankingPLComponentState(
     override val data: PaymentComponentData<OnlineBankingPLPaymentMethod>,
     override val isInputValid: Boolean,

--- a/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLConfiguration.kt
+++ b/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLConfiguration.kt
@@ -24,6 +24,10 @@ import java.util.Locale
 /**
  * Configuration class for the [OnlineBankingPLComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class OnlineBankingPLConfiguration private constructor(
@@ -41,6 +45,10 @@ class OnlineBankingPLConfiguration private constructor(
     /**
      * Builder to create an [OnlineBankingPLConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : IssuerListBuilder<OnlineBankingPLConfiguration, Builder> {
 
         /**
@@ -102,6 +110,10 @@ class OnlineBankingPLConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.onlineBankingPL(
     configuration: @CheckoutConfigurationMarker OnlineBankingPLConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/online-banking-pl/src/test/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLConfigurationTest.kt
+++ b/online-banking-pl/src/test/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.onlinebankingpl
 
 import com.adyen.checkout.components.core.Amount

--- a/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKComponent.kt
+++ b/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKComponent.kt
@@ -21,6 +21,10 @@ import com.adyen.checkout.onlinebankingsk.internal.provider.OnlineBankingSKCompo
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.ONLINE_BANKING_SK] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class OnlineBankingSKComponent internal constructor(
     delegate: OnlineBankingDelegate<OnlineBankingSKPaymentMethod, OnlineBankingSKComponentState>,
     genericActionDelegate: GenericActionDelegate,

--- a/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKComponentState.kt
+++ b/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.OnlineBankingSKPaymentMe
 /**
  * Represents the state of [OnlineBankingSKComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class OnlineBankingSKComponentState(
     override val data: PaymentComponentData<OnlineBankingSKPaymentMethod>,
     override val isInputValid: Boolean,

--- a/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKConfiguration.kt
+++ b/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKConfiguration.kt
@@ -23,6 +23,10 @@ import java.util.Locale
 /**
  * Configuration class for the [OnlineBankingSKComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("LongParameterList")
 @Parcelize
 class OnlineBankingSKConfiguration private constructor(
@@ -38,6 +42,10 @@ class OnlineBankingSKConfiguration private constructor(
     /**
      * Builder to create an [OnlineBankingSKConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : OnlineBankingConfigurationBuilder<OnlineBankingSKConfiguration, Builder> {
 
         /**
@@ -97,6 +105,10 @@ class OnlineBankingSKConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.onlineBankingSK(
     configuration: @CheckoutConfigurationMarker OnlineBankingSKConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/online-banking-sk/src/test/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKConfigurationTest.kt
+++ b/online-banking-sk/src/test/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.onlinebankingsk
 
 import com.adyen.checkout.components.core.Amount

--- a/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingComponent.kt
+++ b/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingComponent.kt
@@ -20,6 +20,10 @@ import com.adyen.checkout.openbanking.internal.provider.OpenBankingComponentProv
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.OPEN_BANKING] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class OpenBankingComponent internal constructor(
     delegate: IssuerListDelegate<OpenBankingPaymentMethod, OpenBankingComponentState>,
     genericActionDelegate: GenericActionDelegate,

--- a/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingComponentState.kt
+++ b/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.OpenBankingPaymentMethod
 /**
  * Represents the state of [OpenBankingComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class OpenBankingComponentState(
     override val data: PaymentComponentData<OpenBankingPaymentMethod>,
     override val isInputValid: Boolean,

--- a/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingConfiguration.kt
+++ b/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingConfiguration.kt
@@ -23,6 +23,10 @@ import java.util.Locale
 /**
  * Configuration class for the [OpenBankingComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class OpenBankingConfiguration private constructor(
@@ -40,6 +44,10 @@ class OpenBankingConfiguration private constructor(
     /**
      * Builder to create an [OpenBankingConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : IssuerListBuilder<OpenBankingConfiguration, Builder> {
 
         /**
@@ -101,6 +109,10 @@ class OpenBankingConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.openBanking(
     configuration: @CheckoutConfigurationMarker OpenBankingConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/openbanking/src/test/java/com/adyen/checkout/openbanking/OpenBankingConfigurationTest.kt
+++ b/openbanking/src/test/java/com/adyen/checkout/openbanking/OpenBankingConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.openbanking
 
 import com.adyen.checkout.components.core.Amount

--- a/paybybank-us/src/main/java/com/adyen/checkout/paybybankus/PayByBankUSComponent.kt
+++ b/paybybank-us/src/main/java/com/adyen/checkout/paybybankus/PayByBankUSComponent.kt
@@ -32,6 +32,10 @@ import kotlinx.coroutines.flow.Flow
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.PAY_BY_BANK_US] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class PayByBankUSComponent internal constructor(
     private val payByBankUSDelegate: PayByBankUSDelegate,
     private val genericActionDelegate: GenericActionDelegate,

--- a/paybybank-us/src/main/java/com/adyen/checkout/paybybankus/PayByBankUSComponentState.kt
+++ b/paybybank-us/src/main/java/com/adyen/checkout/paybybankus/PayByBankUSComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.PayByBankUSPaymentMethod
 /**
  * Represents the state of [PayByBankUSComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class PayByBankUSComponentState(
     override val data: PaymentComponentData<PayByBankUSPaymentMethod>,
     override val isInputValid: Boolean,

--- a/paybybank-us/src/main/java/com/adyen/checkout/paybybankus/PayByBankUSConfiguration.kt
+++ b/paybybank-us/src/main/java/com/adyen/checkout/paybybankus/PayByBankUSConfiguration.kt
@@ -23,6 +23,10 @@ import java.util.Locale
 /**
  * Configuration class for the [PayByBankUSComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class PayByBankUSConfiguration private constructor(
     override val shopperLocale: Locale?,
@@ -33,6 +37,10 @@ class PayByBankUSConfiguration private constructor(
     internal val genericActionConfiguration: GenericActionConfiguration,
 ) : Configuration {
 
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : ActionHandlingPaymentMethodConfigurationBuilder<PayByBankUSConfiguration, Builder> {
 
         /**
@@ -77,6 +85,10 @@ class PayByBankUSConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.payByBankUS(
     configuration: @CheckoutConfigurationMarker PayByBankUSConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/paybybank-us/src/test/java/com/adyen/checkout/paybybankus/PayByBankUSComponentTest.kt
+++ b/paybybank-us/src/test/java/com/adyen/checkout/paybybankus/PayByBankUSComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 5/11/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.paybybankus
 
 import androidx.lifecycle.LifecycleOwner

--- a/paybybank-us/src/test/java/com/adyen/checkout/paybybankus/PayByBankUSConfigurationTest.kt
+++ b/paybybank-us/src/test/java/com/adyen/checkout/paybybankus/PayByBankUSConfigurationTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 24/10/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.paybybankus
 
 import com.adyen.checkout.components.core.Amount

--- a/paybybank-us/src/test/java/com/adyen/checkout/paybybankus/internal/ui/DefaultPayByBankUSDelegateTest.kt
+++ b/paybybank-us/src/test/java/com/adyen/checkout/paybybankus/internal/ui/DefaultPayByBankUSDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 5/11/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.paybybankus.internal.ui
 
 import app.cash.turbine.test

--- a/paybybank-us/src/test/java/com/adyen/checkout/paybybankus/internal/ui/StoredPayByBankUSDelegateTest.kt
+++ b/paybybank-us/src/test/java/com/adyen/checkout/paybybankus/internal/ui/StoredPayByBankUSDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 28/11/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.paybybankus.internal.ui
 
 import com.adyen.checkout.components.core.Amount

--- a/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankComponent.kt
+++ b/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankComponent.kt
@@ -32,6 +32,10 @@ import kotlinx.coroutines.flow.Flow
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.PAY_BY_BANK] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class PayByBankComponent internal constructor(
     private val payByBankDelegate: PayByBankDelegate,
     private val genericActionDelegate: GenericActionDelegate,

--- a/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankComponentState.kt
+++ b/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.PayByBankPaymentMethod
 /**
  * Represents the state of [PayByBankComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class PayByBankComponentState(
     override val data: PaymentComponentData<PayByBankPaymentMethod>,
     override val isInputValid: Boolean,

--- a/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankConfiguration.kt
+++ b/paybybank/src/main/java/com/adyen/checkout/paybybank/PayByBankConfiguration.kt
@@ -24,6 +24,10 @@ import java.util.Locale
 /**
  * Configuration class for the [PayByBankComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class PayByBankConfiguration private constructor(
     override val shopperLocale: Locale?,
@@ -37,6 +41,10 @@ class PayByBankConfiguration private constructor(
     /**
      * Builder to create a [PayByBankConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : ActionHandlingPaymentMethodConfigurationBuilder<PayByBankConfiguration, Builder> {
 
         /**
@@ -95,6 +103,10 @@ class PayByBankConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.payByBank(
     configuration: @CheckoutConfigurationMarker PayByBankConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/paybybank/src/test/java/com/adyen/checkout/paybybank/PayByBankComponentTest.kt
+++ b/paybybank/src/test/java/com/adyen/checkout/paybybank/PayByBankComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 14/12/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.paybybank
 
 import androidx.lifecycle.LifecycleOwner

--- a/paybybank/src/test/java/com/adyen/checkout/paybybank/PayByBankConfigurationTest.kt
+++ b/paybybank/src/test/java/com/adyen/checkout/paybybank/PayByBankConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.paybybank
 
 import com.adyen.checkout.components.core.Amount

--- a/paybybank/src/test/java/com/adyen/checkout/paybybank/internal/ui/DefaultPayByBankDelegateTest.kt
+++ b/paybybank/src/test/java/com/adyen/checkout/paybybank/internal/ui/DefaultPayByBankDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 13/12/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.paybybank.internal.ui
 
 import app.cash.turbine.test

--- a/payeasy/src/main/java/com/adyen/checkout/payeasy/PayEasyComponent.kt
+++ b/payeasy/src/main/java/com/adyen/checkout/payeasy/PayEasyComponent.kt
@@ -21,6 +21,10 @@ import com.adyen.checkout.payeasy.internal.provider.PayEasyComponentProvider
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.ECONTEXT_ATM] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class PayEasyComponent internal constructor(
     delegate: EContextDelegate<PayEasyPaymentMethod, PayEasyComponentState>,
     genericActionDelegate: GenericActionDelegate,

--- a/payeasy/src/main/java/com/adyen/checkout/payeasy/PayEasyComponentState.kt
+++ b/payeasy/src/main/java/com/adyen/checkout/payeasy/PayEasyComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.PayEasyPaymentMethod
 /**
  * Represents the state of [PayEasyComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class PayEasyComponentState(
     override val data: PaymentComponentData<PayEasyPaymentMethod>,
     override val isInputValid: Boolean,

--- a/payeasy/src/main/java/com/adyen/checkout/payeasy/PayEasyConfiguration.kt
+++ b/payeasy/src/main/java/com/adyen/checkout/payeasy/PayEasyConfiguration.kt
@@ -23,6 +23,10 @@ import java.util.Locale
 /**
  * Configuration class for the [PayEasyComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("LongParameterList")
 @Parcelize
 class PayEasyConfiguration private constructor(
@@ -38,6 +42,10 @@ class PayEasyConfiguration private constructor(
     /**
      * Builder to create a [PayEasyConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : EContextConfiguration.Builder<PayEasyConfiguration, Builder> {
 
         /**
@@ -97,6 +105,10 @@ class PayEasyConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.payEasy(
     configuration: @CheckoutConfigurationMarker PayEasyConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/payeasy/src/test/java/com/adyen/checkout/payeasy/PayEasyConfigurationTest.kt
+++ b/payeasy/src/test/java/com/adyen/checkout/payeasy/PayEasyConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.payeasy
 
 import com.adyen.checkout.components.core.Amount

--- a/payto/src/main/java/com/adyen/checkout/payto/PayToComponent.kt
+++ b/payto/src/main/java/com/adyen/checkout/payto/PayToComponent.kt
@@ -34,6 +34,10 @@ import kotlinx.coroutines.flow.Flow
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.PAY_TO] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class PayToComponent internal constructor(
     private val payToDelegate: PayToDelegate,
     private val genericActionDelegate: GenericActionDelegate,

--- a/payto/src/main/java/com/adyen/checkout/payto/PayToComponentState.kt
+++ b/payto/src/main/java/com/adyen/checkout/payto/PayToComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.PayToPaymentMethod
 /**
  * Represents the state of [PayToComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class PayToComponentState(
     override val data: PaymentComponentData<PayToPaymentMethod>,
     override val isInputValid: Boolean,

--- a/payto/src/main/java/com/adyen/checkout/payto/PayToConfiguration.kt
+++ b/payto/src/main/java/com/adyen/checkout/payto/PayToConfiguration.kt
@@ -26,6 +26,10 @@ import java.util.Locale
 /**
  * Configuration class for the [PayToComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class PayToConfiguration(
@@ -41,6 +45,10 @@ class PayToConfiguration(
     /**
      * Builder to create an [PayToConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder :
         ActionHandlingPaymentMethodConfigurationBuilder<PayToConfiguration, Builder>,
         ButtonConfigurationBuilder {
@@ -116,6 +124,10 @@ class PayToConfiguration(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.payTo(
     configuration: @CheckoutConfigurationMarker PayToConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/payto/src/test/java/com/adyen/checkout/payto/PayToComponentTest.kt
+++ b/payto/src/test/java/com/adyen/checkout/payto/PayToComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 3/2/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.payto
 
 import androidx.lifecycle.LifecycleOwner

--- a/payto/src/test/java/com/adyen/checkout/payto/PayToConfigurationTest.kt
+++ b/payto/src/test/java/com/adyen/checkout/payto/PayToConfigurationTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 3/2/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.payto
 
 import com.adyen.checkout.components.core.Amount

--- a/payto/src/test/java/com/adyen/checkout/payto/internal/ui/DefaultPayToDelegateTest.kt
+++ b/payto/src/test/java/com/adyen/checkout/payto/internal/ui/DefaultPayToDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 18/2/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.payto.internal.ui
 
 import app.cash.turbine.test

--- a/payto/src/test/java/com/adyen/checkout/payto/internal/ui/StoredPayToDelegateTest.kt
+++ b/payto/src/test/java/com/adyen/checkout/payto/internal/ui/StoredPayToDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 25/2/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.payto.internal.ui
 
 import com.adyen.checkout.components.core.Amount

--- a/payto/src/test/java/com/adyen/checkout/payto/internal/util/PayToValidationUtilsTest.kt
+++ b/payto/src/test/java/com/adyen/checkout/payto/internal/util/PayToValidationUtilsTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 18/2/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.payto.internal.util
 
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeComponent.kt
+++ b/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeComponent.kt
@@ -30,6 +30,10 @@ import kotlinx.coroutines.flow.Flow
 /**
  * An [ActionComponent] that is able to handle the 'qrCode' action.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class QRCodeComponent internal constructor(
     override val delegate: QRCodeDelegate,
     internal val actionComponentEventHandler: ActionComponentEventHandler,

--- a/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeConfiguration.kt
+++ b/qr-code/src/main/java/com/adyen/checkout/qrcode/QRCodeConfiguration.kt
@@ -22,6 +22,10 @@ import java.util.Locale
 /**
  * Configuration class for the [QRCodeComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class QRCodeConfiguration private constructor(
     override val shopperLocale: Locale?,
@@ -34,6 +38,10 @@ class QRCodeConfiguration private constructor(
     /**
      * Builder to create a [QRCodeConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : BaseConfigurationBuilder<QRCodeConfiguration, Builder> {
 
         /**
@@ -91,6 +99,10 @@ class QRCodeConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.qrCode(
     configuration: @CheckoutConfigurationMarker QRCodeConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/qr-code/src/test/java/com/adyen/checkout/qrcode/QRCodeComponentTest.kt
+++ b/qr-code/src/test/java/com/adyen/checkout/qrcode/QRCodeComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 19/12/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.qrcode
 
 import android.app.Activity

--- a/qr-code/src/test/java/com/adyen/checkout/qrcode/QRCodeConfigurationTest.kt
+++ b/qr-code/src/test/java/com/adyen/checkout/qrcode/QRCodeConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.qrcode
 
 import com.adyen.checkout.components.core.Amount

--- a/qr-code/src/test/java/com/adyen/checkout/qrcode/internal/ui/DefaultQRCodeDelegateTest.kt
+++ b/qr-code/src/test/java/com/adyen/checkout/qrcode/internal/ui/DefaultQRCodeDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 15/8/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.qrcode.internal.ui
 
 import android.app.Activity

--- a/sepa/src/main/java/com/adyen/checkout/sepa/SepaComponent.kt
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/SepaComponent.kt
@@ -33,6 +33,10 @@ import kotlinx.coroutines.flow.Flow
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.SEPA] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class SepaComponent internal constructor(
     private val sepaDelegate: SepaDelegate,
     private val genericActionDelegate: GenericActionDelegate,

--- a/sepa/src/main/java/com/adyen/checkout/sepa/SepaComponentState.kt
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/SepaComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.SepaPaymentMethod
 /**
  * Represents the state of [SepaComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class SepaComponentState(
     override val data: PaymentComponentData<SepaPaymentMethod>,
     override val isInputValid: Boolean,

--- a/sepa/src/main/java/com/adyen/checkout/sepa/SepaConfiguration.kt
+++ b/sepa/src/main/java/com/adyen/checkout/sepa/SepaConfiguration.kt
@@ -25,6 +25,10 @@ import java.util.Locale
 /**
  * Configuration class for the [SepaComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class SepaConfiguration private constructor(
@@ -40,6 +44,10 @@ class SepaConfiguration private constructor(
     /**
      * Builder to create a [SepaConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder :
         ActionHandlingPaymentMethodConfigurationBuilder<SepaConfiguration, Builder>,
         ButtonConfigurationBuilder {
@@ -115,6 +123,10 @@ class SepaConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.sepa(
     configuration: @CheckoutConfigurationMarker SepaConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/sepa/src/test/java/com/adyen/checkout/sepa/SepaComponentTest.kt
+++ b/sepa/src/test/java/com/adyen/checkout/sepa/SepaComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 14/12/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.sepa
 
 import androidx.lifecycle.LifecycleOwner

--- a/sepa/src/test/java/com/adyen/checkout/sepa/SepaConfigurationTest.kt
+++ b/sepa/src/test/java/com/adyen/checkout/sepa/SepaConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.sepa
 
 import com.adyen.checkout.components.core.Amount

--- a/sepa/src/test/java/com/adyen/checkout/sepa/internal/ui/DefaultSepaDelegateTest.kt
+++ b/sepa/src/test/java/com/adyen/checkout/sepa/internal/ui/DefaultSepaDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 21/7/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.sepa.internal.ui
 
 import app.cash.turbine.test

--- a/seven-eleven/src/main/java/com/adyen/checkout/seveneleven/SevenElevenComponent.kt
+++ b/seven-eleven/src/main/java/com/adyen/checkout/seveneleven/SevenElevenComponent.kt
@@ -21,6 +21,10 @@ import com.adyen.checkout.seveneleven.internal.provider.SevenElevenComponentProv
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.ECONTEXT_SEVEN_ELEVEN] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class SevenElevenComponent internal constructor(
     delegate: EContextDelegate<SevenElevenPaymentMethod, SevenElevenComponentState>,
     genericActionDelegate: GenericActionDelegate,

--- a/seven-eleven/src/main/java/com/adyen/checkout/seveneleven/SevenElevenComponentState.kt
+++ b/seven-eleven/src/main/java/com/adyen/checkout/seveneleven/SevenElevenComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.SevenElevenPaymentMethod
 /**
  * Represents the state of [SevenElevenComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class SevenElevenComponentState(
     override val data: PaymentComponentData<SevenElevenPaymentMethod>,
     override val isInputValid: Boolean,

--- a/seven-eleven/src/main/java/com/adyen/checkout/seveneleven/SevenElevenConfiguration.kt
+++ b/seven-eleven/src/main/java/com/adyen/checkout/seveneleven/SevenElevenConfiguration.kt
@@ -23,6 +23,10 @@ import java.util.Locale
 /**
  * Configuration class for the [SevenElevenComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("LongParameterList")
 @Parcelize
 class SevenElevenConfiguration private constructor(
@@ -38,6 +42,10 @@ class SevenElevenConfiguration private constructor(
     /**
      * Builder to create a [SevenElevenConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : EContextConfiguration.Builder<SevenElevenConfiguration, Builder> {
 
         /**
@@ -97,6 +105,10 @@ class SevenElevenConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.sevenEleven(
     configuration: @CheckoutConfigurationMarker SevenElevenConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/seven-eleven/src/test/java/com/adyen/checkout/seveneleven/SevenElevenConfigurationTest.kt
+++ b/seven-eleven/src/test/java/com/adyen/checkout/seveneleven/SevenElevenConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.seveneleven
 
 import com.adyen.checkout.components.core.Amount

--- a/twint-action/src/main/java/com/adyen/checkout/twint/action/TwintActionComponent.kt
+++ b/twint-action/src/main/java/com/adyen/checkout/twint/action/TwintActionComponent.kt
@@ -27,6 +27,10 @@ import kotlinx.coroutines.flow.Flow
 /**
  * An [ActionComponent] that is able to handle the 'twint' action.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class TwintActionComponent internal constructor(
     override val delegate: TwintActionDelegate,
     internal val actionComponentEventHandler: ActionComponentEventHandler,

--- a/twint-action/src/main/java/com/adyen/checkout/twint/action/TwintActionConfiguration.kt
+++ b/twint-action/src/main/java/com/adyen/checkout/twint/action/TwintActionConfiguration.kt
@@ -22,6 +22,10 @@ import java.util.Locale
 /**
  * Configuration class for the [TwintActionComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class TwintActionConfiguration private constructor(
     override val shopperLocale: Locale?,
@@ -31,6 +35,10 @@ class TwintActionConfiguration private constructor(
     override val amount: Amount?,
 ) : Configuration {
 
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : BaseConfigurationBuilder<TwintActionConfiguration, Builder> {
 
         /**
@@ -89,6 +97,10 @@ class TwintActionConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.twintAction(
     configuration: @CheckoutConfigurationMarker TwintActionConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/twint-action/src/test/java/com/adyen/checkout/twint/action/TwintActionComponentTest.kt
+++ b/twint-action/src/test/java/com/adyen/checkout/twint/action/TwintActionComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 9/7/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.twint.action
 
 import android.app.Activity

--- a/twint-action/src/test/java/com/adyen/checkout/twint/action/TwintActionConfigurationTest.kt
+++ b/twint-action/src/test/java/com/adyen/checkout/twint/action/TwintActionConfigurationTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 9/7/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.twint.action
 
 import com.adyen.checkout.components.core.Amount

--- a/twint-action/src/test/java/com/adyen/checkout/twint/action/internal/ui/DefaultTwintActionDelegateTest.kt
+++ b/twint-action/src/test/java/com/adyen/checkout/twint/action/internal/ui/DefaultTwintActionDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 9/7/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.twint.action.internal.ui
 
 import android.app.Activity

--- a/twint/src/main/java/com/adyen/checkout/twint/TwintComponent.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/TwintComponent.kt
@@ -35,6 +35,10 @@ import kotlinx.coroutines.flow.Flow
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.TWINT] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class TwintComponent internal constructor(
     private val twintDelegate: TwintDelegate,
     private val genericActionDelegate: GenericActionDelegate,

--- a/twint/src/main/java/com/adyen/checkout/twint/TwintComponentState.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/TwintComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.TwintPaymentMethod
 /**
  * Represents the state of [TwintComponentState]
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class TwintComponentState(
     override val data: PaymentComponentData<TwintPaymentMethod>,
     override val isInputValid: Boolean,

--- a/twint/src/main/java/com/adyen/checkout/twint/TwintConfiguration.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/TwintConfiguration.kt
@@ -27,6 +27,10 @@ import java.util.Locale
 /**
  * Configuration class for the [TwintComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class TwintConfiguration
 @Suppress("LongParameterList")
@@ -42,6 +46,10 @@ private constructor(
     val actionHandlingMethod: ActionHandlingMethod?,
 ) : Configuration, ButtonConfiguration {
 
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder :
         ActionHandlingPaymentMethodConfigurationBuilder<TwintConfiguration, Builder>,
         ButtonConfigurationBuilder {
@@ -146,6 +154,10 @@ private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.twint(
     configuration: @CheckoutConfigurationMarker TwintConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/twint/src/test/java/com/adyen/checkout/twint/TwintComponentTest.kt
+++ b/twint/src/test/java/com/adyen/checkout/twint/TwintComponentTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.twint
 
 import androidx.lifecycle.LifecycleOwner

--- a/twint/src/test/java/com/adyen/checkout/twint/TwintConfigurationTest.kt
+++ b/twint/src/test/java/com/adyen/checkout/twint/TwintConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.twint
 
 import com.adyen.checkout.components.core.ActionHandlingMethod

--- a/twint/src/test/java/com/adyen/checkout/twint/internal/ui/DefaultTwintDelegateTest.kt
+++ b/twint/src/test/java/com/adyen/checkout/twint/internal/ui/DefaultTwintDelegateTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.twint.internal.ui
 
 import com.adyen.checkout.components.core.ActionHandlingMethod

--- a/twint/src/test/java/com/adyen/checkout/twint/internal/ui/StoredTwintDelegateTest.kt
+++ b/twint/src/test/java/com/adyen/checkout/twint/internal/ui/StoredTwintDelegateTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.twint.internal.ui
 
 import com.adyen.checkout.components.core.Amount

--- a/twint/src/test/java/com/adyen/checkout/twint/internal/ui/model/TwintComponentParamsMapperTest.kt
+++ b/twint/src/test/java/com/adyen/checkout/twint/internal/ui/model/TwintComponentParamsMapperTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.twint.internal.ui.model
 
 import com.adyen.checkout.components.core.ActionHandlingMethod

--- a/upi/src/main/java/com/adyen/checkout/upi/UPIComponent.kt
+++ b/upi/src/main/java/com/adyen/checkout/upi/UPIComponent.kt
@@ -35,6 +35,10 @@ import kotlinx.coroutines.flow.Flow
  * A [PaymentComponent] that supports the [PaymentMethodTypes.UPI], [PaymentMethodTypes.UPI_COLLECT] and
  * [PaymentMethodTypes.UPI_QR] payment methods.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class UPIComponent internal constructor(
     private val upiDelegate: UPIDelegate,
     private val genericActionDelegate: GenericActionDelegate,

--- a/upi/src/main/java/com/adyen/checkout/upi/UPIComponentState.kt
+++ b/upi/src/main/java/com/adyen/checkout/upi/UPIComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.UPIPaymentMethod
 /**
  * Represents the state of [UPIComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class UPIComponentState(
     override val data: PaymentComponentData<UPIPaymentMethod>,
     override val isInputValid: Boolean,

--- a/upi/src/main/java/com/adyen/checkout/upi/UPIConfiguration.kt
+++ b/upi/src/main/java/com/adyen/checkout/upi/UPIConfiguration.kt
@@ -25,6 +25,10 @@ import java.util.Locale
 /**
  * Configuration class for the [UPIComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class UPIConfiguration(
@@ -40,6 +44,10 @@ class UPIConfiguration(
     /**
      * Builder to create a [UPIConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder :
         ActionHandlingPaymentMethodConfigurationBuilder<UPIConfiguration, Builder>,
         ButtonConfigurationBuilder {
@@ -113,6 +121,10 @@ class UPIConfiguration(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.upi(
     configuration: @CheckoutConfigurationMarker UPIConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/upi/src/test/java/com/adyen/checkout/upi/UPIComponentTest.kt
+++ b/upi/src/test/java/com/adyen/checkout/upi/UPIComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 28/2/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.upi
 
 import androidx.lifecycle.LifecycleOwner

--- a/upi/src/test/java/com/adyen/checkout/upi/UPIConfigurationTest.kt
+++ b/upi/src/test/java/com/adyen/checkout/upi/UPIConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.upi
 
 import com.adyen.checkout.components.core.Amount

--- a/upi/src/test/java/com/adyen/checkout/upi/internal/ui/AppDataUtilsTest.kt
+++ b/upi/src/test/java/com/adyen/checkout/upi/internal/ui/AppDataUtilsTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 27/5/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.upi.internal.ui
 
 import com.adyen.checkout.components.core.AppData

--- a/upi/src/test/java/com/adyen/checkout/upi/internal/ui/DefaultUPIDelegateTest.kt
+++ b/upi/src/test/java/com/adyen/checkout/upi/internal/ui/DefaultUPIDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 28/2/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.upi.internal.ui
 
 import app.cash.turbine.test

--- a/upi/src/test/java/com/adyen/checkout/upi/internal/ui/model/UPISelectedModeTest.kt
+++ b/upi/src/test/java/com/adyen/checkout/upi/internal/ui/model/UPISelectedModeTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 27/5/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.upi.internal.ui.model
 
 import com.adyen.checkout.core.old.Environment

--- a/voucher/src/main/java/com/adyen/checkout/voucher/VoucherComponent.kt
+++ b/voucher/src/main/java/com/adyen/checkout/voucher/VoucherComponent.kt
@@ -28,6 +28,10 @@ import kotlinx.coroutines.flow.Flow
 /**
  * An [ActionComponent] that is able to handle the 'voucher' action.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class VoucherComponent internal constructor(
     override val delegate: VoucherDelegate,
     internal val actionComponentEventHandler: ActionComponentEventHandler,

--- a/voucher/src/main/java/com/adyen/checkout/voucher/VoucherConfiguration.kt
+++ b/voucher/src/main/java/com/adyen/checkout/voucher/VoucherConfiguration.kt
@@ -22,6 +22,10 @@ import java.util.Locale
 /**
  * Configuration class for the [VoucherComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class VoucherConfiguration private constructor(
     override val shopperLocale: Locale?,
@@ -34,6 +38,10 @@ class VoucherConfiguration private constructor(
     /**
      * Builder to create a [VoucherConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : BaseConfigurationBuilder<VoucherConfiguration, Builder> {
 
         /**
@@ -91,6 +99,10 @@ class VoucherConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.voucher(
     configuration: @CheckoutConfigurationMarker VoucherConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/voucher/src/test/java/com/adyen/checkout/voucher/VoucherComponentTest.kt
+++ b/voucher/src/test/java/com/adyen/checkout/voucher/VoucherComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 19/12/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.voucher
 
 import android.app.Activity

--- a/voucher/src/test/java/com/adyen/checkout/voucher/VoucherConfigurationTest.kt
+++ b/voucher/src/test/java/com/adyen/checkout/voucher/VoucherConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.voucher
 
 import com.adyen.checkout.components.core.Amount

--- a/voucher/src/test/java/com/adyen/checkout/voucher/internal/ui/DefaultVoucherDelegateTest.kt
+++ b/voucher/src/test/java/com/adyen/checkout/voucher/internal/ui/DefaultVoucherDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 23/8/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.voucher.internal.ui
 
 import android.app.Activity

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionComponent.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionComponent.kt
@@ -29,6 +29,10 @@ import kotlinx.coroutines.flow.Flow
 /**
  * An [ActionComponent] that is able to handle the 'sdk' action.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class WeChatPayActionComponent internal constructor(
     override val delegate: WeChatDelegate,
     internal val actionComponentEventHandler: ActionComponentEventHandler,

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionConfiguration.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayActionConfiguration.kt
@@ -21,6 +21,10 @@ import java.util.Locale
 /**
  * Configuration class for the [WeChatPayActionComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class WeChatPayActionConfiguration private constructor(
     override val shopperLocale: Locale?,
@@ -33,6 +37,10 @@ class WeChatPayActionConfiguration private constructor(
     /**
      * Builder to create a [WeChatPayActionConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : BaseConfigurationBuilder<WeChatPayActionConfiguration, Builder> {
 
         /**
@@ -90,6 +98,10 @@ class WeChatPayActionConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.weChatPayAction(
     configuration: @CheckoutConfigurationMarker WeChatPayActionConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayProvider.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayProvider.kt
@@ -22,6 +22,10 @@ import com.tencent.mm.opensdk.openapi.WXAPIFactory
  * You can directly call /payments after you receive a callback from [isAvailable].
  * You can use [WeChatPayActionComponent] to handle the returned action.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class WeChatPayProvider : PaymentMethodAvailabilityCheck<WeChatPayActionConfiguration> {
 
     override fun isAvailable(

--- a/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayUtils.kt
+++ b/wechatpay/src/main/java/com/adyen/checkout/wechatpay/WeChatPayUtils.kt
@@ -9,6 +9,10 @@ package com.adyen.checkout.wechatpay
 
 import android.content.Intent
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 object WeChatPayUtils {
 
     private const val RESULT_EXTRA_KEY = "_wxapi_baseresp_errstr"

--- a/wechatpay/src/test/java/com/adyen/checkout/wechatpay/WeChatPayActionComponentTest.kt
+++ b/wechatpay/src/test/java/com/adyen/checkout/wechatpay/WeChatPayActionComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 19/12/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.wechatpay
 
 import android.app.Activity

--- a/wechatpay/src/test/java/com/adyen/checkout/wechatpay/WeChatPayActionConfigurationTest.kt
+++ b/wechatpay/src/test/java/com/adyen/checkout/wechatpay/WeChatPayActionConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.wechatpay
 
 import com.adyen.checkout.components.core.Amount

--- a/wechatpay/src/test/java/com/adyen/checkout/wechatpay/internal/ui/DefaultWeChatDelegateTest.kt
+++ b/wechatpay/src/test/java/com/adyen/checkout/wechatpay/internal/ui/DefaultWeChatDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 19/8/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.wechatpay.internal.ui
 
 import android.app.Activity


### PR DESCRIPTION
## Description

Deprecate all v5 public classes with `@Deprecated` annotations to prepare for the v6 release.
Deprecated code will be removed before the v6 production release.

This PR covers the 34 v5-only payment method modules (Phase 15 of the deprecation plan).

### Progress

✅ Phase 1 — [checkout-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2707)
✅ Phase 2 — [ui-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2708)
✅ Phase 3 — [card (.old packages)](https://github.com/Adyen/adyen-android/pull/2709)
✅ Phase 4 — [googlepay (.old packages)](https://github.com/Adyen/adyen-android/pull/2711)
✅ Phase 5 — [drop-in (.old packages)](https://github.com/Adyen/adyen-android/pull/2712)
✅ Phase 6 — [3ds2 (.old packages)](https://github.com/Adyen/adyen-android/pull/2713)
✅ Phase 7 — [mbway (.old packages)](https://github.com/Adyen/adyen-android/pull/2714)
✅ Phase 8 — [blik (.old packages)](https://github.com/Adyen/adyen-android/pull/2715)
✅ Phase 9 — [await (.old packages)](https://github.com/Adyen/adyen-android/pull/2716)
✅ Phase 10 — [redirect (.old packages)](https://github.com/Adyen/adyen-android/pull/2726)
✅ Phase 11 — [components-core (entire v5 module)](https://github.com/Adyen/adyen-android/pull/2727)
✅ Phase 12 — [action-core (entire v5 module)](https://github.com/Adyen/adyen-android/pull/2729)
✅ Phase 13 — [sessions-core (entire v5 module)](https://github.com/Adyen/adyen-android/pull/2730)
✅ Phase 14 — [action, components-compose, drop-in-compose (v5 utility modules)](https://github.com/Adyen/adyen-android/pull/2731)
➡️ **Phase 15 — 34 v5-only payment method modules**

## Ticket Number
COSDK-1121