### PR TITLE
v6 - Minimize customization options

### DIFF
--- a/ui/api/ui.api
+++ b/ui/api/ui.api
@@ -10,24 +10,6 @@ public final class com/adyen/checkout/ui/internal/element/input/CheckoutTextFiel
 	public static final fun rememberTextFieldStateWithCurrentValue (Ljava/lang/String;Landroidx/compose/runtime/Composer;I)Landroidx/compose/foundation/text/input/TextFieldState;
 }
 
-public final class com/adyen/checkout/ui/theme/CheckoutAttributes {
-	public static final field $stable I
-	public static final field Companion Lcom/adyen/checkout/ui/theme/CheckoutAttributes$Companion;
-	public fun <init> (I)V
-	public final fun component1 ()I
-	public final fun copy (I)Lcom/adyen/checkout/ui/theme/CheckoutAttributes;
-	public static synthetic fun copy$default (Lcom/adyen/checkout/ui/theme/CheckoutAttributes;IILjava/lang/Object;)Lcom/adyen/checkout/ui/theme/CheckoutAttributes;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getCornerRadius ()I
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/adyen/checkout/ui/theme/CheckoutAttributes$Companion {
-	public final fun default (I)Lcom/adyen/checkout/ui/theme/CheckoutAttributes;
-	public static synthetic fun default$default (Lcom/adyen/checkout/ui/theme/CheckoutAttributes$Companion;IILjava/lang/Object;)Lcom/adyen/checkout/ui/theme/CheckoutAttributes;
-}
-
 public final class com/adyen/checkout/ui/theme/CheckoutColor {
 	public static final synthetic fun box-impl (J)Lcom/adyen/checkout/ui/theme/CheckoutColor;
 	public static fun constructor-impl (J)J
@@ -86,38 +68,16 @@ public final class com/adyen/checkout/ui/theme/CheckoutColors$Companion {
 	public static synthetic fun light--GY1CCY$default (Lcom/adyen/checkout/ui/theme/CheckoutColors$Companion;JJJJJJJJJJJJJILjava/lang/Object;)Lcom/adyen/checkout/ui/theme/CheckoutColors;
 }
 
-public final class com/adyen/checkout/ui/theme/CheckoutTextStyles {
-	public static final field $stable I
-	public static final field Companion Lcom/adyen/checkout/ui/theme/CheckoutTextStyles$Companion;
-	public fun <init> (Ljava/lang/Integer;)V
-	public final fun component1 ()Ljava/lang/Integer;
-	public final fun copy (Ljava/lang/Integer;)Lcom/adyen/checkout/ui/theme/CheckoutTextStyles;
-	public static synthetic fun copy$default (Lcom/adyen/checkout/ui/theme/CheckoutTextStyles;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/adyen/checkout/ui/theme/CheckoutTextStyles;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getFont ()Ljava/lang/Integer;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/adyen/checkout/ui/theme/CheckoutTextStyles$Companion {
-	public final fun default (Ljava/lang/Integer;)Lcom/adyen/checkout/ui/theme/CheckoutTextStyles;
-	public static synthetic fun default$default (Lcom/adyen/checkout/ui/theme/CheckoutTextStyles$Companion;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/adyen/checkout/ui/theme/CheckoutTextStyles;
-}
-
 public final class com/adyen/checkout/ui/theme/CheckoutTheme {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (Lcom/adyen/checkout/ui/theme/CheckoutColors;Lcom/adyen/checkout/ui/theme/CheckoutTextStyles;Lcom/adyen/checkout/ui/theme/CheckoutAttributes;)V
-	public synthetic fun <init> (Lcom/adyen/checkout/ui/theme/CheckoutColors;Lcom/adyen/checkout/ui/theme/CheckoutTextStyles;Lcom/adyen/checkout/ui/theme/CheckoutAttributes;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/adyen/checkout/ui/theme/CheckoutColors;)V
+	public synthetic fun <init> (Lcom/adyen/checkout/ui/theme/CheckoutColors;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/adyen/checkout/ui/theme/CheckoutColors;
-	public final fun component2 ()Lcom/adyen/checkout/ui/theme/CheckoutTextStyles;
-	public final fun component3 ()Lcom/adyen/checkout/ui/theme/CheckoutAttributes;
-	public final fun copy (Lcom/adyen/checkout/ui/theme/CheckoutColors;Lcom/adyen/checkout/ui/theme/CheckoutTextStyles;Lcom/adyen/checkout/ui/theme/CheckoutAttributes;)Lcom/adyen/checkout/ui/theme/CheckoutTheme;
-	public static synthetic fun copy$default (Lcom/adyen/checkout/ui/theme/CheckoutTheme;Lcom/adyen/checkout/ui/theme/CheckoutColors;Lcom/adyen/checkout/ui/theme/CheckoutTextStyles;Lcom/adyen/checkout/ui/theme/CheckoutAttributes;ILjava/lang/Object;)Lcom/adyen/checkout/ui/theme/CheckoutTheme;
+	public final fun copy (Lcom/adyen/checkout/ui/theme/CheckoutColors;)Lcom/adyen/checkout/ui/theme/CheckoutTheme;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/ui/theme/CheckoutTheme;Lcom/adyen/checkout/ui/theme/CheckoutColors;ILjava/lang/Object;)Lcom/adyen/checkout/ui/theme/CheckoutTheme;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAttributes ()Lcom/adyen/checkout/ui/theme/CheckoutAttributes;
 	public final fun getColors ()Lcom/adyen/checkout/ui/theme/CheckoutColors;
-	public final fun getTextStyles ()Lcom/adyen/checkout/ui/theme/CheckoutTextStyles;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/text/InternalTextStyles.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/text/InternalTextStyles.kt
@@ -10,7 +10,7 @@ package com.adyen.checkout.ui.internal.text
 
 import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Immutable
-import com.adyen.checkout.ui.theme.CheckoutTextStyles
+import com.adyen.checkout.ui.internal.theme.CheckoutTextStyles
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Immutable

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/theme/CheckoutAttributes.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/theme/CheckoutAttributes.kt
@@ -6,12 +6,13 @@
  * Created by oscars on 23/7/2025.
  */
 
-package com.adyen.checkout.ui.theme
+package com.adyen.checkout.ui.internal.theme
 
 import androidx.compose.runtime.Immutable
 
+// This class is internal for now, but if we will support customizing this in the future, it should be public.
 @Immutable
-data class CheckoutAttributes(
+internal data class CheckoutAttributes(
     val cornerRadius: Int,
 ) {
 

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/theme/CheckoutTextStyles.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/theme/CheckoutTextStyles.kt
@@ -6,15 +6,15 @@
  * Created by oscars on 10/4/2025.
  */
 
-package com.adyen.checkout.ui.theme
+package com.adyen.checkout.ui.internal.theme
 
 import androidx.annotation.FontRes
 import androidx.compose.runtime.Immutable
 
-// TODO - Add KDocs
+// This class is internal for now, but if we will support customizing this in the future, it should be public.
 @Immutable
-data class CheckoutTextStyles(
-    @FontRes val font: Int?,
+internal data class CheckoutTextStyles(
+    @field:FontRes val font: Int?,
 ) {
 
     companion object {

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/theme/InternalAttributes.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/theme/InternalAttributes.kt
@@ -10,7 +10,6 @@ package com.adyen.checkout.ui.internal.theme
 
 import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Immutable
-import com.adyen.checkout.ui.theme.CheckoutAttributes
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Immutable

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/theme/InternalCheckoutTheme.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/theme/InternalCheckoutTheme.kt
@@ -16,9 +16,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import com.adyen.checkout.ui.internal.element.InternalElements
 import com.adyen.checkout.ui.internal.text.InternalTextStyles
-import com.adyen.checkout.ui.theme.CheckoutAttributes
 import com.adyen.checkout.ui.theme.CheckoutColors
-import com.adyen.checkout.ui.theme.CheckoutTextStyles
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -28,8 +26,8 @@ fun InternalCheckoutTheme(
     content: @Composable () -> Unit,
 ) {
     val colors = remember(theme.colors) { InternalColors.from(theme.colors) }
-    val textStyles = remember(theme.textStyles) { InternalTextStyles.from(theme.textStyles) }
-    val attributes = remember(theme.attributes) { InternalAttributes.from(CheckoutAttributes.default()) }
+    val textStyles = remember { InternalTextStyles.from(CheckoutTextStyles.default()) }
+    val attributes = remember { InternalAttributes.from(CheckoutAttributes.default()) }
     val elements = remember(colors, attributes) { InternalElements.from(colors, attributes) }
     CompositionLocalProvider(
         LocalColors provides colors,

--- a/ui/src/main/java/com/adyen/checkout/ui/theme/CheckoutColors.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/theme/CheckoutColors.kt
@@ -12,11 +12,35 @@ import androidx.compose.runtime.Immutable
 import com.adyen.checkout.ui.internal.theme.DefaultColorsDark
 import com.adyen.checkout.ui.internal.theme.DefaultColorsLight
 
-// TODO - Add KDocs
+/**
+ * Represents a color value used by the Checkout UI.
+ *
+ * @param value The color value encoded as an ARGB [Long]. For example, `0xFF000000` represents black.
+ */
 @Immutable
 @JvmInline
 value class CheckoutColor(val value: Long)
 
+/**
+ * The color palette for the Checkout UI.
+ *
+ * Use the [light] and [dark] factory methods to create an instance with default colors that can be selectively
+ * overridden.
+ *
+ * @param background The main background color.
+ * @param container The background color for container elements.
+ * @param containerOutline The outline color for container elements.
+ * @param primary The primary color used for prominent UI elements.
+ * @param textOnPrimary The text color displayed on top of [primary].
+ * @param highlight The color used for highlighted elements.
+ * @param destructive The color used for destructive actions.
+ * @param textOnDestructive The text color displayed on top of [destructive].
+ * @param disabled The background color for disabled elements.
+ * @param textOnDisabled The text color displayed on top of [disabled].
+ * @param separator The color used for separators and dividers.
+ * @param text The primary text color.
+ * @param textSecondary The secondary text color.
+ */
 @Immutable
 data class CheckoutColors(
     val background: CheckoutColor,
@@ -36,6 +60,9 @@ data class CheckoutColors(
 
     companion object {
 
+        /**
+         * Creates a [CheckoutColors] instance with light theme defaults. Each color can be individually overridden.
+         */
         @Suppress("LongParameterList")
         fun light(
             background: CheckoutColor = DefaultColorsLight.BackgroundPrimary,
@@ -67,6 +94,9 @@ data class CheckoutColors(
             textSecondary = textSecondary,
         )
 
+        /**
+         * Creates a [CheckoutColors] instance with dark theme defaults. Each color can be individually overridden.
+         */
         @Suppress("LongParameterList")
         fun dark(
             background: CheckoutColor = DefaultColorsDark.BackgroundPrimary,

--- a/ui/src/main/java/com/adyen/checkout/ui/theme/CheckoutTheme.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/theme/CheckoutTheme.kt
@@ -10,7 +10,13 @@ package com.adyen.checkout.ui.theme
 
 import androidx.compose.runtime.Immutable
 
-// TODO - Add KDocs
+/**
+ * The theme configuration for the Checkout UI.
+ *
+ * Use this class to customize the visual appearance of the checkout components.
+ *
+ * @param colors The color palette to apply to the UI components. Defaults to [CheckoutColors.light].
+ */
 @Immutable
 data class CheckoutTheme(
     val colors: CheckoutColors = CheckoutColors.light(),

--- a/ui/src/main/java/com/adyen/checkout/ui/theme/CheckoutTheme.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/theme/CheckoutTheme.kt
@@ -14,6 +14,4 @@ import androidx.compose.runtime.Immutable
 @Immutable
 data class CheckoutTheme(
     val colors: CheckoutColors = CheckoutColors.light(),
-    val textStyles: CheckoutTextStyles = CheckoutTextStyles.default(),
-    val attributes: CheckoutAttributes = CheckoutAttributes.default(),
 )


### PR DESCRIPTION
## Description
This PR minimizes the UI customization options to only colors. The other options can easily added back later if there is demand for it. Also, KDocs are added to the public customization classes.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Aligned public API changes with other platforms (if applicable)