### PR TITLE
v6 - Sessions - Final callback invocation

### DIFF
--- a/core/src/main/java/com/adyen/checkout/core/components/internal/FullCheckoutFlow.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/FullCheckoutFlow.kt
@@ -99,12 +99,9 @@ internal class FullCheckoutFlow(
                 paymentMethodNavigationChannel.trySend(CheckoutPaymentMethodRoute.Action())
             }
 
-            is SubmitResult.Completion -> {
-                // TODO - Handle completion state
-            }
-
+            is SubmitResult.Completion,
             is SubmitResult.Retry -> {
-                // TODO - Handle retry state (re-prompt shopper, optionally surface errorMessage)
+                // No-op: there is nothing we should do in these cases
             }
 
             is SubmitResult.PartialPayment -> {

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/SessionComponentRequestDispatcher.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/SessionComponentRequestDispatcher.kt
@@ -39,7 +39,10 @@ internal class SessionComponentRequestDispatcher(
                 // TODO - Check if we need to support partial payment flow
                 return when {
                     response.action != null -> SubmitResult.Action(response.action)
-                    else -> SubmitResult.Completion(response.resultCode.orEmpty())
+                    else -> {
+                        callbacks.onFinished()
+                        SubmitResult.Completion(response.resultCode.orEmpty())
+                    }
                 }
             },
             onFailure = { error ->

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/SessionComponentRequestDispatcherTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/SessionComponentRequestDispatcherTest.kt
@@ -8,6 +8,7 @@
 
 package com.adyen.checkout.core.components.internal
 
+import com.adyen.checkout.core.action.data.Action
 import com.adyen.checkout.core.action.data.ActionComponentData
 import com.adyen.checkout.core.components.AdditionalDetailsResult
 import com.adyen.checkout.core.components.SessionCheckoutCallbacks
@@ -16,74 +17,177 @@ import com.adyen.checkout.core.components.data.PaymentComponentData
 import com.adyen.checkout.core.components.paymentmethod.PaymentMethodDetails
 import com.adyen.checkout.core.error.CheckoutError
 import com.adyen.checkout.core.sessions.internal.data.api.SessionRepository
+import com.adyen.checkout.core.sessions.internal.data.model.SessionDetailsResponse
+import com.adyen.checkout.core.sessions.internal.data.model.SessionPaymentsResponse
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.io.IOException
 
 @ExtendWith(MockitoExtension::class)
 internal class SessionComponentRequestDispatcherTest(
-    @Mock private val sessionRepository: SessionRepository,
+    @param:Mock private val sessionRepository: SessionRepository,
 ) {
 
-    @Test
-    fun `when submitPayment fails, then retry is returned and onError is invoked`() =
-        runTest {
-            val cause = IOException("network down")
-            whenever(sessionRepository.submitPayment(any(), any(), any())) doReturn Result.failure(cause)
+    @Nested
+    inner class SubmitTest {
 
-            val capturedErrors = mutableListOf<CheckoutError>()
-            val dispatcher = createDispatcher(onError = { capturedErrors += it })
+        @Test
+        fun `when submit succeeds with action, then Action is returned`() = runTest {
+            val action = mock<Action>()
+            val response = createPaymentsResponse(action = action)
+            whenever(sessionRepository.submitPayment(any(), any(), any())) doReturn Result.success(response)
+
+            val dispatcher = createDispatcher()
 
             val result = dispatcher.submit(emptyPaymentComponentData())
 
-            assertEquals(SubmitResult.Retry("network down"), result)
-            assertEquals(1, capturedErrors.size)
+            assertEquals(SubmitResult.Action(action), result)
         }
 
-    @Test
-    fun `when submitDetails fails, then error completion is returned and onError is invoked`() =
-        runTest {
-            val cause = IOException("network down")
-            whenever(sessionRepository.submitDetails(any(), any(), any())) doReturn Result.failure(cause)
+        @Test
+        fun `when submit succeeds with action, then onFinished is not invoked`() = runTest {
+            val response = createPaymentsResponse(action = mock())
+            whenever(sessionRepository.submitPayment(any(), any(), any())) doReturn Result.success(response)
 
-            val capturedErrors = mutableListOf<CheckoutError>()
-            val dispatcher = createDispatcher(onError = { capturedErrors += it })
+            var onFinishedCalls = 0
+            val dispatcher = createDispatcher(onFinished = { onFinishedCalls++ })
+
+            dispatcher.submit(emptyPaymentComponentData())
+
+            assertEquals(0, onFinishedCalls)
+        }
+
+        @Test
+        fun `when submit succeeds without action, then Completion is returned`() = runTest {
+            val response = createPaymentsResponse(resultCode = "Authorised")
+            whenever(sessionRepository.submitPayment(any(), any(), any())) doReturn Result.success(response)
+
+            val dispatcher = createDispatcher()
+
+            val result = dispatcher.submit(emptyPaymentComponentData())
+
+            assertEquals(SubmitResult.Completion("Authorised"), result)
+        }
+
+        @Test
+        fun `when submit succeeds without action, then onFinished is invoked`() = runTest {
+            val response = createPaymentsResponse()
+            whenever(sessionRepository.submitPayment(any(), any(), any())) doReturn Result.success(response)
+
+            var onFinishedCalls = 0
+            val dispatcher = createDispatcher(onFinished = { onFinishedCalls++ })
+
+            dispatcher.submit(emptyPaymentComponentData())
+
+            assertEquals(1, onFinishedCalls)
+        }
+
+        @Test
+        fun `when submit fails, then retry is returned and onError is invoked`() =
+            runTest {
+                val cause = IOException("network down")
+                whenever(sessionRepository.submitPayment(any(), any(), any())) doReturn Result.failure(cause)
+
+                val capturedErrors = mutableListOf<CheckoutError>()
+                val dispatcher = createDispatcher(onError = { capturedErrors += it })
+
+                val result = dispatcher.submit(emptyPaymentComponentData())
+
+                assertEquals(SubmitResult.Retry("network down"), result)
+                assertEquals(1, capturedErrors.size)
+            }
+
+        @Test
+        fun `when submit fails, then onFinished is not invoked`() = runTest {
+            whenever(sessionRepository.submitPayment(any(), any(), any())) doReturn Result.failure(IOException())
+
+            var onFinishedCalls = 0
+            val dispatcher = createDispatcher(onFinished = { onFinishedCalls++ })
+
+            dispatcher.submit(emptyPaymentComponentData())
+
+            assertEquals(0, onFinishedCalls)
+        }
+    }
+
+    @Nested
+    inner class AdditionalDetailsTest {
+
+        @Test
+        fun `when additionalDetails succeeds, then Completion is returned`() = runTest {
+            val response = createDetailsResponse(resultCode = "Authorised")
+            whenever(sessionRepository.submitDetails(any(), any(), any())) doReturn Result.success(response)
+
+            val dispatcher = createDispatcher()
 
             val result = dispatcher.additionalDetails(ActionComponentData())
 
-            assertEquals(AdditionalDetailsResult.Completion("Error"), result)
-            assertEquals(1, capturedErrors.size)
+            assertEquals(AdditionalDetailsResult.Completion("Authorised"), result)
         }
 
-    @Test
-    fun `when submitPayment fails, then onFinished is not invoked`() = runTest {
-        whenever(sessionRepository.submitPayment(any(), any(), any())) doReturn Result.failure(IOException())
+        @Test
+        fun `when additionalDetails succeeds, then onFinished is invoked`() = runTest {
+            val response = createDetailsResponse()
+            whenever(sessionRepository.submitDetails(any(), any(), any())) doReturn Result.success(response)
 
-        var onFinishedCalls = 0
-        val dispatcher = createDispatcher(onFinished = { onFinishedCalls++ })
+            var onFinishedCalls = 0
+            val dispatcher = createDispatcher(onFinished = { onFinishedCalls++ })
 
-        dispatcher.submit(emptyPaymentComponentData())
+            dispatcher.additionalDetails(ActionComponentData())
 
-        assertEquals(0, onFinishedCalls)
+            assertEquals(1, onFinishedCalls)
+        }
+
+        @Test
+        fun `when additionalDetails fails, then error completion is returned and onError is invoked`() =
+            runTest {
+                val cause = IOException("network down")
+                whenever(sessionRepository.submitDetails(any(), any(), any())) doReturn Result.failure(cause)
+
+                val capturedErrors = mutableListOf<CheckoutError>()
+                val dispatcher = createDispatcher(onError = { capturedErrors += it })
+
+                val result = dispatcher.additionalDetails(ActionComponentData())
+
+                assertEquals(AdditionalDetailsResult.Completion("Error"), result)
+                assertEquals(1, capturedErrors.size)
+            }
+
+        @Test
+        fun `when additionalDetails fails, then onFinished is not invoked`() = runTest {
+            whenever(sessionRepository.submitDetails(any(), any(), any())) doReturn Result.failure(IOException())
+
+            var onFinishedCalls = 0
+            val dispatcher = createDispatcher(onFinished = { onFinishedCalls++ })
+
+            dispatcher.additionalDetails(ActionComponentData())
+
+            assertEquals(0, onFinishedCalls)
+        }
     }
 
-    @Test
-    fun `when submitDetails fails, then onFinished is not invoked`() = runTest {
-        whenever(sessionRepository.submitDetails(any(), any(), any())) doReturn Result.failure(IOException())
+    @Nested
+    inner class ErrorTest {
 
-        var onFinishedCalls = 0
-        val dispatcher = createDispatcher(onFinished = { onFinishedCalls++ })
+        @Test
+        fun `when error is called, then onError is invoked`() {
+            val capturedErrors = mutableListOf<CheckoutError>()
+            val dispatcher = createDispatcher(onError = { capturedErrors += it })
 
-        dispatcher.additionalDetails(ActionComponentData())
+            val error = CheckoutError(code = "test", message = "test error")
+            dispatcher.error(error)
 
-        assertEquals(0, onFinishedCalls)
+            assertEquals(listOf(error), capturedErrors)
+        }
     }
 
     private fun createDispatcher(
@@ -97,6 +201,29 @@ internal class SessionComponentRequestDispatcherTest(
             onError = onError,
         ),
         sessionRepository = sessionRepository,
+    )
+
+    private fun createPaymentsResponse(
+        resultCode: String? = null,
+        action: Action? = null,
+    ) = SessionPaymentsResponse(
+        sessionData = "session-data",
+        status = null,
+        resultCode = resultCode,
+        action = action,
+        order = null,
+        sessionResult = null,
+    )
+
+    private fun createDetailsResponse(
+        resultCode: String? = null,
+    ) = SessionDetailsResponse(
+        sessionData = "session-data",
+        status = null,
+        resultCode = resultCode,
+        action = null,
+        sessionResult = null,
+        order = null,
     )
 
     private fun emptyPaymentComponentData(): PaymentComponentData<PaymentMethodDetails> =


### PR DESCRIPTION
## Description
This PR ensures the final callback is invoked when the payment request is successful without an action. In `SessionComponentRequestDispatcherTest` missing test cases were added and the tests are re-organized per function.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

## Ticket Number
COSDK-1252
