### PR TITLE
v6 - Deprecate old public classes - simple payment method modules

### DIFF
--- a/convenience-stores-jp/src/main/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPComponent.kt
+++ b/convenience-stores-jp/src/main/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPComponent.kt
@@ -21,6 +21,10 @@ import com.adyen.checkout.econtext.internal.ui.EContextDelegate
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.ECONTEXT_STORES] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class ConvenienceStoresJPComponent internal constructor(
     delegate: EContextDelegate<ConvenienceStoresJPPaymentMethod, ConvenienceStoresJPComponentState>,
     genericActionDelegate: GenericActionDelegate,

--- a/convenience-stores-jp/src/main/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPComponentState.kt
+++ b/convenience-stores-jp/src/main/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.ConvenienceStoresJPPayme
 /**
  * Represents the state of [ConvenienceStoresJPComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class ConvenienceStoresJPComponentState(
     override val data: PaymentComponentData<ConvenienceStoresJPPaymentMethod>,
     override val isInputValid: Boolean,

--- a/convenience-stores-jp/src/main/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPConfiguration.kt
+++ b/convenience-stores-jp/src/main/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPConfiguration.kt
@@ -23,6 +23,10 @@ import java.util.Locale
 /**
  * Configuration class for the [ConvenienceStoresJPComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("LongParameterList")
 @Parcelize
 class ConvenienceStoresJPConfiguration private constructor(
@@ -38,6 +42,10 @@ class ConvenienceStoresJPConfiguration private constructor(
     /**
      * Builder to create a [ConvenienceStoresJPConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : EContextConfiguration.Builder<ConvenienceStoresJPConfiguration, Builder> {
 
         /**
@@ -97,6 +105,10 @@ class ConvenienceStoresJPConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.convenienceStoresJP(
     configuration: @CheckoutConfigurationMarker ConvenienceStoresJPConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/convenience-stores-jp/src/test/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPConfigurationTest.kt
+++ b/convenience-stores-jp/src/test/java/com/adyen/checkout/conveniencestoresjp/ConvenienceStoresJPConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.conveniencestoresjp
 
 import com.adyen.checkout.components.core.Amount

--- a/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayComponent.kt
+++ b/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayComponent.kt
@@ -20,6 +20,10 @@ import com.adyen.checkout.issuerlist.internal.ui.IssuerListDelegate
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.DOTPAY] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class DotpayComponent internal constructor(
     delegate: IssuerListDelegate<DotpayPaymentMethod, DotpayComponentState>,
     genericActionDelegate: GenericActionDelegate,

--- a/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayComponentState.kt
+++ b/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.DotpayPaymentMethod
 /**
  * Represents the state of [DotpayComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class DotpayComponentState(
     override val data: PaymentComponentData<DotpayPaymentMethod>,
     override val isInputValid: Boolean,

--- a/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayConfiguration.kt
+++ b/dotpay/src/main/java/com/adyen/checkout/dotpay/DotpayConfiguration.kt
@@ -23,6 +23,10 @@ import java.util.Locale
 /**
  * Configuration class for the [DotpayComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class DotpayConfiguration private constructor(
@@ -40,6 +44,10 @@ class DotpayConfiguration private constructor(
     /**
      * Builder to create a [DotpayConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : IssuerListBuilder<DotpayConfiguration, Builder> {
 
         /**
@@ -101,6 +109,10 @@ class DotpayConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.dotpay(
     configuration: @CheckoutConfigurationMarker DotpayConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/dotpay/src/test/java/com/adyen/checkout/dotpay/DotpayConfigurationTest.kt
+++ b/dotpay/src/test/java/com/adyen/checkout/dotpay/DotpayConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.dotpay
 
 import com.adyen.checkout.components.core.Amount

--- a/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextComponent.kt
+++ b/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextComponent.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 13/2/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.econtext
 
 import com.adyen.checkout.action.core.internal.DefaultActionHandlingComponent

--- a/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextComponentState.kt
+++ b/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextComponentState.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 21/2/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.econtext
 
 import com.adyen.checkout.components.core.PaymentComponentData

--- a/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextConfiguration.kt
+++ b/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextConfiguration.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 25/1/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.econtext
 
 import com.adyen.checkout.action.core.GenericActionConfiguration

--- a/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextPaymentMethod.kt
+++ b/econtext/src/test/java/com/adyen/checkout/econtext/TestEContextPaymentMethod.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 25/1/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.econtext
 
 import android.os.Parcel

--- a/econtext/src/test/java/com/adyen/checkout/econtext/internal/EContextComponentTest.kt
+++ b/econtext/src/test/java/com/adyen/checkout/econtext/internal/EContextComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 13/2/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.econtext.internal
 
 import androidx.lifecycle.LifecycleOwner

--- a/econtext/src/test/java/com/adyen/checkout/econtext/internal/ui/DefaultEContextDelegateTest.kt
+++ b/econtext/src/test/java/com/adyen/checkout/econtext/internal/ui/DefaultEContextDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 25/1/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.econtext.internal.ui
 
 import app.cash.turbine.test

--- a/entercash/src/main/java/com/adyen/checkout/entercash/EntercashComponent.kt
+++ b/entercash/src/main/java/com/adyen/checkout/entercash/EntercashComponent.kt
@@ -20,6 +20,10 @@ import com.adyen.checkout.issuerlist.internal.ui.IssuerListDelegate
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.ENTERCASH] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class EntercashComponent internal constructor(
     delegate: IssuerListDelegate<EntercashPaymentMethod, EntercashComponentState>,
     genericActionDelegate: GenericActionDelegate,

--- a/entercash/src/main/java/com/adyen/checkout/entercash/EntercashComponentState.kt
+++ b/entercash/src/main/java/com/adyen/checkout/entercash/EntercashComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.EntercashPaymentMethod
 /**
  * Represents the state of [EntercashComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class EntercashComponentState(
     override val data: PaymentComponentData<EntercashPaymentMethod>,
     override val isInputValid: Boolean,

--- a/entercash/src/main/java/com/adyen/checkout/entercash/EntercashConfiguration.kt
+++ b/entercash/src/main/java/com/adyen/checkout/entercash/EntercashConfiguration.kt
@@ -23,6 +23,10 @@ import java.util.Locale
 /**
  * Configuration class for the [EntercashComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class EntercashConfiguration private constructor(
@@ -40,6 +44,10 @@ class EntercashConfiguration private constructor(
     /**
      * Builder to create an [EntercashConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : IssuerListBuilder<EntercashConfiguration, Builder> {
 
         /**
@@ -101,6 +109,10 @@ class EntercashConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.entercash(
     configuration: @CheckoutConfigurationMarker EntercashConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/entercash/src/test/java/com/adyen/checkout/entercash/EntercashConfigurationTest.kt
+++ b/entercash/src/test/java/com/adyen/checkout/entercash/EntercashConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.entercash
 
 import com.adyen.checkout.components.core.Amount

--- a/eps/src/main/java/com/adyen/checkout/eps/EPSComponent.kt
+++ b/eps/src/main/java/com/adyen/checkout/eps/EPSComponent.kt
@@ -20,6 +20,10 @@ import com.adyen.checkout.issuerlist.internal.ui.IssuerListDelegate
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.EPS] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class EPSComponent internal constructor(
     delegate: IssuerListDelegate<EPSPaymentMethod, EPSComponentState>,
     genericActionDelegate: GenericActionDelegate,

--- a/eps/src/main/java/com/adyen/checkout/eps/EPSComponentState.kt
+++ b/eps/src/main/java/com/adyen/checkout/eps/EPSComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.EPSPaymentMethod
 /**
  * Represents the state of [EPSComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class EPSComponentState(
     override val data: PaymentComponentData<EPSPaymentMethod>,
     override val isInputValid: Boolean,

--- a/eps/src/main/java/com/adyen/checkout/eps/EPSConfiguration.kt
+++ b/eps/src/main/java/com/adyen/checkout/eps/EPSConfiguration.kt
@@ -23,6 +23,10 @@ import java.util.Locale
 /**
  * Configuration class for the [EPSComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class EPSConfiguration private constructor(
@@ -40,6 +44,10 @@ class EPSConfiguration private constructor(
     /**
      * Builder to create an [EPSConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : IssuerListBuilder<EPSConfiguration, Builder> {
 
         /**
@@ -112,6 +120,10 @@ class EPSConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.eps(
     configuration: @CheckoutConfigurationMarker EPSConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/eps/src/test/java/com/adyen/checkout/eps/EPSConfigurationTest.kt
+++ b/eps/src/test/java/com/adyen/checkout/eps/EPSConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.eps
 
 import com.adyen.checkout.components.core.Amount

--- a/molpay/src/main/java/com/adyen/checkout/molpay/MolpayComponent.kt
+++ b/molpay/src/main/java/com/adyen/checkout/molpay/MolpayComponent.kt
@@ -21,6 +21,10 @@ import com.adyen.checkout.molpay.internal.provider.MolpayComponentProvider
  * A [PaymentComponent] that supports the [PaymentMethodTypes.MOLPAY_MALAYSIA], [PaymentMethodTypes.MOLPAY_THAILAND]
  * and [PaymentMethodTypes.MOLPAY_VIETNAM] payment methods.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class MolpayComponent internal constructor(
     delegate: IssuerListDelegate<MolpayPaymentMethod, MolpayComponentState>,
     genericActionDelegate: GenericActionDelegate,

--- a/molpay/src/main/java/com/adyen/checkout/molpay/MolpayComponentState.kt
+++ b/molpay/src/main/java/com/adyen/checkout/molpay/MolpayComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.MolpayPaymentMethod
 /**
  * Represents the state of [MolpayComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class MolpayComponentState(
     override val data: PaymentComponentData<MolpayPaymentMethod>,
     override val isInputValid: Boolean,

--- a/molpay/src/main/java/com/adyen/checkout/molpay/MolpayConfiguration.kt
+++ b/molpay/src/main/java/com/adyen/checkout/molpay/MolpayConfiguration.kt
@@ -22,6 +22,10 @@ import java.util.Locale
 /**
  * Configuration class for the [MolpayComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class MolpayConfiguration private constructor(
@@ -39,6 +43,10 @@ class MolpayConfiguration private constructor(
     /**
      * Builder to create a [MolpayConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : IssuerListBuilder<MolpayConfiguration, Builder> {
 
         /**
@@ -100,6 +108,10 @@ class MolpayConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.molpay(
     configuration: @CheckoutConfigurationMarker MolpayConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/molpay/src/test/java/com/adyen/checkout/molpay/MolpayConfigurationTest.kt
+++ b/molpay/src/test/java/com/adyen/checkout/molpay/MolpayConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.molpay
 
 import com.adyen.checkout.components.core.Amount

--- a/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZComponent.kt
+++ b/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZComponent.kt
@@ -21,6 +21,10 @@ import com.adyen.checkout.onlinebankingcz.internal.provider.OnlineBankingCZCompo
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.ONLINE_BANKING_CZ] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class OnlineBankingCZComponent internal constructor(
     delegate: OnlineBankingDelegate<OnlineBankingCZPaymentMethod, OnlineBankingCZComponentState>,
     genericActionDelegate: GenericActionDelegate,

--- a/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZComponentState.kt
+++ b/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.OnlineBankingCZPaymentMe
 /**
  * Represents the state of [OnlineBankingCZComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class OnlineBankingCZComponentState(
     override val data: PaymentComponentData<OnlineBankingCZPaymentMethod>,
     override val isInputValid: Boolean,

--- a/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZConfiguration.kt
+++ b/online-banking-cz/src/main/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZConfiguration.kt
@@ -23,6 +23,10 @@ import java.util.Locale
 /**
  * Configuration class for the [OnlineBankingCZComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("LongParameterList")
 @Parcelize
 class OnlineBankingCZConfiguration private constructor(
@@ -38,6 +42,10 @@ class OnlineBankingCZConfiguration private constructor(
     /**
      * Builder to create an [OnlineBankingCZConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : OnlineBankingConfigurationBuilder<OnlineBankingCZConfiguration, Builder> {
 
         /**
@@ -97,6 +105,10 @@ class OnlineBankingCZConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.onlineBankingCZ(
     configuration: @CheckoutConfigurationMarker OnlineBankingCZConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/online-banking-cz/src/test/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZConfigurationTest.kt
+++ b/online-banking-cz/src/test/java/com/adyen/checkout/onlinebankingcz/OnlineBankingCZConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.onlinebankingcz
 
 import com.adyen.checkout.components.core.Amount

--- a/online-banking-jp/src/main/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPComponent.kt
+++ b/online-banking-jp/src/main/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPComponent.kt
@@ -21,6 +21,10 @@ import com.adyen.checkout.onlinebankingjp.internal.provider.OnlineBankingJPCompo
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.ECONTEXT_ONLINE] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class OnlineBankingJPComponent internal constructor(
     delegate: EContextDelegate<OnlineBankingJPPaymentMethod, OnlineBankingJPComponentState>,
     genericActionDelegate: GenericActionDelegate,

--- a/online-banking-jp/src/main/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPComponentState.kt
+++ b/online-banking-jp/src/main/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.OnlineBankingJPPaymentMe
 /**
  * Represents the state of [OnlineBankingJPComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class OnlineBankingJPComponentState(
     override val data: PaymentComponentData<OnlineBankingJPPaymentMethod>,
     override val isInputValid: Boolean,

--- a/online-banking-jp/src/main/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPConfiguration.kt
+++ b/online-banking-jp/src/main/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPConfiguration.kt
@@ -23,6 +23,10 @@ import java.util.Locale
 /**
  * Configuration class for the [OnlineBankingJPComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("LongParameterList")
 @Parcelize
 class OnlineBankingJPConfiguration private constructor(
@@ -38,6 +42,10 @@ class OnlineBankingJPConfiguration private constructor(
     /**
      * Builder to create an [OnlineBankingJPConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : EContextConfiguration.Builder<OnlineBankingJPConfiguration, Builder> {
 
         /**
@@ -97,6 +105,10 @@ class OnlineBankingJPConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.onlineBankingJP(
     configuration: @CheckoutConfigurationMarker OnlineBankingJPConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/online-banking-jp/src/test/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPConfigurationTest.kt
+++ b/online-banking-jp/src/test/java/com/adyen/checkout/onlinebankingjp/OnlineBankingJPConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.onlinebankingjp
 
 import com.adyen.checkout.components.core.Amount

--- a/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLComponent.kt
+++ b/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLComponent.kt
@@ -21,6 +21,10 @@ import com.adyen.checkout.onlinebankingpl.internal.provider.OnlineBankingPLCompo
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.ONLINE_BANKING_PL] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class OnlineBankingPLComponent internal constructor(
     delegate: IssuerListDelegate<OnlineBankingPLPaymentMethod, OnlineBankingPLComponentState>,
     genericActionDelegate: GenericActionDelegate,

--- a/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLComponentState.kt
+++ b/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.OnlineBankingPLPaymentMe
 /**
  * Represents the state of [OnlineBankingPLComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class OnlineBankingPLComponentState(
     override val data: PaymentComponentData<OnlineBankingPLPaymentMethod>,
     override val isInputValid: Boolean,

--- a/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLConfiguration.kt
+++ b/online-banking-pl/src/main/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLConfiguration.kt
@@ -24,6 +24,10 @@ import java.util.Locale
 /**
  * Configuration class for the [OnlineBankingPLComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class OnlineBankingPLConfiguration private constructor(
@@ -41,6 +45,10 @@ class OnlineBankingPLConfiguration private constructor(
     /**
      * Builder to create an [OnlineBankingPLConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : IssuerListBuilder<OnlineBankingPLConfiguration, Builder> {
 
         /**
@@ -102,6 +110,10 @@ class OnlineBankingPLConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.onlineBankingPL(
     configuration: @CheckoutConfigurationMarker OnlineBankingPLConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/online-banking-pl/src/test/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLConfigurationTest.kt
+++ b/online-banking-pl/src/test/java/com/adyen/checkout/onlinebankingpl/OnlineBankingPLConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.onlinebankingpl
 
 import com.adyen.checkout.components.core.Amount

--- a/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKComponent.kt
+++ b/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKComponent.kt
@@ -21,6 +21,10 @@ import com.adyen.checkout.onlinebankingsk.internal.provider.OnlineBankingSKCompo
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.ONLINE_BANKING_SK] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class OnlineBankingSKComponent internal constructor(
     delegate: OnlineBankingDelegate<OnlineBankingSKPaymentMethod, OnlineBankingSKComponentState>,
     genericActionDelegate: GenericActionDelegate,

--- a/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKComponentState.kt
+++ b/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.OnlineBankingSKPaymentMe
 /**
  * Represents the state of [OnlineBankingSKComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class OnlineBankingSKComponentState(
     override val data: PaymentComponentData<OnlineBankingSKPaymentMethod>,
     override val isInputValid: Boolean,

--- a/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKConfiguration.kt
+++ b/online-banking-sk/src/main/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKConfiguration.kt
@@ -23,6 +23,10 @@ import java.util.Locale
 /**
  * Configuration class for the [OnlineBankingSKComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("LongParameterList")
 @Parcelize
 class OnlineBankingSKConfiguration private constructor(
@@ -38,6 +42,10 @@ class OnlineBankingSKConfiguration private constructor(
     /**
      * Builder to create an [OnlineBankingSKConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : OnlineBankingConfigurationBuilder<OnlineBankingSKConfiguration, Builder> {
 
         /**
@@ -97,6 +105,10 @@ class OnlineBankingSKConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.onlineBankingSK(
     configuration: @CheckoutConfigurationMarker OnlineBankingSKConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/online-banking-sk/src/test/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKConfigurationTest.kt
+++ b/online-banking-sk/src/test/java/com/adyen/checkout/onlinebankingsk/OnlineBankingSKConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.onlinebankingsk
 
 import com.adyen.checkout.components.core.Amount

--- a/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingComponent.kt
+++ b/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingComponent.kt
@@ -20,6 +20,10 @@ import com.adyen.checkout.openbanking.internal.provider.OpenBankingComponentProv
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.OPEN_BANKING] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class OpenBankingComponent internal constructor(
     delegate: IssuerListDelegate<OpenBankingPaymentMethod, OpenBankingComponentState>,
     genericActionDelegate: GenericActionDelegate,

--- a/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingComponentState.kt
+++ b/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.OpenBankingPaymentMethod
 /**
  * Represents the state of [OpenBankingComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class OpenBankingComponentState(
     override val data: PaymentComponentData<OpenBankingPaymentMethod>,
     override val isInputValid: Boolean,

--- a/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingConfiguration.kt
+++ b/openbanking/src/main/java/com/adyen/checkout/openbanking/OpenBankingConfiguration.kt
@@ -23,6 +23,10 @@ import java.util.Locale
 /**
  * Configuration class for the [OpenBankingComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class OpenBankingConfiguration private constructor(
@@ -40,6 +44,10 @@ class OpenBankingConfiguration private constructor(
     /**
      * Builder to create an [OpenBankingConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : IssuerListBuilder<OpenBankingConfiguration, Builder> {
 
         /**
@@ -101,6 +109,10 @@ class OpenBankingConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.openBanking(
     configuration: @CheckoutConfigurationMarker OpenBankingConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/openbanking/src/test/java/com/adyen/checkout/openbanking/OpenBankingConfigurationTest.kt
+++ b/openbanking/src/test/java/com/adyen/checkout/openbanking/OpenBankingConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.openbanking
 
 import com.adyen.checkout.components.core.Amount

--- a/payeasy/src/main/java/com/adyen/checkout/payeasy/PayEasyComponent.kt
+++ b/payeasy/src/main/java/com/adyen/checkout/payeasy/PayEasyComponent.kt
@@ -21,6 +21,10 @@ import com.adyen.checkout.payeasy.internal.provider.PayEasyComponentProvider
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.ECONTEXT_ATM] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class PayEasyComponent internal constructor(
     delegate: EContextDelegate<PayEasyPaymentMethod, PayEasyComponentState>,
     genericActionDelegate: GenericActionDelegate,

--- a/payeasy/src/main/java/com/adyen/checkout/payeasy/PayEasyComponentState.kt
+++ b/payeasy/src/main/java/com/adyen/checkout/payeasy/PayEasyComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.PayEasyPaymentMethod
 /**
  * Represents the state of [PayEasyComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class PayEasyComponentState(
     override val data: PaymentComponentData<PayEasyPaymentMethod>,
     override val isInputValid: Boolean,

--- a/payeasy/src/main/java/com/adyen/checkout/payeasy/PayEasyConfiguration.kt
+++ b/payeasy/src/main/java/com/adyen/checkout/payeasy/PayEasyConfiguration.kt
@@ -23,6 +23,10 @@ import java.util.Locale
 /**
  * Configuration class for the [PayEasyComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("LongParameterList")
 @Parcelize
 class PayEasyConfiguration private constructor(
@@ -38,6 +42,10 @@ class PayEasyConfiguration private constructor(
     /**
      * Builder to create a [PayEasyConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : EContextConfiguration.Builder<PayEasyConfiguration, Builder> {
 
         /**
@@ -97,6 +105,10 @@ class PayEasyConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.payEasy(
     configuration: @CheckoutConfigurationMarker PayEasyConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/payeasy/src/test/java/com/adyen/checkout/payeasy/PayEasyConfigurationTest.kt
+++ b/payeasy/src/test/java/com/adyen/checkout/payeasy/PayEasyConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.payeasy
 
 import com.adyen.checkout.components.core.Amount

--- a/seven-eleven/src/main/java/com/adyen/checkout/seveneleven/SevenElevenComponent.kt
+++ b/seven-eleven/src/main/java/com/adyen/checkout/seveneleven/SevenElevenComponent.kt
@@ -21,6 +21,10 @@ import com.adyen.checkout.seveneleven.internal.provider.SevenElevenComponentProv
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.ECONTEXT_SEVEN_ELEVEN] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class SevenElevenComponent internal constructor(
     delegate: EContextDelegate<SevenElevenPaymentMethod, SevenElevenComponentState>,
     genericActionDelegate: GenericActionDelegate,

--- a/seven-eleven/src/main/java/com/adyen/checkout/seveneleven/SevenElevenComponentState.kt
+++ b/seven-eleven/src/main/java/com/adyen/checkout/seveneleven/SevenElevenComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.SevenElevenPaymentMethod
 /**
  * Represents the state of [SevenElevenComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class SevenElevenComponentState(
     override val data: PaymentComponentData<SevenElevenPaymentMethod>,
     override val isInputValid: Boolean,

--- a/seven-eleven/src/main/java/com/adyen/checkout/seveneleven/SevenElevenConfiguration.kt
+++ b/seven-eleven/src/main/java/com/adyen/checkout/seveneleven/SevenElevenConfiguration.kt
@@ -23,6 +23,10 @@ import java.util.Locale
 /**
  * Configuration class for the [SevenElevenComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Suppress("LongParameterList")
 @Parcelize
 class SevenElevenConfiguration private constructor(
@@ -38,6 +42,10 @@ class SevenElevenConfiguration private constructor(
     /**
      * Builder to create a [SevenElevenConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : EContextConfiguration.Builder<SevenElevenConfiguration, Builder> {
 
         /**
@@ -97,6 +105,10 @@ class SevenElevenConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.sevenEleven(
     configuration: @CheckoutConfigurationMarker SevenElevenConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/seven-eleven/src/test/java/com/adyen/checkout/seveneleven/SevenElevenConfigurationTest.kt
+++ b/seven-eleven/src/test/java/com/adyen/checkout/seveneleven/SevenElevenConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.seveneleven
 
 import com.adyen.checkout.components.core.Amount


### PR DESCRIPTION
## Description

Deprecate all v5 public classes with `@Deprecated` annotations to prepare for the v6 release.
Deprecated code will be removed before the v6 production release.

This PR covers 13 simple v5-only payment method modules (Phase 15a of the deprecation plan):
`convenience-stores-jp`, `dotpay`, `econtext`, `entercash`, `eps`, `molpay`, `online-banking-cz`, `online-banking-jp`, `online-banking-pl`, `online-banking-sk`, `openbanking`, `payeasy`, `seven-eleven`.

### Progress

✅ Phase 1 — [checkout-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2707)
✅ Phase 2 — [ui-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2708)
✅ Phase 3 — [card (.old packages)](https://github.com/Adyen/adyen-android/pull/2709)
✅ Phase 4 — [googlepay (.old packages)](https://github.com/Adyen/adyen-android/pull/2711)
✅ Phase 5 — [drop-in (.old packages)](https://github.com/Adyen/adyen-android/pull/2712)
✅ Phase 6 — [3ds2 (.old packages)](https://github.com/Adyen/adyen-android/pull/2713)
✅ Phase 7 — [mbway (.old packages)](https://github.com/Adyen/adyen-android/pull/2714)
✅ Phase 8 — [blik (.old packages)](https://github.com/Adyen/adyen-android/pull/2715)
✅ Phase 9 — [await (.old packages)](https://github.com/Adyen/adyen-android/pull/2716)
✅ Phase 10 — [redirect (.old packages)](https://github.com/Adyen/adyen-android/pull/2726)
✅ Phase 11 — [components-core (entire v5 module)](https://github.com/Adyen/adyen-android/pull/2727)
✅ Phase 12 — [action-core (entire v5 module)](https://github.com/Adyen/adyen-android/pull/2729)
✅ Phase 13 — [sessions-core (entire v5 module)](https://github.com/Adyen/adyen-android/pull/2730)
✅ Phase 14 — [action, components-compose, drop-in-compose (v5 utility modules)](https://github.com/Adyen/adyen-android/pull/2731)
➡️ **Phase 15a — 13 simple v5 payment method modules**
Phase 15b — 16 medium v5 payment method modules
Phase 15c — 5 larger v5 payment method modules

## Ticket Number
COSDK-1121