### PR TITLE
v6 - UI - Refactor CheckoutTextField to support external state overrides

### DIFF
--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/BlikCodeField.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/BlikCodeField.kt
@@ -25,6 +25,7 @@ import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.DigitOnlyInputTransformation
 import com.adyen.checkout.ui.internal.element.input.SeparatorsOutputTransformation
 import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
+import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
 import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
@@ -54,7 +55,7 @@ internal fun BlikCodeField(
                 onFocusChange(focusState.hasFocus)
             },
         label = resolveString(CheckoutLocalizationKey.BLIK_CODE),
-        initialValue = blikCodeState.text,
+        state = rememberTextFieldStateWithCurrentValue(blikCodeState.text),
         isError = blikCodeState.isError,
         supportingText = supportingText,
         onValueChange = onValueChange,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
@@ -40,6 +40,7 @@ import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewS
 import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.DigitOnlyInputTransformation
 import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
+import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
 import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
 import com.adyen.checkout.ui.internal.helper.getThemedIcon
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
@@ -103,7 +104,7 @@ private fun CardNumberInputField(
                 onFocusChange(focusState.isFocused)
             },
         label = resolveString(CheckoutLocalizationKey.CARD_NUMBER),
-        initialValue = cardNumberState.text,
+        state = rememberTextFieldStateWithCurrentValue(cardNumberState.text),
         isError = cardNumberState.isError,
         supportingText = supportingTextCardNumber,
         onValueChange = onValueChange,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/ExpiryDateField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/ExpiryDateField.kt
@@ -31,6 +31,7 @@ import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.SeparatorsOutputTransformation
 import com.adyen.checkout.ui.internal.element.input.TextFieldSeparator
 import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
+import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
 import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
 import com.adyen.checkout.ui.internal.helper.getThemedIcon
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
@@ -69,7 +70,7 @@ internal fun ExpiryDateField(
                 onFocusChange(focusState.isFocused)
             },
         label = resolveString(key = CheckoutLocalizationKey.CARD_EXPIRY_DATE) + labelSuffix,
-        initialValue = expiryDateState.text,
+        state = rememberTextFieldStateWithCurrentValue(expiryDateState.text),
         isError = expiryDateState.isError,
         supportingText = supportingTextExpiryDate,
         onValueChange = onValueChange,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/HolderNameField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/HolderNameField.kt
@@ -22,6 +22,7 @@ import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
+import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
 import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
@@ -41,7 +42,7 @@ internal fun HolderNameField(
                 onFocusChange(focusState.isFocused)
             },
         label = resolveString(CheckoutLocalizationKey.CARD_HOLDER_NAME),
-        initialValue = holderNameState.text,
+        state = rememberTextFieldStateWithCurrentValue(holderNameState.text),
         isError = holderNameState.isError,
         supportingText = supportingTextHolderName,
         onValueChange = onValueChange,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPBirthDateOrTaxNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPBirthDateOrTaxNumberField.kt
@@ -23,6 +23,7 @@ import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewS
 import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.DigitOnlyInputTransformation
 import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
+import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
 import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
@@ -56,7 +57,7 @@ internal fun KCPBirthDateOrTaxNumberField(
                 onFocusChange(focusState.isFocused)
             },
         label = label,
-        initialValue = kcpBirthDateOrTaxNumberState.text,
+        state = rememberTextFieldStateWithCurrentValue(kcpBirthDateOrTaxNumberState.text),
         isError = kcpBirthDateOrTaxNumberState.isError,
         supportingText = supportingText,
         onValueChange = onValueChange,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPCardPasswordField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPCardPasswordField.kt
@@ -22,6 +22,7 @@ import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewS
 import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.DigitOnlyInputTransformation
 import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
+import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
 import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
@@ -47,7 +48,7 @@ internal fun KCPCardPasswordField(
                 onFocusChange(focusState.isFocused)
             },
         label = resolveString(CheckoutLocalizationKey.CARD_KCP_CARD_PASSWORD),
-        initialValue = kcpCardPasswordState.text,
+        state = rememberTextFieldStateWithCurrentValue(kcpCardPasswordState.text),
         isError = kcpCardPasswordState.isError,
         supportingText = supportingText,
         onValueChange = onValueChange,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/PostalCodeField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/PostalCodeField.kt
@@ -25,6 +25,7 @@ import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
+import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
 import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
 import com.adyen.checkout.ui.internal.theme.Dimensions
 import com.adyen.checkout.ui.theme.CheckoutTheme
@@ -45,7 +46,7 @@ internal fun PostalCodeField(
                 onFocusChange(focusState.isFocused)
             },
         label = resolveString(CheckoutLocalizationKey.CARD_POSTAL_CODE),
-        initialValue = postalCodeState.text,
+        state = rememberTextFieldStateWithCurrentValue(postalCodeState.text),
         inputTransformation = InputTransformation.maxLength(PostalCodeProperties.POSTAL_CODE_MAX_LENGTH),
         isError = postalCodeState.isError,
         supportingText = supportingTextPostalCode,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SecurityCodeField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SecurityCodeField.kt
@@ -31,6 +31,7 @@ import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewS
 import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.DigitOnlyInputTransformation
 import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
+import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
 import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
 import com.adyen.checkout.ui.internal.helper.getThemedIcon
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
@@ -112,7 +113,7 @@ private fun SecurityCodeFieldInternal(
                 onSecurityCodeFocusChanged(focusState.isFocused)
             },
         label = resolveString(key = CheckoutLocalizationKey.CARD_SECURITY_CODE) + labelSuffix,
-        initialValue = securityCodeState.text,
+        state = rememberTextFieldStateWithCurrentValue(securityCodeState.text),
         isError = securityCodeState.isError,
         supportingText = supportingTextSecurityCode,
         onValueChange = onSecurityCodeChanged,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SocialSecurityNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SocialSecurityNumberField.kt
@@ -23,6 +23,7 @@ import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewS
 import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.DigitOnlyInputTransformation
 import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
+import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
 import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
@@ -50,7 +51,7 @@ internal fun SocialSecurityNumberField(
                 onFocusChange(focusState.isFocused)
             },
         label = resolveString(CheckoutLocalizationKey.CARD_SOCIAL_SECURITY_NUMBER),
-        initialValue = socialSecurityNumberState.text,
+        state = rememberTextFieldStateWithCurrentValue(socialSecurityNumberState.text),
         isError = socialSecurityNumberState.isError,
         supportingText = supportingTextSocialSecurityNumber,
         onValueChange = onValueChange,

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MBWayPhoneNumberField.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MBWayPhoneNumberField.kt
@@ -21,6 +21,7 @@ import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewS
 import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.DigitOnlyInputTransformation
 import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
+import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
 import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
@@ -41,7 +42,7 @@ internal fun MBWayPhoneNumberField(
                 onFocusChange(focusState.hasFocus)
             },
         label = resolveString(CheckoutLocalizationKey.MBWAY_PHONE_NUMBER),
-        initialValue = mbWayPhoneNumberFieldState.text,
+        state = rememberTextFieldStateWithCurrentValue(mbWayPhoneNumberFieldState.text),
         isError = mbWayPhoneNumberFieldState.isError,
         supportingText = supportingTextPhoneNumber,
         prefix = countryCode,

--- a/ui/api/ui.api
+++ b/ui/api/ui.api
@@ -6,6 +6,10 @@ public final class com/adyen/checkout/test/BuildConfig {
 	public fun <init> ()V
 }
 
+public final class com/adyen/checkout/ui/internal/element/input/CheckoutTextFieldKt {
+	public static final fun rememberTextFieldStateWithCurrentValue (Ljava/lang/String;Landroidx/compose/runtime/Composer;I)Landroidx/compose/foundation/text/input/TextFieldState;
+}
+
 public final class com/adyen/checkout/ui/theme/CheckoutAttributes {
 	public static final field $stable I
 	public static final field Companion Lcom/adyen/checkout/ui/theme/CheckoutAttributes$Companion;

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/input/CheckoutTextField.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/input/CheckoutTextField.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.text.input.TextFieldDecorator
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -54,7 +55,8 @@ import kotlinx.coroutines.flow.collectLatest
  *
  * @param label The label text to be displayed for the text field.
  * @param modifier Optional [Modifier] to be applied to this composable.
- * @param initialValue The initial text to be displayed in the text field.
+ * @param state The [TextFieldState] to be used for the text field. Use [rememberTextFieldStateWithCurrentValue]
+ * to create a state that syncs with external value changes.
  * @param onValueChange A callback that is triggered when the text in the field changes.
  * @param enabled Controls the enabled state of the text field. When `false`, the text field
  * is not interactable.
@@ -76,9 +78,8 @@ import kotlinx.coroutines.flow.collectLatest
 @Composable
 fun CheckoutTextField(
     label: String?,
+    state: TextFieldState,
     modifier: Modifier = Modifier,
-    initialValue: String = "",
-    state: TextFieldState = rememberTextFieldState(initialValue),
     onValueChange: ((String) -> Unit)? = null,
     enabled: Boolean = true,
     supportingText: String? = null,
@@ -164,6 +165,18 @@ fun CheckoutTextField(
     }
 }
 
+@Composable
+fun rememberTextFieldStateWithCurrentValue(currentText: String): TextFieldState {
+    val state = rememberTextFieldState(currentText)
+    LaunchedEffect(currentText) {
+        // this allows external state changes to be reflected in the text field
+        if (state.text.toString() != currentText) {
+            state.setTextAndPlaceCursorAtEnd(currentText)
+        }
+    }
+    return state
+}
+
 @Preview
 @Composable
 private fun CheckoutTextFieldPreview(
@@ -173,12 +186,14 @@ private fun CheckoutTextFieldPreview(
         CheckoutTextField(
             onValueChange = {},
             label = "Label",
+            state = rememberTextFieldStateWithCurrentValue(""),
             supportingText = "Description",
         )
 
         CheckoutTextField(
             onValueChange = {},
             label = "Label",
+            state = rememberTextFieldStateWithCurrentValue(""),
             prefix = "Prefix",
         )
 
@@ -186,7 +201,7 @@ private fun CheckoutTextFieldPreview(
         CheckoutTextField(
             onValueChange = {},
             label = "Label",
-            initialValue = "Value",
+            state = rememberTextFieldStateWithCurrentValue("Value"),
             trailingIcon = {
                 Icon(
                     imageVector = ImageVector.vectorResource(R.drawable.ic_checkmark),
@@ -202,7 +217,7 @@ private fun CheckoutTextFieldPreview(
 
         CheckoutTextField(
             onValueChange = {},
-            initialValue = "Value",
+            state = rememberTextFieldStateWithCurrentValue("Value"),
             label = "Label",
             supportingText = "Invalid input",
             isError = true,
@@ -210,7 +225,7 @@ private fun CheckoutTextFieldPreview(
 
         CheckoutTextField(
             onValueChange = {},
-            initialValue = "Value",
+            state = rememberTextFieldStateWithCurrentValue("Value"),
             label = "Password",
             isSecureField = true,
             modifier = Modifier.focusRequester(focusRequester),


### PR DESCRIPTION
## Description
Refactor `CheckoutTextField` to allow external state to override the displayed text field value. This is needed for features like card scanning, where a scanned card number must replace whatever is currently in the field.

**Changes:**
- Remove `initialValue` parameter from `CheckoutTextField`, replace with required `TextFieldState` parameter
- Add `rememberTextFieldStateWithCurrentValue` helper that uses `LaunchedEffect` to sync external state changes into the text field
- Migrate all call sites to use the new approach consistently

## Checklist
- [x] Changes are tested manually