### PR TITLE
v6 - Error - Add Cancelled error code

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -2344,6 +2344,7 @@ public final class com/adyen/checkout/core/error/CheckoutError {
 
 public final class com/adyen/checkout/core/error/CheckoutError$ErrorCode {
 	public static final field $stable I
+	public static final field CANCELLED Ljava/lang/String;
 	public static final field GENERIC Ljava/lang/String;
 	public static final field HTTP Ljava/lang/String;
 	public static final field INSTANCE Lcom/adyen/checkout/core/error/CheckoutError$ErrorCode;

--- a/core/src/main/java/com/adyen/checkout/core/error/CheckoutError.kt
+++ b/core/src/main/java/com/adyen/checkout/core/error/CheckoutError.kt
@@ -36,6 +36,7 @@ data class CheckoutError(
         const val SESSION_SETUP_FAILURE = "SessionSetupFailure"
 
         // General Errors
+        const val CANCELLED = "Cancelled"
         const val HTTP = "HttpError"
         const val PAYMENT_METHOD_FAILURE = "PaymentMethodFailure"
         const val GENERIC = "Generic"


### PR DESCRIPTION
## Description
Add `CANCELLED` error code to `CheckoutError.ErrorCode` to allow merchants to distinguish user-initiated cancellation from actual errors.

Aligned with changes on the error [spec](https://github.com/Adyen/adyen-checkout-sdk-meta/pull/58) and iOS SDK.

## Checklist
- [ ] If applicable, make sure Breaking change label is added.
- [ ] Code is unit tested
- [x] Changes are tested manually
- [x] Aligned public API changes with other platforms (if applicable)
- [ ] Related issues are linked

## Ticket Number
COSDK-589