### PR TITLE
v6 - Add bin lookup callbacks to sessions example app

### DIFF
--- a/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6SessionsViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6SessionsViewModel.kt
@@ -16,6 +16,8 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.adyen.checkout.card.BinLookupData
+import com.adyen.checkout.card.card
 import com.adyen.checkout.core.common.CheckoutContext
 import com.adyen.checkout.core.components.Checkout
 import com.adyen.checkout.core.components.CheckoutController
@@ -93,6 +95,14 @@ internal class V6SessionsViewModel @Inject constructor(
         }
     }
 
+    private fun onBinValue(binValue: String) {
+        Log.d(TAG, "Bin value received: $binValue")
+    }
+
+    private fun onBinLookup(binLookupData: BinLookupData) {
+        Log.d(TAG, "Bin Lookup Data received: $binLookupData")
+    }
+
     private fun onError(error: CheckoutError) {
         Log.d(TAG, "onError: ${error.message}")
     }
@@ -130,7 +140,12 @@ internal class V6SessionsViewModel @Inject constructor(
             callbacks = SessionCheckoutCallbacks(
                 onError = ::onError,
                 onFinished = ::onFinished,
-            ),
+            ) {
+                card(
+                    onBinValue = ::onBinValue,
+                    onBinLookup = ::onBinLookup,
+                )
+            },
             coroutineScope = viewModelScope,
         )
     }

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6ViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6ViewModel.kt
@@ -108,7 +108,7 @@ internal class V6ViewModel @Inject constructor(
     }
 
     private fun onBinLookup(binLookupData: BinLookupData) {
-        Log.d(TAG, "Bin Lookup Data received: ${binLookupData.brands.joinToString(",") { it.brand }}")
+        Log.d(TAG, "Bin Lookup Data received: $binLookupData")
     }
 
     private suspend fun onSubmit(data: PaymentComponentData<*>): SubmitResult {


### PR DESCRIPTION
## Description

Add `onBinValue` and `onBinLookup` card callbacks to `V6SessionsViewModel`, matching the existing setup in `V6ViewModel`. Also simplify the bin lookup log in both view models to print the entire `BinLookupData` object instead of manually formatting individual fields.

## Checklist

- [x] Code is unit tested
- [x] Changes are tested manually
- [x] Aligned public API changes with other platforms (if applicable)

## Ticket Number

COSDK-1204
