### PR TITLE
v6 - Card Scanning - Make card-scanning available by default with opt-out

### DIFF
--- a/card/api/card.api
+++ b/card/api/card.api
@@ -53,6 +53,7 @@ public final class com/adyen/checkout/card/CardConfiguration : com/adyen/checkou
 	public final fun describeContents ()I
 	public final fun getBillingAddressMode ()Lcom/adyen/checkout/card/BillingAddressMode;
 	public final fun getKoreanAuthenticationVisibility ()Lcom/adyen/checkout/card/FieldVisibility;
+	public final fun getShowCardScanner ()Ljava/lang/Boolean;
 	public final fun getShowCardholderName ()Ljava/lang/Boolean;
 	public final fun getShowSecurityCode ()Ljava/lang/Boolean;
 	public final fun getShowSecurityCodeForStoredCard ()Ljava/lang/Boolean;
@@ -74,7 +75,8 @@ public final class com/adyen/checkout/card/CardConfigurationKt {
 	public static final fun card (Lcom/adyen/checkout/core/components/CheckoutConfiguration;Lcom/adyen/checkout/card/BillingAddressMode;Lcom/adyen/checkout/card/FieldVisibility;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lcom/adyen/checkout/core/components/CheckoutConfiguration;
 	public static final fun card (Lcom/adyen/checkout/core/components/CheckoutConfiguration;Lcom/adyen/checkout/card/BillingAddressMode;Lcom/adyen/checkout/card/FieldVisibility;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/adyen/checkout/card/FieldVisibility;)Lcom/adyen/checkout/core/components/CheckoutConfiguration;
 	public static final fun card (Lcom/adyen/checkout/core/components/CheckoutConfiguration;Lcom/adyen/checkout/card/BillingAddressMode;Lcom/adyen/checkout/card/FieldVisibility;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/adyen/checkout/card/FieldVisibility;Ljava/util/List;)Lcom/adyen/checkout/core/components/CheckoutConfiguration;
-	public static synthetic fun card$default (Lcom/adyen/checkout/core/components/CheckoutConfiguration;Lcom/adyen/checkout/card/BillingAddressMode;Lcom/adyen/checkout/card/FieldVisibility;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/adyen/checkout/card/FieldVisibility;Ljava/util/List;ILjava/lang/Object;)Lcom/adyen/checkout/core/components/CheckoutConfiguration;
+	public static final fun card (Lcom/adyen/checkout/core/components/CheckoutConfiguration;Lcom/adyen/checkout/card/BillingAddressMode;Lcom/adyen/checkout/card/FieldVisibility;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/adyen/checkout/card/FieldVisibility;Ljava/util/List;Ljava/lang/Boolean;)Lcom/adyen/checkout/core/components/CheckoutConfiguration;
+	public static synthetic fun card$default (Lcom/adyen/checkout/core/components/CheckoutConfiguration;Lcom/adyen/checkout/card/BillingAddressMode;Lcom/adyen/checkout/card/FieldVisibility;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/adyen/checkout/card/FieldVisibility;Ljava/util/List;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/adyen/checkout/core/components/CheckoutConfiguration;
 }
 
 public final class com/adyen/checkout/card/FieldVisibility : java/lang/Enum {

--- a/card/build.gradle
+++ b/card/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     api project(':cse')
     api project(':ui-core')
     api project(':sessions-core')
-    compileOnly project(':card-scanning')
+    implementation project(':card-scanning')
 
     // Dependencies
     implementation libs.compose.activity

--- a/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
@@ -26,6 +26,7 @@ class CardConfiguration internal constructor(
     val showSupportedCardBrandLogos: Boolean?,
     val socialSecurityNumberVisibility: FieldVisibility?,
     val supportedCardBrands: List<CardBrand>?,
+    val showCardScanner: Boolean?,
     // TODO - Card. Installments
 ) : Configuration
 
@@ -41,6 +42,7 @@ fun CheckoutConfiguration.card(
     showSupportedCardBrandLogos: Boolean? = null,
     socialSecurityNumberVisibility: FieldVisibility? = null,
     supportedCardBrands: List<CardBrand>? = null,
+    showCardScanner: Boolean? = null,
 ): CheckoutConfiguration {
     val config = CardConfiguration(
         billingAddressMode = billingAddressMode,
@@ -52,6 +54,7 @@ fun CheckoutConfiguration.card(
         showSupportedCardBrandLogos = showSupportedCardBrandLogos,
         socialSecurityNumberVisibility = socialSecurityNumberVisibility,
         supportedCardBrands = supportedCardBrands,
+        showCardScanner = showCardScanner,
     )
     addConfiguration(PaymentMethodTypes.SCHEME, config)
     return this

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
@@ -206,6 +206,7 @@ internal class CardComponent(
     }
 
     fun initializeCardScanner(context: Context) {
+        if (!componentParams.showCardScanner) return
         coroutineScope.launch {
             val isAvailable = cardScannerWrapper.initialize(
                 context = context,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/model/CardComponentParams.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/model/CardComponentParams.kt
@@ -26,4 +26,5 @@ data class CardComponentParams(
     val showPostalCode: Boolean,
     val cvcVisibility: CVCVisibility,
     val storedCVCVisibility: StoredCVCVisibility,
+    val showCardScanner: Boolean,
 ) : ComponentParams by commonComponentParams

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapper.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapper.kt
@@ -50,6 +50,7 @@ internal class CardComponentParamsMapper {
             } else {
                 StoredCVCVisibility.SHOW
             },
+            showCardScanner = cardConfiguration?.showCardScanner ?: true,
         )
     }
 

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapperTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapperTest.kt
@@ -57,6 +57,7 @@ internal class CardComponentParamsMapperTest {
                 socialSecurityNumberVisibility = null,
                 koreanAuthenticationVisibility = null,
                 billingAddressMode = null,
+                showCardScanner = null,
             ),
             paymentMethod = null,
         )
@@ -321,6 +322,7 @@ internal class CardComponentParamsMapperTest {
                 socialSecurityNumberVisibility = FieldVisibility.SHOW,
                 koreanAuthenticationVisibility = FieldVisibility.SHOW,
                 billingAddressMode = BillingAddressMode.PostalCode(),
+                showCardScanner = null,
             ),
             paymentMethod = null,
         )
@@ -380,6 +382,7 @@ internal class CardComponentParamsMapperTest {
         socialSecurityNumberVisibility: FieldVisibility? = null,
         koreanAuthenticationVisibility: FieldVisibility? = null,
         billingAddressMode: BillingAddressMode? = null,
+        showCardScanner: Boolean? = null,
     ) = CardConfiguration(
         showCardholderName = showCardholderName,
         supportedCardBrands = supportedCardBrands,
@@ -390,6 +393,7 @@ internal class CardComponentParamsMapperTest {
         socialSecurityNumberVisibility = socialSecurityNumberVisibility,
         koreanAuthenticationVisibility = koreanAuthenticationVisibility,
         billingAddressMode = billingAddressMode,
+        showCardScanner = showCardScanner,
     )
 
     private fun createCardPaymentMethod(
@@ -412,6 +416,7 @@ internal class CardComponentParamsMapperTest {
         showPostalCode: Boolean = false,
         cvcVisibility: CVCVisibility = CVCVisibility.ALWAYS_SHOW,
         storedCVCVisibility: StoredCVCVisibility = StoredCVCVisibility.SHOW,
+        showCardScanner: Boolean = true,
     ) = CardComponentParams(
         commonComponentParams = CommonComponentParams(
             shopperLocale = DEVICE_LOCALE,
@@ -432,6 +437,7 @@ internal class CardComponentParamsMapperTest {
         showPostalCode = showPostalCode,
         cvcVisibility = cvcVisibility,
         storedCVCVisibility = storedCVCVisibility,
+        showCardScanner = showCardScanner,
     )
 
     companion object {

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateFactoryTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateFactoryTest.kt
@@ -221,6 +221,7 @@ internal class CardComponentStateFactoryTest {
             showPostalCode = showPostalCode,
             cvcVisibility = cvcVisibility,
             storedCVCVisibility = StoredCVCVisibility.SHOW,
+            showCardScanner = true,
         ),
     )
 }


### PR DESCRIPTION
## Description

Make card scanning available by default by changing `card-scanning` from a `compileOnly` to an `implementation` dependency. Add `showCardScanner` configuration flag so merchants can opt out.

- **`card/build.gradle`** — change `compileOnly` to `implementation` for `:card-scanning`
- **`CardConfiguration`** — add `showCardScanner: Boolean?` field
- **`CheckoutConfiguration.card()`** — add `showCardScanner` parameter
- **`CardComponentParams`** — add `showCardScanner: Boolean` (resolved, default `true`)
- **`CardComponent`** — skip scanner initialization when `showCardScanner` is `false`
- `runCompileOnly` graceful degradation still works if the merchant manually excludes the module

### Progress

✅ Phase 1 — [Move existing classes to old package](https://github.com/Adyen/adyen-android/pull/2758)
✅ Phase 2 — [Create new internal API in card-scanning module](https://github.com/Adyen/adyen-android/pull/2759)
✅ Phase 3 — [Add scanning state & intents to v6 card component state layer](https://github.com/Adyen/adyen-android/pull/2760)
✅ Phase 4 — [Add scanning analytics events](https://github.com/Adyen/adyen-android/pull/2764)
✅ Phase 5 — [Integrate scanning in v6 CardComponent logic layer](https://github.com/Adyen/adyen-android/pull/2767)
✅ Phase 6 — [Integrate scanning in v6 composable UI](https://github.com/Adyen/adyen-android/pull/2768)
➡️ **Phase 7 — Make card-scanning available by default with opt-out**
Phase 8 — Tests

## Checklist
- [x] Changes are tested manually

COSDK-1195