### PR TITLE
v6 - Card - Inject paymentMethodType into card and stored card components

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
@@ -37,7 +37,6 @@ import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
 import com.adyen.checkout.core.components.internal.ui.state.ComponentStateFlow
 import com.adyen.checkout.core.components.internal.ui.state.viewState
-import com.adyen.checkout.core.components.paymentmethod.CardDetails
 import com.adyen.checkout.core.error.internal.GenericError
 import com.adyen.checkout.core.error.internal.InternalCheckoutError
 import com.adyen.checkout.cse.EncryptionException
@@ -66,6 +65,7 @@ internal class CardComponent(
     viewStateProducer: CardViewStateProducer,
     private val coroutineScope: CoroutineScope,
     private val sdkDataProvider: SdkDataProvider,
+    private val paymentMethodType: String,
     private val onBinValueCallback: OnBinValueCallback?,
     private val onBinLookupCallback: OnBinLookupCallback?,
 ) : PaymentComponent {
@@ -110,6 +110,7 @@ internal class CardComponent(
                 cardEncryptor = cardEncryptor,
                 genericEncryptor = genericEncryptor,
                 sdkDataProvider = sdkDataProvider,
+                paymentMethodType = paymentMethodType,
                 onEncryptionFailed = ::onEncryptionError,
                 onPublicKeyNotFound = ::onPublicKeyNotFound,
             )
@@ -188,7 +189,7 @@ internal class CardComponent(
     }
 
     private fun onEncryptionError(e: EncryptionException) {
-        val event = GenericEvents.error(CardDetails.PAYMENT_METHOD_TYPE, ErrorEvent.ENCRYPTION)
+        val event = GenericEvents.error(paymentMethodType, ErrorEvent.ENCRYPTION)
         analyticsManager.trackEvent(event)
 
         // TODO - Error propagation. Change after EncryptionException extends from CheckoutError
@@ -203,7 +204,7 @@ internal class CardComponent(
 
     // TODO - Error propagation. Change after implementation of specific error for this case
     private fun onPublicKeyNotFound(e: InternalCheckoutError) {
-        val event = GenericEvents.error(CardDetails.PAYMENT_METHOD_TYPE, ErrorEvent.API_PUBLIC_KEY)
+        val event = GenericEvents.error(paymentMethodType, ErrorEvent.API_PUBLIC_KEY)
         analyticsManager.trackEvent(event)
         emitError(e)
     }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardFactory.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardFactory.kt
@@ -41,7 +41,6 @@ import com.adyen.checkout.core.components.internal.PaymentComponentFactory
 import com.adyen.checkout.core.components.internal.StoredPaymentComponentFactory
 import com.adyen.checkout.core.components.internal.data.provider.DefaultSdkDataProvider
 import com.adyen.checkout.core.components.internal.ui.model.ComponentParamsBundle
-import com.adyen.checkout.core.components.paymentmethod.CardDetails
 import com.adyen.checkout.cse.internal.CardEncryptorFactory
 import com.adyen.checkout.cse.internal.GenericEncryptorFactory
 import kotlinx.coroutines.CoroutineScope
@@ -80,13 +79,13 @@ internal class CardFactory :
         val binLookupService = BinLookupService(httpClient, cardComponentParams.clientKey)
         val binLookupCache = BinLookupCache()
         val localCardBrandDetectionService = LocalCardBrandDetectionService(cardComponentParams.supportedCardBrands)
+        val paymentMethodType = paymentMethod.type
         val networkCardBrandDetectionService = NetworkCardBrandDetectionService(
             cardEncryptor,
             binLookupService,
             cardComponentParams.publicKey,
             cardComponentParams.supportedCardBrands,
-            // TODO ensure this is set to BCMC in the BCMC factory supported
-            paymentMethodType = CardDetails.PAYMENT_METHOD_TYPE,
+            paymentMethodType,
         )
         val detectCardTypeRepository = DefaultDetectCardTypeRepository(
             detectCardTypeBinHelper,
@@ -107,6 +106,7 @@ internal class CardFactory :
             viewStateProducer = viewStateProducer,
             coroutineScope = coroutineScope,
             sdkDataProvider = DefaultSdkDataProvider(analyticsManager),
+            paymentMethodType = paymentMethodType,
             onBinValueCallback = additionalCallbacks.getAdditionalCallback<OnBinValueCallback>(),
             onBinLookupCallback = additionalCallbacks.getAdditionalCallback<OnBinLookupCallback>(),
         )

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/StoredCardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/StoredCardComponent.kt
@@ -35,7 +35,6 @@ import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
 import com.adyen.checkout.core.components.internal.ui.state.ComponentStateFlow
 import com.adyen.checkout.core.components.internal.ui.state.viewState
-import com.adyen.checkout.core.components.paymentmethod.CardDetails
 import com.adyen.checkout.core.error.internal.InternalCheckoutError
 import com.adyen.checkout.cse.EncryptionException
 import com.adyen.checkout.cse.internal.BaseCardEncryptor
@@ -114,6 +113,7 @@ internal class StoredCardComponent(
                 cardEncryptor = cardEncryptor,
                 sdkDataProvider = sdkDataProvider,
                 storedPaymentMethodId = storedPaymentMethod.id,
+                paymentMethodType = storedPaymentMethod.type,
                 onEncryptionFailed = ::onEncryptionError,
                 onPublicKeyNotFound = ::onPublicKeyNotFound,
             )
@@ -138,14 +138,14 @@ internal class StoredCardComponent(
 
     @Suppress("UNUSED_PARAMETER")
     private fun onEncryptionError(e: EncryptionException) {
-        val event = GenericEvents.error(CardDetails.PAYMENT_METHOD_TYPE, ErrorEvent.ENCRYPTION)
+        val event = GenericEvents.error(storedPaymentMethod.type, ErrorEvent.ENCRYPTION)
         analyticsManager.trackEvent(event)
         // exceptionChannel.trySend(e)
     }
 
     @Suppress("UNUSED_PARAMETER")
     private fun onPublicKeyNotFound(e: InternalCheckoutError) {
-        val event = GenericEvents.error(CardDetails.PAYMENT_METHOD_TYPE, ErrorEvent.API_PUBLIC_KEY)
+        val event = GenericEvents.error(storedPaymentMethod.type, ErrorEvent.API_PUBLIC_KEY)
         analyticsManager.trackEvent(event)
         // exceptionChannel.trySend(e)
     }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateExt.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateExt.kt
@@ -34,6 +34,7 @@ internal fun CardComponentState.toPaymentComponentState(
     cardEncryptor: BaseCardEncryptor,
     genericEncryptor: BaseGenericEncryptor,
     sdkDataProvider: SdkDataProvider,
+    paymentMethodType: String,
     onEncryptionFailed: (EncryptionException) -> Unit,
     onPublicKeyNotFound: (InternalCheckoutError) -> Unit,
 ): CardPaymentComponentState {
@@ -60,6 +61,7 @@ internal fun CardComponentState.toPaymentComponentState(
         holderName = holderName.getPaymentDataValue(),
         cardBrand = cardBrand(),
         sdkDataProvider = sdkDataProvider,
+        paymentMethodType = paymentMethodType,
         kcpBirthDateOrTaxNumber = kcpBirthDateOrTaxNumber.getPaymentDataValue(),
         encryptedKcpCardPassword = encryptedKcpCardPassword,
     )
@@ -129,10 +131,11 @@ private fun createCardDetails(
     sdkDataProvider: SdkDataProvider,
     holderName: String?,
     cardBrand: CardBrand?,
+    paymentMethodType: String,
     encryptedKcpCardPassword: String?,
     kcpBirthDateOrTaxNumber: String?,
 ) = CardDetails(
-    type = CardDetails.PAYMENT_METHOD_TYPE,
+    type = paymentMethodType,
     sdkData = sdkDataProvider.createEncodedSdkData(
         threeDS2SdkVersion = runCompileOnly { ThreeDS2Service.INSTANCE.sdkVersion }.getOrNull(),
     ),

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardComponentStateExt.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardComponentStateExt.kt
@@ -28,6 +28,7 @@ internal fun StoredCardComponentState.toPaymentComponentState(
     cardEncryptor: BaseCardEncryptor,
     sdkDataProvider: SdkDataProvider,
     storedPaymentMethodId: String?,
+    paymentMethodType: String,
     onEncryptionFailed: (EncryptionException) -> Unit,
     onPublicKeyNotFound: (InternalCheckoutError) -> Unit,
 ): CardPaymentComponentState {
@@ -44,6 +45,7 @@ internal fun StoredCardComponentState.toPaymentComponentState(
         storedCardId = storedPaymentMethodId,
         encryptedCard = encryptedCard,
         sdkDataProvider = sdkDataProvider,
+        paymentMethodType = paymentMethodType,
     )
 
     val paymentComponentData = createPaymentComponentData(cardDetails)
@@ -102,8 +104,9 @@ private fun createCardDetails(
     storedCardId: String?,
     encryptedCard: EncryptedCard,
     sdkDataProvider: SdkDataProvider,
+    paymentMethodType: String,
 ) = CardDetails(
-    type = CardDetails.PAYMENT_METHOD_TYPE,
+    type = paymentMethodType,
     sdkData = sdkDataProvider.createEncodedSdkData(
         threeDS2SdkVersion = runCompileOnly { ThreeDS2Service.INSTANCE.sdkVersion }.getOrNull(),
     ),


### PR DESCRIPTION
## Description
Replace hardcoded `CardDetails.PAYMENT_METHOD_TYPE` with an injected `paymentMethodType` parameter sourced from `PaymentMethod.type` and `StoredPaymentMethod.type`. This prepares the card component to handle different payment method types (e.g. bcmc) in addition to scheme.

## Checklist
- [x] Changes are tested manually