### PR TITLE
v6 - Card / MBWay - Extract composable logic from components

### DIFF
--- a/await/src/main/java/com/adyen/checkout/await/internal/ui/AwaitComponent.kt
+++ b/await/src/main/java/com/adyen/checkout/await/internal/ui/AwaitComponent.kt
@@ -11,7 +11,7 @@ package com.adyen.checkout.await.internal.ui
 import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.adyen.checkout.await.internal.ui.view.AwaitComponent
+import com.adyen.checkout.await.internal.ui.view.AwaitContent
 import com.adyen.checkout.core.action.data.ActionComponentData
 import com.adyen.checkout.core.action.data.AwaitAction
 import com.adyen.checkout.core.action.internal.ActionComponent
@@ -69,7 +69,7 @@ internal class AwaitComponent(
             onError = ::emitError,
         )
 
-        AwaitComponent(modifier)
+        AwaitContent(modifier)
     }
 
     override fun handleAction() {

--- a/await/src/main/java/com/adyen/checkout/await/internal/ui/view/AwaitContent.kt
+++ b/await/src/main/java/com/adyen/checkout/await/internal/ui/view/AwaitContent.kt
@@ -23,7 +23,7 @@ import com.adyen.checkout.ui.internal.text.Body
 import com.adyen.checkout.ui.internal.theme.Dimensions
 
 @Composable
-internal fun AwaitComponent(
+internal fun AwaitContent(
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -38,6 +38,6 @@ internal fun AwaitComponent(
 
 @Preview(showBackground = true)
 @Composable
-private fun AwaitComponentPreview() {
-    AwaitComponent()
+private fun AwaitContentPreview() {
+    AwaitContent()
 }

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/BlikComponent.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/BlikComponent.kt
@@ -18,7 +18,7 @@ import com.adyen.checkout.blik.internal.ui.state.BlikComponentStateValidator
 import com.adyen.checkout.blik.internal.ui.state.BlikIntent
 import com.adyen.checkout.blik.internal.ui.state.BlikViewStateProducer
 import com.adyen.checkout.blik.internal.ui.state.toPaymentComponentState
-import com.adyen.checkout.blik.internal.ui.view.BlikComponent
+import com.adyen.checkout.blik.internal.ui.view.BlikContent
 import com.adyen.checkout.core.analytics.internal.AnalyticsManager
 import com.adyen.checkout.core.common.internal.helper.bufferedChannel
 import com.adyen.checkout.core.components.internal.PaymentComponentEvent
@@ -65,7 +65,7 @@ internal class BlikComponent(
     override fun Content(modifier: Modifier) {
         val viewState by viewState.collectAsStateWithLifecycle()
 
-        BlikComponent(
+        BlikContent(
             viewState = viewState,
             onSubmitClick = ::submit,
             onIntent = ::onIntent,

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/BlikComponent.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/BlikComponent.kt
@@ -9,9 +9,7 @@
 package com.adyen.checkout.blik.internal.ui
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.adyen.checkout.blik.internal.ui.state.BlikComponentStateFactory
 import com.adyen.checkout.blik.internal.ui.state.BlikComponentStateReducer
 import com.adyen.checkout.blik.internal.ui.state.BlikComponentStateValidator
@@ -63,10 +61,8 @@ internal class BlikComponent(
 
     @Composable
     override fun Content(modifier: Modifier) {
-        val viewState by viewState.collectAsStateWithLifecycle()
-
         BlikContent(
-            viewState = viewState,
+            viewStateFlow = viewState,
             onSubmitClick = ::submit,
             onIntent = ::onIntent,
             modifier = modifier,

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/StoredBlikComponent.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/StoredBlikComponent.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.adyen.checkout.blik.internal.ui.state.BlikPaymentComponentState
 import com.adyen.checkout.blik.internal.ui.state.StoredBlikViewState
-import com.adyen.checkout.blik.internal.ui.view.StoredBlikComponent
+import com.adyen.checkout.blik.internal.ui.view.StoredBlikContent
 import com.adyen.checkout.core.analytics.internal.AnalyticsManager
 import com.adyen.checkout.core.common.internal.helper.bufferedChannel
 import com.adyen.checkout.core.components.data.PaymentComponentData
@@ -52,7 +52,7 @@ internal class StoredBlikComponent(
     override fun Content(modifier: Modifier) {
         val isLoading by this.isLoading.collectAsStateWithLifecycle()
 
-        StoredBlikComponent(
+        StoredBlikContent(
             viewState = StoredBlikViewState(isLoading = isLoading),
             onSubmitClick = ::submit,
             modifier = modifier,

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/StoredBlikComponent.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/StoredBlikComponent.kt
@@ -9,9 +9,7 @@
 package com.adyen.checkout.blik.internal.ui
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.adyen.checkout.blik.internal.ui.state.BlikPaymentComponentState
 import com.adyen.checkout.blik.internal.ui.state.StoredBlikViewState
 import com.adyen.checkout.blik.internal.ui.view.StoredBlikContent
@@ -27,6 +25,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
 
 internal class StoredBlikComponent(
     private val storedPaymentMethod: StoredPaymentMethod,
@@ -38,7 +37,7 @@ internal class StoredBlikComponent(
     private val eventChannel = bufferedChannel<PaymentComponentEvent>()
     override val eventFlow: Flow<PaymentComponentEvent> = eventChannel.receiveAsFlow()
 
-    private val isLoading = MutableStateFlow(false)
+    private val viewState = MutableStateFlow(StoredBlikViewState(isLoading = false))
 
     init {
         initializeAnalytics(coroutineScope)
@@ -50,10 +49,8 @@ internal class StoredBlikComponent(
 
     @Composable
     override fun Content(modifier: Modifier) {
-        val isLoading by this.isLoading.collectAsStateWithLifecycle()
-
         StoredBlikContent(
-            viewState = StoredBlikViewState(isLoading = isLoading),
+            viewStateFlow = viewState,
             onSubmitClick = ::submit,
             modifier = modifier,
         )
@@ -67,7 +64,9 @@ internal class StoredBlikComponent(
     override fun requiresUserInteraction(): Boolean = false
 
     override fun setLoading(isLoading: Boolean) {
-        this.isLoading.value = isLoading
+        this.viewState.update {
+            it.copy(isLoading = isLoading)
+        }
     }
 
     override fun onCleared() {

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/BlikContent.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/BlikContent.kt
@@ -11,8 +11,10 @@ package com.adyen.checkout.blik.internal.ui.view
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.adyen.checkout.blik.internal.ui.state.BlikIntent
 import com.adyen.checkout.blik.internal.ui.state.BlikViewState
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
@@ -22,13 +24,30 @@ import com.adyen.checkout.ui.internal.element.ComponentScaffold
 import com.adyen.checkout.ui.internal.element.button.PayButton
 import com.adyen.checkout.ui.internal.text.Body
 import com.adyen.checkout.ui.internal.theme.Dimensions
+import kotlinx.coroutines.flow.StateFlow
 
 @Composable
 internal fun BlikContent(
-    viewState: BlikViewState,
+    viewStateFlow: StateFlow<BlikViewState>,
     onSubmitClick: () -> Unit,
     onIntent: (BlikIntent) -> Unit,
     modifier: Modifier = Modifier,
+) {
+    val viewState by viewStateFlow.collectAsStateWithLifecycle()
+    BlikContent(
+        viewState = viewState,
+        onSubmitClick = onSubmitClick,
+        onIntent = onIntent,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun BlikContent(
+    viewState: BlikViewState,
+    onSubmitClick: () -> Unit,
+    onIntent: (BlikIntent) -> Unit,
+    modifier: Modifier,
 ) {
     ComponentScaffold(
         modifier = modifier,
@@ -64,5 +83,6 @@ private fun BlikContentPreview() {
         ),
         onIntent = {},
         onSubmitClick = {},
+        modifier = Modifier,
     )
 }

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/BlikContent.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/BlikContent.kt
@@ -24,7 +24,7 @@ import com.adyen.checkout.ui.internal.text.Body
 import com.adyen.checkout.ui.internal.theme.Dimensions
 
 @Composable
-internal fun BlikComponent(
+internal fun BlikContent(
     viewState: BlikViewState,
     onSubmitClick: () -> Unit,
     onIntent: (BlikIntent) -> Unit,
@@ -56,8 +56,8 @@ internal fun BlikComponent(
 
 @Preview(showBackground = true)
 @Composable
-private fun BlikComponentPreview() {
-    BlikComponent(
+private fun BlikContentPreview() {
+    BlikContent(
         viewState = BlikViewState(
             blikCode = TextInputViewState(),
             isLoading = false,

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/StoredBlikContent.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/StoredBlikContent.kt
@@ -15,7 +15,7 @@ import com.adyen.checkout.ui.internal.element.ComponentScaffold
 import com.adyen.checkout.ui.internal.element.button.PayButton
 
 @Composable
-internal fun StoredBlikComponent(
+internal fun StoredBlikContent(
     viewState: StoredBlikViewState,
     onSubmitClick: () -> Unit,
     modifier: Modifier,

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/StoredBlikContent.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/StoredBlikContent.kt
@@ -9,13 +9,30 @@
 package com.adyen.checkout.blik.internal.ui.view
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.adyen.checkout.blik.internal.ui.state.StoredBlikViewState
 import com.adyen.checkout.ui.internal.element.ComponentScaffold
 import com.adyen.checkout.ui.internal.element.button.PayButton
+import kotlinx.coroutines.flow.StateFlow
 
 @Composable
 internal fun StoredBlikContent(
+    viewStateFlow: StateFlow<StoredBlikViewState>,
+    onSubmitClick: () -> Unit,
+    modifier: Modifier,
+) {
+    val viewState by viewStateFlow.collectAsStateWithLifecycle()
+    StoredBlikContent(
+        viewState = viewState,
+        onSubmitClick = onSubmitClick,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun StoredBlikContent(
     viewState: StoredBlikViewState,
     onSubmitClick: () -> Unit,
     modifier: Modifier,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
@@ -35,7 +35,7 @@ import com.adyen.checkout.card.internal.ui.state.CardIntent
 import com.adyen.checkout.card.internal.ui.state.CardViewStateProducer
 import com.adyen.checkout.card.internal.ui.state.binValue
 import com.adyen.checkout.card.internal.ui.state.toPaymentComponentState
-import com.adyen.checkout.card.internal.ui.view.CardComponent
+import com.adyen.checkout.card.internal.ui.view.CardContent
 import com.adyen.checkout.card.internal.ui.view.InstallmentPicker
 import com.adyen.checkout.card.internal.util.CardScannerWrapper
 import com.adyen.checkout.core.analytics.internal.AnalyticsManager
@@ -127,7 +127,7 @@ constructor(
         }
 
         val viewState by viewState.collectAsStateWithLifecycle()
-        CardComponent(
+        CardContent(
             viewState = viewState,
             onIntent = ::handleIntent,
             onSubmitClick = ::submit,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
@@ -12,16 +12,10 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.IntentSender
-import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.IntentSenderRequest
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.adyen.checkout.card.OnBinChangeCallback
 import com.adyen.checkout.card.OnBinLookupCallback
 import com.adyen.checkout.card.internal.analytics.CardScannerEvents
@@ -36,7 +30,7 @@ import com.adyen.checkout.card.internal.ui.state.CardViewStateProducer
 import com.adyen.checkout.card.internal.ui.state.binValue
 import com.adyen.checkout.card.internal.ui.state.toPaymentComponentState
 import com.adyen.checkout.card.internal.ui.view.CardContent
-import com.adyen.checkout.card.internal.ui.view.InstallmentPicker
+import com.adyen.checkout.card.internal.ui.view.CardSecondaryContent
 import com.adyen.checkout.card.internal.util.CardScannerWrapper
 import com.adyen.checkout.core.analytics.internal.AnalyticsManager
 import com.adyen.checkout.core.analytics.internal.ErrorEvent
@@ -113,49 +107,27 @@ constructor(
 
     @Composable
     override fun Content(modifier: Modifier) {
-        val context = LocalContext.current
-        LaunchedEffect(Unit) {
-            initializeCardScanner(context)
-        }
-
-        val scannerLauncher = rememberLauncherForActivityResult(
-            contract = ActivityResultContracts.StartIntentSenderForResult(),
-        ) { result ->
-            onCardScannerResult(result.resultCode, result.data)
-            // Re-initialize to get a fresh PendingIntent, as Google's PaymentCardRecognitionPendingIntent is single-use
-            initializeCardScanner(context)
-        }
-
-        val viewState by viewState.collectAsStateWithLifecycle()
         CardContent(
-            viewState = viewState,
+            modifier = modifier,
+            viewStateFlow = viewState,
             onIntent = ::handleIntent,
             onSubmitClick = ::submit,
-            onScanButtonClick = {
-                onScanButtonClick(scannerLauncher)
-            },
             onInstallmentPickerClick = ::onInstallmentPickerClick,
-            modifier = modifier,
+            initializeCardScanner = ::initializeCardScanner,
+            onCardScannerResult = ::onCardScannerResult,
+            onScanButtonClick = ::onScanButtonClick,
         )
     }
 
     @Composable
     override fun SecondaryContent(identifier: String, modifier: Modifier) {
-        val viewState by viewState.collectAsStateWithLifecycle()
-
-        when (identifier) {
-            INSTALLMENTS_IDENTIFIER -> {
-                InstallmentPicker(
-                    installmentOptions = viewState.installmentViewState?.installmentOptions ?: emptyList(),
-                    selectedInstallment = viewState.installmentViewState?.selectedInstallment,
-                    onItemClick = { installment ->
-                        onIntent(CardIntent.UpdateInstallment(installment))
-                        eventChannel.trySend(PaymentComponentEvent.CloseSecondaryScreen)
-                    },
-                    modifier = modifier,
-                )
-            }
-        }
+        CardSecondaryContent(
+            modifier = modifier,
+            identifier = identifier,
+            viewState = viewState,
+            onIntent = ::onIntent,
+            onDismissRequest = { eventChannel.trySend(PaymentComponentEvent.CloseSecondaryScreen) },
+        )
     }
 
     override fun submit() {
@@ -328,6 +300,6 @@ constructor(
     }
 
     companion object {
-        private const val INSTALLMENTS_IDENTIFIER = "installments"
+        internal const val INSTALLMENTS_IDENTIFIER = "installments"
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
@@ -31,6 +31,7 @@ import com.adyen.checkout.card.internal.ui.state.binValue
 import com.adyen.checkout.card.internal.ui.state.toPaymentComponentState
 import com.adyen.checkout.card.internal.ui.view.CardContent
 import com.adyen.checkout.card.internal.ui.view.CardSecondaryContent
+import com.adyen.checkout.card.internal.ui.view.CardSecondaryContentEntry
 import com.adyen.checkout.card.internal.util.CardScannerWrapper
 import com.adyen.checkout.core.analytics.internal.AnalyticsManager
 import com.adyen.checkout.core.analytics.internal.ErrorEvent
@@ -273,7 +274,7 @@ constructor(
     private fun onInstallmentPickerClick() {
         eventChannel.trySend(
             PaymentComponentEvent.SecondaryScreen(
-                identifier = INSTALLMENTS_IDENTIFIER,
+                identifier = CardSecondaryContentEntry.INSTALLMENTS,
             ),
         )
     }
@@ -297,9 +298,5 @@ constructor(
         val event = GenericEvents.error(paymentMethodType, ErrorEvent.API_PUBLIC_KEY)
         analyticsManager.trackEvent(event)
         emitError(e)
-    }
-
-    companion object {
-        internal const val INSTALLMENTS_IDENTIFIER = "installments"
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/StoredCardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/StoredCardComponent.kt
@@ -9,9 +9,7 @@
 package com.adyen.checkout.card.internal.ui
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.adyen.checkout.card.internal.data.model.Brand
 import com.adyen.checkout.card.internal.data.model.DetectedCardType
 import com.adyen.checkout.card.internal.ui.model.CardComponentParams
@@ -101,9 +99,8 @@ internal class StoredCardComponent(
 
     @Composable
     override fun Content(modifier: Modifier) {
-        val viewState by viewState.collectAsStateWithLifecycle()
         StoredCardContent(
-            viewState = viewState,
+            viewStateFlow = viewState,
             onIntent = ::onIntent,
             onSubmitClick = ::submit,
             modifier = modifier,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/StoredCardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/StoredCardComponent.kt
@@ -22,7 +22,7 @@ import com.adyen.checkout.card.internal.ui.state.StoredCardComponentStateValidat
 import com.adyen.checkout.card.internal.ui.state.StoredCardIntent
 import com.adyen.checkout.card.internal.ui.state.StoredCardViewStateProducer
 import com.adyen.checkout.card.internal.ui.state.toPaymentComponentState
-import com.adyen.checkout.card.internal.ui.view.StoredCardComponent
+import com.adyen.checkout.card.internal.ui.view.StoredCardContent
 import com.adyen.checkout.core.analytics.internal.AnalyticsManager
 import com.adyen.checkout.core.analytics.internal.ErrorEvent
 import com.adyen.checkout.core.analytics.internal.GenericEvents
@@ -102,7 +102,7 @@ internal class StoredCardComponent(
     @Composable
     override fun Content(modifier: Modifier) {
         val viewState by viewState.collectAsStateWithLifecycle()
-        StoredCardComponent(
+        StoredCardContent(
             viewState = viewState,
             onIntent = ::onIntent,
             onSubmitClick = ::submit,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardContent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardContent.kt
@@ -8,12 +8,22 @@
 
 package com.adyen.checkout.card.internal.ui.view
 
+import android.content.Context
+import android.content.Intent
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.IntentSenderRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.adyen.checkout.card.internal.ui.model.InstallmentModel
 import com.adyen.checkout.card.internal.ui.model.toDisplayText
 import com.adyen.checkout.card.internal.ui.state.CardBrandViewState
@@ -33,9 +43,47 @@ import com.adyen.checkout.ui.internal.element.input.ValuePickerField
 import com.adyen.checkout.ui.internal.text.Body
 import com.adyen.checkout.ui.internal.text.Subtitle
 import com.adyen.checkout.ui.internal.theme.Dimensions
+import kotlinx.coroutines.flow.StateFlow
 
 @Composable
 internal fun CardContent(
+    modifier: Modifier,
+    viewStateFlow: StateFlow<CardViewState>,
+    onIntent: (CardIntent) -> Unit,
+    onSubmitClick: () -> Unit,
+    onInstallmentPickerClick: () -> Unit,
+    initializeCardScanner: (Context) -> Unit,
+    onCardScannerResult: (Int, Intent?) -> Unit,
+    onScanButtonClick: (ActivityResultLauncher<IntentSenderRequest>) -> Unit,
+) {
+    val context = LocalContext.current
+    LaunchedEffect(Unit) {
+        initializeCardScanner(context)
+    }
+
+    val scannerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartIntentSenderForResult(),
+    ) { result ->
+        onCardScannerResult(result.resultCode, result.data)
+        // Re-initialize to get a fresh PendingIntent, as Google's PaymentCardRecognitionPendingIntent is single-use
+        initializeCardScanner(context)
+    }
+
+    val viewState by viewStateFlow.collectAsStateWithLifecycle()
+    CardContent(
+        viewState = viewState,
+        onIntent = onIntent,
+        onSubmitClick = onSubmitClick,
+        onScanButtonClick = {
+            onScanButtonClick(scannerLauncher)
+        },
+        onInstallmentPickerClick = onInstallmentPickerClick,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun CardContent(
     viewState: CardViewState,
     onIntent: (CardIntent) -> Unit,
     onSubmitClick: () -> Unit,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardContent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardContent.kt
@@ -35,7 +35,7 @@ import com.adyen.checkout.ui.internal.text.Subtitle
 import com.adyen.checkout.ui.internal.theme.Dimensions
 
 @Composable
-internal fun CardComponent(
+internal fun CardContent(
     viewState: CardViewState,
     onIntent: (CardIntent) -> Unit,
     onSubmitClick: () -> Unit,
@@ -155,8 +155,8 @@ private fun CardDetailsSection(
 
 @Preview(showBackground = true)
 @Composable
-private fun CardComponentPreview() {
-    CardComponent(
+private fun CardContentPreview() {
+    CardContent(
         viewState = CardViewState(
             cardNumber = TextInputViewState(
                 text = "5555444433331111",

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardSecondaryContent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardSecondaryContent.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 16/6/2026.
+ */
+
+package com.adyen.checkout.card.internal.ui.view
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.adyen.checkout.card.internal.ui.CardComponent
+import com.adyen.checkout.card.internal.ui.state.CardIntent
+import com.adyen.checkout.card.internal.ui.state.CardViewState
+import com.adyen.checkout.card.internal.ui.state.InstallmentViewState
+import kotlinx.coroutines.flow.StateFlow
+
+@Composable
+internal fun CardSecondaryContent(
+    modifier: Modifier,
+    identifier: String,
+    viewState: StateFlow<CardViewState>,
+    onIntent: (CardIntent) -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    val viewState by viewState.collectAsStateWithLifecycle()
+
+    when (identifier) {
+        CardComponent.INSTALLMENTS_IDENTIFIER -> {
+            Installments(
+                modifier = modifier,
+                installmentViewState = viewState.installmentViewState,
+                onIntent = onIntent,
+                onDismissRequest = onDismissRequest,
+            )
+        }
+    }
+}
+
+@Composable
+internal fun Installments(
+    modifier: Modifier,
+    installmentViewState: InstallmentViewState?,
+    onIntent: (CardIntent) -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    if (installmentViewState == null) return
+    InstallmentPicker(
+        installmentOptions = installmentViewState.installmentOptions,
+        selectedInstallment = installmentViewState.selectedInstallment,
+        onItemClick = { installment ->
+            onIntent(CardIntent.UpdateInstallment(installment))
+            onDismissRequest()
+        },
+        modifier = modifier,
+    )
+}

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardSecondaryContent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardSecondaryContent.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.adyen.checkout.card.internal.ui.CardComponent
 import com.adyen.checkout.card.internal.ui.state.CardIntent
 import com.adyen.checkout.card.internal.ui.state.CardViewState
 import com.adyen.checkout.card.internal.ui.state.InstallmentViewState
@@ -29,7 +28,7 @@ internal fun CardSecondaryContent(
     val viewState by viewState.collectAsStateWithLifecycle()
 
     when (identifier) {
-        CardComponent.INSTALLMENTS_IDENTIFIER -> {
+        CardSecondaryContentEntry.INSTALLMENTS -> {
             Installments(
                 modifier = modifier,
                 installmentViewState = viewState.installmentViewState,
@@ -41,7 +40,7 @@ internal fun CardSecondaryContent(
 }
 
 @Composable
-internal fun Installments(
+private fun Installments(
     modifier: Modifier,
     installmentViewState: InstallmentViewState?,
     onIntent: (CardIntent) -> Unit,
@@ -57,4 +56,8 @@ internal fun Installments(
         },
         modifier = modifier,
     )
+}
+
+internal object CardSecondaryContentEntry {
+    const val INSTALLMENTS: String = "INSTALLMENTS"
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardContent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardContent.kt
@@ -12,19 +12,38 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.adyen.checkout.card.internal.ui.state.StoredCardIntent
 import com.adyen.checkout.card.internal.ui.state.StoredCardViewState
 import com.adyen.checkout.ui.internal.element.ComponentScaffold
 import com.adyen.checkout.ui.internal.element.button.PayButton
 import com.adyen.checkout.ui.internal.theme.Dimensions
+import kotlinx.coroutines.flow.StateFlow
 
 @Composable
 internal fun StoredCardContent(
-    viewState: StoredCardViewState,
+    viewStateFlow: StateFlow<StoredCardViewState>,
     onIntent: (StoredCardIntent) -> Unit,
     onSubmitClick: () -> Unit,
     modifier: Modifier = Modifier,
+) {
+    val viewState by viewStateFlow.collectAsStateWithLifecycle()
+    StoredCardContent(
+        viewState = viewState,
+        onIntent = onIntent,
+        onSubmitClick = onSubmitClick,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun StoredCardContent(
+    viewState: StoredCardViewState,
+    onIntent: (StoredCardIntent) -> Unit,
+    onSubmitClick: () -> Unit,
+    modifier: Modifier,
 ) {
     ComponentScaffold(
         modifier = modifier,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardContent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardContent.kt
@@ -20,7 +20,7 @@ import com.adyen.checkout.ui.internal.element.button.PayButton
 import com.adyen.checkout.ui.internal.theme.Dimensions
 
 @Composable
-internal fun StoredCardComponent(
+internal fun StoredCardContent(
     viewState: StoredCardViewState,
     onIntent: (StoredCardIntent) -> Unit,
     onSubmitClick: () -> Unit,

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/view/GooglePayContent.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/view/GooglePayContent.kt
@@ -11,6 +11,6 @@ package com.adyen.checkout.googlepay.internal.ui.view
 import androidx.compose.runtime.Composable
 
 @Composable
-internal fun GooglePayComponent() {
+internal fun GooglePayContent() {
     TODO("Not yet implemented")
 }

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/MBWayComponent.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/MBWayComponent.kt
@@ -9,9 +9,7 @@
 package com.adyen.checkout.mbway.internal.ui
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.adyen.checkout.core.analytics.internal.AnalyticsManager
 import com.adyen.checkout.core.common.internal.helper.bufferedChannel
 import com.adyen.checkout.core.components.internal.PaymentComponentEvent
@@ -26,8 +24,8 @@ import com.adyen.checkout.mbway.internal.ui.state.MBWayComponentStateValidator
 import com.adyen.checkout.mbway.internal.ui.state.MBWayIntent
 import com.adyen.checkout.mbway.internal.ui.state.MBWayViewStateProducer
 import com.adyen.checkout.mbway.internal.ui.state.toPaymentComponentState
-import com.adyen.checkout.mbway.internal.ui.view.CountryCodePicker
 import com.adyen.checkout.mbway.internal.ui.view.MBWayContent
+import com.adyen.checkout.mbway.internal.ui.view.MBWaySecondaryContent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -66,11 +64,9 @@ internal class MBWayComponent(
 
     @Composable
     override fun Content(modifier: Modifier) {
-        val viewState by viewState.collectAsStateWithLifecycle()
-
         MBWayContent(
             modifier = modifier,
-            viewState = viewState,
+            viewStateFlow = viewState,
             onSubmitClick = ::submit,
             onCountryCodePickerClick = ::onCountryCodePickerClick,
             onIntent = ::onIntent,
@@ -79,15 +75,12 @@ internal class MBWayComponent(
 
     @Composable
     override fun SecondaryContent(identifier: String, modifier: Modifier) {
-        val viewState by viewState.collectAsStateWithLifecycle()
-
-        CountryCodePicker(
-            viewState = viewState,
-            onItemClick = {
-                onIntent(MBWayIntent.UpdateCountry(it))
-                eventChannel.trySend(PaymentComponentEvent.CloseSecondaryScreen)
-            },
+        MBWaySecondaryContent(
             modifier = modifier,
+            identifier = identifier,
+            viewState = viewState,
+            onIntent = ::onIntent,
+            onDismissRequest = { eventChannel.trySend(PaymentComponentEvent.CloseSecondaryScreen) },
         )
     }
 
@@ -127,6 +120,6 @@ internal class MBWayComponent(
     }
 
     companion object {
-        private const val COUNTRY_CODE_IDENTIFIER = "country_code"
+        internal const val COUNTRY_CODE_IDENTIFIER = "country_code"
     }
 }

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/MBWayComponent.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/MBWayComponent.kt
@@ -26,6 +26,7 @@ import com.adyen.checkout.mbway.internal.ui.state.MBWayViewStateProducer
 import com.adyen.checkout.mbway.internal.ui.state.toPaymentComponentState
 import com.adyen.checkout.mbway.internal.ui.view.MBWayContent
 import com.adyen.checkout.mbway.internal.ui.view.MBWaySecondaryContent
+import com.adyen.checkout.mbway.internal.ui.view.MBWaySecondaryContentEntry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -91,7 +92,7 @@ internal class MBWayComponent(
     private fun onCountryCodePickerClick() {
         eventChannel.trySend(
             PaymentComponentEvent.SecondaryScreen(
-                identifier = COUNTRY_CODE_IDENTIFIER,
+                identifier = MBWaySecondaryContentEntry.COUNTRY_CODE_PICKER,
             ),
         )
     }
@@ -117,9 +118,5 @@ internal class MBWayComponent(
 
     override fun onCleared() {
         analyticsManager.clear(this)
-    }
-
-    companion object {
-        internal const val COUNTRY_CODE_IDENTIFIER = "country_code"
     }
 }

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MBWayContent.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MBWayContent.kt
@@ -12,8 +12,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.model.CountryModel
@@ -24,9 +26,29 @@ import com.adyen.checkout.ui.internal.element.ComponentScaffold
 import com.adyen.checkout.ui.internal.element.button.PayButton
 import com.adyen.checkout.ui.internal.element.input.ValuePickerField
 import com.adyen.checkout.ui.internal.theme.Dimensions
+import kotlinx.coroutines.flow.StateFlow
 
 @Composable
 internal fun MBWayContent(
+    modifier: Modifier,
+    viewStateFlow: StateFlow<MBWayViewState>,
+    onIntent: (MBWayIntent) -> Unit,
+    onSubmitClick: () -> Unit,
+    onCountryCodePickerClick: () -> Unit,
+) {
+    val viewState by viewStateFlow.collectAsStateWithLifecycle()
+
+    MBWayContent(
+        modifier = modifier,
+        viewState = viewState,
+        onIntent = onIntent,
+        onSubmitClick = onSubmitClick,
+        onCountryCodePickerClick = onCountryCodePickerClick,
+    )
+}
+
+@Composable
+private fun MBWayContent(
     viewState: MBWayViewState,
     onIntent: (MBWayIntent) -> Unit,
     onSubmitClick: () -> Unit,

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MBWaySecondaryContent.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MBWaySecondaryContent.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 16/6/2026.
+ */
+
+package com.adyen.checkout.mbway.internal.ui.view
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.adyen.checkout.mbway.internal.ui.MBWayComponent
+import com.adyen.checkout.mbway.internal.ui.state.MBWayIntent
+import com.adyen.checkout.mbway.internal.ui.state.MBWayViewState
+import kotlinx.coroutines.flow.StateFlow
+
+@Composable
+internal fun MBWaySecondaryContent(
+    modifier: Modifier,
+    identifier: String,
+    viewState: StateFlow<MBWayViewState>,
+    onIntent: (MBWayIntent) -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    val viewState by viewState.collectAsStateWithLifecycle()
+
+    when (identifier) {
+        MBWayComponent.COUNTRY_CODE_IDENTIFIER -> {
+            CountryCodePicker(
+                viewState = viewState,
+                onItemClick = {
+                    onIntent(MBWayIntent.UpdateCountry(it))
+                    onDismissRequest()
+                },
+                modifier = modifier,
+            )
+        }
+    }
+}

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MBWaySecondaryContent.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MBWaySecondaryContent.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.adyen.checkout.mbway.internal.ui.MBWayComponent
 import com.adyen.checkout.mbway.internal.ui.state.MBWayIntent
 import com.adyen.checkout.mbway.internal.ui.state.MBWayViewState
 import kotlinx.coroutines.flow.StateFlow
@@ -28,7 +27,7 @@ internal fun MBWaySecondaryContent(
     val viewState by viewState.collectAsStateWithLifecycle()
 
     when (identifier) {
-        MBWayComponent.COUNTRY_CODE_IDENTIFIER -> {
+        MBWaySecondaryContentEntry.COUNTRY_CODE_PICKER -> {
             CountryCodePicker(
                 viewState = viewState,
                 onItemClick = {
@@ -39,4 +38,8 @@ internal fun MBWaySecondaryContent(
             )
         }
     }
+}
+
+internal object MBWaySecondaryContentEntry {
+    const val COUNTRY_CODE_PICKER = "COUNTRY_CODE_PICKER"
 }


### PR DESCRIPTION
## Description
Extracts composable logic from `CardComponent` and `MBWayComponent` into dedicated composable files, keeping component classes free of Compose internals.

Three logical steps:
1. **Rename** `view/CardComponent.kt` → `view/CardContent.kt` to free up the name for the composable entry point.
2. **Move compose logic** — scanner launcher setup, `LaunchedEffect`, and `collectAsStateWithLifecycle` calls are moved from the component classes into the `CardContent`/`MBWayContent` (new `StateFlow` overload) and new `CardSecondaryContent`/`MBWaySecondaryContent` composables. Component classes now simply delegate.
3. **Typed secondary screen entry objects** — replace `private const val` identifiers in companion objects with `CardSecondaryContentEntry` / `MBWaySecondaryContentEntry` objects, co-located with the composables that use them.

## Checklist
- [x] Changes are tested manually