### PR TITLE
v6 - Card Scanning - Move existing classes to old package

### DIFF
--- a/card-scanning/api/card-scanning.api
+++ b/card-scanning/api/card-scanning.api
@@ -1,32 +1,32 @@
-public final class com/adyen/checkout/card/scanning/AdyenCardScanner {
-	public fun <init> ()V
-	public final fun getResult (Landroid/content/Intent;)Lcom/adyen/checkout/card/scanning/AdyenCardScannerResult;
-	public final fun initialize (Landroid/content/Context;Lcom/adyen/checkout/core/old/Environment;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun startScanner (Landroid/app/Activity;I)Z
-	public final fun startScanner (Landroidx/fragment/app/Fragment;I)Z
-	public final fun terminate ()V
-}
-
-public final class com/adyen/checkout/card/scanning/AdyenCardScannerResult {
-	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/Integer;
-	public final fun component3 ()Ljava/lang/Integer;
-	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;)Lcom/adyen/checkout/card/scanning/AdyenCardScannerResult;
-	public static synthetic fun copy$default (Lcom/adyen/checkout/card/scanning/AdyenCardScannerResult;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/adyen/checkout/card/scanning/AdyenCardScannerResult;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getExpiryMonth ()Ljava/lang/Integer;
-	public final fun getExpiryYear ()Ljava/lang/Integer;
-	public final fun getPan ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
 public final class com/adyen/checkout/card/scanning/BuildConfig {
 	public static final field BUILD_TYPE Ljava/lang/String;
 	public static final field CHECKOUT_VERSION Ljava/lang/String;
 	public static final field DEBUG Z
 	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
 	public fun <init> ()V
+}
+
+public final class com/adyen/checkout/card/scanning/old/AdyenCardScanner {
+	public fun <init> ()V
+	public final fun getResult (Landroid/content/Intent;)Lcom/adyen/checkout/card/scanning/old/AdyenCardScannerResult;
+	public final fun initialize (Landroid/content/Context;Lcom/adyen/checkout/core/old/Environment;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun startScanner (Landroid/app/Activity;I)Z
+	public final fun startScanner (Landroidx/fragment/app/Fragment;I)Z
+	public final fun terminate ()V
+}
+
+public final class com/adyen/checkout/card/scanning/old/AdyenCardScannerResult {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;)Lcom/adyen/checkout/card/scanning/old/AdyenCardScannerResult;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/card/scanning/old/AdyenCardScannerResult;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/adyen/checkout/card/scanning/old/AdyenCardScannerResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExpiryMonth ()Ljava/lang/Integer;
+	public final fun getExpiryYear ()Ljava/lang/Integer;
+	public final fun getPan ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 

--- a/card-scanning/src/main/java/com/adyen/checkout/card/scanning/old/AdyenCardScanner.kt
+++ b/card-scanning/src/main/java/com/adyen/checkout/card/scanning/old/AdyenCardScanner.kt
@@ -6,7 +6,7 @@
  * Created by oscars on 10/12/2024.
  */
 
-package com.adyen.checkout.card.scanning
+package com.adyen.checkout.card.scanning.old
 
 import android.app.Activity
 import android.app.PendingIntent
@@ -26,6 +26,7 @@ import com.google.android.gms.wallet.WalletConstants
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
 
+@Deprecated("Use the v6 card scanning API instead.")
 class AdyenCardScanner {
 
     private var paymentCardRecognitionPendingIntent: PendingIntent? = null

--- a/card-scanning/src/main/java/com/adyen/checkout/card/scanning/old/AdyenCardScannerResult.kt
+++ b/card-scanning/src/main/java/com/adyen/checkout/card/scanning/old/AdyenCardScannerResult.kt
@@ -6,8 +6,9 @@
  * Created by oscars on 13/2/2025.
  */
 
-package com.adyen.checkout.card.scanning
+package com.adyen.checkout.card.scanning.old
 
+@Deprecated("Use the v6 card scanning API instead.")
 data class AdyenCardScannerResult(
     val pan: String?,
     val expiryMonth: Int?,

--- a/card/src/main/java/com/adyen/checkout/card/old/internal/util/CardScannerWrapper.kt
+++ b/card/src/main/java/com/adyen/checkout/card/old/internal/util/CardScannerWrapper.kt
@@ -11,8 +11,8 @@ package com.adyen.checkout.card.old.internal.util
 import android.content.Context
 import android.content.Intent
 import androidx.fragment.app.Fragment
-import com.adyen.checkout.card.scanning.AdyenCardScanner
-import com.adyen.checkout.card.scanning.AdyenCardScannerResult
+import com.adyen.checkout.card.scanning.old.AdyenCardScanner
+import com.adyen.checkout.card.scanning.old.AdyenCardScannerResult
 import com.adyen.checkout.core.old.Environment
 import com.adyen.checkout.core.old.internal.util.runCompileOnly
 


### PR DESCRIPTION
## Description

Move AdyenCardScanner and AdyenCardScannerResult to `com.adyen.checkout.card.scanning.old` package to preserve v5 compatibility while preparing for the new v6 scanning API.

- Add `@Deprecated` annotations to moved classes
- Update imports in v5 CardScannerWrapper

### Progress

➡️ **Phase 1 — Move existing card-scanning classes to old package**
Phase 2 — Create new v6 internal API in card-scanning module
Phase 3 — Add scanning state & intents to v6 card component state layer
Phase 4 — Add scanning analytics events
Phase 5 — Integrate scanning in v6 CardComponent (logic layer)
Phase 6 — Integrate scanning in v6 composable UI
Phase 7 — Tests

## Checklist
- [x] Code is unit tested
- [x] Changes are tested manually

COSDK-1195