### PR TITLE
v6 - Card Scanning - Fixes and cleanup

### DIFF
--- a/card-scanning/src/main/java/com/adyen/checkout/card/scanning/internal/CardScannerController.kt
+++ b/card-scanning/src/main/java/com/adyen/checkout/card/scanning/internal/CardScannerController.kt
@@ -12,38 +12,25 @@ import android.app.PendingIntent
 import android.content.Intent
 import android.content.IntentSender
 import androidx.annotation.RestrictTo
-import com.adyen.checkout.core.common.AdyenLogLevel
-import com.adyen.checkout.core.common.internal.helper.adyenLog
 import com.google.android.gms.wallet.PaymentCardRecognitionResult
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class CardScannerController internal constructor(
-    pendingIntent: PendingIntent,
+    private val paymentCardRecognitionPendingIntent: PendingIntent,
 ) {
 
-    private var paymentCardRecognitionPendingIntent: PendingIntent? = pendingIntent
-
-    fun getIntentSender(): IntentSender? {
-        if (paymentCardRecognitionPendingIntent == null) {
-            adyenLog(AdyenLogLevel.ERROR) { "CardScannerController has been terminated." }
-            return null
-        }
-        return paymentCardRecognitionPendingIntent?.intentSender
+    fun getIntentSender(): IntentSender {
+        return paymentCardRecognitionPendingIntent.intentSender
     }
 
     fun parseResult(intent: Intent?): CardScanResult? {
         intent ?: return null
-        return PaymentCardRecognitionResult.getFromIntent(intent)
-            ?.let { result ->
-                CardScanResult(
-                    pan = result.pan,
-                    expiryMonth = result.creditCardExpirationDate?.month,
-                    expiryYear = result.creditCardExpirationDate?.year,
-                )
-            }
-    }
-
-    fun terminate() {
-        paymentCardRecognitionPendingIntent = null
+        return PaymentCardRecognitionResult.getFromIntent(intent)?.let { result ->
+            CardScanResult(
+                pan = result.pan,
+                expiryMonth = result.creditCardExpirationDate?.month,
+                expiryYear = result.creditCardExpirationDate?.year,
+            )
+        }
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
@@ -156,7 +156,6 @@ internal class CardComponent(
     }
 
     override fun onCleared() {
-        cardScannerWrapper.terminate()
         analyticsManager.clear(this)
     }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
@@ -183,25 +183,32 @@ internal class CardComponent(
     }
 
     fun onCardScannerResult(resultCode: Int, intent: Intent?) {
-        if (resultCode == Activity.RESULT_CANCELED) {
-            analyticsManager.trackEvent(CardScannerEvents.cardScannerCancelled(paymentMethodType))
-            return
-        }
+        when (resultCode) {
+            Activity.RESULT_CANCELED -> {
+                analyticsManager.trackEvent(CardScannerEvents.cardScannerCancelled(paymentMethodType))
+            }
 
-        val scanResult = cardScannerWrapper.parseResult(intent)
-        if (scanResult == null) {
-            analyticsManager.trackEvent(CardScannerEvents.cardScannerFailure(paymentMethodType))
-            return
-        }
+            Activity.RESULT_OK -> {
+                val scanResult = cardScannerWrapper.parseResult(intent)
+                if (scanResult == null) {
+                    analyticsManager.trackEvent(CardScannerEvents.cardScannerFailure(paymentMethodType))
+                    return
+                }
 
-        analyticsManager.trackEvent(CardScannerEvents.cardScannerSuccess(paymentMethodType))
-        onIntent(
-            CardIntent.UpdateCardScanResult(
-                pan = scanResult.pan,
-                expiryMonth = scanResult.expiryMonth,
-                expiryYear = scanResult.expiryYear,
-            ),
-        )
+                analyticsManager.trackEvent(CardScannerEvents.cardScannerSuccess(paymentMethodType))
+                onIntent(
+                    CardIntent.UpdateCardScanResult(
+                        pan = scanResult.pan,
+                        expiryMonth = scanResult.expiryMonth,
+                        expiryYear = scanResult.expiryYear,
+                    ),
+                )
+            }
+
+            else -> {
+                analyticsManager.trackEvent(CardScannerEvents.cardScannerFailure(paymentMethodType))
+            }
+        }
     }
 
     fun initializeCardScanner(context: Context) {

--- a/card/src/main/java/com/adyen/checkout/card/internal/util/CardScannerWrapper.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/util/CardScannerWrapper.kt
@@ -38,11 +38,6 @@ internal class CardScannerWrapper {
         )
     }
 
-    fun terminate() {
-        controller?.terminate()
-        controller = null
-    }
-
     internal data class ScanResult(
         val pan: String?,
         val expiryMonth: Int?,

--- a/card/src/main/java/com/adyen/checkout/card/internal/util/CardScannerWrapper.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/util/CardScannerWrapper.kt
@@ -21,8 +21,16 @@ internal class CardScannerWrapper {
     private var controller: CardScannerController? = null
 
     suspend fun initialize(context: Context, environment: Environment): Boolean {
-        runCompileOnly { controller = CardScannerInitializer.initialize(context, environment) }
-        return controller != null
+        // we can't use getOrNull() here because CardScannerController is defined inside the card-scanning module
+        // so the JVM will try to resolve the type outside runCompileOnly which will throw a NoClassDefFoundError
+        runCompileOnly {
+            controller = CardScannerInitializer.initialize(context, environment)
+            return controller != null
+        }
+
+        // runCompileOnly didn't return which means the card-scanning module is not included
+        controller = null
+        return false
     }
 
     fun getIntentSender(): IntentSender? {


### PR DESCRIPTION
## Description

Small fixes and cleanup for the card scanning feature:

- **Remove unnecessary terminate logic** — Since the scanner is re-initialized after every scan (single-use `PendingIntent`), there's no lifecycle to manage. Removed `terminate()` from `CardScannerController`, `CardScannerWrapper`, and the `onCleared()` call.
- **Ensure controller is reset when dependency is unavailable** — Move the `controller` assignment and null check inside the `runCompileOnly` block. This ensures that if `initialize` is called again and `runCompileOnly` fails, the previously set `controller` is properly reset to `null`.
- **Handle unexpected result codes** — Refactor `onCardScannerResult` to use `when` with an explicit `else` branch that tracks a failure event for any unexpected `resultCode`.

### Progress

✅ Phase 1 — [Move existing classes to old package](https://github.com/Adyen/adyen-android/pull/2758)
✅ Phase 2 — [Create new internal API](https://github.com/Adyen/adyen-android/pull/2759)
✅ Phase 3 — [Add scanning state and intents](https://github.com/Adyen/adyen-android/pull/2760)
✅ Phase 4 — [Add scanning analytics events](https://github.com/Adyen/adyen-android/pull/2764)
✅ Phase 5 — [Integrate scanning in CardComponent logic layer](https://github.com/Adyen/adyen-android/pull/2767)
✅ Phase 6 — [Integrate scanning in composable UI](https://github.com/Adyen/adyen-android/pull/2768)
✅ Phase 7 — [Make card-scanning available by default with opt-out](https://github.com/Adyen/adyen-android/pull/2777)
✅ Phase 8 — [Unit tests](https://github.com/Adyen/adyen-android/pull/2778)
➡️ **Fixes**

## Checklist
- [x] Changes are tested manually

## Ticket Number
COSDK-1195
