### PR TITLE
Avoid installing Python dependencies from workflow scripts

### DIFF
--- a/.github/workflows/generate_release_notes.yml
+++ b/.github/workflows/generate_release_notes.yml
@@ -61,7 +61,6 @@ jobs:
         run: |
           chmod +x scripts/generate_release_notes.py
           RELEASE_NOTES_FILE_NAME="${VERSION_NAME}.md"
-          pip install requests toml
           python scripts/generate_release_notes.py $RELEASE_NOTES_FILE_NAME
 
       - name: Upload release notes artifact

--- a/.github/workflows/publish_to_maven_central.yml
+++ b/.github/workflows/publish_to_maven_central.yml
@@ -35,7 +35,6 @@ jobs:
           SONATYPE_CENTRAL_PORTAL_PASSWORD: ${{ secrets.SONATYPE_CENTRAL_PORTAL_PASSWORD }}
         run: |
           chmod +x scripts/drop_all_open_ossrh_repositories.py
-          pip install requests toml
           python scripts/drop_all_open_ossrh_repositories.py
 
   publish_to_maven_central:
@@ -100,5 +99,4 @@ jobs:
           PUBLISHING_TYPE: "portal_api"
         run: |
           chmod +x scripts/move_ossrh_repository_to_central_portal.py
-          pip install requests toml
           python scripts/move_ossrh_repository_to_central_portal.py

--- a/.github/workflows/validate_dependencies.yml
+++ b/.github/workflows/validate_dependencies.yml
@@ -16,8 +16,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.14'
+
       - name: Validate dependencies for release notes
         run: |
           chmod +x scripts/validate_dependencies_for_release_notes.py
-          pip install toml
           python scripts/validate_dependencies_for_release_notes.py

--- a/scripts/drop_all_open_ossrh_repositories.py
+++ b/scripts/drop_all_open_ossrh_repositories.py
@@ -1,14 +1,25 @@
 #!/usr/bin/env python3
+import base64
+import json
 import os
 import sys
-import requests
+import urllib.error
 import urllib.parse
+import urllib.request
 
 # --- Configuration ---
 SONATYPE_API_BASE_URL = "https://ossrh-staging-api.central.sonatype.com/manual"
 SEARCH_REPOSITORIES_URL = f"{SONATYPE_API_BASE_URL}/search/repositories"
 DROP_REPOSITORY_BASE_URL = f"{SONATYPE_API_BASE_URL}/drop/repository" # Key will be appended
 TIMEOUT_SECONDS = 60
+
+class _SimpleResponse:
+    def __init__(self, status_code, text):
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        return json.loads(self.text)
 
 def _get_auth_credentials():
     # Retrieves Sonatype username and password from environment variables.
@@ -31,22 +42,44 @@ def _make_api_request(method, url, auth, params=None, headers=None, expected_suc
     if expected_success_codes is None:
         expected_success_codes = [200]
 
+    # Basic auth header
+    credentials = base64.b64encode(f"{auth[0]}:{auth[1]}".encode()).decode()
+    headers["Authorization"] = f"Basic {credentials}"
+
+    # Append query params
+    if params:
+        url = f"{url}?{urllib.parse.urlencode(params)}"
+
     print(f"Making {method} request to: {url}")
     try:
-        response = requests.request(method=method, url=url, auth=auth, params=params, headers=headers, timeout=TIMEOUT_SECONDS)
+        request = urllib.request.Request(url, headers=headers, method=method)
+        with urllib.request.urlopen(request, timeout=TIMEOUT_SECONDS) as response:
+            status_code = response.status
+            body = response.read().decode()
 
-        print(f"Response Status: {response.status_code}")
+        print(f"Response Status: {status_code}")
         # Optionally print response text for debugging, can be verbose
-        # print(f"Response Text: {response.text[:500]}...") # Print first 500 chars
+        # print(f"Response Text: {body[:500]}...") # Print first 500 chars
 
-        if response.status_code in expected_success_codes:
-            return response
+        if status_code in expected_success_codes:
+            return _SimpleResponse(status_code, body)
         else:
-            print(f"Error: API request to {url} failed with status {response.status_code}.")
-            print(f"Response: {response.text}")
+            print(f"Error: API request to {url} failed with status {status_code}.")
+            print(f"Response: {body}")
             return None
 
-    except requests.exceptions.RequestException as e:
+    except urllib.error.HTTPError as e:
+        status_code = e.code
+        body = e.read().decode()
+        print(f"Response Status: {status_code}")
+        if status_code in expected_success_codes:
+            return _SimpleResponse(status_code, body)
+        else:
+            print(f"Error: API request to {url} failed with status {status_code}.")
+            print(f"Response: {body}")
+            return None
+
+    except urllib.error.URLError as e:
         print(f"Error: Request to {url} failed due to an exception: {e}")
         return None
 

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -3,10 +3,10 @@
 import json
 import os
 import re
-import requests
 import subprocess
 import sys
-import toml
+import tomllib
+import urllib.request
 
 # You can test this script locally with this command:
 # ALLOWED_LABELS="Breaking changes,New,Fixed,Improved,Changed,Removed,Deprecated" GITHUB_TOKEN="" GITHUB_REPO="Adyen/adyen-android" python ./scripts/generate_release_notes.py test_output.txt
@@ -40,8 +40,9 @@ def get_pr_number(commit: str) -> str:
 
 def fetch_pr(number: str) -> dict:
     url = 'https://api.github.com/repos/{}/pulls/{}'.format(os.getenv('GITHUB_REPO'), number)
-    headers = {'Authorization': 'token ' + os.getenv('GITHUB_TOKEN')}
-    return requests.get(url, headers=headers).json()
+    request = urllib.request.Request(url, headers = {'Authorization': 'token ' + os.getenv('GITHUB_TOKEN')})
+    with urllib.request.urlopen(request) as response:
+        return json.loads(response.read().decode())
 
 def get_label_content(label: str, pr_body: str) -> str:
     if not pr_body: return ''
@@ -98,15 +99,15 @@ def generate_dependency_updates(latest_tag: str) -> [DependencyUpdate]:
     old_toml_file = subprocess.check_output(['git', 'show', latest_tag + ':' + toml_file_path]
         ).decode(sys.stdout.encoding
         ).strip()
-    old_versions = toml.loads(old_toml_file)
+    old_versions = tomllib.loads(old_toml_file)
 
-    with open(toml_file_path) as file:
-        new_versions = toml.load(file)
+    with open(toml_file_path, 'rb') as file:
+        new_versions = tomllib.load(file)
 
     all_versions = {**old_versions['libraries'], **new_versions['libraries'], **old_versions['plugins'], **new_versions['plugins']}
 
-    with open('.github/release_notes_dependency_list.toml') as file:
-        dependency_list = toml.load(file)
+    with open('.github/release_notes_dependency_list.toml', 'rb') as file:
+        dependency_list = tomllib.load(file)
 
     for value in all_versions.values():
         if 'version' in value:

--- a/scripts/move_ossrh_repository_to_central_portal.py
+++ b/scripts/move_ossrh_repository_to_central_portal.py
@@ -1,14 +1,25 @@
 #!/usr/bin/env python3
+import base64
+import json
 import os
 import sys
-import requests
+import urllib.error
 import urllib.parse
+import urllib.request
 
 # --- Configuration ---
 SONATYPE_API_BASE_URL = "https://ossrh-staging-api.central.sonatype.com/manual"
 SEARCH_REPOSITORIES_URL = f"{SONATYPE_API_BASE_URL}/search/repositories"
 UPLOAD_REPO_BASE_URL = f"{SONATYPE_API_BASE_URL}/upload/repository" # Key will be appended
 TIMEOUT_SECONDS = 180 # Setting a timeout a bit higher, in case the Sonatype API takes longer to respond
+
+class _SimpleResponse:
+    def __init__(self, status_code, text):
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        return json.loads(self.text)
 
 def _get_env_variables():
     # Retrieves Sonatype username, password, and publishing_type from environment variables.
@@ -43,24 +54,45 @@ def _make_api_request(method, url, auth, params=None, headers=None, expected_suc
         else: # Default for GET, DELETE etc.
             expected_success_codes = [200]
 
+    # Basic auth header
+    credentials = base64.b64encode(f"{auth[0]}:{auth[1]}".encode()).decode()
+    headers["Authorization"] = f"Basic {credentials}"
+
+    # Append query params
+    if params:
+        url = f"{url}?{urllib.parse.urlencode(params)}"
+
     print(f"Making {method} request to: {url}")
     try:
-        response = requests.request(method, url, auth=auth, params=params, headers=headers, timeout=TIMEOUT_SECONDS)
+        request = urllib.request.Request(url, headers=headers, method=method)
+        with urllib.request.urlopen(request, timeout=TIMEOUT_SECONDS) as response:
+            status_code = response.status
+            body = response.read().decode()
 
-        print(f"Response Status: {response.status_code}")
+        print(f"Response Status: {status_code}")
         # Optionally print response text for debugging, can be verbose
-        # print(f"Response Text: {response.text[:500]}...") # Print first 500 chars
+        # print(f"Response Text: {body[:500]}...") # Print first 500 chars
 
         # If expected_success_codes is provided, use it for validation
-        if expected_success_codes and response.status_code not in expected_success_codes:
-            print(f"Error: API request to {url} failed with status {response.status_code}.")
-            print(f"Response: {response.text}")
+        if expected_success_codes and status_code not in expected_success_codes:
+            print(f"Error: API request to {url} failed with status {status_code}.")
+            print(f"Response: {body}")
             return None # Indicate failure for unexpected status
 
         # If no expected_success_codes, or if it's in the list, return the response
-        return response
+        return _SimpleResponse(status_code, body)
 
-    except requests.exceptions.RequestException as e:
+    except urllib.error.HTTPError as e:
+        status_code = e.code
+        body = e.read().decode()
+        print(f"Response Status: {status_code}")
+        if expected_success_codes and status_code not in expected_success_codes:
+            print(f"Error: API request to {url} failed with status {status_code}.")
+            print(f"Response: {body}")
+            return None
+        return _SimpleResponse(status_code, body)
+
+    except urllib.error.URLError as e:
         print(f"Error: Request to {url} failed due to an exception: {e}")
         return None
 

--- a/scripts/validate_dependencies_for_release_notes.py
+++ b/scripts/validate_dependencies_for_release_notes.py
@@ -2,7 +2,7 @@
 
 import subprocess
 import sys
-import toml
+import tomllib
 
 def fetch_changed_dependencies() -> dict:
     toml_file_path = 'gradle/libs.versions.toml'
@@ -16,11 +16,11 @@ def fetch_changed_dependencies() -> dict:
     old_toml_file = subprocess.check_output(
         ['git', 'show', base_commit + ':' + toml_file_path]
     ).decode(sys.stdout.encoding).strip()
-    old_versions = toml.loads(old_toml_file)
+    old_versions = tomllib.loads(old_toml_file)
 
     # Load the current version of the file after the PR changes
-    with open(toml_file_path) as file:
-        new_versions = toml.load(file)
+    with open(toml_file_path, 'rb') as file:
+        new_versions = tomllib.load(file)
 
     # Combine libraries and plugins for both old and new versions
     old_dependencies = {**old_versions['libraries'], **old_versions['plugins']}
@@ -38,8 +38,8 @@ def fetch_changed_dependencies() -> dict:
     return added_dependencies
 
 def validate_new_dependencies(added_dependencies):
-    with open('.github/release_notes_dependency_list.toml') as file:
-        dependency_list = toml.load(file)
+    with open('.github/release_notes_dependency_list.toml', 'rb') as file:
+        dependency_list = tomllib.load(file)
 
     for value in added_dependencies.values():
         # Determine the identifier for matching


### PR DESCRIPTION
## Description
By using standard libraries it is not needed to use 3rd party libraries. This mitigates several security risks:
- Python dependencies should be locked to verified versions
- Python package manager scripts should not be executed during installation
