### PR TITLE
v6 - Card Scanning - Add scanning state and intents

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/internal/helper/ExpiryDateParser.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/helper/ExpiryDateParser.kt
@@ -18,6 +18,7 @@ internal object ExpiryDateParser {
     private val MONTH_FORMATTER = DateUtils.getFormatter("MM")
     private val SHORT_YEAR_FORMATTER = DateUtils.getFormatter("yy")
     private val FULL_YEAR_FORMATTER = DateUtils.getFormatter("yyyy")
+    private const val YEAR_MODULUS = 100
 
     /**
      * Parses digit only input into a pair of expiryMonth and expiryYear
@@ -36,6 +37,17 @@ internal object ExpiryDateParser {
         return date?.let {
             getMonthAndYear(date, returnFullYear)
         }
+    }
+
+    /**
+     * Formats month and year integers into a digit-only MMyy string.
+     * Returns an empty string if either value is null.
+     */
+    fun formatToMMyy(month: Int?, year: Int?): String {
+        if (month == null || year == null) return ""
+        val monthStr = month.toString().padStart(2, '0')
+        val yearStr = (year % YEAR_MODULUS).toString().padStart(2, '0')
+        return "$monthStr$yearStr"
     }
 
     private fun getMonthAndYear(date: Date, returnFullYear: Boolean): Pair<String, String> {

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/model/TrailingIcon.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/model/TrailingIcon.kt
@@ -12,6 +12,7 @@ import com.adyen.checkout.core.components.internal.ui.state.model.TrailingIcon
 
 internal sealed class CardNumberTrailingIcon : TrailingIcon() {
     data object BrandLogos : CardNumberTrailingIcon()
+    data object ScanButton : CardNumberTrailingIcon()
     data object Warning : CardNumberTrailingIcon()
 }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentState.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentState.kt
@@ -31,6 +31,7 @@ internal data class CardComponentState(
     val supportedCardBrands: List<CardBrand>,
     val showSupportedCardBrandLogos: Boolean,
     val isLoading: Boolean,
+    val isCardScanningAvailable: Boolean,
 
     // Component state
     val cardBrandState: CardBrandState,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateFactory.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateFactory.kt
@@ -65,6 +65,7 @@ internal class CardComponentStateFactory(
             supportedCardBrands = componentParams.supportedCardBrands,
             showSupportedCardBrandLogos = componentParams.showSupportedCardBrandLogos,
             isLoading = false,
+            isCardScanningAvailable = false,
             cardBrandState = CardBrandState.NoBrandsDetected,
         )
     }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateReducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateReducer.kt
@@ -8,6 +8,7 @@
 
 package com.adyen.checkout.card.internal.ui.state
 
+import com.adyen.checkout.card.internal.helper.ExpiryDateParser
 import com.adyen.checkout.core.components.internal.ui.state.ComponentStateReducer
 
 internal class CardComponentStateReducer(
@@ -95,6 +96,17 @@ internal class CardComponentStateReducer(
 
             is CardIntent.UpdateLoading -> state.copy(
                 isLoading = intent.isLoading,
+            )
+
+            is CardIntent.UpdateCardScanningAvailability -> state.copy(
+                isCardScanningAvailable = intent.isAvailable,
+            )
+
+            is CardIntent.UpdateCardScanResult -> state.copy(
+                cardNumber = state.cardNumber.updateText(intent.pan.orEmpty()),
+                expiryDate = state.expiryDate.updateText(
+                    ExpiryDateParser.formatToMMyy(intent.expiryMonth, intent.expiryYear),
+                ),
             )
 
             is CardIntent.HighlightValidationErrors -> highlightValidationErrors(state)

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardIntent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardIntent.kt
@@ -56,5 +56,9 @@ internal sealed interface CardIntent : ComponentStateIntent {
 
     data class UpdateLoading(val isLoading: Boolean) : CardIntent
 
+    data class UpdateCardScanningAvailability(val isAvailable: Boolean) : CardIntent
+
+    data class UpdateCardScanResult(val pan: String?, val expiryMonth: Int?, val expiryYear: Int?) : CardIntent
+
     data object HighlightValidationErrors : CardIntent
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewState.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewState.kt
@@ -29,6 +29,7 @@ internal data class CardViewState(
     val isSupportedCardBrandsShown: Boolean,
     val detectedCardBrands: List<CardBrand>,
     val isLoading: Boolean,
+    val isCardScanButtonVisible: Boolean,
     val dualBrandData: DualBrandData?,
 ) : ViewState
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
@@ -39,10 +39,11 @@ internal class CardViewStateProducer(
         }
 
         val detectedCardBrands = getDetectedCardBrands(state.cardBrandState)
+        val isCardScanButtonVisible = state.isCardScanningAvailable && state.cardNumber.text.isEmpty()
 
         return CardViewState(
             cardNumber = state.cardNumber.toViewState(
-                trailingIcon = getCardNumberTrailingIcon(state.cardNumber),
+                trailingIcon = getCardNumberTrailingIcon(state.cardNumber, isCardScanButtonVisible),
             ),
             expiryDate = state.expiryDate.toViewState(
                 trailingIcon = getExpiryDateTrailingIcon(state.expiryDate),
@@ -63,6 +64,7 @@ internal class CardViewStateProducer(
             isSupportedCardBrandsShown = isSupportedCardBrandsShown,
             detectedCardBrands = detectedCardBrands,
             isLoading = state.isLoading,
+            isCardScanButtonVisible = isCardScanButtonVisible,
             dualBrandData = dualBrandData,
         )
     }
@@ -79,10 +81,14 @@ internal class CardViewStateProducer(
         }
     }
 
-    private fun getCardNumberTrailingIcon(cardNumber: TextInputComponentState): CardNumberTrailingIcon {
+    private fun getCardNumberTrailingIcon(
+        cardNumber: TextInputComponentState,
+        isCardScanButtonVisible: Boolean,
+    ): CardNumberTrailingIcon {
         val isInvalid = cardNumber.errorMessage != null && cardNumber.showError
         return when {
             isInvalid -> CardNumberTrailingIcon.Warning
+            isCardScanButtonVisible -> CardNumberTrailingIcon.ScanButton
             else -> CardNumberTrailingIcon.BrandLogos
         }
     }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardComponent.kt
@@ -177,6 +177,7 @@ private fun CardComponentPreview() {
             supportedCardBrands = emptyList(),
             isSupportedCardBrandsShown = false,
             isLoading = false,
+            isCardScanButtonVisible = false,
             detectedCardBrands = listOf(CardBrand(CardType.MASTERCARD.txVariant)),
             dualBrandData = null,
         ),

--- a/card/src/test/java/com/adyen/checkout/card/internal/helper/ExpiryDateParserTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/helper/ExpiryDateParserTest.kt
@@ -61,4 +61,46 @@ internal class ExpiryDateParserTest {
         val result = ExpiryDateParser.parseToMonthAndYear("1212", true)
         assertEquals("12" to "2012", result)
     }
+
+    @Test
+    fun `when formatting valid month and year then return MMyy string`() {
+        val result = ExpiryDateParser.formatToMMyy(3, 2026)
+        assertEquals("0326", result)
+    }
+
+    @Test
+    fun `when formatting single digit month then it is zero padded`() {
+        val result = ExpiryDateParser.formatToMMyy(1, 2030)
+        assertEquals("0130", result)
+    }
+
+    @Test
+    fun `when formatting double digit month then it is not padded`() {
+        val result = ExpiryDateParser.formatToMMyy(12, 2025)
+        assertEquals("1225", result)
+    }
+
+    @Test
+    fun `when formatting with two digit year then it is used directly`() {
+        val result = ExpiryDateParser.formatToMMyy(6, 30)
+        assertEquals("0630", result)
+    }
+
+    @Test
+    fun `when month is null then return empty string`() {
+        val result = ExpiryDateParser.formatToMMyy(null, 2026)
+        assertEquals("", result)
+    }
+
+    @Test
+    fun `when year is null then return empty string`() {
+        val result = ExpiryDateParser.formatToMMyy(3, null)
+        assertEquals("", result)
+    }
+
+    @Test
+    fun `when both month and year are null then return empty string`() {
+        val result = ExpiryDateParser.formatToMMyy(null, null)
+        assertEquals("", result)
+    }
 }

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandlerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandlerTest.kt
@@ -678,6 +678,7 @@ internal class CardBrandIntentsHandlerTest(
         supportedCardBrands = emptyList(),
         showSupportedCardBrandLogos = true,
         isLoading = false,
+        isCardScanningAvailable = false,
         cardBrandState = CardBrandState.NoBrandsDetected,
     )
 

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateReducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateReducerTest.kt
@@ -255,6 +255,7 @@ internal class CardComponentStateReducerTest {
         supportedCardBrands = emptyList(),
         showSupportedCardBrandLogos = true,
         isLoading = false,
+        isCardScanningAvailable = false,
         cardBrandState = CardBrandState.NoBrandsDetected,
     )
 }

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateValidatorTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateValidatorTest.kt
@@ -301,6 +301,7 @@ internal class CardComponentStateValidatorTest {
         supportedCardBrands = emptyList(),
         showSupportedCardBrandLogos = true,
         isLoading = false,
+        isCardScanningAvailable = false,
         cardBrandState = CardBrandState.NoBrandsDetected,
     )
 }

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
@@ -299,6 +299,7 @@ internal class CardViewStateProducerTest {
         supportedCardBrands = emptyList(),
         showSupportedCardBrandLogos = showSupportedCardBrandLogos,
         isLoading = false,
+        isCardScanningAvailable = false,
         cardBrandState = cardBrandState,
     )
 


### PR DESCRIPTION
## Description

Add card scanning state and intents to the v6 card component state layer.

- Add `CardIntent.UpdateCardScanningAvailability` and `CardIntent.UpdateCardScanResult` intents
- Add `isCardScanningAvailable` field to `CardComponentState`
- Add `isCardScanButtonVisible` to `CardViewState`
- Add `CardNumberTrailingIcon.ScanButton` variant
- Update `CardViewStateProducer` to derive scan button visibility and trailing icon
- Update `CardComponentStateReducer` to handle new intents
- Add `ExpiryDateParser.formatToMMyy()` utility with tests

### Progress

✅ Phase 1 — [Move existing classes to old package](https://github.com/Adyen/adyen-android/pull/2758)
✅ Phase 2 — [Create new internal API in card-scanning module](https://github.com/Adyen/adyen-android/pull/2759)
➡️ **Phase 3 — Add scanning state & intents to v6 card component state layer**
Phase 4 — Add scanning analytics events
Phase 5 — Integrate scanning in v6 CardComponent (logic layer)
Phase 6 — Integrate scanning in v6 composable UI
Phase 7 — Tests

## Checklist
- [x] Code is unit tested
- [x] Changes are tested manually

COSDK-1195