### PR TITLE
v6 - Card Scanning - Integrate scanning in CardComponent logic layer

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
@@ -8,12 +8,17 @@
 
 package com.adyen.checkout.card.internal.ui
 
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.content.IntentSender
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.adyen.checkout.card.OnBinLookupCallback
 import com.adyen.checkout.card.OnBinValueCallback
+import com.adyen.checkout.card.internal.analytics.CardScannerEvents
 import com.adyen.checkout.card.internal.data.api.DetectCardTypeRepository
 import com.adyen.checkout.card.internal.helper.toBinLookupData
 import com.adyen.checkout.card.internal.ui.model.CardComponentParams
@@ -28,6 +33,7 @@ import com.adyen.checkout.card.internal.ui.state.CardViewStateProducer
 import com.adyen.checkout.card.internal.ui.state.binValue
 import com.adyen.checkout.card.internal.ui.state.toPaymentComponentState
 import com.adyen.checkout.card.internal.ui.view.CardComponent
+import com.adyen.checkout.card.internal.util.CardScannerWrapper
 import com.adyen.checkout.core.analytics.internal.AnalyticsManager
 import com.adyen.checkout.core.analytics.internal.ErrorEvent
 import com.adyen.checkout.core.analytics.internal.GenericEvents
@@ -51,6 +57,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
 
 @Suppress("TooManyFunctions", "LongParameterList")
 internal class CardComponent(
@@ -68,6 +75,7 @@ internal class CardComponent(
     private val paymentMethodType: String,
     private val onBinValueCallback: OnBinValueCallback?,
     private val onBinLookupCallback: OnBinLookupCallback?,
+    private val cardScannerWrapper: CardScannerWrapper,
 ) : PaymentComponent {
 
     private val eventChannel = bufferedChannel<PaymentComponentEvent>()
@@ -126,7 +134,59 @@ internal class CardComponent(
     }
 
     override fun onCleared() {
+        cardScannerWrapper.terminate()
         analyticsManager.clear(this)
+    }
+
+    fun getCardScannerIntentSender(): IntentSender? {
+        return cardScannerWrapper.getIntentSender()
+    }
+
+    fun onCardScannerPresented(didDisplay: Boolean) {
+        val event = if (didDisplay) {
+            CardScannerEvents.cardScannerPresented(paymentMethodType)
+        } else {
+            CardScannerEvents.cardScannerFailure(paymentMethodType)
+        }
+        analyticsManager.trackEvent(event)
+    }
+
+    fun onCardScannerResult(resultCode: Int, intent: Intent?) {
+        if (resultCode == Activity.RESULT_CANCELED) {
+            analyticsManager.trackEvent(CardScannerEvents.cardScannerCancelled(paymentMethodType))
+            return
+        }
+
+        val scanResult = cardScannerWrapper.parseResult(intent)
+        if (scanResult == null) {
+            analyticsManager.trackEvent(CardScannerEvents.cardScannerFailure(paymentMethodType))
+            return
+        }
+
+        analyticsManager.trackEvent(CardScannerEvents.cardScannerSuccess(paymentMethodType))
+        onIntent(
+            CardIntent.UpdateCardScanResult(
+                pan = scanResult.pan,
+                expiryMonth = scanResult.expiryMonth,
+                expiryYear = scanResult.expiryYear,
+            ),
+        )
+    }
+
+    fun initializeCardScanner(context: Context) {
+        coroutineScope.launch {
+            val isAvailable = cardScannerWrapper.initialize(
+                context = context,
+                environment = componentParams.environment,
+            )
+            onIntent(CardIntent.UpdateCardScanningAvailability(isAvailable))
+            val event = if (isAvailable) {
+                CardScannerEvents.cardScannerAvailable(paymentMethodType)
+            } else {
+                CardScannerEvents.cardScannerUnavailable(paymentMethodType)
+            }
+            analyticsManager.trackEvent(event)
+        }
     }
 
     private fun onIntent(intent: CardIntent) {

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardFactory.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardFactory.kt
@@ -28,6 +28,7 @@ import com.adyen.checkout.card.internal.ui.state.StoredCardComponentStateFactory
 import com.adyen.checkout.card.internal.ui.state.StoredCardComponentStateReducer
 import com.adyen.checkout.card.internal.ui.state.StoredCardComponentStateValidator
 import com.adyen.checkout.card.internal.ui.state.StoredCardViewStateProducer
+import com.adyen.checkout.card.internal.util.CardScannerWrapper
 import com.adyen.checkout.core.analytics.internal.AnalyticsManager
 import com.adyen.checkout.core.common.internal.api.HttpClientFactory
 import com.adyen.checkout.core.components.CheckoutAdditionalCallback
@@ -109,6 +110,7 @@ internal class CardFactory :
             paymentMethodType = paymentMethodType,
             onBinValueCallback = additionalCallbacks.getAdditionalCallback<OnBinValueCallback>(),
             onBinLookupCallback = additionalCallbacks.getAdditionalCallback<OnBinLookupCallback>(),
+            cardScannerWrapper = CardScannerWrapper(),
         )
     }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/util/CardScannerWrapper.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/util/CardScannerWrapper.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 21/5/2026.
+ */
+
+package com.adyen.checkout.card.internal.util
+
+import android.content.Context
+import android.content.Intent
+import android.content.IntentSender
+import com.adyen.checkout.card.scanning.internal.CardScannerController
+import com.adyen.checkout.card.scanning.internal.CardScannerInitializer
+import com.adyen.checkout.core.common.Environment
+import com.adyen.checkout.core.common.helper.runCompileOnly
+
+internal class CardScannerWrapper {
+
+    private var controller: CardScannerController? = null
+
+    suspend fun initialize(context: Context, environment: Environment): Boolean {
+        controller = runCompileOnly { CardScannerInitializer.initialize(context, environment) }.getOrNull()
+        return controller != null
+    }
+
+    fun getIntentSender(): IntentSender? {
+        return controller?.getIntentSender()
+    }
+
+    fun parseResult(intent: Intent?): ScanResult? {
+        val result = controller?.parseResult(intent) ?: return null
+        return ScanResult(
+            pan = result.pan,
+            expiryMonth = result.expiryMonth,
+            expiryYear = result.expiryYear,
+        )
+    }
+
+    fun terminate() {
+        controller?.terminate()
+        controller = null
+    }
+
+    internal data class ScanResult(
+        val pan: String?,
+        val expiryMonth: Int?,
+        val expiryYear: Int?,
+    )
+}


### PR DESCRIPTION
## Description

Integrate card scanning into the v6 `CardComponent` logic layer.

- **`CardScannerWrapper`** — wraps `card-scanning` module via `runCompileOnly`, handles initialization, intent sender access, result parsing, and cleanup
- **`CardComponent`** — exposes `initializeCardScanner(context)`, `getCardScannerIntentSender()`, `onCardScannerPresented()`, `onCardScannerResult()`; dispatches availability/scan intents and tracks analytics
- **`CardFactory`** — creates and passes `CardScannerWrapper` to `CardComponent`

### Progress

✅ Phase 1 — [Move existing classes to old package](https://github.com/Adyen/adyen-android/pull/2758)
✅ Phase 2 — [Create new internal API in card-scanning module](https://github.com/Adyen/adyen-android/pull/2759)
✅ Phase 3 — [Add scanning state & intents to v6 card component state layer](https://github.com/Adyen/adyen-android/pull/2760)
✅ Phase 4 — [Add scanning analytics events](https://github.com/Adyen/adyen-android/pull/2764)
➡️ **Phase 5 — Integrate scanning in v6 CardComponent (logic layer)**
Phase 6 — Integrate scanning in v6 composable UI
Phase 7 — Tests

## Checklist
- [x] Code is unit tested
- [x] Changes are tested manually

COSDK-1195