### PR TITLE
v6 - Deprecate old public classes - larger payment method modules

### DIFF
--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/CashAppPayComponent.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/CashAppPayComponent.kt
@@ -36,6 +36,10 @@ import kotlinx.coroutines.flow.Flow
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.CASH_APP_PAY] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class CashAppPayComponent internal constructor(
     private val cashAppPayDelegate: CashAppPayDelegate,
     private val genericActionDelegate: GenericActionDelegate,

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/CashAppPayComponentState.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/CashAppPayComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.CashAppPayPaymentMethod
 /**
  * Represents the state of [CashAppPayComponent]
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class CashAppPayComponentState(
     override val data: PaymentComponentData<CashAppPayPaymentMethod>,
     override val isInputValid: Boolean,

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/CashAppPayConfiguration.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/CashAppPayConfiguration.kt
@@ -26,6 +26,10 @@ import java.util.Locale
 /**
  * Configuration class for the [CashAppPayComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class CashAppPayConfiguration
 @Suppress("LongParameterList")
@@ -43,6 +47,10 @@ private constructor(
     val storePaymentMethod: Boolean?,
 ) : Configuration, ButtonConfiguration {
 
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder :
         ActionHandlingPaymentMethodConfigurationBuilder<CashAppPayConfiguration, Builder>,
         ButtonConfigurationBuilder {
@@ -184,6 +192,10 @@ private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.cashAppPay(
     configuration: @CheckoutConfigurationMarker CashAppPayConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/cashapppay/src/main/java/com/adyen/checkout/cashapppay/CashAppPayEnvironment.kt
+++ b/cashapppay/src/main/java/com/adyen/checkout/cashapppay/CashAppPayEnvironment.kt
@@ -8,6 +8,10 @@
 
 package com.adyen.checkout.cashapppay
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 enum class CashAppPayEnvironment {
     SANDBOX,
     PRODUCTION,

--- a/cashapppay/src/test/java/com/adyen/checkout/cashapppay/CashAppPayComponentTest.kt
+++ b/cashapppay/src/test/java/com/adyen/checkout/cashapppay/CashAppPayComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 4/7/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.cashapppay
 
 import androidx.lifecycle.LifecycleOwner

--- a/cashapppay/src/test/java/com/adyen/checkout/cashapppay/CashAppPayConfigurationTest.kt
+++ b/cashapppay/src/test/java/com/adyen/checkout/cashapppay/CashAppPayConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.cashapppay
 
 import com.adyen.checkout.components.core.Amount

--- a/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/DefaultCashAppPayDelegateTest.kt
+++ b/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/DefaultCashAppPayDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 5/7/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.cashapppay.internal.ui
 
 import android.app.Application

--- a/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/StoredCashAppPayDelegateTest.kt
+++ b/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/StoredCashAppPayDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 4/7/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.cashapppay.internal.ui
 
 import android.app.Application

--- a/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/model/CashAppPayComponentParamsMapperTest.kt
+++ b/cashapppay/src/test/java/com/adyen/checkout/cashapppay/internal/ui/model/CashAppPayComponentParamsMapperTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 4/7/2023.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.cashapppay.internal.ui.model
 
 import android.app.Application

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardAction.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardAction.kt
@@ -10,6 +10,10 @@ import kotlinx.parcelize.Parcelize
  * in partial payments flow. This class is used to distinguish separate actions that can be taken when submit button
  * is clicked.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @SuppressLint("ObjectInPublicSealedClass")
 @Parcelize
 sealed class GiftCardAction : Parcelable {
@@ -17,20 +21,36 @@ sealed class GiftCardAction : Parcelable {
     /**
      * No action to be taken.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     object Idle : GiftCardAction()
 
     /**
      * Check balance of the partial payment method.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     object CheckBalance : GiftCardAction()
 
     /**
      * Submit the payment.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     object SendPayment : GiftCardAction()
 
     /**
      * Create an order.
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     object CreateOrder : GiftCardAction()
 }

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardComponent.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardComponent.kt
@@ -36,6 +36,10 @@ import kotlinx.coroutines.flow.Flow
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.GIFTCARD] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 open class GiftCardComponent
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 constructor(

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardComponentCallback.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardComponentCallback.kt
@@ -17,6 +17,10 @@ import org.json.JSONObject
 /**
  * Implement this callback to interact with a GiftCardComponent.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 interface GiftCardComponentCallback : ComponentCallback<GiftCardComponentState> {
     /**
      * In this method you should make a network call to the /orders endpoint of the Checkout API through your server.

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardComponentState.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardComponentState.kt
@@ -16,6 +16,10 @@ import kotlinx.parcelize.Parcelize
 /**
  * Represents the state of [GiftCardComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 data class GiftCardComponentState(
     override val data: PaymentComponentData<GiftCardPaymentMethod>,

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardConfiguration.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardConfiguration.kt
@@ -25,6 +25,10 @@ import java.util.Locale
 /**
  * Configuration class for the [GiftCardComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class GiftCardConfiguration private constructor(
@@ -41,6 +45,10 @@ class GiftCardConfiguration private constructor(
     /**
      * Builder to create a [GiftCardConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder :
         ActionHandlingPaymentMethodConfigurationBuilder<GiftCardConfiguration, Builder>,
         ButtonConfigurationBuilder {
@@ -131,6 +139,10 @@ class GiftCardConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.giftCard(
     configuration: @CheckoutConfigurationMarker GiftCardConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardException.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/GiftCardException.kt
@@ -13,4 +13,8 @@ import com.adyen.checkout.core.old.exception.CheckoutException
 /**
  * Exception thrown when an error occurs during a payment flow using Gift Cards.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class GiftCardException(errorMessage: String) : CheckoutException(errorMessage)

--- a/giftcard/src/main/java/com/adyen/checkout/giftcard/SessionsGiftCardComponentCallback.kt
+++ b/giftcard/src/main/java/com/adyen/checkout/giftcard/SessionsGiftCardComponentCallback.kt
@@ -22,6 +22,10 @@ import org.json.JSONObject
 /**
  * Implement this callback to interact with a [GiftCardComponent] initialized with a session.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 interface SessionsGiftCardComponentCallback : SessionComponentCallback<GiftCardComponentState> {
 
     /**

--- a/giftcard/src/test/java/com/adyen/checkout/giftcard/GiftCardComponentTest.kt
+++ b/giftcard/src/test/java/com/adyen/checkout/giftcard/GiftCardComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by josephj on 13/12/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.giftcard
 
 import androidx.lifecycle.LifecycleOwner

--- a/giftcard/src/test/java/com/adyen/checkout/giftcard/GiftCardConfigurationTest.kt
+++ b/giftcard/src/test/java/com/adyen/checkout/giftcard/GiftCardConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.giftcard
 
 import com.adyen.checkout.components.core.Amount

--- a/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/ui/DefaultGiftCardDelegateTest.kt
+++ b/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/ui/DefaultGiftCardDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by oscars on 18/7/2022.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.giftcard.internal.ui
 
 import app.cash.turbine.test

--- a/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/ui/model/GiftCardComponentParamsMapperTest.kt
+++ b/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/ui/model/GiftCardComponentParamsMapperTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.giftcard.internal.ui.model
 
 import com.adyen.checkout.components.core.Amount

--- a/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/util/GiftCardBalanceUtilsTest.kt
+++ b/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/util/GiftCardBalanceUtilsTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.giftcard.internal.util
 
 import com.adyen.checkout.components.core.Amount

--- a/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/util/GiftCardNumberUtilsTest.kt
+++ b/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/util/GiftCardNumberUtilsTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.giftcard.internal.util
 
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/util/GiftCardPinUtilsTest.kt
+++ b/giftcard/src/test/java/com/adyen/checkout/giftcard/internal/util/GiftCardPinUtilsTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 20/8/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.giftcard.internal.util
 
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/paybybank-us/src/main/java/com/adyen/checkout/paybybankus/PayByBankUSComponent.kt
+++ b/paybybank-us/src/main/java/com/adyen/checkout/paybybankus/PayByBankUSComponent.kt
@@ -32,6 +32,10 @@ import kotlinx.coroutines.flow.Flow
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.PAY_BY_BANK_US] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class PayByBankUSComponent internal constructor(
     private val payByBankUSDelegate: PayByBankUSDelegate,
     private val genericActionDelegate: GenericActionDelegate,

--- a/paybybank-us/src/main/java/com/adyen/checkout/paybybankus/PayByBankUSComponentState.kt
+++ b/paybybank-us/src/main/java/com/adyen/checkout/paybybankus/PayByBankUSComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.PayByBankUSPaymentMethod
 /**
  * Represents the state of [PayByBankUSComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class PayByBankUSComponentState(
     override val data: PaymentComponentData<PayByBankUSPaymentMethod>,
     override val isInputValid: Boolean,

--- a/paybybank-us/src/main/java/com/adyen/checkout/paybybankus/PayByBankUSConfiguration.kt
+++ b/paybybank-us/src/main/java/com/adyen/checkout/paybybankus/PayByBankUSConfiguration.kt
@@ -23,6 +23,10 @@ import java.util.Locale
 /**
  * Configuration class for the [PayByBankUSComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class PayByBankUSConfiguration private constructor(
     override val shopperLocale: Locale?,
@@ -33,6 +37,10 @@ class PayByBankUSConfiguration private constructor(
     internal val genericActionConfiguration: GenericActionConfiguration,
 ) : Configuration {
 
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder : ActionHandlingPaymentMethodConfigurationBuilder<PayByBankUSConfiguration, Builder> {
 
         /**
@@ -77,6 +85,10 @@ class PayByBankUSConfiguration private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.payByBankUS(
     configuration: @CheckoutConfigurationMarker PayByBankUSConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/paybybank-us/src/test/java/com/adyen/checkout/paybybankus/PayByBankUSComponentTest.kt
+++ b/paybybank-us/src/test/java/com/adyen/checkout/paybybankus/PayByBankUSComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 5/11/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.paybybankus
 
 import androidx.lifecycle.LifecycleOwner

--- a/paybybank-us/src/test/java/com/adyen/checkout/paybybankus/PayByBankUSConfigurationTest.kt
+++ b/paybybank-us/src/test/java/com/adyen/checkout/paybybankus/PayByBankUSConfigurationTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 24/10/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.paybybankus
 
 import com.adyen.checkout.components.core.Amount

--- a/paybybank-us/src/test/java/com/adyen/checkout/paybybankus/internal/ui/DefaultPayByBankUSDelegateTest.kt
+++ b/paybybank-us/src/test/java/com/adyen/checkout/paybybankus/internal/ui/DefaultPayByBankUSDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 5/11/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.paybybankus.internal.ui
 
 import app.cash.turbine.test

--- a/paybybank-us/src/test/java/com/adyen/checkout/paybybankus/internal/ui/StoredPayByBankUSDelegateTest.kt
+++ b/paybybank-us/src/test/java/com/adyen/checkout/paybybankus/internal/ui/StoredPayByBankUSDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by ozgur on 28/11/2024.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.paybybankus.internal.ui
 
 import com.adyen.checkout.components.core.Amount

--- a/payto/src/main/java/com/adyen/checkout/payto/PayToComponent.kt
+++ b/payto/src/main/java/com/adyen/checkout/payto/PayToComponent.kt
@@ -34,6 +34,10 @@ import kotlinx.coroutines.flow.Flow
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.PAY_TO] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class PayToComponent internal constructor(
     private val payToDelegate: PayToDelegate,
     private val genericActionDelegate: GenericActionDelegate,

--- a/payto/src/main/java/com/adyen/checkout/payto/PayToComponentState.kt
+++ b/payto/src/main/java/com/adyen/checkout/payto/PayToComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.PayToPaymentMethod
 /**
  * Represents the state of [PayToComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class PayToComponentState(
     override val data: PaymentComponentData<PayToPaymentMethod>,
     override val isInputValid: Boolean,

--- a/payto/src/main/java/com/adyen/checkout/payto/PayToConfiguration.kt
+++ b/payto/src/main/java/com/adyen/checkout/payto/PayToConfiguration.kt
@@ -26,6 +26,10 @@ import java.util.Locale
 /**
  * Configuration class for the [PayToComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 @Suppress("LongParameterList")
 class PayToConfiguration(
@@ -41,6 +45,10 @@ class PayToConfiguration(
     /**
      * Builder to create an [PayToConfiguration].
      */
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder :
         ActionHandlingPaymentMethodConfigurationBuilder<PayToConfiguration, Builder>,
         ButtonConfigurationBuilder {
@@ -116,6 +124,10 @@ class PayToConfiguration(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.payTo(
     configuration: @CheckoutConfigurationMarker PayToConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/payto/src/test/java/com/adyen/checkout/payto/PayToComponentTest.kt
+++ b/payto/src/test/java/com/adyen/checkout/payto/PayToComponentTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 3/2/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.payto
 
 import androidx.lifecycle.LifecycleOwner

--- a/payto/src/test/java/com/adyen/checkout/payto/PayToConfigurationTest.kt
+++ b/payto/src/test/java/com/adyen/checkout/payto/PayToConfigurationTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 3/2/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.payto
 
 import com.adyen.checkout.components.core.Amount

--- a/payto/src/test/java/com/adyen/checkout/payto/internal/ui/DefaultPayToDelegateTest.kt
+++ b/payto/src/test/java/com/adyen/checkout/payto/internal/ui/DefaultPayToDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 18/2/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.payto.internal.ui
 
 import app.cash.turbine.test

--- a/payto/src/test/java/com/adyen/checkout/payto/internal/ui/StoredPayToDelegateTest.kt
+++ b/payto/src/test/java/com/adyen/checkout/payto/internal/ui/StoredPayToDelegateTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 25/2/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.payto.internal.ui
 
 import com.adyen.checkout.components.core.Amount

--- a/payto/src/test/java/com/adyen/checkout/payto/internal/util/PayToValidationUtilsTest.kt
+++ b/payto/src/test/java/com/adyen/checkout/payto/internal/util/PayToValidationUtilsTest.kt
@@ -6,6 +6,8 @@
  * Created by ararat on 18/2/2025.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.payto.internal.util
 
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/twint/src/main/java/com/adyen/checkout/twint/TwintComponent.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/TwintComponent.kt
@@ -35,6 +35,10 @@ import kotlinx.coroutines.flow.Flow
 /**
  * A [PaymentComponent] that supports the [PaymentMethodTypes.TWINT] payment method.
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 class TwintComponent internal constructor(
     private val twintDelegate: TwintDelegate,
     private val genericActionDelegate: GenericActionDelegate,

--- a/twint/src/main/java/com/adyen/checkout/twint/TwintComponentState.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/TwintComponentState.kt
@@ -15,6 +15,10 @@ import com.adyen.checkout.components.core.paymentmethod.TwintPaymentMethod
 /**
  * Represents the state of [TwintComponentState]
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 data class TwintComponentState(
     override val data: PaymentComponentData<TwintPaymentMethod>,
     override val isInputValid: Boolean,

--- a/twint/src/main/java/com/adyen/checkout/twint/TwintConfiguration.kt
+++ b/twint/src/main/java/com/adyen/checkout/twint/TwintConfiguration.kt
@@ -27,6 +27,10 @@ import java.util.Locale
 /**
  * Configuration class for the [TwintComponent].
  */
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 @Parcelize
 class TwintConfiguration
 @Suppress("LongParameterList")
@@ -42,6 +46,10 @@ private constructor(
     val actionHandlingMethod: ActionHandlingMethod?,
 ) : Configuration, ButtonConfiguration {
 
+    @Deprecated(
+        message = "Deprecated. This will be removed in a future release.",
+        level = DeprecationLevel.WARNING,
+    )
     class Builder :
         ActionHandlingPaymentMethodConfigurationBuilder<TwintConfiguration, Builder>,
         ButtonConfigurationBuilder {
@@ -146,6 +154,10 @@ private constructor(
     }
 }
 
+@Deprecated(
+    message = "Deprecated. This will be removed in a future release.",
+    level = DeprecationLevel.WARNING,
+)
 fun CheckoutConfiguration.twint(
     configuration: @CheckoutConfigurationMarker TwintConfiguration.Builder.() -> Unit = {}
 ): CheckoutConfiguration {

--- a/twint/src/test/java/com/adyen/checkout/twint/TwintComponentTest.kt
+++ b/twint/src/test/java/com/adyen/checkout/twint/TwintComponentTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.twint
 
 import androidx.lifecycle.LifecycleOwner

--- a/twint/src/test/java/com/adyen/checkout/twint/TwintConfigurationTest.kt
+++ b/twint/src/test/java/com/adyen/checkout/twint/TwintConfigurationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.twint
 
 import com.adyen.checkout.components.core.ActionHandlingMethod

--- a/twint/src/test/java/com/adyen/checkout/twint/internal/ui/DefaultTwintDelegateTest.kt
+++ b/twint/src/test/java/com/adyen/checkout/twint/internal/ui/DefaultTwintDelegateTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.twint.internal.ui
 
 import com.adyen.checkout.components.core.ActionHandlingMethod

--- a/twint/src/test/java/com/adyen/checkout/twint/internal/ui/StoredTwintDelegateTest.kt
+++ b/twint/src/test/java/com/adyen/checkout/twint/internal/ui/StoredTwintDelegateTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.twint.internal.ui
 
 import com.adyen.checkout.components.core.Amount

--- a/twint/src/test/java/com/adyen/checkout/twint/internal/ui/model/TwintComponentParamsMapperTest.kt
+++ b/twint/src/test/java/com/adyen/checkout/twint/internal/ui/model/TwintComponentParamsMapperTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.adyen.checkout.twint.internal.ui.model
 
 import com.adyen.checkout.components.core.ActionHandlingMethod


### PR DESCRIPTION
## Description

Deprecate all v5 public classes with `@Deprecated` annotations to prepare for the v6 release.
Deprecated code will be removed before the v6 production release.

This PR covers 5 larger v5-only payment method modules (Phase 15c of the deprecation plan):
`cashapppay`, `giftcard`, `paybybank-us`, `payto`, `twint`.

### Progress

✅ Phase 1 — [checkout-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2707)
✅ Phase 2 — [ui-core (.old packages)](https://github.com/Adyen/adyen-android/pull/2708)
✅ Phase 3 — [card (.old packages)](https://github.com/Adyen/adyen-android/pull/2709)
✅ Phase 4 — [googlepay (.old packages)](https://github.com/Adyen/adyen-android/pull/2711)
✅ Phase 5 — [drop-in (.old packages)](https://github.com/Adyen/adyen-android/pull/2712)
✅ Phase 6 — [3ds2 (.old packages)](https://github.com/Adyen/adyen-android/pull/2713)
✅ Phase 7 — [mbway (.old packages)](https://github.com/Adyen/adyen-android/pull/2714)
✅ Phase 8 — [blik (.old packages)](https://github.com/Adyen/adyen-android/pull/2715)
✅ Phase 9 — [await (.old packages)](https://github.com/Adyen/adyen-android/pull/2716)
✅ Phase 10 — [redirect (.old packages)](https://github.com/Adyen/adyen-android/pull/2726)
✅ Phase 11 — [components-core (entire v5 module)](https://github.com/Adyen/adyen-android/pull/2727)
✅ Phase 12 — [action-core (entire v5 module)](https://github.com/Adyen/adyen-android/pull/2729)
✅ Phase 13 — [sessions-core (entire v5 module)](https://github.com/Adyen/adyen-android/pull/2730)
✅ Phase 14 — [action, components-compose, drop-in-compose (v5 utility modules)](https://github.com/Adyen/adyen-android/pull/2731)
✅ Phase 15a — [13 simple v5 payment method modules](https://github.com/Adyen/adyen-android/pull/2733)
✅ Phase 15b — [16 medium v5 payment method modules](https://github.com/Adyen/adyen-android/pull/2734)
➡️ **Phase 15c — 5 larger v5 payment method modules**

## Ticket Number
COSDK-1121