### PR TITLE
v6 - Field scope minimization

### DIFF
--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/BlikCodeField.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/BlikCodeField.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.blik.internal.ui.properties.BlikCodeProperties.BLIK_CODE_MAX_LENGTH
 import com.adyen.checkout.blik.internal.ui.properties.BlikCodeProperties.BLIK_CODE_SEPARATOR
 import com.adyen.checkout.blik.internal.ui.properties.BlikCodeProperties.BLIK_CODE_SEPARATORS
-import com.adyen.checkout.blik.internal.ui.state.BlikIntent
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
@@ -32,7 +31,8 @@ import com.adyen.checkout.ui.theme.CheckoutTheme
 @Composable
 internal fun BlikCodeField(
     blikCodeState: TextInputViewState,
-    onIntent: (BlikIntent) -> Unit,
+    onValueChange: (String) -> Unit,
+    onFocusChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val supportingText = blikCodeState.supportingText?.let { resolveString(it) }
@@ -51,15 +51,13 @@ internal fun BlikCodeField(
         modifier = modifier
             .fillMaxWidth()
             .onFocusChanged { focusState ->
-                onIntent(BlikIntent.UpdateBlikCodeFocus(focusState.hasFocus))
+                onFocusChange(focusState.hasFocus)
             },
         label = resolveString(CheckoutLocalizationKey.BLIK_CODE),
         initialValue = blikCodeState.text,
         isError = blikCodeState.isError,
         supportingText = supportingText,
-        onValueChange = { value ->
-            onIntent(BlikIntent.UpdateBlikCode(value))
-        },
+        onValueChange = onValueChange,
         inputTransformation = inputTransformation,
         outputTransformation = outputTransformation,
         shouldFocus = blikCodeState.isFocused,
@@ -76,7 +74,8 @@ private fun BlikCodeFieldPreview(
             blikCodeState = TextInputViewState(
                 text = "123456",
             ),
-            onIntent = {},
+            onValueChange = {},
+            onFocusChange = {},
         )
     }
 }

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/BlikComponent.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/BlikComponent.kt
@@ -46,7 +46,8 @@ internal fun BlikComponent(
             if (viewState.blikCode != null) {
                 BlikCodeField(
                     blikCodeState = viewState.blikCode,
-                    onIntent = onIntent,
+                    onValueChange = { onIntent(BlikIntent.UpdateBlikCode(it)) },
+                    onFocusChange = { onIntent(BlikIntent.UpdateBlikCodeFocus(it)) },
                 )
             }
         }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardComponent.kt
@@ -78,44 +78,51 @@ private fun CardDetailsSection(
                 isSupportedCardBrandsShown = viewState.isSupportedCardBrandsShown,
                 detectedCardBrands = viewState.detectedCardBrands,
                 isAmex = viewState.isAmex,
-                onIntent = onIntent,
+                onValueChange = { onIntent(CardIntent.UpdateCardNumber(it)) },
+                onFocusChange = { onIntent(CardIntent.UpdateCardNumberFocus(it)) },
             )
         }
         if (viewState.expiryDate != null) {
             ExpiryDateField(
                 expiryDateState = viewState.expiryDate,
-                onIntent = onIntent,
+                onValueChange = { onIntent(CardIntent.UpdateExpiryDate(it)) },
+                onFocusChange = { onIntent(CardIntent.UpdateExpiryDateFocus(it)) },
             )
         }
         if (viewState.securityCode != null) {
             SecurityCodeField(
                 securityCodeState = viewState.securityCode,
                 isAmex = viewState.isAmex,
-                onIntent = onIntent,
+                onValueChange = { onIntent(CardIntent.UpdateSecurityCode(it)) },
+                onFocusChange = { onIntent(CardIntent.UpdateSecurityCodeFocus(it)) },
             )
         }
         if (viewState.holderName != null) {
             HolderNameField(
                 holderNameState = viewState.holderName,
-                onIntent = onIntent,
+                onValueChange = { onIntent(CardIntent.UpdateHolderName(it)) },
+                onFocusChange = { onIntent(CardIntent.UpdateHolderNameFocus(it)) },
             )
         }
         if (viewState.socialSecurityNumber != null) {
             SocialSecurityNumberField(
                 socialSecurityNumberState = viewState.socialSecurityNumber,
-                onIntent = onIntent,
+                onValueChange = { onIntent(CardIntent.UpdateSocialSecurityNumber(it)) },
+                onFocusChange = { onIntent(CardIntent.UpdateSocialSecurityNumberFocus(it)) },
             )
         }
         if (viewState.kcpBirthDateOrTaxNumber != null) {
             KCPBirthDateOrTaxNumberField(
                 kcpBirthDateOrTaxNumberState = viewState.kcpBirthDateOrTaxNumber,
-                onIntent = onIntent,
+                onValueChange = { onIntent(CardIntent.UpdateKcpBirthDateOrTaxNumber(it)) },
+                onFocusChange = { onIntent(CardIntent.UpdateKcpBirthDateOrTaxNumberFocus(it)) },
             )
         }
         if (viewState.kcpCardPassword != null) {
             KCPCardPasswordField(
                 kcpCardPasswordState = viewState.kcpCardPassword,
-                onIntent = onIntent,
+                onValueChange = { onIntent(CardIntent.UpdateKcpCardPassword(it)) },
+                onFocusChange = { onIntent(CardIntent.UpdateKcpCardPasswordFocus(it)) },
             )
         }
         if (viewState.postalCode != null) {

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardComponent.kt
@@ -128,12 +128,8 @@ private fun CardDetailsSection(
         if (viewState.postalCode != null) {
             PostalCodeField(
                 postalCodeState = viewState.postalCode,
-                onFocusChanged = { isFocused ->
-                    onIntent(CardIntent.UpdatePostalCodeFocus(isFocused))
-                },
-                onValueChange = { value ->
-                    onIntent(CardIntent.UpdatePostalCode(value))
-                },
+                onFocusChange = { onIntent(CardIntent.UpdatePostalCodeFocus(it)) },
+                onValueChange = { onIntent(CardIntent.UpdatePostalCode(it)) },
             )
         }
         if (viewState.isStorePaymentFieldVisible) {

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
@@ -106,9 +106,7 @@ private fun CardNumberInputField(
         initialValue = cardNumberState.text,
         isError = cardNumberState.isError,
         supportingText = supportingTextCardNumber,
-        onValueChange = { value ->
-            onValueChange(value)
-        },
+        onValueChange = onValueChange,
         inputTransformation = inputTransformation,
         outputTransformation = outputTransformation,
         shouldFocus = cardNumberState.isFocused,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.card.R
 import com.adyen.checkout.card.internal.ui.model.CardNumberTrailingIcon
-import com.adyen.checkout.card.internal.ui.state.CardIntent
 import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.common.CardType
 import com.adyen.checkout.core.common.internal.properties.CardNumberProperties.CARD_NUMBER_MAXIMUM_LENGTH
@@ -54,7 +53,8 @@ internal fun CardNumberField(
     isSupportedCardBrandsShown: Boolean,
     detectedCardBrands: List<CardBrand>,
     isAmex: Boolean?,
-    onIntent: (CardIntent) -> Unit,
+    onValueChange: (String) -> Unit,
+    onFocusChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -64,7 +64,8 @@ internal fun CardNumberField(
             cardNumberState = cardNumberState,
             isAmex = isAmex,
             detectedCardBrands = detectedCardBrands,
-            onIntent = onIntent,
+            onValueChange = onValueChange,
+            onFocusChange = onFocusChange,
         )
 
         CardBrandsList(
@@ -79,7 +80,8 @@ private fun CardNumberInputField(
     cardNumberState: TextInputViewState,
     isAmex: Boolean?,
     detectedCardBrands: List<CardBrand>,
-    onIntent: (CardIntent) -> Unit,
+    onValueChange: (String) -> Unit,
+    onFocusChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val supportingTextCardNumber = cardNumberState.supportingText?.let { resolveString(it) }
@@ -98,14 +100,14 @@ private fun CardNumberInputField(
         modifier = modifier
             .fillMaxWidth()
             .onFocusChanged { focusState ->
-                onIntent(CardIntent.UpdateCardNumberFocus(focusState.isFocused))
+                onFocusChange(focusState.isFocused)
             },
         label = resolveString(CheckoutLocalizationKey.CARD_NUMBER),
         initialValue = cardNumberState.text,
         isError = cardNumberState.isError,
         supportingText = supportingTextCardNumber,
         onValueChange = { value ->
-            onIntent(CardIntent.UpdateCardNumber(value))
+            onValueChange(value)
         },
         inputTransformation = inputTransformation,
         outputTransformation = outputTransformation,
@@ -215,7 +217,8 @@ private fun CardNumberFieldPreview(
             isSupportedCardBrandsShown = true,
             detectedCardBrands = listOf(CardBrand(CardType.MASTERCARD.txVariant)),
             isAmex = false,
-            onIntent = {},
+            onValueChange = {},
+            onFocusChange = {},
         )
 
         CardNumberField(
@@ -229,7 +232,8 @@ private fun CardNumberFieldPreview(
             isSupportedCardBrandsShown = false,
             detectedCardBrands = emptyList(),
             isAmex = true,
-            onIntent = {},
+            onValueChange = {},
+            onFocusChange = {},
         )
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/ExpiryDateField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/ExpiryDateField.kt
@@ -72,9 +72,7 @@ internal fun ExpiryDateField(
         initialValue = expiryDateState.text,
         isError = expiryDateState.isError,
         supportingText = supportingTextExpiryDate,
-        onValueChange = { value ->
-            onValueChange(value)
-        },
+        onValueChange = onValueChange,
         inputTransformation = inputTransformation,
         outputTransformation = outputTransformation,
         shouldFocus = expiryDateState.isFocused,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/ExpiryDateField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/ExpiryDateField.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.card.R
 import com.adyen.checkout.card.internal.ui.model.ExpiryDateTrailingIcon
-import com.adyen.checkout.card.internal.ui.state.CardIntent
 import com.adyen.checkout.core.common.internal.properties.ExpiryDateProperties
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
@@ -41,7 +40,8 @@ import com.adyen.checkout.ui.theme.CheckoutTheme
 @Composable
 internal fun ExpiryDateField(
     expiryDateState: TextInputViewState,
-    onIntent: (CardIntent) -> Unit,
+    onValueChange: (String) -> Unit,
+    onFocusChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val supportingTextExpiryDate = expiryDateState.supportingText?.let { resolveString(it) }
@@ -66,14 +66,14 @@ internal fun ExpiryDateField(
         modifier = modifier
             .fillMaxWidth()
             .onFocusChanged { focusState ->
-                onIntent(CardIntent.UpdateExpiryDateFocus(focusState.isFocused))
+                onFocusChange(focusState.isFocused)
             },
         label = resolveString(key = CheckoutLocalizationKey.CARD_EXPIRY_DATE) + labelSuffix,
         initialValue = expiryDateState.text,
         isError = expiryDateState.isError,
         supportingText = supportingTextExpiryDate,
         onValueChange = { value ->
-            onIntent(CardIntent.UpdateExpiryDate(value))
+            onValueChange(value)
         },
         inputTransformation = inputTransformation,
         outputTransformation = outputTransformation,
@@ -135,13 +135,15 @@ private fun ExpiryDateFieldPreview(
             expiryDateState = TextInputViewState(
                 text = "0330",
             ),
-            onIntent = {},
+            onValueChange = {},
+            onFocusChange = {},
         )
         ExpiryDateField(
             expiryDateState = TextInputViewState(
                 isOptional = true,
             ),
-            onIntent = {},
+            onValueChange = {},
+            onFocusChange = {},
         )
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/HolderNameField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/HolderNameField.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import com.adyen.checkout.card.internal.ui.state.CardIntent
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
@@ -29,7 +28,8 @@ import com.adyen.checkout.ui.theme.CheckoutTheme
 @Composable
 internal fun HolderNameField(
     holderNameState: TextInputViewState,
-    onIntent: (CardIntent) -> Unit,
+    onValueChange: (String) -> Unit,
+    onFocusChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val supportingTextHolderName = holderNameState.supportingText?.let { resolveString(it) }
@@ -38,14 +38,14 @@ internal fun HolderNameField(
         modifier = modifier
             .fillMaxWidth()
             .onFocusChanged { focusState ->
-                onIntent(CardIntent.UpdateHolderNameFocus(focusState.isFocused))
+                onFocusChange(focusState.isFocused)
             },
         label = resolveString(CheckoutLocalizationKey.CARD_HOLDER_NAME),
         initialValue = holderNameState.text,
         isError = holderNameState.isError,
         supportingText = supportingTextHolderName,
         onValueChange = { value ->
-            onIntent(CardIntent.UpdateHolderName(value))
+            onValueChange(value)
         },
         keyboardOptions = KeyboardOptions(
             keyboardType = KeyboardType.Text,
@@ -65,7 +65,8 @@ private fun HolderNameFieldPreview(
             holderNameState = TextInputViewState(
                 text = "John Smith",
             ),
-            onIntent = {},
+            onValueChange = {},
+            onFocusChange = {},
         )
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/HolderNameField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/HolderNameField.kt
@@ -44,9 +44,7 @@ internal fun HolderNameField(
         initialValue = holderNameState.text,
         isError = holderNameState.isError,
         supportingText = supportingTextHolderName,
-        onValueChange = { value ->
-            onValueChange(value)
-        },
+        onValueChange = onValueChange,
         keyboardOptions = KeyboardOptions(
             keyboardType = KeyboardType.Text,
             capitalization = KeyboardCapitalization.Words,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPBirthDateOrTaxNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPBirthDateOrTaxNumberField.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.card.internal.ui.properties.KCPBirthDateOrTaxNumberProperties.KCP_BIRTH_DATE_OR_TAX_NUMBER_MAX_LENGTH
 import com.adyen.checkout.card.internal.ui.properties.KCPBirthDateOrTaxNumberProperties.KCP_BIRTH_DATE_VALID_LENGTH
-import com.adyen.checkout.card.internal.ui.state.CardIntent
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
@@ -30,7 +29,8 @@ import com.adyen.checkout.ui.theme.CheckoutTheme
 @Composable
 internal fun KCPBirthDateOrTaxNumberField(
     kcpBirthDateOrTaxNumberState: TextInputViewState,
-    onIntent: (CardIntent) -> Unit,
+    onValueChange: (String) -> Unit,
+    onFocusChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val textLength = kcpBirthDateOrTaxNumberState.text.length
@@ -53,14 +53,14 @@ internal fun KCPBirthDateOrTaxNumberField(
         modifier = modifier
             .fillMaxWidth()
             .onFocusChanged { focusState ->
-                onIntent(CardIntent.UpdateKcpBirthDateOrTaxNumberFocus(focusState.isFocused))
+                onFocusChange(focusState.isFocused)
             },
         label = label,
         initialValue = kcpBirthDateOrTaxNumberState.text,
         isError = kcpBirthDateOrTaxNumberState.isError,
         supportingText = supportingText,
         onValueChange = { value ->
-            onIntent(CardIntent.UpdateKcpBirthDateOrTaxNumber(value))
+            onValueChange(value)
         },
         shouldFocus = kcpBirthDateOrTaxNumberState.isFocused,
         inputTransformation = inputTransformation,
@@ -77,7 +77,8 @@ private fun KCPBirthDateOrTaxNumberFieldPreview(
             kcpBirthDateOrTaxNumberState = TextInputViewState(
                 text = "230704",
             ),
-            onIntent = {},
+            onValueChange = {},
+            onFocusChange = {},
         )
 
         KCPBirthDateOrTaxNumberField(
@@ -85,7 +86,8 @@ private fun KCPBirthDateOrTaxNumberFieldPreview(
                 text = "1234567890",
                 isError = true,
             ),
-            onIntent = {},
+            onValueChange = {},
+            onFocusChange = {},
         )
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPBirthDateOrTaxNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPBirthDateOrTaxNumberField.kt
@@ -59,9 +59,7 @@ internal fun KCPBirthDateOrTaxNumberField(
         initialValue = kcpBirthDateOrTaxNumberState.text,
         isError = kcpBirthDateOrTaxNumberState.isError,
         supportingText = supportingText,
-        onValueChange = { value ->
-            onValueChange(value)
-        },
+        onValueChange = onValueChange,
         shouldFocus = kcpBirthDateOrTaxNumberState.isFocused,
         inputTransformation = inputTransformation,
     )

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPCardPasswordField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPCardPasswordField.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.card.internal.ui.properties.KCPCardPasswordProperties.KCP_CARD_PASSWORD_MAX_LENGTH
-import com.adyen.checkout.card.internal.ui.state.CardIntent
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
@@ -29,7 +28,8 @@ import com.adyen.checkout.ui.theme.CheckoutTheme
 @Composable
 internal fun KCPCardPasswordField(
     kcpCardPasswordState: TextInputViewState,
-    onIntent: (CardIntent) -> Unit,
+    onValueChange: (String) -> Unit,
+    onFocusChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val supportingText = kcpCardPasswordState.supportingText?.let { resolveString(it) }
@@ -44,14 +44,14 @@ internal fun KCPCardPasswordField(
         modifier = modifier
             .fillMaxWidth()
             .onFocusChanged { focusState ->
-                onIntent(CardIntent.UpdateKcpCardPasswordFocus(focusState.isFocused))
+                onFocusChange(focusState.isFocused)
             },
         label = resolveString(CheckoutLocalizationKey.CARD_KCP_CARD_PASSWORD),
         initialValue = kcpCardPasswordState.text,
         isError = kcpCardPasswordState.isError,
         supportingText = supportingText,
         onValueChange = { value ->
-            onIntent(CardIntent.UpdateKcpCardPassword(value))
+            onValueChange(value)
         },
         shouldFocus = kcpCardPasswordState.isFocused,
         inputTransformation = inputTransformation,
@@ -69,7 +69,8 @@ private fun KCPCardPasswordFieldPreview(
             kcpCardPasswordState = TextInputViewState(
                 text = "12",
             ),
-            onIntent = {},
+            onValueChange = {},
+            onFocusChange = {},
         )
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPCardPasswordField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPCardPasswordField.kt
@@ -50,9 +50,7 @@ internal fun KCPCardPasswordField(
         initialValue = kcpCardPasswordState.text,
         isError = kcpCardPasswordState.isError,
         supportingText = supportingText,
-        onValueChange = { value ->
-            onValueChange(value)
-        },
+        onValueChange = onValueChange,
         shouldFocus = kcpCardPasswordState.isFocused,
         inputTransformation = inputTransformation,
         isSecureField = true,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/PostalCodeField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/PostalCodeField.kt
@@ -32,8 +32,8 @@ import com.adyen.checkout.ui.theme.CheckoutTheme
 @Composable
 internal fun PostalCodeField(
     postalCodeState: TextInputViewState,
-    onFocusChanged: (Boolean) -> Unit,
     onValueChange: (String) -> Unit,
+    onFocusChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val supportingTextPostalCode = postalCodeState.supportingText?.let { resolveString(it) }
@@ -42,16 +42,14 @@ internal fun PostalCodeField(
         modifier = modifier
             .fillMaxWidth()
             .onFocusChanged { focusState ->
-                onFocusChanged(focusState.isFocused)
+                onFocusChange(focusState.isFocused)
             },
         label = resolveString(CheckoutLocalizationKey.CARD_POSTAL_CODE),
         initialValue = postalCodeState.text,
         inputTransformation = InputTransformation.maxLength(PostalCodeProperties.POSTAL_CODE_MAX_LENGTH),
         isError = postalCodeState.isError,
         supportingText = supportingTextPostalCode,
-        onValueChange = { value ->
-            onValueChange(value)
-        },
+        onValueChange = onValueChange,
         keyboardOptions = KeyboardOptions(
             keyboardType = KeyboardType.Text,
             capitalization = KeyboardCapitalization.Unspecified,
@@ -108,7 +106,7 @@ private fun PostalCodeFieldPreview(
             postalCodeState = TextInputViewState(
                 text = "1234 AB",
             ),
-            onFocusChanged = {},
+            onFocusChange = {},
             onValueChange = {},
         )
     }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SecurityCodeField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SecurityCodeField.kt
@@ -23,8 +23,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.card.R
 import com.adyen.checkout.card.internal.ui.model.SecurityCodeTrailingIcon
-import com.adyen.checkout.card.internal.ui.state.CardIntent
-import com.adyen.checkout.card.internal.ui.state.StoredCardIntent
 import com.adyen.checkout.core.common.internal.properties.SecurityCodeProperties.SECURITY_CODE_MAX_LENGTH_AMEX
 import com.adyen.checkout.core.common.internal.properties.SecurityCodeProperties.SECURITY_CODE_MAX_LENGTH_DEFAULT
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
@@ -43,14 +41,15 @@ import com.adyen.checkout.ui.theme.CheckoutTheme
 internal fun SecurityCodeField(
     securityCodeState: TextInputViewState,
     isAmex: Boolean?,
-    onIntent: (CardIntent) -> Unit,
+    onValueChange: (String) -> Unit,
+    onFocusChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     SecurityCodeFieldInternal(
         securityCodeState = securityCodeState,
         isAmex = isAmex,
-        onSecurityCodeChanged = { onIntent(CardIntent.UpdateSecurityCode(it)) },
-        onSecurityCodeFocusChanged = { onIntent(CardIntent.UpdateSecurityCodeFocus(it)) },
+        onSecurityCodeChanged = onValueChange,
+        onSecurityCodeFocusChanged = onFocusChange,
         modifier = modifier,
     )
 }
@@ -59,14 +58,15 @@ internal fun SecurityCodeField(
 internal fun StoredCardSecurityCodeField(
     securityCodeState: TextInputViewState,
     isAmex: Boolean?,
-    onIntent: (StoredCardIntent) -> Unit,
+    onValueChange: (String) -> Unit,
+    onFocusChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     SecurityCodeFieldInternal(
         securityCodeState = securityCodeState,
         isAmex = isAmex,
-        onSecurityCodeChanged = { onIntent(StoredCardIntent.UpdateSecurityCode(it)) },
-        onSecurityCodeFocusChanged = { onIntent(StoredCardIntent.UpdateSecurityCodeFocus(it)) },
+        onSecurityCodeChanged = onValueChange,
+        onSecurityCodeFocusChanged = onFocusChange,
         modifier = modifier,
     )
 }
@@ -181,7 +181,8 @@ private fun SecurityCodeFieldPreview(
                 text = "123",
             ),
             isAmex = false,
-            onIntent = {},
+            onValueChange = {},
+            onFocusChange = {},
         )
 
         SecurityCodeField(
@@ -189,7 +190,8 @@ private fun SecurityCodeFieldPreview(
                 isOptional = true,
             ),
             isAmex = true,
-            onIntent = {},
+            onValueChange = {},
+            onFocusChange = {},
         )
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SecurityCodeField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SecurityCodeField.kt
@@ -115,9 +115,7 @@ private fun SecurityCodeFieldInternal(
         initialValue = securityCodeState.text,
         isError = securityCodeState.isError,
         supportingText = supportingTextSecurityCode,
-        onValueChange = { value ->
-            onSecurityCodeChanged(value)
-        },
+        onValueChange = onSecurityCodeChanged,
         inputTransformation = inputTransformation,
         shouldFocus = securityCodeState.isFocused,
         trailingIcon = {

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SocialSecurityNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SocialSecurityNumberField.kt
@@ -53,9 +53,7 @@ internal fun SocialSecurityNumberField(
         initialValue = socialSecurityNumberState.text,
         isError = socialSecurityNumberState.isError,
         supportingText = supportingTextSocialSecurityNumber,
-        onValueChange = { value ->
-            onValueChange(value)
-        },
+        onValueChange = onValueChange,
         shouldFocus = socialSecurityNumberState.isFocused,
         inputTransformation = inputTransformation,
         outputTransformation = outputTransformation,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SocialSecurityNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SocialSecurityNumberField.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.card.internal.ui.properties.SocialSecurityNumberProperties.SOCIAL_SECURITY_MAX_LENGTH
 import com.adyen.checkout.card.internal.ui.properties.SocialSecurityNumberProperties.SOCIAL_SECURITY_SEPARATORS
-import com.adyen.checkout.card.internal.ui.state.CardIntent
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
@@ -30,7 +29,8 @@ import com.adyen.checkout.ui.theme.CheckoutTheme
 @Composable
 internal fun SocialSecurityNumberField(
     socialSecurityNumberState: TextInputViewState,
-    onIntent: (CardIntent) -> Unit,
+    onValueChange: (String) -> Unit,
+    onFocusChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val supportingTextSocialSecurityNumber = socialSecurityNumberState.supportingText?.let { resolveString(it) }
@@ -47,14 +47,14 @@ internal fun SocialSecurityNumberField(
         modifier = modifier
             .fillMaxWidth()
             .onFocusChanged { focusState ->
-                onIntent(CardIntent.UpdateSocialSecurityNumberFocus(focusState.isFocused))
+                onFocusChange(focusState.isFocused)
             },
         label = resolveString(CheckoutLocalizationKey.CARD_SOCIAL_SECURITY_NUMBER),
         initialValue = socialSecurityNumberState.text,
         isError = socialSecurityNumberState.isError,
         supportingText = supportingTextSocialSecurityNumber,
         onValueChange = { value ->
-            onIntent(CardIntent.UpdateSocialSecurityNumber(value))
+            onValueChange(value)
         },
         shouldFocus = socialSecurityNumberState.isFocused,
         inputTransformation = inputTransformation,
@@ -72,14 +72,16 @@ private fun SocialSecurityNumberFieldPreview(
             socialSecurityNumberState = TextInputViewState(
                 text = "12312312312",
             ),
-            onIntent = {},
+            onValueChange = {},
+            onFocusChange = {},
         )
 
         SocialSecurityNumberField(
             socialSecurityNumberState = TextInputViewState(
                 text = "12123123123412",
             ),
-            onIntent = {},
+            onValueChange = {},
+            onFocusChange = {},
         )
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardComponent.kt
@@ -40,8 +40,9 @@ internal fun StoredCardComponent(
             ) {
                 StoredCardSecurityCodeField(
                     securityCodeState = viewState.securityCode,
-                    onIntent = onIntent,
                     isAmex = viewState.isAmex,
+                    onValueChange = { onIntent(StoredCardIntent.UpdateSecurityCode(it)) },
+                    onFocusChange = { onIntent(StoredCardIntent.UpdateSecurityCodeFocus(it)) },
                 )
             }
         }

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MBWayContent.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MBWayContent.kt
@@ -58,7 +58,8 @@ internal fun MBWayContent(
                 MBWayPhoneNumberField(
                     mbWayPhoneNumberFieldState = viewState.phoneNumber,
                     countryCode = country.callingCode,
-                    onIntent = onIntent,
+                    onValueChange = { onIntent(MBWayIntent.UpdatePhoneNumber(it)) },
+                    onFocusChange = { onIntent(MBWayIntent.UpdatePhoneNumberFocus(it)) },
                 )
             }
         }

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MBWayPhoneNumberField.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MBWayPhoneNumberField.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
-import com.adyen.checkout.mbway.internal.ui.state.MBWayIntent
 import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.DigitOnlyInputTransformation
 import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
@@ -29,7 +28,8 @@ import com.adyen.checkout.ui.theme.CheckoutTheme
 internal fun MBWayPhoneNumberField(
     mbWayPhoneNumberFieldState: TextInputViewState,
     countryCode: String,
-    onIntent: (MBWayIntent) -> Unit,
+    onValueChange: (String) -> Unit,
+    onFocusChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val supportingTextPhoneNumber = mbWayPhoneNumberFieldState.supportingText?.let { resolveString(it) }
@@ -38,16 +38,14 @@ internal fun MBWayPhoneNumberField(
         modifier = modifier
             .fillMaxWidth()
             .onFocusChanged { focusState ->
-                onIntent(MBWayIntent.UpdatePhoneNumberFocus(focusState.hasFocus))
+                onFocusChange(focusState.hasFocus)
             },
         label = resolveString(CheckoutLocalizationKey.MBWAY_PHONE_NUMBER),
         initialValue = mbWayPhoneNumberFieldState.text,
         isError = mbWayPhoneNumberFieldState.isError,
         supportingText = supportingTextPhoneNumber,
         prefix = countryCode,
-        onValueChange = { value ->
-            onIntent(MBWayIntent.UpdatePhoneNumber(value))
-        },
+        onValueChange = onValueChange,
         inputTransformation = inputTransformation,
         shouldFocus = mbWayPhoneNumberFieldState.isFocused,
     )
@@ -64,7 +62,8 @@ private fun MBWayPhoneNumberFieldPreview(
                 text = "12345612",
             ),
             countryCode = "+31",
-            onIntent = {},
+            onValueChange = {},
+            onFocusChange = {},
         )
     }
 }


### PR DESCRIPTION
## Description
Refactor field composables to use specific lambdas instead of intent callbacks.

This internal refactor replaces `onIntent` with `onValueChange: (String) -> Unit` and `onFocusChange: (Boolean) -> Unit` in field composables across the card, blik, and mbway modules. This enforces the principle of least privilege — each field can only dispatch value and focus changes, with intent mapping happening exclusively at the call site.

**Card module:**
- Updated 8 field composables: `HolderNameField`, `ExpiryDateField`, `SecurityCodeField`, `CardNumberField`, `SocialSecurityNumberField`, `KCPBirthDateOrTaxNumberField`, `KCPCardPasswordField`, `PostalCodeField`
- Updated call sites: `CardComponent.kt` and `StoredCardComponent.kt`
- Removed `CardIntent` and `StoredCardIntent` imports from all field files
- Removed redundant lambda wrappers (`{ value -> onValueChange(value) }` → `onValueChange`)
- Standardized parameter naming (`onFocusChanged` → `onFocusChange`) and ordering

**Blik module:**
- Updated `BlikCodeField` and its call site in `BlikComponent.kt`

**MbWay module:**
- Updated `MBWayPhoneNumberField` and its call site in `MBWayContent.kt`

**Benefits:**
- Compile-time safety: Fields cannot dispatch unrelated intents
- Clear separation of concerns: Intent mapping centralized at call sites
- No behavior changes: Identical runtime behavior

## Checklist
- [x] Code is unit tested
- [x] Changes are tested manually

COSDK-1192