### PR TITLE
v6 - Card Scanning - Create new internal API

### DIFF
--- a/card-scanning/build.gradle
+++ b/card-scanning/build.gradle
@@ -30,6 +30,7 @@ android {
 
 dependencies {
     api project(':checkout-core')
+    api project(':core')
 
     implementation(libs.google.pay.play.services.wallet)
 }

--- a/card-scanning/src/main/java/com/adyen/checkout/card/scanning/internal/CardScanResult.kt
+++ b/card-scanning/src/main/java/com/adyen/checkout/card/scanning/internal/CardScanResult.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 18/5/2026.
+ */
+
+package com.adyen.checkout.card.scanning.internal
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class CardScanResult(
+    val pan: String?,
+    val expiryMonth: Int?,
+    val expiryYear: Int?,
+)

--- a/card-scanning/src/main/java/com/adyen/checkout/card/scanning/internal/CardScannerController.kt
+++ b/card-scanning/src/main/java/com/adyen/checkout/card/scanning/internal/CardScannerController.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 18/5/2026.
+ */
+
+package com.adyen.checkout.card.scanning.internal
+
+import android.app.PendingIntent
+import android.content.Intent
+import android.content.IntentSender
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.core.common.AdyenLogLevel
+import com.adyen.checkout.core.common.internal.helper.adyenLog
+import com.google.android.gms.wallet.PaymentCardRecognitionResult
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class CardScannerController internal constructor(
+    pendingIntent: PendingIntent,
+) {
+
+    private var paymentCardRecognitionPendingIntent: PendingIntent? = pendingIntent
+
+    fun getIntentSender(): IntentSender? {
+        if (paymentCardRecognitionPendingIntent == null) {
+            adyenLog(AdyenLogLevel.ERROR) { "CardScannerController has been terminated." }
+            return null
+        }
+        return paymentCardRecognitionPendingIntent?.intentSender
+    }
+
+    fun parseResult(intent: Intent?): CardScanResult? {
+        intent ?: return null
+        return PaymentCardRecognitionResult.getFromIntent(intent)
+            ?.let { result ->
+                CardScanResult(
+                    pan = result.pan,
+                    expiryMonth = result.creditCardExpirationDate?.month,
+                    expiryYear = result.creditCardExpirationDate?.year,
+                )
+            }
+    }
+
+    fun terminate() {
+        paymentCardRecognitionPendingIntent = null
+    }
+}

--- a/card-scanning/src/main/java/com/adyen/checkout/card/scanning/internal/CardScannerInitializer.kt
+++ b/card-scanning/src/main/java/com/adyen/checkout/card/scanning/internal/CardScannerInitializer.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 18/5/2026.
+ */
+
+package com.adyen.checkout.card.scanning.internal
+
+import android.content.Context
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.core.common.AdyenLogLevel
+import com.adyen.checkout.core.common.Environment
+import com.adyen.checkout.core.common.internal.helper.adyenLog
+import com.google.android.gms.wallet.PaymentCardRecognitionIntentRequest
+import com.google.android.gms.wallet.PaymentsClient
+import com.google.android.gms.wallet.Wallet
+import com.google.android.gms.wallet.WalletConstants
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+object CardScannerInitializer {
+
+    suspend fun initialize(context: Context, environment: Environment): CardScannerController? {
+        val paymentsClient = createPaymentsClient(context, environment)
+        return initializeCardRecognition(paymentsClient)
+    }
+
+    private fun createPaymentsClient(context: Context, environment: Environment): PaymentsClient {
+        val googleEnv = if (environment == Environment.TEST) {
+            WalletConstants.ENVIRONMENT_TEST
+        } else {
+            WalletConstants.ENVIRONMENT_PRODUCTION
+        }
+
+        val walletOptions = Wallet.WalletOptions.Builder()
+            .setEnvironment(googleEnv)
+            .build()
+
+        return Wallet.getPaymentsClient(context, walletOptions)
+    }
+
+    private suspend fun initializeCardRecognition(paymentsClient: PaymentsClient): CardScannerController? {
+        return suspendCancellableCoroutine { continuation ->
+            val request = PaymentCardRecognitionIntentRequest.getDefaultInstance()
+            paymentsClient
+                .getPaymentCardRecognitionIntent(request)
+                .addOnSuccessListener { intentResponse ->
+                    if (continuation.isActive) {
+                        continuation.resume(
+                            CardScannerController(intentResponse.paymentCardRecognitionPendingIntent),
+                        )
+                    }
+                }
+                .addOnFailureListener { e ->
+                    adyenLog(
+                        AdyenLogLevel.WARN,
+                        TAG,
+                        e,
+                    ) { "Card scanning not available" }
+                    if (continuation.isActive) {
+                        continuation.resume(null)
+                    }
+                }
+                .addOnCanceledListener {
+                    if (continuation.isActive) {
+                        continuation.cancel()
+                    }
+                }
+        }
+    }
+
+    private const val TAG = "CardScannerInitializer"
+}


### PR DESCRIPTION
## Description

Create a new Compose-friendly, library-internal API for card scanning in the `card-scanning` module.

- `CardScannerInitializer` — wraps Google Pay `PaymentsClient` initialization, returns `CardScannerController?`
- `CardScannerController` — provides `getIntentSender()`, `parseResult()`, and `terminate()`
- `CardScanResult` — data class with `pan`, `expiryMonth`, `expiryYear`
- All classes annotated with `@RestrictTo(LIBRARY_GROUP)`
- Added `core` module dependency for v6 `Environment` and logging

### Progress

✅ Phase 1 — [Move existing classes to old package](https://github.com/Adyen/adyen-android/pull/2758)
➡️ **Phase 2 — Create new internal API in card-scanning module**
Phase 3 — Add scanning state & intents to v6 card component state layer
Phase 4 — Add scanning analytics events
Phase 5 — Integrate scanning in v6 CardComponent (logic layer)
Phase 6 — Integrate scanning in v6 composable UI
Phase 7 — Tests

## Checklist
- [x] Code is unit tested
- [x] Changes are tested manually

COSDK-1195