### PR TITLE
AI - Skills - Commit

### DIFF
--- a/.agents/skills/android-commit.md
+++ b/.agents/skills/android-commit.md
@@ -1,0 +1,79 @@
+# android-commit
+
+Create a verified, properly formatted commit for the Adyen Android SDK.
+
+## Usage
+
+Invoke this skill after completing a phase of work and you are ready to commit. This skill runs pre-commit checks, then creates the commit following project conventions.
+
+## Steps
+
+### 1. Verify branch
+
+Check the current branch with `git rev-parse --abbrev-ref HEAD`. If the current branch is `main` or `v5`, **stop immediately** and warn the user. Never commit directly to `main` or `v5`. Suggest using the `android-branch-create` skill to create a feature/fix/chore branch first.
+
+Also ensure the branch is up to date with its upstream branch. If behind, pull the latest changes before proceeding.
+
+### 2. Run pre-commit checks
+
+Use the `android-check` skill (`.agents/skills/android-check.md`) to run verification checks. Scope the checks to the modules that have changes.
+
+**If checks fail:** Do not proceed to committing.
+
+### 3. Review changes
+
+Run `git status` and `git diff` to understand what will be committed. Present a brief summary of changed files to the user.
+
+### 4. Ask for ticket number
+
+Ask the user for the ticket number (format: `COSDK-XXXX`). If the user has already provided a ticket number earlier in the session, reuse it — if necessary, confirm with the user that the same ticket applies.
+
+### 5. Stage files
+
+Stage only the specific files that were modified and are necessary for the commit. **Never use `git add -A` or `git add .`**. Use `git add <file1> <file2> ...` for individual files.
+
+Include any `.api` files if they were updated (e.g., after running `apiDump` for intentional public API changes).
+
+### 6. Security scan
+
+Run `git diff --cached` to review the staged diff for:
+- API keys, tokens, or secrets
+- Credentials or passwords
+- `.env` values or sensitive configuration
+
+**If anything sensitive is found:** Stop immediately and warn the user. Do not commit.
+
+### 7. Compose commit message
+
+Format:
+```
+Short imperative description of the change.
+
+COSDK-XXXX
+```
+
+- First line: concise summary of what was done (imperative mood)
+- Blank line
+- Ticket number
+
+### 8. Confirm with user
+
+Show the user:
+- The list of staged files
+- The proposed commit message
+
+Ask for approval before executing the commit. If the user wants changes, adjust and re-confirm.
+
+### 9. Execute commit
+
+Run `git commit -m "..."` with the approved message.
+
+Confirm the commit was created successfully by running `git log --oneline -1`.
+
+## Important
+
+- Never skip pre-commit checks.
+- Never use `git add -A` or `git add .`.
+- Always ask for ticket number if not already known.
+- Always confirm the commit message with the user before executing.
+- Stop immediately if secrets are detected in the diff.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,11 +38,7 @@ This document outlines important patterns, practices, and rules to follow when w
 
 **Commit workflow - CRITICAL:**
 - **Complete one phase fully before moving to the next**
-- After completing a phase:
-  1. Run `./gradlew apiDump`
-  2. Run `./gradlew check` (or module-specific check)
-  3. Commit the phase with a descriptive message
-  4. Only then proceed to the next phase
+- After completing a phase, use the `android-commit` skill (`.agents/skills/android-commit.md`) to commit
 - Never accumulate multiple phases in a single commit
 - Each commit should represent a logical, complete unit of work
 - This ensures work can be reviewed incrementally and rolled back if needed
@@ -103,6 +99,11 @@ class CardConfiguration { }
 ```
 
 **When making public API changes:**
+
+**Update API dump files:**
+- When you intentionally change the public API, run `./gradlew apiDump` (or `./gradlew :<module>:apiDump`) to regenerate the `.api` files
+- These files document the public API surface and must be included in your commit
+- Do **not** run `apiDump` automatically — only run it after confirming the API change is intentional. This ensures accidental API changes are caught by `apiCheck` during verification.
 
 **Carefully review all changes:**
 - Review each change carefully to ensure it's necessary and correct. If in doubt, ask questions.
@@ -284,37 +285,6 @@ if (checkCompileOnly("com.external.sdk.SomeClass")) {
 }
 ```
 
-## Commit Guidelines
-
-### Staging Files for Commit
-**NEVER use `git add -A` or `git add .`**
-- Only stage the specific files that were modified and are necessary for the commit
-- Use `git add <file1> <file2> ...` to add individual files
-- This prevents accidentally committing unrelated changes or generated files that shouldn't be included
-
-### Commit Message Format
-All commits must follow this format:
-```
-Short commit message describing the change.
-
-COSDK-XXX
-```
-
-**Important:**
-- **ALWAYS ask the user for the ticket number** before making a commit
-- For each task/plan, the ticket number should be the same. Remember the number once provided for the rest of the commits.
-- Replace `XXX` with the actual ticket number (e.g., `COSDK-1234`)
-- **Verify the commit message with the user** before executing the commit
-- The first line should be a concise description of the change
-- Leave a blank line between the description and the ticket reference
-
-### Example Commit Messages
-```
-Add holder name localization keys and strings.
-
-COSDK-1234
-```
-
 ## Verification Checklist
 
 Before considering work complete:
@@ -335,7 +305,6 @@ Before considering work complete:
 2. **Ask questions** rather than making assumptions
 3. **Run `./gradlew check`** to catch issues early
 4. **Read compiler error messages carefully** - they often tell you exactly what's wrong
-5. **Ask for the ticket number** before making any commits
 
 ## Resources
 [Public Documentation](https://docs.adyen.com/online-payments/build-your-integration/?platform=Android)


### PR DESCRIPTION
## Description

Extract commit workflow guidelines from AGENTS.md into a standalone skill at `.agents/skills/android-commit.md`.

The skill covers:
- Branch safety guard (prevents commits on `main`/`v5`)
- Pre-commit checks (`apiDump` + `check`, auto-scoped to affected modules)
- Security scan for secrets in diff
- Ticket number handling
- Explicit file staging (never `git add -A`)
- Commit message formatting and user confirmation

Removed from AGENTS.md:
- "Commit Guidelines" section (staging, message format, examples)
- Detailed commit workflow steps in section 2 (replaced with skill reference)
- "When in Doubt" item about ticket numbers

## Checklist
- [x] Changes are tested manually

## Ticket Number
COSDK-1246