### PR TITLE
v6 - Generic payment component

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1398,6 +1398,27 @@ public final class com/adyen/checkout/core/components/data/model/paymentmethod/E
 public final class com/adyen/checkout/core/components/data/model/paymentmethod/EContextPaymentMethod$Companion {
 }
 
+public final class com/adyen/checkout/core/components/data/model/paymentmethod/GenericPaymentMethod : com/adyen/checkout/core/components/data/model/paymentmethod/PaymentMethod {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/adyen/checkout/core/components/data/model/paymentmethod/GenericPaymentMethod$Companion;
+	public static final field SERIALIZER Lcom/adyen/checkout/core/common/internal/model/ModelObject$Serializer;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/core/components/data/model/paymentmethod/GenericPaymentMethod;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/core/components/data/model/paymentmethod/GenericPaymentMethod;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/core/components/data/model/paymentmethod/GenericPaymentMethod;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public final fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/adyen/checkout/core/components/data/model/paymentmethod/GenericPaymentMethod$Companion {
+}
+
 public final class com/adyen/checkout/core/components/data/model/paymentmethod/GiftCardPaymentMethod : com/adyen/checkout/core/components/data/model/paymentmethod/PaymentMethod {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
@@ -1444,27 +1465,6 @@ public final class com/adyen/checkout/core/components/data/model/paymentmethod/G
 }
 
 public final class com/adyen/checkout/core/components/data/model/paymentmethod/GooglePayPaymentMethod$Companion {
-}
-
-public final class com/adyen/checkout/core/components/data/model/paymentmethod/InstantPaymentMethod : com/adyen/checkout/core/components/data/model/paymentmethod/PaymentMethod {
-	public static final field $stable I
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public static final field Companion Lcom/adyen/checkout/core/components/data/model/paymentmethod/InstantPaymentMethod$Companion;
-	public static final field SERIALIZER Lcom/adyen/checkout/core/common/internal/model/ModelObject$Serializer;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/core/components/data/model/paymentmethod/InstantPaymentMethod;
-	public static synthetic fun copy$default (Lcom/adyen/checkout/core/components/data/model/paymentmethod/InstantPaymentMethod;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/core/components/data/model/paymentmethod/InstantPaymentMethod;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun getName ()Ljava/lang/String;
-	public fun getType ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-	public final fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
-public final class com/adyen/checkout/core/components/data/model/paymentmethod/InstantPaymentMethod$Companion {
 }
 
 public final class com/adyen/checkout/core/components/data/model/paymentmethod/IssuerListPaymentMethod : com/adyen/checkout/core/components/data/model/paymentmethod/PaymentMethod {
@@ -2149,7 +2149,6 @@ public final class com/adyen/checkout/core/components/paymentmethod/GenericDetai
 	public static final field Companion Lcom/adyen/checkout/core/components/paymentmethod/GenericDetails$Companion;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/common/internal/model/ModelObject$Serializer;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;

--- a/core/src/main/java/com/adyen/checkout/core/components/data/model/paymentmethod/GenericPaymentMethod.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/data/model/paymentmethod/GenericPaymentMethod.kt
@@ -18,24 +18,24 @@ import org.json.JSONObject
  * It contains only the base fields.
  */
 @Parcelize
-data class InstantPaymentMethod(
+data class GenericPaymentMethod(
     override val type: String,
     override val name: String,
 ) : PaymentMethod() {
 
     companion object {
         @JvmField
-        val SERIALIZER: Serializer<InstantPaymentMethod> =
-            object : Serializer<InstantPaymentMethod> {
-                override fun serialize(modelObject: InstantPaymentMethod): JSONObject {
+        val SERIALIZER: Serializer<GenericPaymentMethod> =
+            object : Serializer<GenericPaymentMethod> {
+                override fun serialize(modelObject: GenericPaymentMethod): JSONObject {
                     return JSONObject().apply {
                         put(TYPE, modelObject.type)
                         put(NAME, modelObject.name)
                     }
                 }
 
-                override fun deserialize(jsonObject: JSONObject): InstantPaymentMethod {
-                    return InstantPaymentMethod(
+                override fun deserialize(jsonObject: JSONObject): GenericPaymentMethod {
+                    return GenericPaymentMethod(
                         type = jsonObject.getString(TYPE),
                         name = jsonObject.getString(NAME),
                     )

--- a/core/src/main/java/com/adyen/checkout/core/components/data/model/paymentmethod/PaymentMethod.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/data/model/paymentmethod/PaymentMethod.kt
@@ -18,7 +18,7 @@ import org.json.JSONObject
  *
  * Specific payment method types extend this class with their own fields.
  * Explicitly unsupported payment methods are deserialized as [UnsupportedPaymentMethod],
- * while other unknown types fall back to [InstantPaymentMethod].
+ * while other unknown types fall back to [GenericPaymentMethod].
  */
 abstract class PaymentMethod
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -110,7 +110,7 @@ constructor() : PaymentMethodResponse() {
                 PaymentMethodTypes.UPI_QR -> UPIPaymentMethod.SERIALIZER
 
                 in PaymentMethodTypes.UNSUPPORTED_PAYMENT_METHODS -> UnsupportedPaymentMethod.SERIALIZER
-                else -> InstantPaymentMethod.SERIALIZER
+                else -> GenericPaymentMethod.SERIALIZER
             }
 
             @Suppress("UNCHECKED_CAST")

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentMethodProvider.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentMethodProvider.kt
@@ -50,7 +50,7 @@ object PaymentMethodProvider {
         val txVariant = paymentMethod.type
 
         val registeredFactory = factories[txVariant] ?: if (paymentMethod is GenericPaymentMethod) {
-            GenericPaymentComponentFactory()
+            GenericPaymentComponentFactory
         } else {
             null
         }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentMethodProvider.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentMethodProvider.kt
@@ -13,7 +13,7 @@ import androidx.annotation.VisibleForTesting
 import com.adyen.checkout.core.analytics.internal.AnalyticsManager
 import com.adyen.checkout.core.common.internal.CheckoutParams
 import com.adyen.checkout.core.components.CheckoutAdditionalCallback
-import com.adyen.checkout.core.components.data.model.paymentmethod.InstantPaymentMethod
+import com.adyen.checkout.core.components.data.model.paymentmethod.GenericPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPaymentMethod
 import com.adyen.checkout.core.components.internal.ui.GenericPaymentComponentFactory
@@ -49,7 +49,7 @@ object PaymentMethodProvider {
     ): PaymentComponent? {
         val txVariant = paymentMethod.type
 
-        val registeredFactory = factories[txVariant] ?: if (paymentMethod is InstantPaymentMethod) {
+        val registeredFactory = factories[txVariant] ?: if (paymentMethod is GenericPaymentMethod) {
             GenericPaymentComponentFactory()
         } else {
             null

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentMethodProvider.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentMethodProvider.kt
@@ -13,8 +13,10 @@ import androidx.annotation.VisibleForTesting
 import com.adyen.checkout.core.analytics.internal.AnalyticsManager
 import com.adyen.checkout.core.common.internal.CheckoutParams
 import com.adyen.checkout.core.components.CheckoutAdditionalCallback
+import com.adyen.checkout.core.components.data.model.paymentmethod.InstantPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPaymentMethod
+import com.adyen.checkout.core.components.internal.ui.GenericPaymentComponentFactory
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
 import kotlinx.coroutines.CoroutineScope
 import java.util.concurrent.ConcurrentHashMap
@@ -47,7 +49,13 @@ object PaymentMethodProvider {
     ): PaymentComponent? {
         val txVariant = paymentMethod.type
 
-        return factories[txVariant]?.create(
+        val registeredFactory = factories[txVariant] ?: if (paymentMethod is InstantPaymentMethod) {
+            GenericPaymentComponentFactory()
+        } else {
+            null
+        }
+
+        return registeredFactory?.create(
             paymentMethod = paymentMethod,
             coroutineScope = coroutineScope,
             analyticsManager = analyticsManager,

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/GenericPaymentComponent.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/GenericPaymentComponent.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 10/6/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.adyen.checkout.core.analytics.internal.AnalyticsManager
+import com.adyen.checkout.core.common.internal.helper.bufferedChannel
+import com.adyen.checkout.core.components.data.PaymentComponentData
+import com.adyen.checkout.core.components.internal.PaymentComponentEvent
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
+import com.adyen.checkout.core.components.internal.ui.state.GenericPaymentComponentState
+import com.adyen.checkout.core.components.paymentmethod.GenericDetails
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
+
+internal class GenericPaymentComponent(
+    private val analyticsManager: AnalyticsManager,
+    private val paymentMethodType: String,
+    private val sdkDataProvider: SdkDataProvider,
+    coroutineScope: CoroutineScope,
+) : PaymentComponent {
+
+    private val eventChannel = bufferedChannel<PaymentComponentEvent>()
+    override val eventFlow: Flow<PaymentComponentEvent> = eventChannel.receiveAsFlow()
+
+    init {
+        initializeAnalytics(coroutineScope)
+    }
+
+    private fun initializeAnalytics(coroutineScope: CoroutineScope) {
+        analyticsManager.initialize(this, coroutineScope)
+    }
+
+    @Composable
+    override fun Content(modifier: Modifier) {
+        // This component has no UI
+    }
+
+    override fun submit() {
+        val paymentComponentState = GenericPaymentComponentState(
+            data = PaymentComponentData(
+                paymentMethod = GenericDetails(
+                    type = paymentMethodType,
+                    sdkData = sdkDataProvider.createEncodedSdkData(),
+                    // TODO - Check if we should remove subtype from GenericDetails
+                    subtype = null,
+                ),
+                order = null,
+            ),
+            isValid = true,
+        )
+
+        eventChannel.trySend(
+            PaymentComponentEvent.Submit(paymentComponentState),
+        )
+    }
+
+    override fun requiresUserInteraction(): Boolean = false
+
+    override fun setLoading(isLoading: Boolean) {
+        // There is no UI to display a loading state
+    }
+
+    override fun onCleared() {
+        analyticsManager.clear(this)
+    }
+}

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/GenericPaymentComponentFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/GenericPaymentComponentFactory.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 10/6/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui
+
+import com.adyen.checkout.core.analytics.internal.AnalyticsManager
+import com.adyen.checkout.core.common.internal.CheckoutParams
+import com.adyen.checkout.core.components.CheckoutAdditionalCallback
+import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
+import com.adyen.checkout.core.components.internal.PaymentComponentFactory
+import com.adyen.checkout.core.components.internal.data.provider.DefaultSdkDataProvider
+import kotlinx.coroutines.CoroutineScope
+
+internal class GenericPaymentComponentFactory : PaymentComponentFactory<GenericPaymentComponent> {
+
+    override fun create(
+        paymentMethod: PaymentMethod,
+        coroutineScope: CoroutineScope,
+        analyticsManager: AnalyticsManager,
+        params: CheckoutParams,
+        additionalCallbacks: Set<CheckoutAdditionalCallback>
+    ): GenericPaymentComponent {
+        return GenericPaymentComponent(
+            analyticsManager = analyticsManager,
+            paymentMethodType = paymentMethod.type,
+            sdkDataProvider = DefaultSdkDataProvider(analyticsManager),
+            coroutineScope = coroutineScope,
+        )
+    }
+}

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/GenericPaymentComponentFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/GenericPaymentComponentFactory.kt
@@ -16,7 +16,7 @@ import com.adyen.checkout.core.components.internal.PaymentComponentFactory
 import com.adyen.checkout.core.components.internal.data.provider.DefaultSdkDataProvider
 import kotlinx.coroutines.CoroutineScope
 
-internal class GenericPaymentComponentFactory : PaymentComponentFactory<GenericPaymentComponent> {
+internal object GenericPaymentComponentFactory : PaymentComponentFactory<GenericPaymentComponent> {
 
     override fun create(
         paymentMethod: PaymentMethod,

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericPaymentComponentState.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericPaymentComponentState.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 10/6/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui.state
+
+import com.adyen.checkout.core.components.data.PaymentComponentData
+import com.adyen.checkout.core.components.paymentmethod.GenericDetails
+import com.adyen.checkout.core.components.paymentmethod.PaymentComponentState
+
+internal data class GenericPaymentComponentState(
+    override val data: PaymentComponentData<GenericDetails>,
+    override val isValid: Boolean,
+) : PaymentComponentState<GenericDetails>

--- a/core/src/main/java/com/adyen/checkout/core/components/paymentmethod/GenericDetails.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/paymentmethod/GenericDetails.kt
@@ -15,7 +15,7 @@ import org.json.JSONObject
 @Parcelize
 data class GenericDetails(
     override val type: String?,
-    override val sdkData: String? = null,
+    override val sdkData: String?,
     val subtype: String?,
 ) : PaymentMethodDetails() {
 

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/FullCheckoutFlowTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/FullCheckoutFlowTest.kt
@@ -24,7 +24,7 @@ import com.adyen.checkout.core.components.CheckoutSecondaryRoute
 import com.adyen.checkout.core.components.CheckoutTarget
 import com.adyen.checkout.core.components.SubmitResult
 import com.adyen.checkout.core.components.data.PaymentComponentData
-import com.adyen.checkout.core.components.data.model.paymentmethod.InstantPaymentMethod
+import com.adyen.checkout.core.components.data.model.paymentmethod.GenericPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethods
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
 import com.adyen.checkout.core.components.internal.ui.TestPaymentComponent
@@ -201,7 +201,7 @@ internal class FullCheckoutFlowTest(
         return CheckoutContext.Advanced(
             paymentMethods = PaymentMethods(
                 paymentMethods = listOf(
-                    InstantPaymentMethod(type = TEST_PAYMENT_METHOD_TYPE, name = "Test"),
+                    GenericPaymentMethod(type = TEST_PAYMENT_METHOD_TYPE, name = "Test"),
                 ),
             ),
             checkoutConfiguration = createCheckoutConfiguration(),

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentMethodProviderTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentMethodProviderTest.kt
@@ -214,7 +214,7 @@ internal class PaymentMethodProviderTest {
         }
 
     @Test
-    fun `when get is called for an unregistered and unsupported payment method, then GenericPaymentComponent is returned`() =
+    fun `when get is called for an unregistered and unsupported payment method, then null is returned`() =
         runTest {
             val actualComponent = PaymentMethodProvider.getPaymentComponent(
                 paymentMethod = UnsupportedPaymentMethod(type = "unregistered_txVariant", name = "name"),

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentMethodProviderTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentMethodProviderTest.kt
@@ -13,7 +13,7 @@ import com.adyen.checkout.core.analytics.internal.TestAnalyticsManager
 import com.adyen.checkout.core.common.Environment
 import com.adyen.checkout.core.common.internal.CheckoutParams
 import com.adyen.checkout.core.components.CheckoutAdditionalCallback
-import com.adyen.checkout.core.components.data.model.paymentmethod.InstantPaymentMethod
+import com.adyen.checkout.core.components.data.model.paymentmethod.GenericPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredBLIKPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPaymentMethod
@@ -107,7 +107,7 @@ internal class PaymentMethodProviderTest {
             PaymentMethodProvider.register("txVariant", secondaryFactory)
 
             val actualComponent = PaymentMethodProvider.getPaymentComponent(
-                paymentMethod = InstantPaymentMethod(type = "txVariant", name = "name"),
+                paymentMethod = GenericPaymentMethod(type = "txVariant", name = "name"),
                 coroutineScope = this,
                 analyticsManager = TestAnalyticsManager(),
                 params = generateCheckoutParams(),
@@ -167,7 +167,7 @@ internal class PaymentMethodProviderTest {
             PaymentMethodProvider.register("txVariant", factory)
 
             val actualComponent = PaymentMethodProvider.getPaymentComponent(
-                paymentMethod = InstantPaymentMethod(type = "txVariant", name = "name"),
+                paymentMethod = GenericPaymentMethod(type = "txVariant", name = "name"),
                 coroutineScope = this,
                 analyticsManager = TestAnalyticsManager(),
                 params = generateCheckoutParams(),
@@ -200,7 +200,7 @@ internal class PaymentMethodProviderTest {
     @Test
     fun `when get is called for an unregistered factory, then null is returned`() = runTest {
         val actualComponent = PaymentMethodProvider.getPaymentComponent(
-            paymentMethod = InstantPaymentMethod(type = "unregistered_txVariant", name = "name"),
+            paymentMethod = GenericPaymentMethod(type = "unregistered_txVariant", name = "name"),
             coroutineScope = this,
             analyticsManager = TestAnalyticsManager(),
             params = generateCheckoutParams(),

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentMethodProviderTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentMethodProviderTest.kt
@@ -17,6 +17,8 @@ import com.adyen.checkout.core.components.data.model.paymentmethod.GenericPaymen
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredBLIKPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPaymentMethod
+import com.adyen.checkout.core.components.data.model.paymentmethod.UnsupportedPaymentMethod
+import com.adyen.checkout.core.components.internal.ui.GenericPaymentComponent
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
 import com.adyen.checkout.core.components.internal.ui.TestPaymentComponent
 import kotlinx.coroutines.CoroutineScope
@@ -27,6 +29,7 @@ import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertInstanceOf
 import org.junit.jupiter.api.assertNull
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.junit.jupiter.MockitoExtension
@@ -198,16 +201,30 @@ internal class PaymentMethodProviderTest {
         }
 
     @Test
-    fun `when get is called for an unregistered factory, then null is returned`() = runTest {
-        val actualComponent = PaymentMethodProvider.getPaymentComponent(
-            paymentMethod = GenericPaymentMethod(type = "unregistered_txVariant", name = "name"),
-            coroutineScope = this,
-            analyticsManager = TestAnalyticsManager(),
-            params = generateCheckoutParams(),
-            additionalCallbacks = emptySet(),
-        )
-        assertNull(actualComponent)
-    }
+    fun `when get is called for an unregistered and unknown payment method, then GenericPaymentComponent is returned`() =
+        runTest {
+            val actualComponent = PaymentMethodProvider.getPaymentComponent(
+                paymentMethod = GenericPaymentMethod(type = "unregistered_txVariant", name = "name"),
+                coroutineScope = this,
+                analyticsManager = TestAnalyticsManager(),
+                params = generateCheckoutParams(),
+                additionalCallbacks = emptySet(),
+            )
+            assertInstanceOf<GenericPaymentComponent>(actualComponent)
+        }
+
+    @Test
+    fun `when get is called for an unregistered and unsupported payment method, then GenericPaymentComponent is returned`() =
+        runTest {
+            val actualComponent = PaymentMethodProvider.getPaymentComponent(
+                paymentMethod = UnsupportedPaymentMethod(type = "unregistered_txVariant", name = "name"),
+                coroutineScope = this,
+                analyticsManager = TestAnalyticsManager(),
+                params = generateCheckoutParams(),
+                additionalCallbacks = emptySet(),
+            )
+            assertNull(actualComponent)
+        }
 
     @Test
     fun `when get is called for an unregistered stored factory, then null is returned`() = runTest {

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/ui/GenericPaymentComponentTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/ui/GenericPaymentComponentTest.kt
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 10/6/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui
+
+import com.adyen.checkout.core.analytics.internal.TestAnalyticsManager
+import com.adyen.checkout.core.common.test
+import com.adyen.checkout.core.components.internal.PaymentComponentEvent
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
+import com.adyen.checkout.core.components.internal.ui.state.GenericPaymentComponentState
+import com.adyen.checkout.core.components.paymentmethod.GenericDetails
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(MockitoExtension::class)
+internal class GenericPaymentComponentTest(
+    @param:Mock private val sdkDataProvider: SdkDataProvider,
+) {
+
+    private lateinit var analyticsManager: TestAnalyticsManager
+
+    @BeforeEach
+    fun setUp() {
+        analyticsManager = TestAnalyticsManager()
+    }
+
+    @Test
+    fun `when component is created, then analytics is initialized`() = runTest {
+        // GIVEN - WHEN
+        createComponent(this)
+
+        // THEN
+        analyticsManager.assertIsInitialized()
+    }
+
+    @Test
+    fun `when submit is called, then eventFlow emits Submit event`() = runTest {
+        // GIVEN
+        whenever(sdkDataProvider.createEncodedSdkData()) doReturn TEST_SDK_DATA
+        val component = createComponent(this)
+        val events = component.eventFlow.test(testScheduler)
+
+        // WHEN
+        component.submit()
+
+        // THEN
+        assertEquals(1, events.values.size)
+        assertInstanceOf(PaymentComponentEvent.Submit::class.java, events.latestValue)
+    }
+
+    @Test
+    fun `when submit is called, then state contains correct payment method type`() = runTest {
+        // GIVEN
+        whenever(sdkDataProvider.createEncodedSdkData()) doReturn TEST_SDK_DATA
+        val component = createComponent(this)
+        val events = component.eventFlow.test(testScheduler)
+
+        // WHEN
+        component.submit()
+
+        // THEN
+        val state = (events.latestValue as PaymentComponentEvent.Submit).state
+        assertInstanceOf(GenericPaymentComponentState::class.java, state)
+        val details = (state as GenericPaymentComponentState).data.paymentMethod
+        assertInstanceOf(GenericDetails::class.java, details)
+        assertEquals(TEST_PAYMENT_METHOD_TYPE, details!!.type)
+    }
+
+    @Test
+    fun `when submit is called, then state contains sdk data from provider`() = runTest {
+        // GIVEN
+        whenever(sdkDataProvider.createEncodedSdkData()) doReturn TEST_SDK_DATA
+        val component = createComponent(this)
+        val events = component.eventFlow.test(testScheduler)
+
+        // WHEN
+        component.submit()
+
+        // THEN
+        val state = (events.latestValue as PaymentComponentEvent.Submit).state as GenericPaymentComponentState
+        assertEquals(TEST_SDK_DATA, state.data.paymentMethod!!.sdkData)
+    }
+
+    @Test
+    fun `when submit is called, then state subtype is null`() = runTest {
+        // GIVEN
+        whenever(sdkDataProvider.createEncodedSdkData()) doReturn TEST_SDK_DATA
+        val component = createComponent(this)
+        val events = component.eventFlow.test(testScheduler)
+
+        // WHEN
+        component.submit()
+
+        // THEN
+        val state = (events.latestValue as PaymentComponentEvent.Submit).state as GenericPaymentComponentState
+        assertNull(state.data.paymentMethod!!.subtype)
+    }
+
+    @Test
+    fun `when submit is called, then state order is null`() = runTest {
+        // GIVEN
+        whenever(sdkDataProvider.createEncodedSdkData()) doReturn TEST_SDK_DATA
+        val component = createComponent(this)
+        val events = component.eventFlow.test(testScheduler)
+
+        // WHEN
+        component.submit()
+
+        // THEN
+        val state = (events.latestValue as PaymentComponentEvent.Submit).state as GenericPaymentComponentState
+        assertNull(state.data.order)
+    }
+
+    @Test
+    fun `when submit is called, then state is valid`() = runTest {
+        // GIVEN
+        whenever(sdkDataProvider.createEncodedSdkData()) doReturn TEST_SDK_DATA
+        val component = createComponent(this)
+        val events = component.eventFlow.test(testScheduler)
+
+        // WHEN
+        component.submit()
+
+        // THEN
+        val state = (events.latestValue as PaymentComponentEvent.Submit).state as GenericPaymentComponentState
+        assertTrue(state.isValid)
+    }
+
+    @Test
+    fun `when submit is called, then sdk data provider is called`() = runTest {
+        // GIVEN
+        whenever(sdkDataProvider.createEncodedSdkData()) doReturn TEST_SDK_DATA
+        val component = createComponent(this)
+        component.eventFlow.test(testScheduler)
+
+        // WHEN
+        component.submit()
+
+        // THEN
+        verify(sdkDataProvider).createEncodedSdkData()
+    }
+
+    @Test
+    fun `when onCleared is called, then analytics is cleared`() = runTest {
+        // GIVEN
+        val component = createComponent(this)
+
+        // WHEN
+        component.onCleared()
+
+        // THEN
+        analyticsManager.assertIsCleared()
+    }
+
+    private fun createComponent(coroutineScope: CoroutineScope): GenericPaymentComponent {
+        return GenericPaymentComponent(
+            analyticsManager = analyticsManager,
+            paymentMethodType = TEST_PAYMENT_METHOD_TYPE,
+            sdkDataProvider = sdkDataProvider,
+            coroutineScope = coroutineScope,
+        )
+    }
+
+    companion object {
+        private const val TEST_PAYMENT_METHOD_TYPE = "test_payment_method"
+        private const val TEST_SDK_DATA = "test_sdk_data"
+    }
+}

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/internal/data/DefaultPaymentMethodRepositoryTest.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/internal/data/DefaultPaymentMethodRepositoryTest.kt
@@ -8,7 +8,7 @@
 
 package com.adyen.checkout.dropin.internal.data
 
-import com.adyen.checkout.core.components.data.model.paymentmethod.InstantPaymentMethod
+import com.adyen.checkout.core.components.data.model.paymentmethod.GenericPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethods
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredCardPaymentMethod
 import kotlinx.coroutines.flow.first
@@ -20,7 +20,7 @@ internal class DefaultPaymentMethodRepositoryTest {
 
     @Test
     fun `when initialized with payment methods, then regulars are set`() {
-        val paymentMethods = listOf(InstantPaymentMethod(type = "scheme", name = "Cards"))
+        val paymentMethods = listOf(GenericPaymentMethod(type = "scheme", name = "Cards"))
         val response = PaymentMethods(paymentMethods = paymentMethods)
 
         val repository = DefaultPaymentMethodRepository(response)
@@ -34,7 +34,7 @@ internal class DefaultPaymentMethodRepositoryTest {
 
         val repository = DefaultPaymentMethodRepository(response)
 
-        assertEquals(emptyList<InstantPaymentMethod>(), repository.paymentMethods)
+        assertEquals(emptyList<GenericPaymentMethod>(), repository.paymentMethods)
     }
 
     @Test

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/v6/CheckoutContextExt.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/v6/CheckoutContextExt.kt
@@ -9,6 +9,7 @@
 package com.adyen.checkout.example.ui.v6
 
 import com.adyen.checkout.core.common.CheckoutContext
+import com.adyen.checkout.core.components.data.model.paymentmethod.InstantPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
 import com.adyen.checkout.core.components.paymentmethod.PaymentMethodTypes
 
@@ -28,5 +29,5 @@ internal fun CheckoutContext.getPaymentMethods(): List<PaymentMethod> {
 
     return paymentMethods
         .orEmpty()
-        .filter { SUPPORTED_V6_PAYMENT_METHODS.contains(it.type) }
+        .filter { SUPPORTED_V6_PAYMENT_METHODS.contains(it.type) || it is InstantPaymentMethod }
 }

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/v6/CheckoutContextExt.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/v6/CheckoutContextExt.kt
@@ -9,7 +9,7 @@
 package com.adyen.checkout.example.ui.v6
 
 import com.adyen.checkout.core.common.CheckoutContext
-import com.adyen.checkout.core.components.data.model.paymentmethod.InstantPaymentMethod
+import com.adyen.checkout.core.components.data.model.paymentmethod.GenericPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
 import com.adyen.checkout.core.components.paymentmethod.PaymentMethodTypes
 
@@ -29,5 +29,5 @@ internal fun CheckoutContext.getPaymentMethods(): List<PaymentMethod> {
 
     return paymentMethods
         .orEmpty()
-        .filter { SUPPORTED_V6_PAYMENT_METHODS.contains(it.type) || it is InstantPaymentMethod }
+        .filter { SUPPORTED_V6_PAYMENT_METHODS.contains(it.type) || it is GenericPaymentMethod }
 }

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6Screen.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6Screen.kt
@@ -126,7 +126,10 @@ private fun Component(
         var showButton by remember { mutableStateOf(true) }
         if (!uiState.checkoutController.requiresUserInteraction() && showButton) {
             Button(
-                onClick = { uiState.checkoutController.submit() },
+                onClick = {
+                    showButton = false
+                    uiState.checkoutController.submit()
+                },
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(ExampleTheme.dimensions.grid_2),

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6Screen.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6Screen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuDefaults
@@ -120,6 +121,18 @@ private fun Component(
                 onDismissRequest = { shouldShowDialog = false },
                 theme = theme,
             )
+        }
+
+        var showButton by remember { mutableStateOf(true) }
+        if (!uiState.checkoutController.requiresUserInteraction() && showButton) {
+            Button(
+                onClick = { uiState.checkoutController.submit() },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(ExampleTheme.dimensions.grid_2),
+            ) {
+                Text("Submit")
+            }
         }
 
         CheckoutPaymentFlow(


### PR DESCRIPTION
## Description
This PR add the `GenericPaymentComponent`. This component can handle payment methods that don't require any user input. To use this component from the example implementation a button was added.


https://github.com/user-attachments/assets/39e4b6a5-6c57-40ce-b2ca-25606fea3fad

In the video you can see an example of the iDeal/Wero flow. When returning from the browser, it seems like the redirect component does not continue properly. This will be investigated and fixed in a follow up PR.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually
- [x] Aligned public API changes with other platforms (if applicable)

## Ticket Number
COSDK-1119