### PR TITLE
v6 - Update warning icon

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
@@ -196,7 +196,7 @@ private fun CardNumberFieldIcon(
     AnimatedContent(targetState = trailingIcon, modifier = modifier) { trailingIcon ->
         when (trailingIcon) {
             CardNumberTrailingIcon.Warning -> Icon(
-                modifier = Modifier.size(Dimensions.LogoSize.smallSquare),
+                modifier = Modifier.size(Dimensions.LogoSize.small),
                 imageVector = ImageVector.vectorResource(com.adyen.checkout.test.R.drawable.ic_warning),
                 contentDescription = null,
                 tint = Color.Unspecified,
@@ -267,6 +267,21 @@ private fun CardNumberFieldPreview(
                 CardBrand(CardType.MASTERCARD.txVariant),
                 CardBrand(CardType.AMERICAN_EXPRESS.txVariant),
             ),
+            isSupportedCardBrandsShown = false,
+            detectedCardBrands = emptyList(),
+            isAmex = true,
+            onValueChange = {},
+            onFocusChange = {},
+            onScanButtonClick = {},
+        )
+
+        CardNumberField(
+            cardNumberState = TextInputViewState(
+                text = "1234",
+                isError = true,
+                trailingIcon = CardNumberTrailingIcon.Warning,
+            ),
+            supportedCardBrands = emptyList(),
             isSupportedCardBrandsShown = false,
             detectedCardBrands = emptyList(),
             isAmex = true,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -199,7 +198,7 @@ private fun CardNumberFieldIcon(
                 modifier = Modifier.size(Dimensions.LogoSize.small),
                 imageVector = ImageVector.vectorResource(com.adyen.checkout.test.R.drawable.ic_warning),
                 contentDescription = null,
-                tint = Color.Unspecified,
+                tint = CheckoutThemeProvider.colors.destructive,
             )
 
             CardNumberTrailingIcon.ScanButton -> IconButton(
@@ -218,6 +217,7 @@ private fun CardNumberFieldIcon(
     }
 }
 
+@Suppress("LongMethod")
 @Preview
 @Composable
 private fun CardNumberFieldPreview(

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/ExpiryDateField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/ExpiryDateField.kt
@@ -90,14 +90,27 @@ private fun ExpiryDateIcon(
 ) {
     val trailingIcon = state.trailingIcon as? ExpiryDateTrailingIcon
 
-    val resourceId = when (trailingIcon) {
-        ExpiryDateTrailingIcon.Checkmark -> com.adyen.checkout.test.R.drawable.ic_checkmark
-        ExpiryDateTrailingIcon.Warning -> com.adyen.checkout.test.R.drawable.ic_warning
-        else -> getThemedIcon(
-            backgroundColor = CheckoutThemeProvider.elements.textField.backgroundColor,
-            lightDrawableId = R.drawable.ic_card_expiry_date_light,
-            darkDrawableId = R.drawable.ic_card_expiry_date_dark,
-        )
+    val resourceId: Int
+    val tint: Color
+    when (trailingIcon) {
+        ExpiryDateTrailingIcon.Checkmark -> {
+            resourceId = com.adyen.checkout.test.R.drawable.ic_checkmark
+            tint = CheckoutThemeProvider.colors.primary
+        }
+
+        ExpiryDateTrailingIcon.Warning -> {
+            resourceId = com.adyen.checkout.test.R.drawable.ic_warning
+            tint = CheckoutThemeProvider.colors.destructive
+        }
+
+        else -> {
+            resourceId = getThemedIcon(
+                backgroundColor = CheckoutThemeProvider.elements.textField.backgroundColor,
+                lightDrawableId = R.drawable.ic_card_expiry_date_light,
+                darkDrawableId = R.drawable.ic_card_expiry_date_dark,
+            )
+            tint = Color.Unspecified
+        }
     }
 
     AnimatedContent(
@@ -109,7 +122,7 @@ private fun ExpiryDateIcon(
             modifier = Modifier.size(Dimensions.LogoSize.small),
             imageVector = ImageVector.vectorResource(targetResourceId),
             contentDescription = null,
-            tint = Color.Unspecified,
+            tint = tint,
         )
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/ExpiryDateField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/ExpiryDateField.kt
@@ -100,23 +100,13 @@ private fun ExpiryDateIcon(
         )
     }
 
-    val isInvalid = trailingIcon == ExpiryDateTrailingIcon.Warning
-
     AnimatedContent(
         targetState = resourceId,
         modifier = modifier,
         label = "ExpiryDateIcon",
     ) { targetResourceId ->
-        val iconSize = remember(isInvalid) {
-            if (isInvalid) {
-                Dimensions.LogoSize.smallSquare
-            } else {
-                Dimensions.LogoSize.small
-            }
-        }
-
         Icon(
-            modifier = Modifier.size(iconSize),
+            modifier = Modifier.size(Dimensions.LogoSize.small),
             imageVector = ImageVector.vectorResource(targetResourceId),
             contentDescription = null,
             tint = Color.Unspecified,
@@ -140,6 +130,15 @@ private fun ExpiryDateFieldPreview(
         ExpiryDateField(
             expiryDateState = TextInputViewState(
                 isOptional = true,
+            ),
+            onValueChange = {},
+            onFocusChange = {},
+        )
+
+        ExpiryDateField(
+            expiryDateState = TextInputViewState(
+                isError = true,
+                trailingIcon = ExpiryDateTrailingIcon.Warning,
             ),
             onValueChange = {},
             onFocusChange = {},

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/PostalCodeField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/PostalCodeField.kt
@@ -26,6 +26,7 @@ import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
 import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
 import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
+import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
 import com.adyen.checkout.ui.internal.theme.Dimensions
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
@@ -66,22 +67,31 @@ private fun PostalCodeIcon(
     state: TextInputViewState,
     modifier: Modifier = Modifier,
 ) {
-    val resourceId = when (state.trailingIcon as? PostalCodeTrailingIcon) {
-        PostalCodeTrailingIcon.Warning -> com.adyen.checkout.test.R.drawable.ic_warning
-        else -> null
+    val resourceId: Int?
+    val tint: Color
+    when (state.trailingIcon as? PostalCodeTrailingIcon) {
+        PostalCodeTrailingIcon.Warning -> {
+            resourceId = com.adyen.checkout.test.R.drawable.ic_warning
+            tint = CheckoutThemeProvider.colors.destructive
+        }
+
+        else -> {
+            resourceId = null
+            tint = Color.Unspecified
+        }
     }
 
-    if (resourceId != null) {
-        AnimatedContent(
-            targetState = resourceId,
-            modifier = modifier,
-            label = "PostalCodeIcon",
-        ) { targetResourceId ->
+    AnimatedContent(
+        targetState = resourceId,
+        modifier = modifier,
+        label = "PostalCodeIcon",
+    ) { targetResourceId ->
+        if (targetResourceId != null) {
             Icon(
                 modifier = Modifier.size(Dimensions.LogoSize.small),
                 imageVector = ImageVector.vectorResource(targetResourceId),
                 contentDescription = null,
-                tint = Color.Unspecified,
+                tint = tint,
             )
         }
     }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/PostalCodeField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/PostalCodeField.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.text.input.InputTransformation
 import androidx.compose.foundation.text.input.maxLength
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
@@ -58,7 +57,7 @@ internal fun PostalCodeField(
         shouldFocus = postalCodeState.isFocused,
         trailingIcon = {
             PostalCodeIcon(state = postalCodeState)
-        }
+        },
     )
 }
 
@@ -67,7 +66,6 @@ private fun PostalCodeIcon(
     state: TextInputViewState,
     modifier: Modifier = Modifier,
 ) {
-    val isInvalid = state.trailingIcon == PostalCodeTrailingIcon.Warning
     val resourceId = when (state.trailingIcon as? PostalCodeTrailingIcon) {
         PostalCodeTrailingIcon.Warning -> com.adyen.checkout.test.R.drawable.ic_warning
         else -> null
@@ -79,16 +77,8 @@ private fun PostalCodeIcon(
             modifier = modifier,
             label = "PostalCodeIcon",
         ) { targetResourceId ->
-            val iconSize = remember(isInvalid) {
-                if (isInvalid) {
-                    Dimensions.LogoSize.smallSquare
-                } else {
-                    Dimensions.LogoSize.small
-                }
-            }
-
             Icon(
-                modifier = Modifier.size(iconSize),
+                modifier = Modifier.size(Dimensions.LogoSize.small),
                 imageVector = ImageVector.vectorResource(targetResourceId),
                 contentDescription = null,
                 tint = Color.Unspecified,
@@ -106,6 +96,16 @@ private fun PostalCodeFieldPreview(
         PostalCodeField(
             postalCodeState = TextInputViewState(
                 text = "1234 AB",
+            ),
+            onFocusChange = {},
+            onValueChange = {},
+        )
+
+        PostalCodeField(
+            postalCodeState = TextInputViewState(
+                text = "12",
+                isError = true,
+                trailingIcon = PostalCodeTrailingIcon.Warning,
             ),
             onFocusChange = {},
             onValueChange = {},

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SecurityCodeField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SecurityCodeField.kt
@@ -130,20 +130,36 @@ private fun SecurityCodeIcon(
     state: TextInputViewState,
     modifier: Modifier = Modifier,
 ) {
-    val resourceId = when (state.trailingIcon as? SecurityCodeTrailingIcon) {
-        SecurityCodeTrailingIcon.Warning -> com.adyen.checkout.test.R.drawable.ic_warning
-        SecurityCodeTrailingIcon.Checkmark -> com.adyen.checkout.test.R.drawable.ic_checkmark
-        SecurityCodeTrailingIcon.PlaceholderAmex -> getThemedIcon(
-            backgroundColor = CheckoutThemeProvider.elements.textField.backgroundColor,
-            lightDrawableId = R.drawable.ic_card_cvc_front_light,
-            darkDrawableId = R.drawable.ic_card_cvc_front_dark,
-        )
+    val resourceId: Int
+    val tint: Color
+    when (state.trailingIcon as? SecurityCodeTrailingIcon) {
+        SecurityCodeTrailingIcon.Warning -> {
+            resourceId = com.adyen.checkout.test.R.drawable.ic_warning
+            tint = CheckoutThemeProvider.colors.destructive
+        }
 
-        else -> getThemedIcon(
-            backgroundColor = CheckoutThemeProvider.elements.textField.backgroundColor,
-            lightDrawableId = R.drawable.ic_card_cvc_back_light,
-            darkDrawableId = R.drawable.ic_card_cvc_back_dark,
-        )
+        SecurityCodeTrailingIcon.Checkmark -> {
+            resourceId = com.adyen.checkout.test.R.drawable.ic_checkmark
+            tint = CheckoutThemeProvider.colors.primary
+        }
+
+        SecurityCodeTrailingIcon.PlaceholderAmex -> {
+            resourceId = getThemedIcon(
+                backgroundColor = CheckoutThemeProvider.elements.textField.backgroundColor,
+                lightDrawableId = R.drawable.ic_card_cvc_front_light,
+                darkDrawableId = R.drawable.ic_card_cvc_front_dark,
+            )
+            tint = Color.Unspecified
+        }
+
+        else -> {
+            resourceId = getThemedIcon(
+                backgroundColor = CheckoutThemeProvider.elements.textField.backgroundColor,
+                lightDrawableId = R.drawable.ic_card_cvc_back_light,
+                darkDrawableId = R.drawable.ic_card_cvc_back_dark,
+            )
+            tint = Color.Unspecified
+        }
     }
 
     AnimatedContent(
@@ -155,7 +171,7 @@ private fun SecurityCodeIcon(
             modifier = Modifier.size(Dimensions.LogoSize.small),
             imageVector = ImageVector.vectorResource(targetResourceId),
             contentDescription = null,
-            tint = Color.Unspecified,
+            tint = tint,
         )
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SecurityCodeField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SecurityCodeField.kt
@@ -130,7 +130,6 @@ private fun SecurityCodeIcon(
     state: TextInputViewState,
     modifier: Modifier = Modifier,
 ) {
-    val isInvalid = state.trailingIcon == SecurityCodeTrailingIcon.Warning
     val resourceId = when (state.trailingIcon as? SecurityCodeTrailingIcon) {
         SecurityCodeTrailingIcon.Warning -> com.adyen.checkout.test.R.drawable.ic_warning
         SecurityCodeTrailingIcon.Checkmark -> com.adyen.checkout.test.R.drawable.ic_checkmark
@@ -152,16 +151,8 @@ private fun SecurityCodeIcon(
         modifier = modifier,
         label = "SecurityCodeIcon",
     ) { targetResourceId ->
-        val iconSize = remember(isInvalid) {
-            if (isInvalid) {
-                Dimensions.LogoSize.smallSquare
-            } else {
-                Dimensions.LogoSize.small
-            }
-        }
-
         Icon(
-            modifier = Modifier.size(iconSize),
+            modifier = Modifier.size(Dimensions.LogoSize.small),
             imageVector = ImageVector.vectorResource(targetResourceId),
             contentDescription = null,
             tint = Color.Unspecified,
@@ -189,6 +180,17 @@ private fun SecurityCodeFieldPreview(
                 isOptional = true,
             ),
             isAmex = true,
+            onValueChange = {},
+            onFocusChange = {},
+        )
+
+        SecurityCodeField(
+            securityCodeState = TextInputViewState(
+                text = "123",
+                isError = true,
+                trailingIcon = SecurityCodeTrailingIcon.Warning,
+            ),
+            isAmex = false,
             onValueChange = {},
             onFocusChange = {},
         )

--- a/ui/src/main/res/drawable/ic_warning.xml
+++ b/ui/src/main/res/drawable/ic_warning.xml
@@ -1,18 +1,30 @@
 <!--
-  ~ Copyright (c) 2025 Adyen N.V.
+  ~ Copyright (C) 2026 The Android Open Source Project
   ~
-  ~ This file is open source and available under the MIT license. See the LICENSE file for more info.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ Created by ozgur on 21/11/2025.
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
-
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
   <path
-      android:pathData="M22,12C22,17.523 17.523,22 12,22C6.477,22 2,17.523 2,12C2,6.477 6.477,2 12,2C17.523,2 22,6.477 22,12ZM11,17V15H13V17H11ZM11,7V13H13V7H11Z"
-      android:fillColor="#B00020"
-      android:fillType="evenOdd"/>
+      android:pathData="M8.21,10.35C8.4,10.38 8.58,10.48 8.72,10.62C8.86,10.76 8.95,10.94 8.99,11.13C9.03,11.33 9.01,11.53 8.93,11.71C8.85,11.89 8.72,12.05 8.56,12.16C8.39,12.27 8.2,12.33 8,12.33L8.01,12.34C7.74,12.34 7.49,12.24 7.3,12.05C7.12,11.86 7.01,11.61 7.01,11.34C7.01,11.14 7.07,10.94 7.18,10.78C7.29,10.61 7.45,10.49 7.63,10.41C7.81,10.33 8.02,10.31 8.21,10.35Z"
+      android:fillColor="#DC3801"/>
+  <path
+      android:pathData="M8.75,9.08H7.25V4.58H8.75V9.08Z"
+      android:fillColor="#DC3801"/>
+  <path
+      android:pathData="M5.725,2.458C6.843,0.797 9.353,0.853 10.379,2.624L15,10.624C16.059,12.453 14.738,14.749 12.62,14.749H3.38C1.262,14.749 -0.058,12.453 1.001,10.624L5.621,2.624L5.725,2.458ZM9.081,3.375C8.6,2.545 7.4,2.544 6.919,3.374L6.92,3.375L2.3,11.375C1.819,12.206 2.419,13.249 3.38,13.249H12.62C13.521,13.249 14.106,12.332 13.779,11.533L13.701,11.375L9.081,3.375Z"
+      android:fillColor="#DC3801"/>
 </vector>


### PR DESCRIPTION
## Description
This PR updates the warning icon that is used as trailing icon in text fields. It also ensures the correct size and tint is used.

<img width="444" height="512" alt="image" src="https://github.com/user-attachments/assets/be4a57c5-fa40-45ae-8009-a5ccf0ab4eaf" />

## Next steps
- Make showing the warning and checkmark icons more generic - every text field has custom input to display these icons, but we could simplify this and share the logic.
- Rethink how icons are represented in the state objects

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

## Ticket Number
COSDK-1136
