### PR TITLE
AI - Skills - Check

### DIFF
--- a/.agents/skills/android-check.md
+++ b/.agents/skills/android-check.md
@@ -1,0 +1,29 @@
+# android-check
+
+Run verification checks for the Adyen Android SDK.
+
+## Usage
+
+Invoke this skill to verify the project compiles, tests pass, and lint is clean.
+
+**Optional parameter:** A module name to scope checks to a single module (e.g., `card`, `drop-in`, `checkout-core`). If not provided, checks run for the entire project.
+
+## Steps
+
+### 1. Run check
+
+Run the full check task (compile, lint, unit tests):
+
+- **Module-scoped:** `./gradlew :<module>:check`
+- **Full project:** `./gradlew check`
+
+### 2. Report results
+
+- **On success:** Confirm all checks passed.
+- **On failure:** Parse the Gradle output and provide a concise summary of what failed (compilation errors, test failures, lint violations). Include file paths and line numbers when available. Do not dump the entire Gradle log.
+  - **If the failure is a public API mismatch** (e.g., `apiCheck` task fails): This means `.api` dump files are out of date. Inform the developer that they need to run `./gradlew apiDump` (or `./gradlew :<module>:apiDump` if module-scoped) to regenerate the `.api` files, and include those files in their commit.
+
+## Important
+
+- Do not make any code changes. This skill is read-only verification.
+- If a module name is provided, use it consistently for all Gradle commands.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,31 +79,6 @@ fun `when holder name is empty then validation fails`() {
 - Ensure all tests that cover your code changes pass before proceeding
 - Don't accumulate too many changes without verification
 
-### 4. Always Run Checks Before Committing
-After completing a phase of work and before each commit, **ALWAYS run these commands in order**:
-
-```bash
-./gradlew apiDump
-./gradlew check
-```
-
-**Why these commands:**
-- `apiDump` - Updates the public API files to capture any API changes
-- `check` - Ensures all code compiles correctly, all tests pass, and no lint errors are introduced
-
-**IMPORTANT: Include generated `.api` files in commits**
-- After running `apiDump`, the command generates `.api` files in module `api/` directories (e.g., `core/api/core.api`)
-- These files MUST be included in your commit along with the code changes
-- They document the public API surface and are used for API compatibility checks
-
-This ensures:
-- All public API changes are documented
-- API files are kept in sync with code changes
-- All code compiles correctly
-- All tests pass
-- No lint errors are introduced
-- The codebase remains in a healthy state
-
 ## Implementation Guidelines
 
 ### Public API Changes


### PR DESCRIPTION
## Description

Extract the "Always Run Checks Before Committing" section from AGENTS.md into a standalone skill at `.agents/skills/android-check.md`.

The skill covers:
- Running `./gradlew check` (full project or module-scoped)
- Reporting results with concise error summaries
- Guiding the developer to run `apiDump` when a public API mismatch is detected

## Checklist
- [x] Changes are tested manually

## Ticket Number
COSDK-1246