### PR TITLE
v6 - Core - Introduce CompileOnlyResult to replace nullable return in runCompileOnly

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateExt.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateExt.kt
@@ -134,7 +134,7 @@ private fun createCardDetails(
 ) = CardDetails(
     type = CardDetails.PAYMENT_METHOD_TYPE,
     sdkData = sdkDataProvider.createEncodedSdkData(
-        threeDS2SdkVersion = runCompileOnly { ThreeDS2Service.INSTANCE.sdkVersion },
+        threeDS2SdkVersion = runCompileOnly { ThreeDS2Service.INSTANCE.sdkVersion }.getOrNull(),
     ),
     encryptedCardNumber = encryptedCard.encryptedCardNumber,
     encryptedExpiryMonth = encryptedCard.encryptedExpiryMonth,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardComponentStateExt.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardComponentStateExt.kt
@@ -105,7 +105,7 @@ private fun createCardDetails(
 ) = CardDetails(
     type = CardDetails.PAYMENT_METHOD_TYPE,
     sdkData = sdkDataProvider.createEncodedSdkData(
-        threeDS2SdkVersion = runCompileOnly { ThreeDS2Service.INSTANCE.sdkVersion },
+        threeDS2SdkVersion = runCompileOnly { ThreeDS2Service.INSTANCE.sdkVersion }.getOrNull(),
     ),
     storedPaymentMethodId = storedPaymentMethodId(storedCardId),
     encryptedSecurityCode = encryptedCard.encryptedSecurityCode,

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -555,6 +555,17 @@ public final class com/adyen/checkout/core/common/helper/CardSecurityCodeValidat
 	public static synthetic fun validateSecurityCode$default (Lcom/adyen/checkout/core/common/helper/CardSecurityCodeValidator;Ljava/lang/String;Lcom/adyen/checkout/core/common/CardBrand;ILjava/lang/Object;)Lcom/adyen/checkout/core/common/helper/CardSecurityCodeValidationResult;
 }
 
+public final class com/adyen/checkout/core/common/helper/CompileOnlyResult$Available : com/adyen/checkout/core/common/helper/CompileOnlyResult {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun getValue ()Ljava/lang/Object;
+}
+
+public final class com/adyen/checkout/core/common/helper/CompileOnlyResult$Unavailable : com/adyen/checkout/core/common/helper/CompileOnlyResult {
+	public static final field $stable I
+	public fun <init> ()V
+}
+
 public final class com/adyen/checkout/core/common/internal/DefaultImageLoader$Companion {
 }
 

--- a/core/src/main/java/com/adyen/checkout/core/common/helper/CompileOnlyResult.kt
+++ b/core/src/main/java/com/adyen/checkout/core/common/helper/CompileOnlyResult.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 22/5/2026.
+ */
+
+package com.adyen.checkout.core.common.helper
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+sealed interface CompileOnlyResult<out R> {
+    data class Available<R>(val value: R) : CompileOnlyResult<R>
+    data object Unavailable : CompileOnlyResult<Nothing>
+
+    fun getOrNull(): R? = when (this) {
+        is Available -> value
+        is Unavailable -> null
+    }
+}

--- a/core/src/main/java/com/adyen/checkout/core/common/helper/RunCompileOnly.kt
+++ b/core/src/main/java/com/adyen/checkout/core/common/helper/RunCompileOnly.kt
@@ -13,14 +13,14 @@ import com.adyen.checkout.core.common.AdyenLogLevel
 import com.adyen.checkout.core.common.internal.helper.adyenLog
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-inline fun <R : Any> runCompileOnly(block: () -> R): R? {
+inline fun <R> runCompileOnly(block: () -> R): CompileOnlyResult<R> {
     try {
-        return block()
+        return CompileOnlyResult.Available(block())
     } catch (e: ClassNotFoundException) {
         adyenLog(AdyenLogLevel.WARN, "runCompileOnly", e) { "Class not found. Are you missing a dependency?" }
     } catch (e: NoClassDefFoundError) {
         adyenLog(AdyenLogLevel.WARN, "runCompileOnly", e) { "Class not found. Are you missing a dependency?" }
     }
 
-    return null
+    return CompileOnlyResult.Unavailable
 }

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/helper/GooglePayUtils.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/helper/GooglePayUtils.kt
@@ -160,7 +160,7 @@ internal object GooglePayUtils {
             sdkData = sdkData,
             googlePayToken = googlePayToken,
             googlePayCardNetwork = googlePayCardNetwork,
-            threeDS2SdkVersion = runCompileOnly { ThreeDS2Service.INSTANCE.sdkVersion }
+            threeDS2SdkVersion = runCompileOnly { ThreeDS2Service.INSTANCE.sdkVersion }.getOrNull()
         )
     }
 


### PR DESCRIPTION
## Description

`runCompileOnly` previously used `null` to indicate a missing compile-only dependency and constrained `R : Any`, preventing nullable return types. This introduces a `CompileOnlyResult` sealed class with `Available`/`Unavailable` variants, making the API type-safe and allowing nullable `R`.

- Introduced `CompileOnlyResult<R>` sealed class with `getOrNull()` member
- Updated `runCompileOnly` to return `CompileOnlyResult<R>` instead of `R?`
- Removed `R : Any` constraint
- Updated all new-code call sites to use `.getOrNull()`

## Checklist
- [x] Code is unit tested
- [x] Changes are tested manually
