### PR TITLE
v6 - Treat iDeal as an instant payment method

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1624,7 +1624,6 @@ public abstract class com/adyen/checkout/core/components/data/model/paymentmetho
 }
 
 public final class com/adyen/checkout/core/components/data/model/paymentmethod/PaymentMethod$Companion {
-	public final fun getChildSerializer (Ljava/lang/String;)Lcom/adyen/checkout/core/common/internal/model/ModelObject$Serializer;
 }
 
 public abstract class com/adyen/checkout/core/components/data/model/paymentmethod/PaymentMethodResponse : com/adyen/checkout/core/common/internal/model/ModelObject {

--- a/core/src/main/java/com/adyen/checkout/core/components/data/model/paymentmethod/PaymentMethod.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/data/model/paymentmethod/PaymentMethod.kt
@@ -55,11 +55,10 @@ constructor() : PaymentMethodResponse() {
         }
 
         @Suppress("CyclomaticComplexMethod")
-        fun getChildSerializer(paymentMethodType: String): Serializer<PaymentMethod> {
+        private fun getChildSerializer(paymentMethodType: String): Serializer<PaymentMethod> {
             val serializer = when (paymentMethodType) {
                 PaymentMethodTypes.SCHEME -> CardPaymentMethod.SERIALIZER
                 PaymentMethodTypes.BCMC -> BCMCPaymentMethod.SERIALIZER
-                PaymentMethodTypes.IDEAL,
                 PaymentMethodTypes.DOTPAY,
                 PaymentMethodTypes.EPS,
                 PaymentMethodTypes.ENTERCASH,
@@ -68,13 +67,16 @@ constructor() : PaymentMethodResponse() {
                 PaymentMethodTypes.MOLPAY_THAILAND,
                 PaymentMethodTypes.MOLPAY_VIETNAM,
                 PaymentMethodTypes.ONLINE_BANKING_PL -> IssuerListPaymentMethod.SERIALIZER
+
                 PaymentMethodTypes.ONLINE_BANKING_CZ,
                 PaymentMethodTypes.ONLINE_BANKING_SK -> OnlineBankingPaymentMethod.SERIALIZER
+
                 PaymentMethodTypes.SEPA -> SEPADirectDebitPaymentMethod.SERIALIZER
                 PaymentMethodTypes.BACS -> BACSDirectDebitPaymentMethod.SERIALIZER
                 PaymentMethodTypes.ACH -> ACHDirectDebitPaymentMethod.SERIALIZER
                 PaymentMethodTypes.GOOGLE_PAY,
                 PaymentMethodTypes.GOOGLE_PAY_LEGACY -> GooglePayPaymentMethod.SERIALIZER
+
                 PaymentMethodTypes.WECHAT_PAY_SDK -> WeChatPayPaymentMethod.SERIALIZER
                 PaymentMethodTypes.MB_WAY -> MBWayPaymentMethod.SERIALIZER
                 PaymentMethodTypes.BLIK -> BLIKPaymentMethod.SERIALIZER
@@ -83,10 +85,12 @@ constructor() : PaymentMethodResponse() {
                 PaymentMethodTypes.MEAL_VOUCHER_FR_SODEXO,
                 PaymentMethodTypes.MEAL_VOUCHER_FR_NATIXIS,
                 PaymentMethodTypes.MEAL_VOUCHER_FR_GROUPEUP -> MealVoucherPaymentMethod.SERIALIZER
+
                 PaymentMethodTypes.ECONTEXT_ATM,
                 PaymentMethodTypes.ECONTEXT_ONLINE,
                 PaymentMethodTypes.ECONTEXT_SEVEN_ELEVEN,
                 PaymentMethodTypes.ECONTEXT_STORES -> EContextPaymentMethod.SERIALIZER
+
                 PaymentMethodTypes.BOLETOBANCARIO,
                 PaymentMethodTypes.BOLETOBANCARIO_BANCODOBRASIL,
                 PaymentMethodTypes.BOLETOBANCARIO_BRADESCO,
@@ -94,6 +98,7 @@ constructor() : PaymentMethodResponse() {
                 PaymentMethodTypes.BOLETOBANCARIO_ITAU,
                 PaymentMethodTypes.BOLETOBANCARIO_SANTANDER,
                 PaymentMethodTypes.BOLETO_PRIMEIRO_PAY -> BoletoPaymentMethod.SERIALIZER
+
                 PaymentMethodTypes.CASH_APP_PAY -> CashAppPayPaymentMethod.SERIALIZER
                 PaymentMethodTypes.TWINT -> TwintPaymentMethod.SERIALIZER
                 PaymentMethodTypes.PAY_BY_BANK -> PayByBankPaymentMethod.SERIALIZER
@@ -103,6 +108,7 @@ constructor() : PaymentMethodResponse() {
                 PaymentMethodTypes.UPI_INTENT,
                 PaymentMethodTypes.UPI_COLLECT,
                 PaymentMethodTypes.UPI_QR -> UPIPaymentMethod.SERIALIZER
+
                 in PaymentMethodTypes.UNSUPPORTED_PAYMENT_METHODS -> UnsupportedPaymentMethod.SERIALIZER
                 else -> InstantPaymentMethod.SERIALIZER
             }


### PR DESCRIPTION
## Description
iDeal was incorrectly treated as an issuer list payment method. This PR fixes that.
