### PR TITLE
v6 - Requires user interaction check

### DIFF
--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/BlikComponent.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/BlikComponent.kt
@@ -86,6 +86,8 @@ internal class BlikComponent(
         }
     }
 
+    override fun requiresUserInteraction(): Boolean = true
+
     override fun setLoading(isLoading: Boolean) {
         componentState.handleIntent(BlikIntent.UpdateLoading(isLoading))
     }

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/StoredBlikComponent.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/StoredBlikComponent.kt
@@ -63,6 +63,8 @@ internal class StoredBlikComponent(
         eventChannel.trySend(PaymentComponentEvent.Submit(paymentComponentState))
     }
 
+    override fun requiresUserInteraction(): Boolean = false
+
     override fun setLoading(isLoading: Boolean) {
         this.isLoading.value = isLoading
     }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
@@ -154,6 +154,8 @@ constructor(
         }
     }
 
+    override fun requiresUserInteraction(): Boolean = true
+
     override fun setLoading(isLoading: Boolean) {
         onIntent(CardIntent.UpdateLoading(isLoading))
     }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/StoredCardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/StoredCardComponent.kt
@@ -126,6 +126,8 @@ internal class StoredCardComponent(
         }
     }
 
+    override fun requiresUserInteraction(): Boolean = true
+
     override fun setLoading(isLoading: Boolean) {
         onIntent(StoredCardIntent.UpdateLoading(isLoading))
     }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/StoredCardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/StoredCardComponent.kt
@@ -34,6 +34,7 @@ import com.adyen.checkout.core.components.internal.PaymentComponentEvent
 import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
 import com.adyen.checkout.core.components.internal.ui.state.ComponentStateFlow
+import com.adyen.checkout.core.components.internal.ui.state.model.RequirementPolicy
 import com.adyen.checkout.core.components.internal.ui.state.viewState
 import com.adyen.checkout.core.error.internal.InternalCheckoutError
 import com.adyen.checkout.cse.EncryptionException
@@ -126,7 +127,8 @@ internal class StoredCardComponent(
         }
     }
 
-    override fun requiresUserInteraction(): Boolean = true
+    override fun requiresUserInteraction(): Boolean =
+        componentState.value.securityCode.requirementPolicy == RequirementPolicy.Required
 
     override fun setLoading(isLoading: Boolean) {
         onIntent(StoredCardIntent.UpdateLoading(isLoading))

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -758,6 +758,7 @@ public final class com/adyen/checkout/core/components/CheckoutConfiguration$CREA
 
 public final class com/adyen/checkout/core/components/CheckoutController {
 	public static final field $stable I
+	public final fun requiresUserInteraction ()Z
 	public final fun submit ()V
 }
 

--- a/core/src/main/java/com/adyen/checkout/core/components/CheckoutController.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/CheckoutController.kt
@@ -59,4 +59,6 @@ class CheckoutController internal constructor(
     fun submit() {
         flow.submit()
     }
+
+    fun requiresUserInteraction(): Boolean = flow.requiresUserInteraction()
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/CheckoutController.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/CheckoutController.kt
@@ -56,9 +56,29 @@ class CheckoutController internal constructor(
 
     internal val secondaryNavigation: Flow<CheckoutSecondaryRoute> get() = flow.secondaryNavigation
 
+    /**
+     * Submits the current payment data.
+     *
+     * After calling this method, the input data is validated. If validation fails, the corresponding errors
+     * are displayed in the UI and the submission is aborted.
+     *
+     * If [requiresUserInteraction] returns `false`, this can be called directly without waiting for
+     * user input.
+     */
     fun submit() {
         flow.submit()
     }
 
+    /**
+     * Indicates whether the payment method requires user interaction before submitting.
+     *
+     * When this returns `false`, no UI needs to be rendered and [submit] can be called directly
+     * without requiring a user action (e.g. a button click).
+     *
+     * When this returns `true`, the payment method UI should be displayed so the user can provide
+     * the required input before calling [submit].
+     *
+     * @return `true` if user interaction is needed, `false` otherwise.
+     */
     fun requiresUserInteraction(): Boolean = flow.requiresUserInteraction()
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ActionOnlyCheckoutFlow.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ActionOnlyCheckoutFlow.kt
@@ -36,4 +36,7 @@ internal class ActionOnlyCheckoutFlow(
     override fun submit() {
         // No-op: action-only flow does not support submit
     }
+
+    // Action only flows do not require user interaction
+    override fun requiresUserInteraction(): Boolean = false
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutFlow.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutFlow.kt
@@ -25,4 +25,6 @@ internal interface CheckoutFlow {
     val secondaryNavigation: Flow<CheckoutSecondaryRoute>
 
     fun submit()
+
+    fun requiresUserInteraction(): Boolean
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/FullCheckoutFlow.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/FullCheckoutFlow.kt
@@ -92,6 +92,9 @@ internal class FullCheckoutFlow(
         paymentComponent?.submit()
     }
 
+    override fun requiresUserInteraction(): Boolean =
+        actionComponent == null && paymentComponent?.requiresUserInteraction() == true
+
     private fun handleResult(submitResult: SubmitResult) {
         when (submitResult) {
             is SubmitResult.Action -> {

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/PaymentComponent.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/PaymentComponent.kt
@@ -21,6 +21,8 @@ interface PaymentComponent : EventComponent<PaymentComponentEvent> {
 
     fun submit()
 
+    fun requiresUserInteraction(): Boolean
+
     fun setLoading(isLoading: Boolean)
 
     fun onCleared()

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/FullCheckoutFlowTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/FullCheckoutFlowTest.kt
@@ -9,6 +9,7 @@
 package com.adyen.checkout.core.components.internal
 
 import com.adyen.checkout.core.action.data.RedirectAction
+import com.adyen.checkout.core.action.internal.ActionComponent
 import com.adyen.checkout.core.analytics.internal.AnalyticsManager
 import com.adyen.checkout.core.analytics.internal.TestAnalyticsManager
 import com.adyen.checkout.core.common.CheckoutContext
@@ -35,6 +36,8 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -44,20 +47,18 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.util.Locale
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(MockitoExtension::class)
-internal class FullCheckoutFlowTest {
+internal class FullCheckoutFlowTest(
+    @param:Mock private val componentRequestDispatcher: ComponentRequestDispatcher,
+    @param:Mock private val actionHandler: ActionHandler,
+) {
 
     private val eventFlow = MutableSharedFlow<PaymentComponentEvent>()
-
-    @Mock
-    private lateinit var componentRequestDispatcher: ComponentRequestDispatcher
-
-    @Mock
-    private lateinit var actionHandler: ActionHandler
 
     @BeforeEach
     fun setUp() {
@@ -122,8 +123,51 @@ internal class FullCheckoutFlowTest {
             }
     }
 
-    private fun createFullCheckoutFlow(coroutineScope: CoroutineScope): FullCheckoutFlow {
-        val testComponent = TestPaymentComponent(eventFlow)
+    @Nested
+    inner class RequiresUserInteractionTest {
+
+        @Test
+        fun `when action component is null and payment component requires user interaction, then returns true`() =
+            runTest {
+                val flow = createFullCheckoutFlow(CoroutineScope(UnconfinedTestDispatcher()))
+
+                assertTrue(flow.requiresUserInteraction())
+            }
+
+        @Test
+        fun `when action component is not null, then returns false`() = runTest {
+            whenever(actionHandler.actionComponent) doReturn mock<ActionComponent>()
+
+            val flow = createFullCheckoutFlow(CoroutineScope(UnconfinedTestDispatcher()))
+
+            assertFalse(flow.requiresUserInteraction())
+        }
+
+        @Test
+        fun `when payment component is null, then returns false`() = runTest {
+            val flow = createFullCheckoutFlowWithoutPaymentComponent(
+                CoroutineScope(UnconfinedTestDispatcher()),
+            )
+
+            assertFalse(flow.requiresUserInteraction())
+        }
+
+        @Test
+        fun `when payment component does not require user interaction, then returns false`() = runTest {
+            val flow = createFullCheckoutFlow(
+                coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+                requiresUserInteraction = false,
+            )
+
+            assertFalse(flow.requiresUserInteraction())
+        }
+    }
+
+    private fun createFullCheckoutFlow(
+        coroutineScope: CoroutineScope,
+        requiresUserInteraction: Boolean = true,
+    ): FullCheckoutFlow {
+        val testComponent = TestPaymentComponent(eventFlow, requiresUserInteraction)
         registerComponent(testComponent)
 
         return FullCheckoutFlow(
@@ -192,6 +236,21 @@ internal class FullCheckoutFlowTest {
     }
 
     private class TestCheckoutCallbacks : CheckoutCallbacks(additionalCallbacksBlock = {})
+
+    private fun createFullCheckoutFlowWithoutPaymentComponent(
+        coroutineScope: CoroutineScope,
+    ): FullCheckoutFlow {
+        return FullCheckoutFlow(
+            target = CheckoutTarget.PaymentMethod(TEST_PAYMENT_METHOD_TYPE),
+            context = createCheckoutContext(),
+            callbacks = TestCheckoutCallbacks(),
+            componentRequestDispatcher = componentRequestDispatcher,
+            coroutineScope = coroutineScope,
+            analyticsManager = TestAnalyticsManager(),
+            params = generateCheckoutParams(),
+            actionHandler = actionHandler,
+        )
+    }
 
     companion object {
         private const val TEST_PAYMENT_METHOD_TYPE = "test_payment_method"

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/ui/TestPaymentComponent.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/ui/TestPaymentComponent.kt
@@ -23,6 +23,8 @@ internal class TestPaymentComponent(
 
     override fun submit() = Unit
 
+    override fun requiresUserInteraction(): Boolean = true
+
     override fun setLoading(isLoading: Boolean) = Unit
 
     override fun onCleared() = Unit

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/ui/TestPaymentComponent.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/ui/TestPaymentComponent.kt
@@ -15,7 +15,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 
 internal class TestPaymentComponent(
-    override val eventFlow: Flow<PaymentComponentEvent> = flowOf()
+    override val eventFlow: Flow<PaymentComponentEvent> = flowOf(),
+    private val requiresUserInteraction: Boolean = true,
 ) : PaymentComponent {
 
     @Composable
@@ -23,7 +24,7 @@ internal class TestPaymentComponent(
 
     override fun submit() = Unit
 
-    override fun requiresUserInteraction(): Boolean = true
+    override fun requiresUserInteraction(): Boolean = requiresUserInteraction
 
     override fun setLoading(isLoading: Boolean) = Unit
 

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/GooglePayComponent.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/GooglePayComponent.kt
@@ -29,6 +29,10 @@ internal class GooglePayComponent : PaymentComponent {
         TODO("Not yet implemented")
     }
 
+    override fun requiresUserInteraction(): Boolean {
+        TODO("Not yet implemented")
+    }
+
     override fun setLoading(isLoading: Boolean) {
         TODO("Not yet implemented")
     }

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/MBWayComponent.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/MBWayComponent.kt
@@ -116,6 +116,8 @@ internal class MBWayComponent(
         }
     }
 
+    override fun requiresUserInteraction(): Boolean = true
+
     override fun setLoading(isLoading: Boolean) {
         componentState.handleIntent(MBWayIntent.UpdateLoading(isLoading))
     }


### PR DESCRIPTION
## Description
This PR adds a function to `CheckoutController` which lets merchants check if a payment components needs users input before `submit()` can be called. This will be useful for components that have no UI (known as instant) or components with conditional UI.

## Ticket Number
COSDK-1119
