### PR TITLE
v6 - Card Scanning - Add unit tests

### DIFF
--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapperTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/model/CardComponentParamsMapperTest.kt
@@ -21,6 +21,8 @@ import com.adyen.checkout.core.components.internal.ui.model.CommonComponentParam
 import com.adyen.checkout.core.components.internal.ui.model.ComponentParamsBundle
 import com.adyen.checkout.core.sessions.internal.model.SessionParams
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments.arguments
@@ -151,6 +153,39 @@ internal class CardComponentParamsMapperTest {
         )
 
         assertEquals(StoredCVCVisibility.HIDE, params.storedCVCVisibility)
+    }
+
+    @Test
+    fun `when showCardScanner is null then it defaults to true`() {
+        val params = mapper.mapToParams(
+            componentParamsBundle = createComponentParamsBundle(),
+            cardConfiguration = createCardConfiguration(showCardScanner = null),
+            paymentMethod = null,
+        )
+
+        assertTrue(params.showCardScanner)
+    }
+
+    @Test
+    fun `when showCardScanner is true then it is passed through`() {
+        val params = mapper.mapToParams(
+            componentParamsBundle = createComponentParamsBundle(),
+            cardConfiguration = createCardConfiguration(showCardScanner = true),
+            paymentMethod = null,
+        )
+
+        assertTrue(params.showCardScanner)
+    }
+
+    @Test
+    fun `when showCardScanner is false then it is passed through`() {
+        val params = mapper.mapToParams(
+            componentParamsBundle = createComponentParamsBundle(),
+            cardConfiguration = createCardConfiguration(showCardScanner = false),
+            paymentMethod = null,
+        )
+
+        assertFalse(params.showCardScanner)
     }
 
     @Test
@@ -322,7 +357,7 @@ internal class CardComponentParamsMapperTest {
                 socialSecurityNumberVisibility = FieldVisibility.SHOW,
                 koreanAuthenticationVisibility = FieldVisibility.SHOW,
                 billingAddressMode = BillingAddressMode.PostalCode(),
-                showCardScanner = null,
+                showCardScanner = false,
             ),
             paymentMethod = null,
         )
@@ -337,6 +372,7 @@ internal class CardComponentParamsMapperTest {
             showPostalCode = true,
             cvcVisibility = CVCVisibility.ALWAYS_HIDE,
             storedCVCVisibility = StoredCVCVisibility.HIDE,
+            showCardScanner = false,
         )
 
         assertEquals(expected, params)

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateReducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateReducerTest.kt
@@ -241,6 +241,63 @@ internal class CardComponentStateReducerTest {
         assertFalse(actual.securityCode.isFocused)
     }
 
+    @Test
+    fun `when intent is UpdateCardScanningAvailability with true, then isCardScanningAvailable is true`() {
+        val state = createInitialState()
+
+        val actual = reducer.reduce(state, CardIntent.UpdateCardScanningAvailability(true))
+
+        assertTrue(actual.isCardScanningAvailable)
+    }
+
+    @Test
+    fun `when intent is UpdateCardScanningAvailability with false, then isCardScanningAvailable is false`() {
+        val state = createInitialState().copy(isCardScanningAvailable = true)
+
+        val actual = reducer.reduce(state, CardIntent.UpdateCardScanningAvailability(false))
+
+        assertFalse(actual.isCardScanningAvailable)
+    }
+
+    @Test
+    fun `when intent is UpdateCardScanResult with pan and expiry, then cardNumber and expiryDate are updated`() {
+        val state = createInitialState()
+
+        val actual = reducer.reduce(
+            state,
+            CardIntent.UpdateCardScanResult(pan = "4111111111111111", expiryMonth = 12, expiryYear = 2025),
+        )
+
+        assertEquals("4111111111111111", actual.cardNumber.text)
+        assertEquals("1225", actual.expiryDate.text)
+    }
+
+    @Test
+    fun `when intent is UpdateCardScanResult with null pan, then cardNumber is empty`() {
+        val state = createInitialState()
+
+        val actual = reducer.reduce(
+            state,
+            CardIntent.UpdateCardScanResult(pan = null, expiryMonth = 3, expiryYear = 2026),
+        )
+
+        assertEquals("", actual.cardNumber.text)
+        assertEquals("0326", actual.expiryDate.text)
+    }
+
+    @Test
+    fun `when intent is UpdateCardScanResult with null expiry, then expiryDate is empty`() {
+        val state = createInitialState()
+
+        val actual = reducer.reduce(
+            state,
+            CardIntent.UpdateCardScanResult(pan = "5500000000000004", expiryMonth = null, expiryYear = null),
+        )
+
+        assertEquals("5500000000000004", actual.cardNumber.text)
+        assertEquals("", actual.expiryDate.text)
+    }
+
     private fun createInitialState() = CardComponentState(
         cardNumber = TextInputComponentState(),
         expiryDate = TextInputComponentState(),

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
@@ -280,11 +280,78 @@ internal class CardViewStateProducerTest {
         assertFalse(viewState.isSupportedCardBrandsShown)
     }
 
+    @Test
+    fun `when card scanning is available and card number is empty, then scan button is visible and trailing icon is ScanButton`() {
+        // GIVEN
+        val componentState = createComponentState(
+            cardNumber = TextInputComponentState(text = ""),
+            isCardScanningAvailable = true,
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertTrue(viewState.isCardScanButtonVisible)
+        assertEquals(CardNumberTrailingIcon.ScanButton, viewState.cardNumber?.trailingIcon)
+    }
+
+    @Test
+    fun `when card scanning is available and card number is not empty, then scan button is not visible`() {
+        // GIVEN
+        val componentState = createComponentState(
+            cardNumber = TextInputComponentState(text = "4111"),
+            isCardScanningAvailable = true,
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertFalse(viewState.isCardScanButtonVisible)
+    }
+
+    @Test
+    fun `when card scanning is not available and card number is empty, then scan button is not visible`() {
+        // GIVEN
+        val componentState = createComponentState(
+            cardNumber = TextInputComponentState(text = ""),
+            isCardScanningAvailable = false,
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertFalse(viewState.isCardScanButtonVisible)
+    }
+
+    @Test
+    fun `when card scanning is available and card number has error, then trailing icon is Warning not ScanButton`() {
+        // GIVEN
+        val componentState = createComponentState(
+            cardNumber = TextInputComponentState(
+                text = "",
+                errorMessage = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
+                showError = true,
+            ),
+            isCardScanningAvailable = true,
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertTrue(viewState.isCardScanButtonVisible)
+        assertEquals(CardNumberTrailingIcon.Warning, viewState.cardNumber?.trailingIcon)
+    }
+
     private fun createComponentState(
         cardNumber: TextInputComponentState = TextInputComponentState(),
         cardBrandState: CardBrandState = CardBrandState.NoBrandsDetected,
         postalCode: TextInputComponentState = TextInputComponentState(),
         showSupportedCardBrandLogos: Boolean = true,
+        isCardScanningAvailable: Boolean = false,
     ) = CardComponentState(
         cardNumber = cardNumber,
         expiryDate = TextInputComponentState(),
@@ -299,7 +366,7 @@ internal class CardViewStateProducerTest {
         supportedCardBrands = emptyList(),
         showSupportedCardBrandLogos = showSupportedCardBrandLogos,
         isLoading = false,
-        isCardScanningAvailable = false,
+        isCardScanningAvailable = isCardScanningAvailable,
         cardBrandState = cardBrandState,
     )
 


### PR DESCRIPTION
## Description

Add unit tests for the card scanning v6 feature.

- **CardComponentStateReducer** — `UpdateCardScanningAvailability` (true/false), `UpdateCardScanResult` (full data, null pan, null expiry)
- **CardViewStateProducer** — scan button visibility logic, `ScanButton` trailing icon, warning overrides scan button
- **CardComponentParamsMapper** — `showCardScanner` mapping (null→true, true, false)

### Progress

✅ Phase 1 — [Move existing classes to old package](https://github.com/Adyen/adyen-android/pull/2758)
✅ Phase 2 — [Create new internal API in card-scanning module](https://github.com/Adyen/adyen-android/pull/2759)
✅ Phase 3 — [Add scanning state & intents to v6 card component state layer](https://github.com/Adyen/adyen-android/pull/2760)
✅ Phase 4 — [Add scanning analytics events](https://github.com/Adyen/adyen-android/pull/2764)
✅ Phase 5 — [Integrate scanning in v6 CardComponent logic layer](https://github.com/Adyen/adyen-android/pull/2767)
✅ Phase 6 — [Integrate scanning in v6 composable UI](https://github.com/Adyen/adyen-android/pull/2768)
✅ Phase 7 — [Make card-scanning available by default with opt-out](https://github.com/Adyen/adyen-android/pull/2777)
➡️ **Phase 8 — Tests**

## Checklist
- [x] Code is unit tested

COSDK-1195