### PR TITLE
[WIP] v6 - Card brands - US debit cards (restricted cards)

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/internal/helper/RestrictedCardType.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/helper/RestrictedCardType.kt
@@ -6,7 +6,7 @@
  * Created by ozgur on 6/10/2025.
  */
 
-package com.adyen.checkout.card.internal.ui.model
+package com.adyen.checkout.card.internal.helper
 
 internal enum class RestrictedCardType(val txVariant: String) {
     ACCEL("accel"),

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
@@ -167,6 +167,7 @@ internal class CardComponent(
             .launchIn(coroutineScope)
     }
 
+    // TODO: Bin lookup - Adjust the returned card brands after aligning with other platforms
     /**
      * Only return the reliable card brands in the onBinLookup callback
      */
@@ -174,8 +175,10 @@ internal class CardComponent(
         return when (val cardBrandState = state.cardBrandState) {
             is CardBrandState.DualBrand -> cardBrandState.cardBrandDataList
             is CardBrandState.DualBrandWithShopperSelection -> cardBrandState.cardBrandDataList
+            is CardBrandState.DualBrandWithRestrictedBrand -> listOf(cardBrandState.cardBrandData)
             is CardBrandState.SingleReliableBrand -> listOf(cardBrandState.cardBrandData)
             is CardBrandState.NoBrandsDetected,
+            is CardBrandState.RestrictedBrand,
             is CardBrandState.SingleUnreliableBrand,
             is CardBrandState.UnsupportedBrand -> null
         }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapper.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapper.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.card.internal.ui.model
 
 import com.adyen.checkout.card.CardConfiguration
 import com.adyen.checkout.card.FieldMode
+import com.adyen.checkout.card.internal.helper.RestrictedCardType
 import com.adyen.checkout.core.common.AdyenLogLevel
 import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.common.CardType

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapper.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapper.kt
@@ -10,7 +10,6 @@ package com.adyen.checkout.card.internal.ui.model
 
 import com.adyen.checkout.card.CardConfiguration
 import com.adyen.checkout.card.FieldMode
-import com.adyen.checkout.card.internal.helper.RestrictedCardType
 import com.adyen.checkout.core.common.AdyenLogLevel
 import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.common.CardType
@@ -54,7 +53,6 @@ internal class CardComponentParamsMapper {
     /**
      * Check which set of supported cards to pass to the component.
      * Priority is: Custom -> PaymentMethod.brands -> Default
-     * remove restricted card type
      */
     private fun getSupportedCardBrands(
         cardConfiguration: CardConfiguration?,
@@ -78,11 +76,7 @@ internal class CardComponentParamsMapper {
                 adyenLog(AdyenLogLevel.VERBOSE) { "Falling back to CardConfiguration.DEFAULT_SUPPORTED_CARDS_LIST" }
                 DEFAULT_SUPPORTED_CARDS_LIST
             }
-        }.removeRestrictedCards()
-    }
-
-    private fun List<CardBrand>.removeRestrictedCards(): List<CardBrand> {
-        return this.filter { !RestrictedCardType.isRestrictedCardType(it.txVariant) }
+        }
     }
 
     private fun getStorePaymentFieldVisible(

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandler.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandler.kt
@@ -13,6 +13,7 @@ import com.adyen.checkout.card.internal.data.model.Brand
 import com.adyen.checkout.card.internal.data.model.DetectedCardType
 import com.adyen.checkout.card.internal.data.model.DetectedCardTypeList
 import com.adyen.checkout.card.internal.helper.DetectCardTypeBinHelper
+import com.adyen.checkout.card.internal.helper.RestrictedCardType
 import com.adyen.checkout.card.internal.helper.toCardBrandData
 import com.adyen.checkout.card.internal.ui.model.CVCVisibility
 import com.adyen.checkout.card.internal.ui.model.CardComponentParams
@@ -51,17 +52,28 @@ internal class CardBrandIntentsHandler(
     ): CardBrandState {
         val detectedCardTypes = intent.detectedCardTypeList.detectedCardTypes
         val supportedDetectedCardTypes = detectedCardTypes.filter { it.isSupported }
+        // Strip restricted brands defensively even when the backend marked them supported=true
+        // (which happens when the merchant explicitly listed them in supportedCardBrands).
+        val nonRestrictedSupported = supportedDetectedCardTypes.filterNot {
+            RestrictedCardType.isRestrictedCardType(it.cardBrand.txVariant)
+        }
+        // Check the FULL detected list (not the supported-filtered subset). The backend returns
+        // restricted brands with supported=false when the merchant didn't list them, so we'd
+        // otherwise miss them.
+        val anyRestrictedDetected = detectedCardTypes.any {
+            RestrictedCardType.isRestrictedCardType(it.cardBrand.txVariant)
+        }
 
         return when (intent.detectedCardTypeList.source) {
             DetectedCardTypeList.Source.LOCAL -> {
-                if (supportedDetectedCardTypes.isEmpty()) {
+                if (nonRestrictedSupported.isEmpty()) {
                     // local detection + no supported brands
                     CardBrandState.NoBrandsDetected
                 } else {
                     // local detection + supported brands
                     // select the first brand and discard the rest
                     CardBrandState.SingleUnreliableBrand(
-                        cardBrandData = supportedDetectedCardTypes.first().toCardBrandData(),
+                        cardBrandData = nonRestrictedSupported.first().toCardBrandData(),
                     )
                 }
             }
@@ -71,19 +83,29 @@ internal class CardBrandIntentsHandler(
                     // network detection + no detected brands
                     detectedCardTypes.isEmpty() -> CardBrandState.NoBrandsDetected
 
-                    // network detection + detected brands but no supported brands
-                    supportedDetectedCardTypes.isEmpty() -> CardBrandState.UnsupportedBrand
+                    // network detection + only restricted brand(s) detected
+                    nonRestrictedSupported.isEmpty() && anyRestrictedDetected ->
+                        CardBrandState.RestrictedBrand
+
+                    // network detection + detected brands but no supported, non-restricted brands
+                    nonRestrictedSupported.isEmpty() -> CardBrandState.UnsupportedBrand
+
+                    // network detection + 1 supported non-restricted brand alongside restricted
+                    anyRestrictedDetected && nonRestrictedSupported.size == 1 ->
+                        CardBrandState.DualBrandWithRestrictedBrand(
+                            cardBrandData = nonRestrictedSupported.first().toCardBrandData(),
+                        )
 
                     // network detection + 1 detected brand
-                    supportedDetectedCardTypes.size == 1 -> {
+                    nonRestrictedSupported.size == 1 -> {
                         CardBrandState.SingleReliableBrand(
-                            cardBrandData = supportedDetectedCardTypes.first().toCardBrandData(),
+                            cardBrandData = nonRestrictedSupported.first().toCardBrandData(),
                         )
                     }
 
                     // network detection + multiple detected brands
                     else -> {
-                        getDualBrandedCardBrandState(currentState.cardBrandState, supportedDetectedCardTypes)
+                        getDualBrandedCardBrandState(currentState.cardBrandState, nonRestrictedSupported)
                     }
                 }
             }
@@ -149,9 +171,11 @@ internal class CardBrandIntentsHandler(
             is CardBrandState.DualBrandWithShopperSelection -> cardBrandState.shopperSelectedCardBrandData
             is CardBrandState.DualBrand -> cardBrandState.cardBrandDataList.first()
             is CardBrandState.SingleReliableBrand -> cardBrandState.cardBrandData
+            is CardBrandState.DualBrandWithRestrictedBrand -> cardBrandState.cardBrandData
             is CardBrandState.NoBrandsDetected,
             is CardBrandState.SingleUnreliableBrand,
-            is CardBrandState.UnsupportedBrand -> null
+            is CardBrandState.UnsupportedBrand,
+            is CardBrandState.RestrictedBrand -> null
         }
         val cvcPolicy = selectedOrFirstOrReliableCardBrandData?.cvcPolicy
         val expiryDatePolicy = selectedOrFirstOrReliableCardBrandData?.expiryDatePolicy

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentState.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentState.kt
@@ -37,6 +37,7 @@ internal data class CardComponentState(
 internal sealed class CardBrandState {
     data object NoBrandsDetected : CardBrandState()
     data object UnsupportedBrand : CardBrandState()
+    data object RestrictedBrand : CardBrandState()
     data class SingleReliableBrand(val cardBrandData: CardBrandData) : CardBrandState()
     data class SingleUnreliableBrand(val cardBrandData: CardBrandData) : CardBrandState()
     data class DualBrand(val cardBrandDataList: List<CardBrandData>) : CardBrandState()
@@ -44,6 +45,7 @@ internal sealed class CardBrandState {
         val cardBrandDataList: List<CardBrandData>,
         val shopperSelectedCardBrandData: CardBrandData,
     ) : CardBrandState()
+    data class DualBrandWithRestrictedBrand(val cardBrandData: CardBrandData) : CardBrandState()
 }
 
 internal data class CardBrandData(

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateExt.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateExt.kt
@@ -182,7 +182,9 @@ private fun CardComponentState.cardBrand(): CardBrand? {
         is CardBrandState.SingleReliableBrand -> cardBrandState.cardBrandData.cardBrand
         is CardBrandState.DualBrandWithShopperSelection -> cardBrandState.shopperSelectedCardBrandData.cardBrand
         is CardBrandState.DualBrand,
+        is CardBrandState.DualBrandWithRestrictedBrand,
         is CardBrandState.NoBrandsDetected,
+        is CardBrandState.RestrictedBrand,
         is CardBrandState.SingleUnreliableBrand,
         is CardBrandState.UnsupportedBrand -> null
     }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateValidator.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateValidator.kt
@@ -24,7 +24,9 @@ internal class CardComponentStateValidator(
             is CardBrandState.SingleUnreliableBrand -> cardBrandState.cardBrandData
             is CardBrandState.DualBrandWithShopperSelection -> cardBrandState.shopperSelectedCardBrandData
             is CardBrandState.DualBrand -> cardBrandState.cardBrandDataList.first()
+            is CardBrandState.DualBrandWithRestrictedBrand -> cardBrandState.cardBrandData
             is CardBrandState.NoBrandsDetected,
+            is CardBrandState.RestrictedBrand,
             is CardBrandState.UnsupportedBrand -> null
         }
         val isUnsupportedBrand = state.cardBrandState is CardBrandState.UnsupportedBrand

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
@@ -28,11 +28,13 @@ internal class CardViewStateProducer(
         // we only show all supported card brands when we do not detect any brands for this specific card
         val isSupportedCardBrandsShown = when (state.cardBrandState) {
             is CardBrandState.UnsupportedBrand,
+            is CardBrandState.RestrictedBrand,
             is CardBrandState.NoBrandsDetected -> true
 
             is CardBrandState.SingleReliableBrand,
             is CardBrandState.SingleUnreliableBrand,
             is CardBrandState.DualBrand,
+            is CardBrandState.DualBrandWithRestrictedBrand,
             is CardBrandState.DualBrandWithShopperSelection -> false
         }
 
@@ -67,9 +69,11 @@ internal class CardViewStateProducer(
         return when (cardBrandState) {
             is CardBrandState.DualBrand -> cardBrandState.cardBrandDataList.map { it.cardBrand }
             is CardBrandState.DualBrandWithShopperSelection -> cardBrandState.cardBrandDataList.map { it.cardBrand }
+            is CardBrandState.DualBrandWithRestrictedBrand -> listOf(cardBrandState.cardBrandData.cardBrand)
             is CardBrandState.SingleReliableBrand -> listOf(cardBrandState.cardBrandData.cardBrand)
             is CardBrandState.SingleUnreliableBrand -> listOf(cardBrandState.cardBrandData.cardBrand)
             is CardBrandState.NoBrandsDetected,
+            is CardBrandState.RestrictedBrand,
             is CardBrandState.UnsupportedBrand -> emptyList()
         }
     }

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandlerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandlerTest.kt
@@ -290,6 +290,139 @@ internal class CardBrandIntentsHandlerTest(
         }
 
         @Test
+        fun `and list has one supported brand alongside an unsupported restricted brand then state should be dual branded with restricted brand`() {
+            val state = createInitialState().copy(
+                cardBrandState = CardBrandState.SingleReliableBrand(createCardBrandData()),
+            )
+            val detectedCardTypes = listOf(
+                createDetectedCardType().copy(cardBrand = CardBrand("visa")),
+                createDetectedCardType().copy(cardBrand = CardBrand("accel"), isSupported = false),
+            )
+            val detectedCardTypeList = DetectedCardTypeList(
+                detectedCardTypes,
+                DetectedCardTypeList.Source.NETWORK,
+                null,
+            )
+
+            val actual = cardBrandIntentsHandler.onUpdateDetectedCardTypes(
+                state,
+                CardIntent.UpdateDetectedCardTypes(detectedCardTypeList),
+            )
+
+            val expectedState = CardBrandState.DualBrandWithRestrictedBrand(
+                createCardBrandData().copy(cardBrand = CardBrand("visa")),
+            )
+
+            assertEquals(expectedState, actual.cardBrandState)
+        }
+
+        @Test
+        fun `and list has one supported brand alongside a supported restricted brand then state should be dual branded with restricted brand`() {
+            val state = createInitialState().copy(
+                cardBrandState = CardBrandState.SingleReliableBrand(createCardBrandData()),
+            )
+            val detectedCardTypes = listOf(
+                createDetectedCardType().copy(cardBrand = CardBrand("visa")),
+                createDetectedCardType().copy(cardBrand = CardBrand("accel")),
+            )
+            val detectedCardTypeList = DetectedCardTypeList(
+                detectedCardTypes,
+                DetectedCardTypeList.Source.NETWORK,
+                null,
+            )
+
+            val actual = cardBrandIntentsHandler.onUpdateDetectedCardTypes(
+                state,
+                CardIntent.UpdateDetectedCardTypes(detectedCardTypeList),
+            )
+
+            val expectedState = CardBrandState.DualBrandWithRestrictedBrand(
+                createCardBrandData().copy(cardBrand = CardBrand("visa")),
+            )
+
+            assertEquals(expectedState, actual.cardBrandState)
+        }
+
+        @Test
+        fun `and list has only an unsupported restricted brand then state should be restricted brand`() {
+            val state = createInitialState().copy(
+                cardBrandState = CardBrandState.SingleReliableBrand(createCardBrandData()),
+            )
+            val detectedCardTypes = listOf(
+                createDetectedCardType().copy(cardBrand = CardBrand("accel"), isSupported = false),
+            )
+            val detectedCardTypeList = DetectedCardTypeList(
+                detectedCardTypes,
+                DetectedCardTypeList.Source.NETWORK,
+                null,
+            )
+
+            val actual = cardBrandIntentsHandler.onUpdateDetectedCardTypes(
+                state,
+                CardIntent.UpdateDetectedCardTypes(detectedCardTypeList),
+            )
+
+            assertEquals(CardBrandState.RestrictedBrand, actual.cardBrandState)
+        }
+
+        @Test
+        fun `and list has only a supported restricted brand then state should be restricted brand`() {
+            val state = createInitialState().copy(
+                cardBrandState = CardBrandState.SingleReliableBrand(createCardBrandData()),
+            )
+            val detectedCardTypes = listOf(
+                createDetectedCardType().copy(cardBrand = CardBrand("accel")),
+            )
+            val detectedCardTypeList = DetectedCardTypeList(
+                detectedCardTypes,
+                DetectedCardTypeList.Source.NETWORK,
+                null,
+            )
+
+            val actual = cardBrandIntentsHandler.onUpdateDetectedCardTypes(
+                state,
+                CardIntent.UpdateDetectedCardTypes(detectedCardTypeList),
+            )
+
+            assertEquals(CardBrandState.RestrictedBrand, actual.cardBrandState)
+        }
+
+        @Test
+        fun `and list has multiple supported brands alongside a restricted brand then state should be dual branded with shopper selection`() {
+            val state = createInitialState().copy(
+                cardBrandState = CardBrandState.SingleReliableBrand(createCardBrandData()),
+            )
+            val detectedCardTypes = listOf(
+                createDetectedCardType().copy(cardBrand = CardBrand("visa")),
+                createDetectedCardType().copy(
+                    cardBrand = CardBrand("cartebancaire"),
+                    isShopperSelectionAllowedInDualBranded = true,
+                ),
+                createDetectedCardType().copy(cardBrand = CardBrand("accel"), isSupported = false),
+            )
+            val detectedCardTypeList = DetectedCardTypeList(
+                detectedCardTypes,
+                DetectedCardTypeList.Source.NETWORK,
+                null,
+            )
+
+            val actual = cardBrandIntentsHandler.onUpdateDetectedCardTypes(
+                state,
+                CardIntent.UpdateDetectedCardTypes(detectedCardTypeList),
+            )
+
+            val expectedState = CardBrandState.DualBrandWithShopperSelection(
+                cardBrandDataList = listOf(
+                    createCardBrandData().copy(cardBrand = CardBrand("visa")),
+                    createCardBrandData().copy(cardBrand = CardBrand("cartebancaire")),
+                ),
+                shopperSelectedCardBrandData = createCardBrandData().copy(cardBrand = CardBrand("visa")),
+            )
+
+            assertEquals(expectedState, actual.cardBrandState)
+        }
+
+        @Test
         fun `and list has two supported brands with no shopper selection allowed then state should be a dual branded`() {
             val state = createInitialState().copy(
                 cardBrandState = CardBrandState.SingleReliableBrand(createCardBrandData()),
@@ -500,6 +633,26 @@ internal class CardBrandIntentsHandlerTest(
         val actual = cardBrandIntentsHandler.getUpdatedCardComponentState(createInitialState(), cardBrandState)
 
         assertEquals(RequirementPolicy.Required, actual.expiryDate.requirementPolicy)
+    }
+
+    @Test
+    fun `when state is restricted brand then expiryDate requirementPolicy defaults to Required`() {
+        val cardBrandState = CardBrandState.RestrictedBrand
+
+        val actual = cardBrandIntentsHandler.getUpdatedCardComponentState(createInitialState(), cardBrandState)
+
+        assertEquals(RequirementPolicy.Required, actual.expiryDate.requirementPolicy)
+    }
+
+    @Test
+    fun `when state is dual branded with restricted brand and expiryDatePolicy is OPTIONAL then expiryDate requirementPolicy is Optional`() {
+        val cardBrandState = CardBrandState.DualBrandWithRestrictedBrand(
+            createCardBrandData().copy(expiryDatePolicy = Brand.FieldPolicy.OPTIONAL),
+        )
+
+        val actual = cardBrandIntentsHandler.getUpdatedCardComponentState(createInitialState(), cardBrandState)
+
+        assertEquals(RequirementPolicy.Optional, actual.expiryDate.requirementPolicy)
     }
 
     @Test

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateValidatorTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateValidatorTest.kt
@@ -8,6 +8,8 @@
 
 package com.adyen.checkout.card.internal.ui.state
 
+import com.adyen.checkout.card.internal.data.model.Brand
+import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.components.internal.ui.state.model.RequirementPolicy
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -240,6 +242,38 @@ internal class CardComponentStateValidatorTest {
         val validatedState = validator.validate(state)
 
         assertNotNull(validatedState.cardNumber.errorMessage)
+    }
+
+    @Test
+    fun `when card brand is restricted, then card number has no unsupported error`() {
+        val state = createValidState().copy(
+            cardBrandState = CardBrandState.RestrictedBrand,
+        )
+
+        val validatedState = validator.validate(state)
+
+        assertNull(validatedState.cardNumber.errorMessage)
+    }
+
+    @Test
+    fun `when card brand is dual branded with restricted brand, then card number has no unsupported error`() {
+        val state = createValidState().copy(
+            cardBrandState = CardBrandState.DualBrandWithRestrictedBrand(
+                CardBrandData(
+                    cardBrand = CardBrand("visa"),
+                    enableLuhnCheck = true,
+                    cvcPolicy = Brand.FieldPolicy.REQUIRED,
+                    expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
+                    panLength = null,
+                    paymentMethodVariant = null,
+                    localizedBrand = null,
+                ),
+            ),
+        )
+
+        val validatedState = validator.validate(state)
+
+        assertNull(validatedState.cardNumber.errorMessage)
     }
 
     private fun createValidState() = CardComponentState(

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
@@ -76,6 +76,39 @@ internal class CardViewStateProducerTest {
         assertTrue(viewState.isSupportedCardBrandsShown)
     }
 
+    @Test
+    fun `when only restricted brand is detected, then supported card brands should be shown and detected brands list is empty`() {
+        // GIVEN
+        val componentState = createComponentState(
+            cardBrandState = CardBrandState.RestrictedBrand,
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertTrue(viewState.isSupportedCardBrandsShown)
+        assertTrue(viewState.detectedCardBrands.isEmpty())
+    }
+
+    @Test
+    fun `when dual branded with restricted brand is detected, then only the supported brand logo is shown`() {
+        // GIVEN
+        val supportedBrand = CardBrand("visa")
+        val componentState = createComponentState(
+            cardBrandState = CardBrandState.DualBrandWithRestrictedBrand(
+                getCardBrandData().copy(cardBrand = supportedBrand),
+            ),
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertFalse(viewState.isSupportedCardBrandsShown)
+        assertEquals(listOf(supportedBrand), viewState.detectedCardBrands)
+    }
+
     // UC6: Error Hides Brand Logos
     @Test
     fun `when card number has error with detected brand, then trailing icon is warning and supported brands are hidden`() {


### PR DESCRIPTION
## Description

Phase 1 of restricted-brand handling alignment with Web/iOS.

Restricted brands (`accel`, `pulse`, `star`, `nyce` — US ATM/debit network rails) were stripped from `supportedCardBrands` client-side before the BIN lookup request was built. That caused the backend to return them as `supported=false`, the state handler to drop them, and merchants to never know the card had a restricted rail. It also caused `brand=visa` to be sent in `/payments` for `[visa, accel]` cards, even though the actual routing rail is ambiguous.

This PR moves restricted-brand handling from a client-side filter to the data-to-state classification boundary, matching Web/iOS behavior:

- `CardComponentParamsMapper.removeRestrictedCards()` is removed. Restricted brands flow through to the BIN lookup request.
- `RestrictedCardType` moves from `internal.ui.model` to `internal.helper` (no longer a UI mapper concern).
- Two new `internal` `CardBrandState` variants:
  - `RestrictedBrand` — only restricted brand(s) detected. UI mirrors `NoBrandsDetected`. No `brand` sent in `/payments`.
  - `DualBrandWithRestrictedBrand(cardBrandData)` — single supported brand alongside restricted brand(s) (e.g. `[visa, accel]`). Only the supported logo is shown; restricted logos are never rendered. No `brand` sent in `/payments` since the rail is ambiguous.
- Classification logic uses the **full** detected card type list to identify restricted brands, so we catch them whether the backend returned them with `supported=true` (merchant configured the brand) or `supported=false` (merchant did not).

3 commits, all on `internal` code. No public API change. `apiDump` produces no diff.

### Behavior matrix

| Scenario | Detected | Logos shown | `brand` in payload | State |
|---|---|---|---|---|
| Standard single | `[visa]` | visa | yes | `SingleReliableBrand` (unchanged) |
| Standard dual | `[visa, mc]` | both | yes | `DualBrand` (unchanged) |
| Standard dual w/ selection | `[visa, cartebancaire]` | both | yes (selected) | `DualBrandWithShopperSelection` (unchanged) |
| **Dual with restricted** | `[visa, accel]` | visa only | **no** | **`DualBrandWithRestrictedBrand`** (new) |
| 3 brands with restricted | `[visa, cartebancaire, accel]` | visa + cartebancaire | yes (selected) | `DualBrandWithShopperSelection` (existing path) |
| **Restricted only** | `[accel]` | placeholder + grid | **no** | **`RestrictedBrand`** (new) |
| All unsupported | `[discover]` (merchant=`[visa]`) | error | n/a | `UnsupportedBrand` (unchanged) |
| No detection | `[]` | grid | n/a | `NoBrandsDetected` (unchanged) |

### Out of scope (separate PR)

The `onBinLookup` callback still only fires for "supported" classifications and drops restricted brand info. Surfacing all detected brands to merchants via `BinLookupData` requires public API changes and cross-platform alignment with iOS/Web on the callback shape. Tracked as Phase 2; will land in a separate PR after team alignment.

## Checklist

- [x] Code is unit tested
- [ ] Changes are tested manually
- [ ] Aligned public API changes with other platforms (if applicable)

## Ticket Number

COSDK-1204
