### PR TITLE
v6 - Rename onError to onFailure

### DIFF
--- a/core/src/main/java/com/adyen/checkout/core/components/ActionOnlyCheckoutCallbacks.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/ActionOnlyCheckoutCallbacks.kt
@@ -13,6 +13,6 @@ import com.adyen.checkout.core.error.CheckoutError
 
 class ActionOnlyCheckoutCallbacks(
     internal val onAdditionalDetails: suspend (data: ActionComponentData) -> AdditionalDetailsResult,
-    internal val onError: (CheckoutError) -> Unit,
+    internal val onFailure: (CheckoutError) -> Unit,
     additionalCallbacksBlock: CheckoutCallbacks.() -> Unit = {},
 ) : CheckoutCallbacks(additionalCallbacksBlock)

--- a/core/src/main/java/com/adyen/checkout/core/components/AdvancedCheckoutCallbacks.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/AdvancedCheckoutCallbacks.kt
@@ -15,6 +15,6 @@ import com.adyen.checkout.core.error.CheckoutError
 class AdvancedCheckoutCallbacks(
     internal val onSubmit: suspend (data: PaymentComponentData<*>) -> SubmitResult,
     internal val onAdditionalDetails: suspend (data: ActionComponentData) -> AdditionalDetailsResult,
-    internal val onError: (CheckoutError) -> Unit,
+    internal val onFailure: (CheckoutError) -> Unit,
     additionalCallbacksBlock: CheckoutCallbacks.() -> Unit = {},
 ) : CheckoutCallbacks(additionalCallbacksBlock)

--- a/core/src/main/java/com/adyen/checkout/core/components/SessionCheckoutCallbacks.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/SessionCheckoutCallbacks.kt
@@ -13,7 +13,7 @@ import com.adyen.checkout.core.error.CheckoutError
 
 class SessionCheckoutCallbacks(
     internal val onFinished: () -> Unit,
-    internal val onError: (CheckoutError) -> Unit,
+    internal val onFailure: (CheckoutError) -> Unit,
     internal val beforeSubmit: (suspend (data: PaymentComponentData<*>) -> Unit)? = null,
     additionalCallbacksBlock: CheckoutCallbacks.() -> Unit = {},
 ) : CheckoutCallbacks(additionalCallbacksBlock)

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ActionHandler.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ActionHandler.kt
@@ -55,7 +55,7 @@ internal class ActionHandler(
                     }
 
                     is ActionComponentEvent.Error -> {
-                        componentRequestDispatcher.error(event.error.toCheckoutError())
+                        componentRequestDispatcher.failure(event.error.toCheckoutError())
                     }
                 }
             }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ActionOnlyComponentRequestDispatcher.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ActionOnlyComponentRequestDispatcher.kt
@@ -21,7 +21,7 @@ internal class ActionOnlyComponentRequestDispatcher(
         return callbacks.onAdditionalDetails(data)
     }
 
-    override fun error(error: CheckoutError) {
-        callbacks.onError(error)
+    override fun failure(error: CheckoutError) {
+        callbacks.onFailure(error)
     }
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/AdvancedComponentRequestDispatcher.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/AdvancedComponentRequestDispatcher.kt
@@ -27,7 +27,7 @@ internal class AdvancedComponentRequestDispatcher(
         return callbacks.onAdditionalDetails(data)
     }
 
-    override fun error(error: CheckoutError) {
-        callbacks.onError(error)
+    override fun failure(error: CheckoutError) {
+        callbacks.onFailure(error)
     }
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ComponentRequestDispatcher.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ComponentRequestDispatcher.kt
@@ -18,7 +18,7 @@ internal interface ComponentRequestDispatcher {
 
     suspend fun additionalDetails(data: ActionComponentData): AdditionalDetailsResult
 
-    fun error(error: CheckoutError)
+    fun failure(error: CheckoutError)
 }
 
 internal interface SubmittableComponentRequestDispatcher : ComponentRequestDispatcher {

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/FullCheckoutFlow.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/FullCheckoutFlow.kt
@@ -51,7 +51,7 @@ internal class FullCheckoutFlow(
                     }
 
                     is PaymentComponentEvent.Error -> {
-                        componentRequestDispatcher.error(event.error.toCheckoutError())
+                        componentRequestDispatcher.failure(event.error.toCheckoutError())
                     }
 
                     is PaymentComponentEvent.SecondaryScreen -> {

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/SessionComponentRequestDispatcher.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/SessionComponentRequestDispatcher.kt
@@ -52,7 +52,7 @@ internal class SessionComponentRequestDispatcher(
 //                    event = ErrorEvent.API_PAYMENTS,
 //                )
 //                analyticsManager.trackEvent(event)
-                callbacks.onError(error.toCheckoutError())
+                callbacks.onFailure(error.toCheckoutError())
                 return SubmitResult.Retry(error.message)
             },
         )
@@ -70,13 +70,13 @@ internal class SessionComponentRequestDispatcher(
                 return AdditionalDetailsResult.Completion(response.resultCode.orEmpty())
             },
             onFailure = { error ->
-                callbacks.onError(error.toCheckoutError())
+                callbacks.onFailure(error.toCheckoutError())
                 return AdditionalDetailsResult.Completion("Error")
             },
         )
     }
 
-    override fun error(error: CheckoutError) {
-        callbacks.onError(error)
+    override fun failure(error: CheckoutError) {
+        callbacks.onFailure(error)
     }
 }

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/ActionHandlerTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/ActionHandlerTest.kt
@@ -120,7 +120,7 @@ internal class ActionHandlerTest(
             eventFlow.emit(ActionComponentEvent.Error(internalError))
 
             val captor = argumentCaptor<CheckoutError>()
-            verify(componentRequestDispatcher).error(captor.capture())
+            verify(componentRequestDispatcher).failure(captor.capture())
             assertEquals("test error message", captor.firstValue.message)
         }
     }

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/SessionComponentRequestDispatcherTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/SessionComponentRequestDispatcherTest.kt
@@ -92,13 +92,13 @@ internal class SessionComponentRequestDispatcherTest(
         }
 
         @Test
-        fun `when submit fails, then retry is returned and onError is invoked`() =
+        fun `when submit fails, then retry is returned and onFailure is invoked`() =
             runTest {
                 val cause = IOException("network down")
                 whenever(sessionRepository.submitPayment(any(), any(), any())) doReturn Result.failure(cause)
 
                 val capturedErrors = mutableListOf<CheckoutError>()
-                val dispatcher = createDispatcher(onError = { capturedErrors += it })
+                val dispatcher = createDispatcher(onFailure = { capturedErrors += it })
 
                 val result = dispatcher.submit(emptyPaymentComponentData())
 
@@ -148,13 +148,13 @@ internal class SessionComponentRequestDispatcherTest(
         }
 
         @Test
-        fun `when additionalDetails fails, then error completion is returned and onError is invoked`() =
+        fun `when additionalDetails fails, then error completion is returned and onFailure is invoked`() =
             runTest {
                 val cause = IOException("network down")
                 whenever(sessionRepository.submitDetails(any(), any(), any())) doReturn Result.failure(cause)
 
                 val capturedErrors = mutableListOf<CheckoutError>()
-                val dispatcher = createDispatcher(onError = { capturedErrors += it })
+                val dispatcher = createDispatcher(onFailure = { capturedErrors += it })
 
                 val result = dispatcher.additionalDetails(ActionComponentData())
 
@@ -179,12 +179,12 @@ internal class SessionComponentRequestDispatcherTest(
     inner class ErrorTest {
 
         @Test
-        fun `when error is called, then onError is invoked`() {
+        fun `when error is called, then onFailure is invoked`() {
             val capturedErrors = mutableListOf<CheckoutError>()
-            val dispatcher = createDispatcher(onError = { capturedErrors += it })
+            val dispatcher = createDispatcher(onFailure = { capturedErrors += it })
 
             val error = CheckoutError(code = "test", message = "test error")
-            dispatcher.error(error)
+            dispatcher.failure(error)
 
             assertEquals(listOf(error), capturedErrors)
         }
@@ -192,13 +192,13 @@ internal class SessionComponentRequestDispatcherTest(
 
     private fun createDispatcher(
         onFinished: () -> Unit = {},
-        onError: (CheckoutError) -> Unit = {},
+        onFailure: (CheckoutError) -> Unit = {},
     ): SessionComponentRequestDispatcher = SessionComponentRequestDispatcher(
         initialSessionData = "session-data",
         sessionId = "session-id",
         callbacks = SessionCheckoutCallbacks(
             onFinished = onFinished,
-            onError = onError,
+            onFailure = onFailure,
         ),
         sessionRepository = sessionRepository,
     )

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/service/DropInServiceManager.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/service/DropInServiceManager.kt
@@ -53,7 +53,7 @@ internal class DropInServiceManager(
         _paymentResultFlow.emit(paymentResult)
     }
 
-    suspend fun onError(error: CheckoutError) {
+    suspend fun onFailure(error: CheckoutError) {
         _errorFlow.emit(error)
     }
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodViewModel.kt
@@ -89,7 +89,7 @@ internal class PaymentMethodViewModel(
                     callbacks = AdvancedCheckoutCallbacks(
                         onSubmit = ::onSubmit,
                         onAdditionalDetails = ::onAdditionalDetails,
-                        onError = ::onError,
+                        onFailure = ::onFailure,
                     ),
                     coroutineScope = viewModelScope,
                 )
@@ -101,7 +101,7 @@ internal class PaymentMethodViewModel(
                     context = checkoutContext,
                     callbacks = SessionCheckoutCallbacks(
                         beforeSubmit = ::beforeSubmit,
-                        onError = ::onError,
+                        onFailure = ::onFailure,
                         onFinished = ::onFinished,
                     ),
                     coroutineScope = viewModelScope,
@@ -124,9 +124,9 @@ internal class PaymentMethodViewModel(
         return dropInServiceManager.requestOnAdditionalDetails(data)
     }
 
-    private fun onError(error: CheckoutError) {
+    private fun onFailure(error: CheckoutError) {
         viewModelScope.launch {
-            dropInServiceManager.onError(error)
+            dropInServiceManager.onFailure(error)
         }
     }
 

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6SessionsViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6SessionsViewModel.kt
@@ -103,8 +103,8 @@ internal class V6SessionsViewModel @Inject constructor(
         Log.d(TAG, "Bin Lookup Data received: $binLookupData")
     }
 
-    private fun onError(error: CheckoutError) {
-        Log.d(TAG, "onError: ${error.message}")
+    private fun onFailure(error: CheckoutError) {
+        Log.d(TAG, "onFailure: ${error.message}")
     }
 
     private fun onFinished() {
@@ -138,7 +138,7 @@ internal class V6SessionsViewModel @Inject constructor(
             target = CheckoutTarget.PaymentMethod(paymentMethod.type),
             context = checkoutContext,
             callbacks = SessionCheckoutCallbacks(
-                onError = ::onError,
+                onFailure = ::onFailure,
                 onFinished = ::onFinished,
             ) {
                 card(

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6ViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6ViewModel.kt
@@ -167,7 +167,7 @@ internal class V6ViewModel @Inject constructor(
         return AdditionalDetailsResult.Completion(resultCode)
     }
 
-    private fun onError(error: CheckoutError) {
+    private fun onFailure(error: CheckoutError) {
         uiState = V6UiState.Error(UIText.String(error.message.orEmpty()))
     }
 
@@ -200,7 +200,7 @@ internal class V6ViewModel @Inject constructor(
             callbacks = AdvancedCheckoutCallbacks(
                 onSubmit = ::onSubmit,
                 onAdditionalDetails = ::onAdditionalDetails,
-                onError = ::onError,
+                onFailure = ::onFailure,
             ) {
                 card(
                     onBinValue = ::onBinValue,


### PR DESCRIPTION
## Description
This PR renames the `onError` callbacks to `onFailure` for alignment reasons. Some internals are also renamed for consistency.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Aligned public API changes with other platforms (if applicable)

## Ticket Number
COSDK-1249