### PR TITLE
v6 - Card - Brands - CardBrandViewState

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardBrandViewState.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardBrandViewState.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 4/6/2026.
+ */
+
+package com.adyen.checkout.card.internal.ui.state
+
+import com.adyen.checkout.core.common.CardBrand
+
+internal sealed class CardBrandViewState {
+    data object Placeholder : CardBrandViewState()
+    data class SingleBrand(val brand: CardBrand) : CardBrandViewState()
+    data class DualBrand(val brands: List<CardBrand>) : CardBrandViewState()
+    data class SelectableDualBrand(val brands: List<SelectableCardBrandItem>) : CardBrandViewState()
+}
+
+internal data class SelectableCardBrandItem(
+    val brand: CardBrand,
+    val isSelected: Boolean,
+)

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardNumberFormat.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardNumberFormat.kt
@@ -8,7 +8,18 @@
 
 package com.adyen.checkout.card.internal.ui.state
 
+import com.adyen.checkout.core.common.CardBrand
+import com.adyen.checkout.core.common.CardType
+
 internal enum class CardNumberFormat {
     DEFAULT,
     AMEX,
+}
+
+internal fun CardBrand?.toCardNumberFormat(): CardNumberFormat {
+    return if (this?.txVariant == CardType.AMERICAN_EXPRESS.txVariant) {
+        CardNumberFormat.AMEX
+    } else {
+        CardNumberFormat.DEFAULT
+    }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardNumberFormat.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardNumberFormat.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 9/6/2026.
+ */
+
+package com.adyen.checkout.card.internal.ui.state
+
+internal enum class CardNumberFormat {
+    DEFAULT,
+    AMEX,
+}

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewState.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewState.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.card.internal.ui.state
 
 import com.adyen.checkout.core.common.CardBrand
-import com.adyen.checkout.core.common.CardType
 import com.adyen.checkout.core.components.internal.ui.state.ViewState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 
@@ -26,12 +25,9 @@ internal data class CardViewState(
     val isStorePaymentFieldVisible: Boolean,
     val supportedCardBrands: List<CardBrand>,
     val isSupportedCardBrandsShown: Boolean,
-    val detectedCardBrands: List<CardBrand>,
+    val cardBrandViewState: CardBrandViewState,
+    // TODO - Move isAmex to another layer if necessary/possible
+    val isAmex: Boolean,
     val isLoading: Boolean,
     val isCardScanButtonVisible: Boolean,
 ) : ViewState
-
-internal val CardViewState.isAmex: Boolean?
-    get() = detectedCardBrands.firstOrNull()?.let { detectedCard ->
-        detectedCard.txVariant == CardType.AMERICAN_EXPRESS.txVariant
-    }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewState.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewState.kt
@@ -26,8 +26,7 @@ internal data class CardViewState(
     val supportedCardBrands: List<CardBrand>,
     val isSupportedCardBrandsShown: Boolean,
     val cardBrandViewState: CardBrandViewState,
-    // TODO - Move isAmex to another layer if necessary/possible
-    val isAmex: Boolean,
+    val cardNumberFormat: CardNumberFormat,
     val isLoading: Boolean,
     val isCardScanButtonVisible: Boolean,
 ) : ViewState

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
@@ -13,7 +13,6 @@ import com.adyen.checkout.card.internal.ui.model.CardNumberTrailingIcon
 import com.adyen.checkout.card.internal.ui.model.ExpiryDateTrailingIcon
 import com.adyen.checkout.card.internal.ui.model.PostalCodeTrailingIcon
 import com.adyen.checkout.card.internal.ui.model.SecurityCodeTrailingIcon
-import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.common.CardType
 import com.adyen.checkout.core.components.internal.ui.state.ViewStateProducer
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
@@ -36,7 +35,8 @@ internal class CardViewStateProducer : ViewStateProducer<CardComponentState, Car
             is CardBrandState.DualBrandWithShopperSelection -> false
         }
 
-        val detectedCardBrands = getDetectedCardBrands(state.cardBrandState)
+        val cardBrandViewState = getCardBrandViewState(state.cardBrandState)
+        val isAmex = getIsAmex(state.cardBrandState)
         val isCardScanButtonVisible = state.isCardScanningAvailable && state.cardNumber.text.isEmpty()
 
         return CardViewState(
@@ -47,14 +47,14 @@ internal class CardViewStateProducer : ViewStateProducer<CardComponentState, Car
                 trailingIcon = getExpiryDateTrailingIcon(state.expiryDate),
             ),
             securityCode = state.securityCode.toViewState(
-                trailingIcon = getSecurityCodeTrailingIcon(state.securityCode, detectedCardBrands),
+                trailingIcon = getSecurityCodeTrailingIcon(state.securityCode, isAmex),
             ),
             holderName = state.holderName.toViewState(),
             socialSecurityNumber = state.socialSecurityNumber.toViewState(),
             kcpBirthDateOrTaxNumber = state.kcpBirthDateOrTaxNumber.toViewState(),
             kcpCardPassword = state.kcpCardPassword.toViewState(),
             postalCode = state.postalCode.toViewState(
-                trailingIcon = getPostalCodeTrailingIcon(state.postalCode)
+                trailingIcon = getPostalCodeTrailingIcon(state.postalCode),
             ),
             storePaymentMethod = state.storePaymentMethod,
             isStorePaymentFieldVisible = state.isStorePaymentFieldVisible,
@@ -62,25 +62,56 @@ internal class CardViewStateProducer : ViewStateProducer<CardComponentState, Car
                 isHiddenCardType(it.txVariant)
             },
             isSupportedCardBrandsShown = isSupportedCardBrandsShown,
-            detectedCardBrands = detectedCardBrands,
+            cardBrandViewState = cardBrandViewState,
+            isAmex = isAmex,
             isLoading = state.isLoading,
             isCardScanButtonVisible = isCardScanButtonVisible,
         )
     }
 
-    // detected card brands are shown on the UI in all flows
-    private fun getDetectedCardBrands(cardBrandState: CardBrandState): List<CardBrand> {
+    private fun getCardBrandViewState(cardBrandState: CardBrandState): CardBrandViewState {
         return when (cardBrandState) {
             is CardBrandState.NoBrandsDetected,
             is CardBrandState.UnsupportedBrand,
-            is CardBrandState.HiddenBrand -> emptyList()
+            is CardBrandState.HiddenBrand -> CardBrandViewState.Placeholder
 
-            is CardBrandState.SingleUnreliableBrand -> listOf(cardBrandState.cardBrandData.cardBrand)
-            is CardBrandState.SingleReliableBrand -> listOf(cardBrandState.cardBrandData.cardBrand)
-            is CardBrandState.SingleReliableWithHiddenBrand -> listOf(cardBrandState.cardBrandData.cardBrand)
-            is CardBrandState.DualBrand -> cardBrandState.cardBrandDataList.map { it.cardBrand }
-            is CardBrandState.DualBrandWithShopperSelection -> cardBrandState.cardBrandDataList.map { it.cardBrand }
+            is CardBrandState.SingleUnreliableBrand ->
+                CardBrandViewState.SingleBrand(cardBrandState.cardBrandData.cardBrand)
+
+            is CardBrandState.SingleReliableBrand ->
+                CardBrandViewState.SingleBrand(cardBrandState.cardBrandData.cardBrand)
+
+            is CardBrandState.SingleReliableWithHiddenBrand ->
+                CardBrandViewState.SingleBrand(cardBrandState.cardBrandData.cardBrand)
+
+            is CardBrandState.DualBrand -> CardBrandViewState.DualBrand(
+                cardBrandState.cardBrandDataList.map { it.cardBrand },
+            )
+
+            is CardBrandState.DualBrandWithShopperSelection -> CardBrandViewState.SelectableDualBrand(
+                cardBrandState.cardBrandDataList.map { cardBrandData ->
+                    SelectableCardBrandItem(
+                        brand = cardBrandData.cardBrand,
+                        isSelected = cardBrandData == cardBrandState.shopperSelectedCardBrandData,
+                    )
+                },
+            )
         }
+    }
+
+    private fun getIsAmex(cardBrandState: CardBrandState): Boolean {
+        val cardBrandData = when (cardBrandState) {
+            is CardBrandState.NoBrandsDetected,
+            is CardBrandState.UnsupportedBrand,
+            is CardBrandState.HiddenBrand -> null
+
+            is CardBrandState.SingleUnreliableBrand -> cardBrandState.cardBrandData
+            is CardBrandState.SingleReliableBrand -> cardBrandState.cardBrandData
+            is CardBrandState.SingleReliableWithHiddenBrand -> cardBrandState.cardBrandData
+            is CardBrandState.DualBrand -> cardBrandState.cardBrandDataList.firstOrNull()
+            is CardBrandState.DualBrandWithShopperSelection -> cardBrandState.shopperSelectedCardBrandData
+        }
+        return cardBrandData?.cardBrand?.txVariant == CardType.AMERICAN_EXPRESS.txVariant
     }
 
     private fun getCardNumberTrailingIcon(
@@ -110,18 +141,15 @@ internal class CardViewStateProducer : ViewStateProducer<CardComponentState, Car
 
     private fun getSecurityCodeTrailingIcon(
         securityCode: TextInputComponentState,
-        detectedCardBrands: List<CardBrand>
+        isAmex: Boolean,
     ): SecurityCodeTrailingIcon {
         val isValid = securityCode.errorMessage == null && securityCode.text.isNotEmpty()
         val isInvalid = securityCode.errorMessage != null && securityCode.showError
-        val isAmex = detectedCardBrands.firstOrNull()?.let { detectedCard ->
-            detectedCard.txVariant == CardType.AMERICAN_EXPRESS.txVariant
-        }
 
         return when {
             isValid -> SecurityCodeTrailingIcon.Checkmark
             isInvalid -> SecurityCodeTrailingIcon.Warning
-            isAmex == true -> SecurityCodeTrailingIcon.PlaceholderAmex
+            isAmex -> SecurityCodeTrailingIcon.PlaceholderAmex
             else -> SecurityCodeTrailingIcon.PlaceholderDefault
         }
     }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
@@ -36,7 +36,7 @@ internal class CardViewStateProducer : ViewStateProducer<CardComponentState, Car
         }
 
         val cardBrandViewState = getCardBrandViewState(state.cardBrandState)
-        val isAmex = getIsAmex(state.cardBrandState)
+        val cardNumberFormat = getCardNumberFormat(state.cardBrandState)
         val isCardScanButtonVisible = state.isCardScanningAvailable && state.cardNumber.text.isEmpty()
 
         return CardViewState(
@@ -47,7 +47,7 @@ internal class CardViewStateProducer : ViewStateProducer<CardComponentState, Car
                 trailingIcon = getExpiryDateTrailingIcon(state.expiryDate),
             ),
             securityCode = state.securityCode.toViewState(
-                trailingIcon = getSecurityCodeTrailingIcon(state.securityCode, isAmex),
+                trailingIcon = getSecurityCodeTrailingIcon(state.securityCode, cardNumberFormat),
             ),
             holderName = state.holderName.toViewState(),
             socialSecurityNumber = state.socialSecurityNumber.toViewState(),
@@ -63,7 +63,7 @@ internal class CardViewStateProducer : ViewStateProducer<CardComponentState, Car
             },
             isSupportedCardBrandsShown = isSupportedCardBrandsShown,
             cardBrandViewState = cardBrandViewState,
-            isAmex = isAmex,
+            cardNumberFormat = cardNumberFormat,
             isLoading = state.isLoading,
             isCardScanButtonVisible = isCardScanButtonVisible,
         )
@@ -99,7 +99,7 @@ internal class CardViewStateProducer : ViewStateProducer<CardComponentState, Car
         }
     }
 
-    private fun getIsAmex(cardBrandState: CardBrandState): Boolean {
+    private fun getCardNumberFormat(cardBrandState: CardBrandState): CardNumberFormat {
         val cardBrandData = when (cardBrandState) {
             is CardBrandState.NoBrandsDetected,
             is CardBrandState.UnsupportedBrand,
@@ -111,7 +111,12 @@ internal class CardViewStateProducer : ViewStateProducer<CardComponentState, Car
             is CardBrandState.DualBrand -> cardBrandState.cardBrandDataList.firstOrNull()
             is CardBrandState.DualBrandWithShopperSelection -> cardBrandState.shopperSelectedCardBrandData
         }
-        return cardBrandData?.cardBrand?.txVariant == CardType.AMERICAN_EXPRESS.txVariant
+
+        return if (cardBrandData?.cardBrand?.txVariant == CardType.AMERICAN_EXPRESS.txVariant) {
+            CardNumberFormat.AMEX
+        } else {
+            CardNumberFormat.DEFAULT
+        }
     }
 
     private fun getCardNumberTrailingIcon(
@@ -141,7 +146,7 @@ internal class CardViewStateProducer : ViewStateProducer<CardComponentState, Car
 
     private fun getSecurityCodeTrailingIcon(
         securityCode: TextInputComponentState,
-        isAmex: Boolean,
+        cardNumberFormat: CardNumberFormat,
     ): SecurityCodeTrailingIcon {
         val isValid = securityCode.errorMessage == null && securityCode.text.isNotEmpty()
         val isInvalid = securityCode.errorMessage != null && securityCode.showError
@@ -149,7 +154,7 @@ internal class CardViewStateProducer : ViewStateProducer<CardComponentState, Car
         return when {
             isValid -> SecurityCodeTrailingIcon.Checkmark
             isInvalid -> SecurityCodeTrailingIcon.Warning
-            isAmex -> SecurityCodeTrailingIcon.PlaceholderAmex
+            cardNumberFormat == CardNumberFormat.AMEX -> SecurityCodeTrailingIcon.PlaceholderAmex
             else -> SecurityCodeTrailingIcon.PlaceholderDefault
         }
     }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
@@ -13,7 +13,6 @@ import com.adyen.checkout.card.internal.ui.model.CardNumberTrailingIcon
 import com.adyen.checkout.card.internal.ui.model.ExpiryDateTrailingIcon
 import com.adyen.checkout.card.internal.ui.model.PostalCodeTrailingIcon
 import com.adyen.checkout.card.internal.ui.model.SecurityCodeTrailingIcon
-import com.adyen.checkout.core.common.CardType
 import com.adyen.checkout.core.components.internal.ui.state.ViewStateProducer
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
 import com.adyen.checkout.core.components.internal.ui.state.model.toViewState
@@ -112,11 +111,7 @@ internal class CardViewStateProducer : ViewStateProducer<CardComponentState, Car
             is CardBrandState.DualBrandWithShopperSelection -> cardBrandState.shopperSelectedCardBrandData
         }
 
-        return if (cardBrandData?.cardBrand?.txVariant == CardType.AMERICAN_EXPRESS.txVariant) {
-            CardNumberFormat.AMEX
-        } else {
-            CardNumberFormat.DEFAULT
-        }
+        return cardBrandData?.cardBrand.toCardNumberFormat()
     }
 
     private fun getCardNumberTrailingIcon(

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewState.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewState.kt
@@ -9,19 +9,12 @@
 package com.adyen.checkout.card.internal.ui.state
 
 import com.adyen.checkout.core.common.CardBrand
-import com.adyen.checkout.core.common.CardType
 import com.adyen.checkout.core.components.internal.ui.state.ViewState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 
 internal data class StoredCardViewState(
     val securityCode: TextInputViewState?,
     val brand: CardBrand?,
+    val cardNumberFormat: CardNumberFormat,
     val isLoading: Boolean,
 ) : ViewState
-
-internal val StoredCardViewState.cardNumberFormat: CardNumberFormat
-    get() = if (brand?.txVariant == CardType.AMERICAN_EXPRESS.txVariant) {
-        CardNumberFormat.AMEX
-    } else {
-        CardNumberFormat.DEFAULT
-    }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewState.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewState.kt
@@ -19,5 +19,9 @@ internal data class StoredCardViewState(
     val isLoading: Boolean,
 ) : ViewState
 
-internal val StoredCardViewState.isAmex: Boolean
-    get() = brand?.txVariant == CardType.AMERICAN_EXPRESS.txVariant
+internal val StoredCardViewState.cardNumberFormat: CardNumberFormat
+    get() = if (brand?.txVariant == CardType.AMERICAN_EXPRESS.txVariant) {
+        CardNumberFormat.AMEX
+    } else {
+        CardNumberFormat.DEFAULT
+    }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewStateProducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewStateProducer.kt
@@ -17,20 +17,29 @@ import com.adyen.checkout.core.components.internal.ui.state.model.toViewState
 internal class StoredCardViewStateProducer : ViewStateProducer<StoredCardComponentState, StoredCardViewState> {
 
     override fun produce(state: StoredCardComponentState): StoredCardViewState {
-        val isAmex = state.detectedCardType?.cardBrand?.txVariant == CardType.AMERICAN_EXPRESS.txVariant
+        val cardNumberFormat = getCardNumberFormat(state)
 
         return StoredCardViewState(
             securityCode = state.securityCode.toViewState(
-                trailingIcon = getSecurityCodeTrailingIcon(state.securityCode, isAmex),
+                trailingIcon = getSecurityCodeTrailingIcon(state.securityCode, cardNumberFormat),
             ),
             brand = state.detectedCardType?.cardBrand,
+            cardNumberFormat = cardNumberFormat,
             isLoading = state.isLoading,
         )
     }
 
+    private fun getCardNumberFormat(state: StoredCardComponentState): CardNumberFormat {
+        return if (state.detectedCardType?.cardBrand?.txVariant == CardType.AMERICAN_EXPRESS.txVariant) {
+            CardNumberFormat.AMEX
+        } else {
+            CardNumberFormat.DEFAULT
+        }
+    }
+
     private fun getSecurityCodeTrailingIcon(
         securityCode: TextInputComponentState,
-        isAmex: Boolean,
+        cardNumberFormat: CardNumberFormat,
     ): SecurityCodeTrailingIcon {
         val isValid = securityCode.errorMessage == null && securityCode.text.isNotEmpty()
         val isInvalid = securityCode.errorMessage != null && securityCode.showError
@@ -38,7 +47,7 @@ internal class StoredCardViewStateProducer : ViewStateProducer<StoredCardCompone
         return when {
             isValid -> SecurityCodeTrailingIcon.Checkmark
             isInvalid -> SecurityCodeTrailingIcon.Warning
-            isAmex -> SecurityCodeTrailingIcon.PlaceholderAmex
+            cardNumberFormat == CardNumberFormat.AMEX -> SecurityCodeTrailingIcon.PlaceholderAmex
             else -> SecurityCodeTrailingIcon.PlaceholderDefault
         }
     }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewStateProducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewStateProducer.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.card.internal.ui.state
 
 import com.adyen.checkout.card.internal.ui.model.SecurityCodeTrailingIcon
-import com.adyen.checkout.core.common.CardType
 import com.adyen.checkout.core.components.internal.ui.state.ViewStateProducer
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
 import com.adyen.checkout.core.components.internal.ui.state.model.toViewState
@@ -17,7 +16,7 @@ import com.adyen.checkout.core.components.internal.ui.state.model.toViewState
 internal class StoredCardViewStateProducer : ViewStateProducer<StoredCardComponentState, StoredCardViewState> {
 
     override fun produce(state: StoredCardComponentState): StoredCardViewState {
-        val cardNumberFormat = getCardNumberFormat(state)
+        val cardNumberFormat = state.detectedCardType?.cardBrand.toCardNumberFormat()
 
         return StoredCardViewState(
             securityCode = state.securityCode.toViewState(
@@ -27,14 +26,6 @@ internal class StoredCardViewStateProducer : ViewStateProducer<StoredCardCompone
             cardNumberFormat = cardNumberFormat,
             isLoading = state.isLoading,
         )
-    }
-
-    private fun getCardNumberFormat(state: StoredCardComponentState): CardNumberFormat {
-        return if (state.detectedCardType?.cardBrand?.txVariant == CardType.AMERICAN_EXPRESS.txVariant) {
-            CardNumberFormat.AMEX
-        } else {
-            CardNumberFormat.DEFAULT
-        }
     }
 
     private fun getSecurityCodeTrailingIcon(

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardComponent.kt
@@ -14,9 +14,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import com.adyen.checkout.card.internal.ui.state.CardBrandViewState
 import com.adyen.checkout.card.internal.ui.state.CardIntent
 import com.adyen.checkout.card.internal.ui.state.CardViewState
-import com.adyen.checkout.card.internal.ui.state.isAmex
 import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.common.CardType
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
@@ -67,7 +67,7 @@ private fun CardDetailsSection(
                 cardNumberState = viewState.cardNumber,
                 supportedCardBrands = viewState.supportedCardBrands,
                 isSupportedCardBrandsShown = viewState.isSupportedCardBrandsShown,
-                detectedCardBrands = viewState.detectedCardBrands,
+                cardBrandViewState = viewState.cardBrandViewState,
                 isAmex = viewState.isAmex,
                 onValueChange = { onIntent(CardIntent.UpdateCardNumber(it)) },
                 onFocusChange = { onIntent(CardIntent.UpdateCardNumberFocus(it)) },
@@ -170,7 +170,8 @@ private fun CardComponentPreview() {
             isSupportedCardBrandsShown = false,
             isLoading = false,
             isCardScanButtonVisible = false,
-            detectedCardBrands = listOf(CardBrand(CardType.MASTERCARD.txVariant)),
+            cardBrandViewState = CardBrandViewState.SingleBrand(CardBrand(CardType.MASTERCARD.txVariant)),
+            isAmex = false,
         ),
         onIntent = {},
         onSubmitClick = {},

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardComponent.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.adyen.checkout.card.internal.ui.state.CardBrandViewState
 import com.adyen.checkout.card.internal.ui.state.CardIntent
+import com.adyen.checkout.card.internal.ui.state.CardNumberFormat
 import com.adyen.checkout.card.internal.ui.state.CardViewState
 import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.common.CardType
@@ -68,7 +69,7 @@ private fun CardDetailsSection(
                 supportedCardBrands = viewState.supportedCardBrands,
                 isSupportedCardBrandsShown = viewState.isSupportedCardBrandsShown,
                 cardBrandViewState = viewState.cardBrandViewState,
-                isAmex = viewState.isAmex,
+                cardNumberFormat = viewState.cardNumberFormat,
                 onValueChange = { onIntent(CardIntent.UpdateCardNumber(it)) },
                 onFocusChange = { onIntent(CardIntent.UpdateCardNumberFocus(it)) },
                 onScanButtonClick = onScanButtonClick,
@@ -84,7 +85,7 @@ private fun CardDetailsSection(
         if (viewState.securityCode != null) {
             SecurityCodeField(
                 securityCodeState = viewState.securityCode,
-                isAmex = viewState.isAmex,
+                cardNumberFormat = viewState.cardNumberFormat,
                 onValueChange = { onIntent(CardIntent.UpdateSecurityCode(it)) },
                 onFocusChange = { onIntent(CardIntent.UpdateSecurityCodeFocus(it)) },
             )
@@ -171,7 +172,7 @@ private fun CardComponentPreview() {
             isLoading = false,
             isCardScanButtonVisible = false,
             cardBrandViewState = CardBrandViewState.SingleBrand(CardBrand(CardType.MASTERCARD.txVariant)),
-            isAmex = false,
+            cardNumberFormat = CardNumberFormat.DEFAULT,
         ),
         onIntent = {},
         onSubmitClick = {},

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.card.R
 import com.adyen.checkout.card.internal.ui.model.CardNumberTrailingIcon
+import com.adyen.checkout.card.internal.ui.state.CardBrandViewState
 import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.common.CardType
 import com.adyen.checkout.core.common.internal.properties.CardNumberProperties.CARD_NUMBER_MAXIMUM_LENGTH
@@ -52,8 +53,8 @@ internal fun CardNumberField(
     cardNumberState: TextInputViewState,
     supportedCardBrands: List<CardBrand>,
     isSupportedCardBrandsShown: Boolean,
-    detectedCardBrands: List<CardBrand>,
-    isAmex: Boolean?,
+    cardBrandViewState: CardBrandViewState,
+    isAmex: Boolean,
     onValueChange: (String) -> Unit,
     onFocusChange: (Boolean) -> Unit,
     onScanButtonClick: () -> Unit,
@@ -65,7 +66,7 @@ internal fun CardNumberField(
         CardNumberInputField(
             cardNumberState = cardNumberState,
             isAmex = isAmex,
-            detectedCardBrands = detectedCardBrands,
+            cardBrandViewState = cardBrandViewState,
             onValueChange = onValueChange,
             onFocusChange = onFocusChange,
             onScanButtonClick = onScanButtonClick,
@@ -81,8 +82,8 @@ internal fun CardNumberField(
 @Composable
 private fun CardNumberInputField(
     cardNumberState: TextInputViewState,
-    isAmex: Boolean?,
-    detectedCardBrands: List<CardBrand>,
+    isAmex: Boolean,
+    cardBrandViewState: CardBrandViewState,
     onValueChange: (String) -> Unit,
     onFocusChange: (Boolean) -> Unit,
     onScanButtonClick: () -> Unit,
@@ -97,7 +98,7 @@ private fun CardNumberInputField(
         )
     }
     val outputTransformation = remember(isAmex) {
-        CardNumberOutputTransformation(isAmex = isAmex ?: false)
+        CardNumberOutputTransformation(isAmex = isAmex)
     }
 
     CheckoutTextField(
@@ -117,7 +118,7 @@ private fun CardNumberInputField(
         trailingIcon = {
             CardNumberFieldIcon(
                 state = cardNumberState,
-                detectedBrands = detectedCardBrands,
+                cardBrandViewState = cardBrandViewState,
                 onScanButtonClick = onScanButtonClick,
             )
         },
@@ -126,18 +127,22 @@ private fun CardNumberInputField(
 
 @Composable
 private fun DetectedBrandsList(
-    detectedCardBrands: List<CardBrand>,
+    cardBrandViewState: CardBrandViewState,
     modifier: Modifier = Modifier,
 ) {
     Row(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(Dimensions.Spacing.ExtraSmall),
     ) {
-        if (detectedCardBrands.isEmpty()) {
-            BrandLogo(txVariant = null)
-        } else {
-            detectedCardBrands.take(2).forEach { cardBrand ->
-                BrandLogo(cardBrand.txVariant)
+        when (cardBrandViewState) {
+            is CardBrandViewState.Placeholder -> BrandLogo(txVariant = null)
+            is CardBrandViewState.SingleBrand -> BrandLogo(cardBrandViewState.brand.txVariant)
+            is CardBrandViewState.DualBrand -> cardBrandViewState.brands.forEach { brand ->
+                BrandLogo(brand.txVariant)
+            }
+            // TODO - Co-badged selectable cards [COSDK-1193]
+            is CardBrandViewState.SelectableDualBrand -> cardBrandViewState.brands.forEach { brandItem ->
+                BrandLogo(brandItem.brand.txVariant)
             }
         }
     }
@@ -187,7 +192,7 @@ private fun CardBrandsList(
 @Composable
 private fun CardNumberFieldIcon(
     state: TextInputViewState,
-    detectedBrands: List<CardBrand>,
+    cardBrandViewState: CardBrandViewState,
     onScanButtonClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -212,7 +217,7 @@ private fun CardNumberFieldIcon(
                 )
             }
 
-            else -> DetectedBrandsList(detectedBrands)
+            else -> DetectedBrandsList(cardBrandViewState)
         }
     }
 }
@@ -235,7 +240,7 @@ private fun CardNumberFieldPreview(
                 CardBrand(CardType.AMERICAN_EXPRESS.txVariant),
             ),
             isSupportedCardBrandsShown = true,
-            detectedCardBrands = emptyList(),
+            cardBrandViewState = CardBrandViewState.Placeholder,
             isAmex = false,
             onValueChange = {},
             onFocusChange = {},
@@ -252,7 +257,7 @@ private fun CardNumberFieldPreview(
                 CardBrand(CardType.AMERICAN_EXPRESS.txVariant),
             ),
             isSupportedCardBrandsShown = true,
-            detectedCardBrands = listOf(CardBrand(CardType.MASTERCARD.txVariant)),
+            cardBrandViewState = CardBrandViewState.SingleBrand(CardBrand(CardType.MASTERCARD.txVariant)),
             isAmex = false,
             onValueChange = {},
             onFocusChange = {},
@@ -268,7 +273,7 @@ private fun CardNumberFieldPreview(
                 CardBrand(CardType.AMERICAN_EXPRESS.txVariant),
             ),
             isSupportedCardBrandsShown = false,
-            detectedCardBrands = emptyList(),
+            cardBrandViewState = CardBrandViewState.Placeholder,
             isAmex = true,
             onValueChange = {},
             onFocusChange = {},
@@ -283,7 +288,7 @@ private fun CardNumberFieldPreview(
             ),
             supportedCardBrands = emptyList(),
             isSupportedCardBrandsShown = false,
-            detectedCardBrands = emptyList(),
+            cardBrandViewState = CardBrandViewState.Placeholder,
             isAmex = true,
             onValueChange = {},
             onFocusChange = {},

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.card.R
 import com.adyen.checkout.card.internal.ui.model.CardNumberTrailingIcon
 import com.adyen.checkout.card.internal.ui.state.CardBrandViewState
+import com.adyen.checkout.card.internal.ui.state.CardNumberFormat
 import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.common.CardType
 import com.adyen.checkout.core.common.internal.properties.CardNumberProperties.CARD_NUMBER_MAXIMUM_LENGTH
@@ -54,7 +55,7 @@ internal fun CardNumberField(
     supportedCardBrands: List<CardBrand>,
     isSupportedCardBrandsShown: Boolean,
     cardBrandViewState: CardBrandViewState,
-    isAmex: Boolean,
+    cardNumberFormat: CardNumberFormat,
     onValueChange: (String) -> Unit,
     onFocusChange: (Boolean) -> Unit,
     onScanButtonClick: () -> Unit,
@@ -65,7 +66,7 @@ internal fun CardNumberField(
     ) {
         CardNumberInputField(
             cardNumberState = cardNumberState,
-            isAmex = isAmex,
+            cardNumberFormat = cardNumberFormat,
             cardBrandViewState = cardBrandViewState,
             onValueChange = onValueChange,
             onFocusChange = onFocusChange,
@@ -82,7 +83,7 @@ internal fun CardNumberField(
 @Composable
 private fun CardNumberInputField(
     cardNumberState: TextInputViewState,
-    isAmex: Boolean,
+    cardNumberFormat: CardNumberFormat,
     cardBrandViewState: CardBrandViewState,
     onValueChange: (String) -> Unit,
     onFocusChange: (Boolean) -> Unit,
@@ -97,8 +98,8 @@ private fun CardNumberInputField(
             maxLengthWithoutSeparators = CARD_NUMBER_MAXIMUM_LENGTH,
         )
     }
-    val outputTransformation = remember(isAmex) {
-        CardNumberOutputTransformation(isAmex = isAmex)
+    val outputTransformation = remember(cardNumberFormat) {
+        CardNumberOutputTransformation(cardNumberFormat = cardNumberFormat)
     }
 
     CheckoutTextField(
@@ -241,7 +242,7 @@ private fun CardNumberFieldPreview(
             ),
             isSupportedCardBrandsShown = true,
             cardBrandViewState = CardBrandViewState.Placeholder,
-            isAmex = false,
+            cardNumberFormat = CardNumberFormat.DEFAULT,
             onValueChange = {},
             onFocusChange = {},
             onScanButtonClick = {},
@@ -258,7 +259,7 @@ private fun CardNumberFieldPreview(
             ),
             isSupportedCardBrandsShown = true,
             cardBrandViewState = CardBrandViewState.SingleBrand(CardBrand(CardType.MASTERCARD.txVariant)),
-            isAmex = false,
+            cardNumberFormat = CardNumberFormat.DEFAULT,
             onValueChange = {},
             onFocusChange = {},
             onScanButtonClick = {},
@@ -274,7 +275,7 @@ private fun CardNumberFieldPreview(
             ),
             isSupportedCardBrandsShown = false,
             cardBrandViewState = CardBrandViewState.Placeholder,
-            isAmex = true,
+            cardNumberFormat = CardNumberFormat.AMEX,
             onValueChange = {},
             onFocusChange = {},
             onScanButtonClick = {},
@@ -289,7 +290,7 @@ private fun CardNumberFieldPreview(
             supportedCardBrands = emptyList(),
             isSupportedCardBrandsShown = false,
             cardBrandViewState = CardBrandViewState.Placeholder,
-            isAmex = true,
+            cardNumberFormat = CardNumberFormat.AMEX,
             onValueChange = {},
             onFocusChange = {},
             onScanButtonClick = {},

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberOutputTransformation.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberOutputTransformation.kt
@@ -11,17 +11,21 @@ package com.adyen.checkout.card.internal.ui.view
 import androidx.compose.foundation.text.input.OutputTransformation
 import androidx.compose.foundation.text.input.TextFieldBuffer
 import androidx.compose.runtime.Stable
+import com.adyen.checkout.card.internal.ui.state.CardNumberFormat
 import com.adyen.checkout.core.common.internal.properties.CardNumberProperties.CARD_NUMBER_AMEX_SEPARATORS
 import com.adyen.checkout.core.common.internal.properties.CardNumberProperties.CARD_NUMBER_DEFAULT_SEPARATORS
 import com.adyen.checkout.ui.internal.element.input.SeparatorsTextFieldBufferTransformation
 
 @Stable
 internal class CardNumberOutputTransformation(
-    val isAmex: Boolean,
+    val cardNumberFormat: CardNumberFormat,
 ) : OutputTransformation {
 
     private val outputTransformation = SeparatorsTextFieldBufferTransformation()
-    private val separators = if (isAmex) CARD_NUMBER_AMEX_SEPARATORS else CARD_NUMBER_DEFAULT_SEPARATORS
+    private val separators = when (cardNumberFormat) {
+        CardNumberFormat.AMEX -> CARD_NUMBER_AMEX_SEPARATORS
+        CardNumberFormat.DEFAULT -> CARD_NUMBER_DEFAULT_SEPARATORS
+    }
 
     override fun TextFieldBuffer.transformOutput() {
         outputTransformation.transformOutput(this, separators)

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SecurityCodeField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SecurityCodeField.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.card.R
 import com.adyen.checkout.card.internal.ui.model.SecurityCodeTrailingIcon
+import com.adyen.checkout.card.internal.ui.state.CardNumberFormat
 import com.adyen.checkout.core.common.internal.properties.SecurityCodeProperties.SECURITY_CODE_MAX_LENGTH_AMEX
 import com.adyen.checkout.core.common.internal.properties.SecurityCodeProperties.SECURITY_CODE_MAX_LENGTH_DEFAULT
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
@@ -41,14 +42,14 @@ import com.adyen.checkout.ui.theme.CheckoutTheme
 @Composable
 internal fun SecurityCodeField(
     securityCodeState: TextInputViewState,
-    isAmex: Boolean?,
+    cardNumberFormat: CardNumberFormat,
     onValueChange: (String) -> Unit,
     onFocusChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     SecurityCodeFieldInternal(
         securityCodeState = securityCodeState,
-        isAmex = isAmex,
+        cardNumberFormat = cardNumberFormat,
         onSecurityCodeChanged = onValueChange,
         onSecurityCodeFocusChanged = onFocusChange,
         modifier = modifier,
@@ -58,14 +59,14 @@ internal fun SecurityCodeField(
 @Composable
 internal fun StoredCardSecurityCodeField(
     securityCodeState: TextInputViewState,
-    isAmex: Boolean?,
+    cardNumberFormat: CardNumberFormat,
     onValueChange: (String) -> Unit,
     onFocusChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     SecurityCodeFieldInternal(
         securityCodeState = securityCodeState,
-        isAmex = isAmex,
+        cardNumberFormat = cardNumberFormat,
         onSecurityCodeChanged = onValueChange,
         onSecurityCodeFocusChanged = onFocusChange,
         modifier = modifier,
@@ -75,17 +76,16 @@ internal fun StoredCardSecurityCodeField(
 @Composable
 private fun SecurityCodeFieldInternal(
     securityCodeState: TextInputViewState,
-    isAmex: Boolean?,
+    cardNumberFormat: CardNumberFormat,
     onSecurityCodeChanged: (String) -> Unit,
     onSecurityCodeFocusChanged: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val supportingTextSecurityCode = securityCodeState.supportingText?.let { resolveString(it) }
         ?: resolveString(
-            if (isAmex == null || !isAmex) {
-                CheckoutLocalizationKey.CARD_SECURITY_CODE_HINT_3_DIGITS
-            } else {
-                CheckoutLocalizationKey.CARD_SECURITY_CODE_HINT_4_DIGITS
+            when (cardNumberFormat) {
+                CardNumberFormat.AMEX -> CheckoutLocalizationKey.CARD_SECURITY_CODE_HINT_4_DIGITS
+                CardNumberFormat.DEFAULT -> CheckoutLocalizationKey.CARD_SECURITY_CODE_HINT_3_DIGITS
             },
         )
 
@@ -95,11 +95,10 @@ private fun SecurityCodeFieldInternal(
         ""
     }
 
-    val inputTransformation = remember(isAmex) {
-        val maxLength = if (isAmex == true) {
-            SECURITY_CODE_MAX_LENGTH_AMEX
-        } else {
-            SECURITY_CODE_MAX_LENGTH_DEFAULT
+    val inputTransformation = remember(cardNumberFormat) {
+        val maxLength = when (cardNumberFormat) {
+            CardNumberFormat.AMEX -> SECURITY_CODE_MAX_LENGTH_AMEX
+            CardNumberFormat.DEFAULT -> SECURITY_CODE_MAX_LENGTH_DEFAULT
         }
         DigitOnlyInputTransformation(
             maxLengthWithoutSeparators = maxLength,
@@ -186,7 +185,7 @@ private fun SecurityCodeFieldPreview(
             securityCodeState = TextInputViewState(
                 text = "123",
             ),
-            isAmex = false,
+            cardNumberFormat = CardNumberFormat.DEFAULT,
             onValueChange = {},
             onFocusChange = {},
         )
@@ -195,7 +194,7 @@ private fun SecurityCodeFieldPreview(
             securityCodeState = TextInputViewState(
                 isOptional = true,
             ),
-            isAmex = true,
+            cardNumberFormat = CardNumberFormat.AMEX,
             onValueChange = {},
             onFocusChange = {},
         )
@@ -206,7 +205,7 @@ private fun SecurityCodeFieldPreview(
                 isError = true,
                 trailingIcon = SecurityCodeTrailingIcon.Warning,
             ),
-            isAmex = false,
+            cardNumberFormat = CardNumberFormat.DEFAULT,
             onValueChange = {},
             onFocusChange = {},
         )

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardComponent.kt
@@ -15,7 +15,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.adyen.checkout.card.internal.ui.state.StoredCardIntent
 import com.adyen.checkout.card.internal.ui.state.StoredCardViewState
-import com.adyen.checkout.card.internal.ui.state.cardNumberFormat
 import com.adyen.checkout.ui.internal.element.ComponentScaffold
 import com.adyen.checkout.ui.internal.element.button.PayButton
 import com.adyen.checkout.ui.internal.theme.Dimensions

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardComponent.kt
@@ -15,7 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.adyen.checkout.card.internal.ui.state.StoredCardIntent
 import com.adyen.checkout.card.internal.ui.state.StoredCardViewState
-import com.adyen.checkout.card.internal.ui.state.isAmex
+import com.adyen.checkout.card.internal.ui.state.cardNumberFormat
 import com.adyen.checkout.ui.internal.element.ComponentScaffold
 import com.adyen.checkout.ui.internal.element.button.PayButton
 import com.adyen.checkout.ui.internal.theme.Dimensions
@@ -40,7 +40,7 @@ internal fun StoredCardComponent(
             ) {
                 StoredCardSecurityCodeField(
                     securityCodeState = viewState.securityCode,
-                    isAmex = viewState.isAmex,
+                    cardNumberFormat = viewState.cardNumberFormat,
                     onValueChange = { onIntent(StoredCardIntent.UpdateSecurityCode(it)) },
                     onFocusChange = { onIntent(StoredCardIntent.UpdateSecurityCodeFocus(it)) },
                 )

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardNumberFormatTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardNumberFormatTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 9/6/2026.
+ */
+
+package com.adyen.checkout.card.internal.ui.state
+
+import com.adyen.checkout.core.common.CardBrand
+import com.adyen.checkout.core.common.CardType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class CardNumberFormatTest {
+
+    @Test
+    fun `when card brand is amex, then format is AMEX`() {
+        // GIVEN
+        val brand = CardBrand(CardType.AMERICAN_EXPRESS.txVariant)
+
+        // WHEN
+        val result = brand.toCardNumberFormat()
+
+        // THEN
+        assertEquals(CardNumberFormat.AMEX, result)
+    }
+
+    @Test
+    fun `when card brand is visa, then format is DEFAULT`() {
+        // GIVEN
+        val brand = CardBrand("visa")
+
+        // WHEN
+        val result = brand.toCardNumberFormat()
+
+        // THEN
+        assertEquals(CardNumberFormat.DEFAULT, result)
+    }
+
+    @Test
+    fun `when card brand is mastercard, then format is DEFAULT`() {
+        // GIVEN
+        val brand = CardBrand("mc")
+
+        // WHEN
+        val result = brand.toCardNumberFormat()
+
+        // THEN
+        assertEquals(CardNumberFormat.DEFAULT, result)
+    }
+
+    @Test
+    fun `when card brand is null, then format is DEFAULT`() {
+        // GIVEN
+        val brand: CardBrand? = null
+
+        // WHEN
+        val result = brand.toCardNumberFormat()
+
+        // THEN
+        assertEquals(CardNumberFormat.DEFAULT, result)
+    }
+}

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
@@ -12,6 +12,7 @@ import com.adyen.checkout.card.internal.data.model.Brand
 import com.adyen.checkout.card.internal.ui.model.CardNumberTrailingIcon
 import com.adyen.checkout.card.internal.ui.model.PostalCodeTrailingIcon
 import com.adyen.checkout.core.common.CardBrand
+import com.adyen.checkout.core.common.CardType
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -75,7 +76,7 @@ internal class CardViewStateProducerTest {
     }
 
     @Test
-    fun `when hidden brand is detected, then supported card brands should be shown and detected brands should be empty`() {
+    fun `when hidden brand is detected, then supported card brands should be shown and card brand view state should be placeholder`() {
         // GIVEN
         val componentState = createComponentState(
             cardBrandState = CardBrandState.HiddenBrand,
@@ -86,11 +87,11 @@ internal class CardViewStateProducerTest {
 
         // THEN
         assertTrue(viewState.isSupportedCardBrandsShown)
-        assertTrue(viewState.detectedCardBrands.isEmpty())
+        assertEquals(CardBrandViewState.Placeholder, viewState.cardBrandViewState)
     }
 
     @Test
-    fun `when single reliable with hidden brand is detected, then supported card brands should be hidden and detected brands should contain non-hidden brand`() {
+    fun `when single reliable with hidden brand is detected, then supported card brands should be hidden and card brand view state should be single brand`() {
         // GIVEN
         val cardBrandData = getCardBrandData().copy(cardBrand = CardBrand("visa"))
         val componentState = createComponentState(
@@ -102,7 +103,144 @@ internal class CardViewStateProducerTest {
 
         // THEN
         assertFalse(viewState.isSupportedCardBrandsShown)
-        assertEquals(listOf(CardBrand("visa")), viewState.detectedCardBrands)
+        assertEquals(CardBrandViewState.SingleBrand(CardBrand("visa")), viewState.cardBrandViewState)
+    }
+
+    @Test
+    fun `when dual brand is detected, then card brand view state should be dual brand`() {
+        // GIVEN
+        val visaBrandData = getCardBrandData().copy(cardBrand = CardBrand("visa"))
+        val mcBrandData = getCardBrandData().copy(cardBrand = CardBrand("mc"))
+        val componentState = createComponentState(
+            cardBrandState = CardBrandState.DualBrand(listOf(visaBrandData, mcBrandData)),
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertFalse(viewState.isSupportedCardBrandsShown)
+        assertEquals(
+            CardBrandViewState.DualBrand(listOf(CardBrand("visa"), CardBrand("mc"))),
+            viewState.cardBrandViewState,
+        )
+    }
+
+    @Test
+    fun `when dual brand with shopper selection is detected, then card brand view state should be selectable dual brand`() {
+        // GIVEN
+        val visaBrandData = getCardBrandData().copy(cardBrand = CardBrand("visa"))
+        val mcBrandData = getCardBrandData().copy(cardBrand = CardBrand("mc"))
+        val componentState = createComponentState(
+            cardBrandState = CardBrandState.DualBrandWithShopperSelection(
+                cardBrandDataList = listOf(visaBrandData, mcBrandData),
+                shopperSelectedCardBrandData = visaBrandData,
+            ),
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertFalse(viewState.isSupportedCardBrandsShown)
+        assertEquals(
+            CardBrandViewState.SelectableDualBrand(
+                listOf(
+                    SelectableCardBrandItem(brand = CardBrand("visa"), isSelected = true),
+                    SelectableCardBrandItem(brand = CardBrand("mc"), isSelected = false),
+                ),
+            ),
+            viewState.cardBrandViewState,
+        )
+    }
+
+    @Test
+    fun `when amex brand is detected, then isAmex should be true`() {
+        // GIVEN
+        val amexBrandData = getCardBrandData().copy(
+            cardBrand = CardBrand(CardType.AMERICAN_EXPRESS.txVariant),
+        )
+        val componentState = createComponentState(
+            cardBrandState = CardBrandState.SingleReliableBrand(amexBrandData),
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertTrue(viewState.isAmex)
+    }
+
+    @Test
+    fun `when non-amex brand is detected, then isAmex should be false`() {
+        // GIVEN
+        val componentState = createComponentState(
+            cardBrandState = CardBrandState.SingleReliableBrand(
+                getCardBrandData().copy(cardBrand = CardBrand("visa")),
+            ),
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertFalse(viewState.isAmex)
+    }
+
+    @Test
+    fun `when no brand is detected, then isAmex should be false`() {
+        // GIVEN
+        val componentState = createComponentState(
+            cardBrandState = CardBrandState.NoBrandsDetected,
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertFalse(viewState.isAmex)
+    }
+
+    @Test
+    fun `when dual brand with amex selected, then isAmex should be true`() {
+        // GIVEN
+        val amexBrandData = getCardBrandData().copy(
+            cardBrand = CardBrand(CardType.AMERICAN_EXPRESS.txVariant),
+        )
+        val visaBrandData = getCardBrandData().copy(cardBrand = CardBrand("visa"))
+        val componentState = createComponentState(
+            cardBrandState = CardBrandState.DualBrandWithShopperSelection(
+                cardBrandDataList = listOf(amexBrandData, visaBrandData),
+                shopperSelectedCardBrandData = amexBrandData,
+            ),
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertTrue(viewState.isAmex)
+    }
+
+    @Test
+    fun `when dual brand with non-amex selected, then isAmex should be false`() {
+        // GIVEN
+        val amexBrandData = getCardBrandData().copy(
+            cardBrand = CardBrand(CardType.AMERICAN_EXPRESS.txVariant),
+        )
+        val visaBrandData = getCardBrandData().copy(cardBrand = CardBrand("visa"))
+        val componentState = createComponentState(
+            cardBrandState = CardBrandState.DualBrandWithShopperSelection(
+                cardBrandDataList = listOf(amexBrandData, visaBrandData),
+                shopperSelectedCardBrandData = visaBrandData,
+            ),
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertFalse(viewState.isAmex)
     }
 
     // UC6: Error Hides Brand Logos

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
@@ -12,7 +12,6 @@ import com.adyen.checkout.card.internal.data.model.Brand
 import com.adyen.checkout.card.internal.ui.model.CardNumberTrailingIcon
 import com.adyen.checkout.card.internal.ui.model.PostalCodeTrailingIcon
 import com.adyen.checkout.core.common.CardBrand
-import com.adyen.checkout.core.common.CardType
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -155,10 +154,10 @@ internal class CardViewStateProducerTest {
     }
 
     @Test
-    fun `when amex brand is detected, then isAmex should be true`() {
+    fun `when amex brand is detected, then cardNumberFormat should be Amex`() {
         // GIVEN
         val amexBrandData = getCardBrandData().copy(
-            cardBrand = CardBrand(CardType.AMERICAN_EXPRESS.txVariant),
+            cardBrand = CardBrand("amex"),
         )
         val componentState = createComponentState(
             cardBrandState = CardBrandState.SingleReliableBrand(amexBrandData),
@@ -168,11 +167,11 @@ internal class CardViewStateProducerTest {
         val viewState = producer.produce(componentState)
 
         // THEN
-        assertTrue(viewState.isAmex)
+        assertEquals(CardNumberFormat.AMEX, viewState.cardNumberFormat)
     }
 
     @Test
-    fun `when non-amex brand is detected, then isAmex should be false`() {
+    fun `when non-amex brand is detected, then cardNumberFormat should be Default`() {
         // GIVEN
         val componentState = createComponentState(
             cardBrandState = CardBrandState.SingleReliableBrand(
@@ -184,11 +183,11 @@ internal class CardViewStateProducerTest {
         val viewState = producer.produce(componentState)
 
         // THEN
-        assertFalse(viewState.isAmex)
+        assertEquals(CardNumberFormat.DEFAULT, viewState.cardNumberFormat)
     }
 
     @Test
-    fun `when no brand is detected, then isAmex should be false`() {
+    fun `when no brand is detected, then cardNumberFormat should be Default`() {
         // GIVEN
         val componentState = createComponentState(
             cardBrandState = CardBrandState.NoBrandsDetected,
@@ -198,14 +197,14 @@ internal class CardViewStateProducerTest {
         val viewState = producer.produce(componentState)
 
         // THEN
-        assertFalse(viewState.isAmex)
+        assertEquals(CardNumberFormat.DEFAULT, viewState.cardNumberFormat)
     }
 
     @Test
-    fun `when dual brand with amex selected, then isAmex should be true`() {
+    fun `when dual brand with amex selected, then cardNumberFormat should be Amex`() {
         // GIVEN
         val amexBrandData = getCardBrandData().copy(
-            cardBrand = CardBrand(CardType.AMERICAN_EXPRESS.txVariant),
+            cardBrand = CardBrand("amex"),
         )
         val visaBrandData = getCardBrandData().copy(cardBrand = CardBrand("visa"))
         val componentState = createComponentState(
@@ -219,14 +218,14 @@ internal class CardViewStateProducerTest {
         val viewState = producer.produce(componentState)
 
         // THEN
-        assertTrue(viewState.isAmex)
+        assertEquals(CardNumberFormat.AMEX, viewState.cardNumberFormat)
     }
 
     @Test
-    fun `when dual brand with non-amex selected, then isAmex should be false`() {
+    fun `when dual brand with non-amex selected, then cardNumberFormat should be Default`() {
         // GIVEN
         val amexBrandData = getCardBrandData().copy(
-            cardBrand = CardBrand(CardType.AMERICAN_EXPRESS.txVariant),
+            cardBrand = CardBrand("amex"),
         )
         val visaBrandData = getCardBrandData().copy(cardBrand = CardBrand("visa"))
         val componentState = createComponentState(
@@ -240,7 +239,7 @@ internal class CardViewStateProducerTest {
         val viewState = producer.produce(componentState)
 
         // THEN
-        assertFalse(viewState.isAmex)
+        assertEquals(CardNumberFormat.DEFAULT, viewState.cardNumberFormat)
     }
 
     // UC6: Error Hides Brand Logos

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/view/CardNumberOutputTransformationTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/view/CardNumberOutputTransformationTest.kt
@@ -9,6 +9,7 @@
 package com.adyen.checkout.card.internal.ui.view
 
 import androidx.compose.foundation.text.input.TextFieldState
+import com.adyen.checkout.card.internal.ui.state.CardNumberFormat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments.arguments
@@ -22,7 +23,7 @@ class CardNumberOutputTransformationTest {
         rawText: String,
         formattedText: String
     ) {
-        val outputTransformation = CardNumberOutputTransformation(isAmex = false)
+        val outputTransformation = CardNumberOutputTransformation(cardNumberFormat = CardNumberFormat.DEFAULT)
         val state = TextFieldState(rawText)
         state.edit {
             with(outputTransformation) { transformOutput() }
@@ -37,7 +38,7 @@ class CardNumberOutputTransformationTest {
         rawText: String,
         formattedText: String
     ) {
-        val outputTransformation = CardNumberOutputTransformation(isAmex = true)
+        val outputTransformation = CardNumberOutputTransformation(cardNumberFormat = CardNumberFormat.AMEX)
         val state = TextFieldState(rawText)
         state.edit {
             with(outputTransformation) { transformOutput() }


### PR DESCRIPTION
## Description

Introduce `CardBrandViewState` sealed class to replace raw brand lists in `CardViewState`. Replace `isAmex: Boolean` with a `CardNumberFormat` enum for better extensibility. Extract `CardBrand?.toCardNumberFormat()` extension for reuse across producers.

### Progress

✅ Phase 1 — [Remove old dual brand selector UI](https://github.com/Adyen/adyen-android/pull/2807)
➡️ **Phase 2 — Introduce `CardBrandViewState` and refactor `CardViewState` (this PR)**

## Checklist
- [x] Code is unit tested
- [x] Related issues are linked

## Ticket Number
COSDK-1253