### PR TITLE
v6 - Error - Payment component cannot be created

### DIFF
--- a/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutControllerFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutControllerFactory.kt
@@ -24,11 +24,12 @@ import com.adyen.checkout.core.components.CheckoutController
 import com.adyen.checkout.core.components.CheckoutTarget
 import com.adyen.checkout.core.components.SessionCheckoutCallbacks
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethods
-import com.adyen.checkout.core.components.internal.ui.PaymentComponent
+import com.adyen.checkout.core.error.CheckoutError
 import com.adyen.checkout.core.sessions.internal.data.api.SessionRepository
 import com.adyen.checkout.core.sessions.internal.data.api.SessionService
 import kotlinx.coroutines.CoroutineScope
 
+@Suppress("TooManyFunctions")
 internal class CheckoutControllerFactory {
 
     fun create(
@@ -101,7 +102,7 @@ internal class CheckoutControllerFactory {
             params = checkoutParams,
         )
 
-        val paymentComponent = createPaymentComponent(
+        val paymentComponentResult = createPaymentComponent(
             target = target,
             context = context,
             callbacks = callbacks,
@@ -109,6 +110,19 @@ internal class CheckoutControllerFactory {
             analyticsManager = analyticsManager,
             checkoutParams = checkoutParams,
         )
+
+        val paymentComponent = when (paymentComponentResult) {
+            is PaymentComponentResult.Success -> paymentComponentResult.component
+            is PaymentComponentResult.Failure -> {
+                componentRequestDispatcher.failure(
+                    CheckoutError(
+                        code = CheckoutError.ErrorCode.PAYMENT_METHOD_FAILURE,
+                        message = paymentComponentResult.message,
+                    ),
+                )
+                null
+            }
+        }
 
         val flow = FullCheckoutFlow(
             componentRequestDispatcher = componentRequestDispatcher,
@@ -182,39 +196,87 @@ internal class CheckoutControllerFactory {
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
         checkoutParams: CheckoutParams,
-    ): PaymentComponent? {
+    ): PaymentComponentResult {
         return when (target) {
-            is CheckoutTarget.PaymentMethod -> {
-                context.getPaymentMethodResponse()
-                    ?.paymentMethods
-                    ?.find { it.type == target.type }
-                    ?.let { paymentMethod ->
-                        PaymentMethodProvider.getPaymentComponent(
-                            paymentMethod = paymentMethod,
-                            coroutineScope = coroutineScope,
-                            analyticsManager = analyticsManager,
-                            params = checkoutParams,
-                            additionalCallbacks = callbacks.additionalCallbacks,
-                        )
-                    }
-            }
+            is CheckoutTarget.PaymentMethod -> createPaymentComponent(
+                target = target,
+                context = context,
+                callbacks = callbacks,
+                coroutineScope = coroutineScope,
+                analyticsManager = analyticsManager,
+                checkoutParams = checkoutParams,
+            )
 
-            is CheckoutTarget.StoredPaymentMethod -> {
-                context.getPaymentMethodResponse()
-                    ?.storedPaymentMethods
-                    ?.find { it.id == target.id }
-                    ?.let { storedPaymentMethod ->
-                        PaymentMethodProvider.getStoredPaymentComponent(
-                            storedPaymentMethod = storedPaymentMethod,
-                            coroutineScope = coroutineScope,
-                            analyticsManager = analyticsManager,
-                            params = checkoutParams,
-                        )
-                    }
-            }
+            is CheckoutTarget.StoredPaymentMethod -> createStoredPaymentComponent(
+                target = target,
+                context = context,
+                coroutineScope = coroutineScope,
+                analyticsManager = analyticsManager,
+                checkoutParams = checkoutParams,
+            )
 
-            else -> null
+            else -> PaymentComponentResult.Failure("Unsupported checkout target.")
         }
+    }
+
+    @Suppress("LongParameterList", "ReturnCount")
+    private fun createPaymentComponent(
+        target: CheckoutTarget.PaymentMethod,
+        context: CheckoutContext,
+        callbacks: CheckoutCallbacks,
+        coroutineScope: CoroutineScope,
+        analyticsManager: AnalyticsManager,
+        checkoutParams: CheckoutParams,
+    ): PaymentComponentResult {
+        val paymentMethods = context.getPaymentMethodResponse()?.paymentMethods
+            ?: return PaymentComponentResult.Failure("No payment methods response available.")
+
+        val paymentMethod = paymentMethods.find { it.type == target.type }
+            ?: return PaymentComponentResult.Failure(
+                "Payment method '${target.type}' was not found in the payment methods response.",
+            )
+
+        val component = PaymentMethodProvider.getPaymentComponent(
+            paymentMethod = paymentMethod,
+            coroutineScope = coroutineScope,
+            analyticsManager = analyticsManager,
+            params = checkoutParams,
+            additionalCallbacks = callbacks.additionalCallbacks,
+        ) ?: return PaymentComponentResult.Failure(
+            "Payment method '${target.type}' is not supported. " +
+                "Ensure the corresponding module is included in your build dependencies.",
+        )
+
+        return PaymentComponentResult.Success(component)
+    }
+
+    @Suppress("ReturnCount")
+    private fun createStoredPaymentComponent(
+        target: CheckoutTarget.StoredPaymentMethod,
+        context: CheckoutContext,
+        coroutineScope: CoroutineScope,
+        analyticsManager: AnalyticsManager,
+        checkoutParams: CheckoutParams,
+    ): PaymentComponentResult {
+        val storedPaymentMethods = context.getPaymentMethodResponse()?.storedPaymentMethods
+            ?: return PaymentComponentResult.Failure("No payment methods response available.")
+
+        val storedPaymentMethod = storedPaymentMethods.find { it.id == target.id }
+            ?: return PaymentComponentResult.Failure(
+                "Stored payment method with id '${target.id}' was not found in the payment methods response.",
+            )
+
+        val component = PaymentMethodProvider.getStoredPaymentComponent(
+            storedPaymentMethod = storedPaymentMethod,
+            coroutineScope = coroutineScope,
+            analyticsManager = analyticsManager,
+            params = checkoutParams,
+        ) ?: return PaymentComponentResult.Failure(
+            "Stored payment method type '${storedPaymentMethod.type}' is not supported. " +
+                "Ensure the corresponding module is included in your build dependencies.",
+        )
+
+        return PaymentComponentResult.Success(component)
     }
 
     private fun CheckoutContext.getPaymentMethodResponse(): PaymentMethods? {

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutControllerFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutControllerFactory.kt
@@ -23,13 +23,11 @@ import com.adyen.checkout.core.components.CheckoutCallbacks
 import com.adyen.checkout.core.components.CheckoutController
 import com.adyen.checkout.core.components.CheckoutTarget
 import com.adyen.checkout.core.components.SessionCheckoutCallbacks
-import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethods
 import com.adyen.checkout.core.error.CheckoutError
 import com.adyen.checkout.core.sessions.internal.data.api.SessionRepository
 import com.adyen.checkout.core.sessions.internal.data.api.SessionService
 import kotlinx.coroutines.CoroutineScope
 
-@Suppress("TooManyFunctions")
 internal class CheckoutControllerFactory {
 
     fun create(
@@ -102,7 +100,7 @@ internal class CheckoutControllerFactory {
             params = checkoutParams,
         )
 
-        val paymentComponentResult = createPaymentComponent(
+        val paymentComponentResult = PaymentComponentResolver.resolve(
             target = target,
             context = context,
             callbacks = callbacks,
@@ -187,103 +185,4 @@ internal class CheckoutControllerFactory {
         val checkoutParams: CheckoutParams,
         val analyticsManager: AnalyticsManager,
     )
-
-    @Suppress("LongParameterList")
-    private fun createPaymentComponent(
-        target: CheckoutTarget,
-        context: CheckoutContext,
-        callbacks: CheckoutCallbacks,
-        coroutineScope: CoroutineScope,
-        analyticsManager: AnalyticsManager,
-        checkoutParams: CheckoutParams,
-    ): PaymentComponentResult {
-        return when (target) {
-            is CheckoutTarget.PaymentMethod -> createPaymentComponent(
-                target = target,
-                context = context,
-                callbacks = callbacks,
-                coroutineScope = coroutineScope,
-                analyticsManager = analyticsManager,
-                checkoutParams = checkoutParams,
-            )
-
-            is CheckoutTarget.StoredPaymentMethod -> createStoredPaymentComponent(
-                target = target,
-                context = context,
-                coroutineScope = coroutineScope,
-                analyticsManager = analyticsManager,
-                checkoutParams = checkoutParams,
-            )
-
-            else -> PaymentComponentResult.Failure("Unsupported checkout target.")
-        }
-    }
-
-    @Suppress("LongParameterList", "ReturnCount")
-    private fun createPaymentComponent(
-        target: CheckoutTarget.PaymentMethod,
-        context: CheckoutContext,
-        callbacks: CheckoutCallbacks,
-        coroutineScope: CoroutineScope,
-        analyticsManager: AnalyticsManager,
-        checkoutParams: CheckoutParams,
-    ): PaymentComponentResult {
-        val paymentMethods = context.getPaymentMethodResponse()?.paymentMethods
-            ?: return PaymentComponentResult.Failure("No payment methods response available.")
-
-        val paymentMethod = paymentMethods.find { it.type == target.type }
-            ?: return PaymentComponentResult.Failure(
-                "Payment method '${target.type}' was not found in the payment methods response.",
-            )
-
-        val component = PaymentMethodProvider.getPaymentComponent(
-            paymentMethod = paymentMethod,
-            coroutineScope = coroutineScope,
-            analyticsManager = analyticsManager,
-            params = checkoutParams,
-            additionalCallbacks = callbacks.additionalCallbacks,
-        ) ?: return PaymentComponentResult.Failure(
-            "Payment method '${target.type}' is not supported. " +
-                "Ensure the corresponding module is included in your build dependencies.",
-        )
-
-        return PaymentComponentResult.Success(component)
-    }
-
-    @Suppress("ReturnCount")
-    private fun createStoredPaymentComponent(
-        target: CheckoutTarget.StoredPaymentMethod,
-        context: CheckoutContext,
-        coroutineScope: CoroutineScope,
-        analyticsManager: AnalyticsManager,
-        checkoutParams: CheckoutParams,
-    ): PaymentComponentResult {
-        val storedPaymentMethods = context.getPaymentMethodResponse()?.storedPaymentMethods
-            ?: return PaymentComponentResult.Failure("No payment methods response available.")
-
-        val storedPaymentMethod = storedPaymentMethods.find { it.id == target.id }
-            ?: return PaymentComponentResult.Failure(
-                "Stored payment method with id '${target.id}' was not found in the payment methods response.",
-            )
-
-        val component = PaymentMethodProvider.getStoredPaymentComponent(
-            storedPaymentMethod = storedPaymentMethod,
-            coroutineScope = coroutineScope,
-            analyticsManager = analyticsManager,
-            params = checkoutParams,
-        ) ?: return PaymentComponentResult.Failure(
-            "Stored payment method type '${storedPaymentMethod.type}' is not supported. " +
-                "Ensure the corresponding module is included in your build dependencies.",
-        )
-
-        return PaymentComponentResult.Success(component)
-    }
-
-    private fun CheckoutContext.getPaymentMethodResponse(): PaymentMethods? {
-        return when (this) {
-            is CheckoutContext.Advanced -> paymentMethods
-            is CheckoutContext.Sessions -> checkoutSession.sessionSetupResponse.paymentMethods
-            is CheckoutContext.ActionOnly -> null
-        }
-    }
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentComponentResolver.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentComponentResolver.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 18/6/2026.
+ */
+
+package com.adyen.checkout.core.components.internal
+
+import com.adyen.checkout.core.analytics.internal.AnalyticsManager
+import com.adyen.checkout.core.common.CheckoutContext
+import com.adyen.checkout.core.common.internal.CheckoutParams
+import com.adyen.checkout.core.components.CheckoutCallbacks
+import com.adyen.checkout.core.components.CheckoutTarget
+import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethods
+import kotlinx.coroutines.CoroutineScope
+
+internal object PaymentComponentResolver {
+
+    @Suppress("LongParameterList")
+    fun resolve(
+        target: CheckoutTarget,
+        context: CheckoutContext,
+        callbacks: CheckoutCallbacks,
+        coroutineScope: CoroutineScope,
+        analyticsManager: AnalyticsManager,
+        checkoutParams: CheckoutParams,
+    ): PaymentComponentResult {
+        return when (target) {
+            is CheckoutTarget.PaymentMethod -> resolvePaymentMethod(
+                target = target,
+                context = context,
+                callbacks = callbacks,
+                coroutineScope = coroutineScope,
+                analyticsManager = analyticsManager,
+                checkoutParams = checkoutParams,
+            )
+
+            is CheckoutTarget.StoredPaymentMethod -> resolveStoredPaymentMethod(
+                target = target,
+                context = context,
+                coroutineScope = coroutineScope,
+                analyticsManager = analyticsManager,
+                checkoutParams = checkoutParams,
+            )
+
+            else -> PaymentComponentResult.Failure("Unsupported checkout target.")
+        }
+    }
+
+    @Suppress("LongParameterList", "ReturnCount")
+    private fun resolvePaymentMethod(
+        target: CheckoutTarget.PaymentMethod,
+        context: CheckoutContext,
+        callbacks: CheckoutCallbacks,
+        coroutineScope: CoroutineScope,
+        analyticsManager: AnalyticsManager,
+        checkoutParams: CheckoutParams,
+    ): PaymentComponentResult {
+        val paymentMethods = context.getPaymentMethodResponse()?.paymentMethods
+            ?: return PaymentComponentResult.Failure("No payment methods response available.")
+
+        val paymentMethod = paymentMethods.find { it.type == target.type }
+            ?: return PaymentComponentResult.Failure(
+                "Payment method '${target.type}' was not found in the payment methods response.",
+            )
+
+        val component = PaymentMethodProvider.getPaymentComponent(
+            paymentMethod = paymentMethod,
+            coroutineScope = coroutineScope,
+            analyticsManager = analyticsManager,
+            params = checkoutParams,
+            additionalCallbacks = callbacks.additionalCallbacks,
+        ) ?: return PaymentComponentResult.Failure(
+            "Payment method '${target.type}' is not supported. " +
+                "Ensure the corresponding module is included in your build dependencies.",
+        )
+
+        return PaymentComponentResult.Success(component)
+    }
+
+    @Suppress("ReturnCount")
+    private fun resolveStoredPaymentMethod(
+        target: CheckoutTarget.StoredPaymentMethod,
+        context: CheckoutContext,
+        coroutineScope: CoroutineScope,
+        analyticsManager: AnalyticsManager,
+        checkoutParams: CheckoutParams,
+    ): PaymentComponentResult {
+        val storedPaymentMethods = context.getPaymentMethodResponse()?.storedPaymentMethods
+            ?: return PaymentComponentResult.Failure("No payment methods response available.")
+
+        val storedPaymentMethod = storedPaymentMethods.find { it.id == target.id }
+            ?: return PaymentComponentResult.Failure(
+                "Stored payment method with id '${target.id}' was not found in the payment methods response.",
+            )
+
+        val component = PaymentMethodProvider.getStoredPaymentComponent(
+            storedPaymentMethod = storedPaymentMethod,
+            coroutineScope = coroutineScope,
+            analyticsManager = analyticsManager,
+            params = checkoutParams,
+        ) ?: return PaymentComponentResult.Failure(
+            "Stored payment method type '${storedPaymentMethod.type}' is not supported. " +
+                "Ensure the corresponding module is included in your build dependencies.",
+        )
+
+        return PaymentComponentResult.Success(component)
+    }
+
+    private fun CheckoutContext.getPaymentMethodResponse(): PaymentMethods? {
+        return when (this) {
+            is CheckoutContext.Advanced -> paymentMethods
+            is CheckoutContext.Sessions -> checkoutSession.sessionSetupResponse.paymentMethods
+            is CheckoutContext.ActionOnly -> null
+        }
+    }
+}

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentComponentResult.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentComponentResult.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 18/6/2026.
+ */
+
+package com.adyen.checkout.core.components.internal
+
+import com.adyen.checkout.core.components.internal.ui.PaymentComponent
+
+internal sealed class PaymentComponentResult {
+
+    data class Success(val component: PaymentComponent) : PaymentComponentResult()
+
+    data class Failure(val message: String) : PaymentComponentResult()
+}

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentComponentResolverTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentComponentResolverTest.kt
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 18/6/2026.
+ */
+
+package com.adyen.checkout.core.components.internal
+
+import com.adyen.checkout.core.analytics.internal.AnalyticsManager
+import com.adyen.checkout.core.analytics.internal.TestAnalyticsManager
+import com.adyen.checkout.core.common.CheckoutContext
+import com.adyen.checkout.core.common.Environment
+import com.adyen.checkout.core.common.internal.CheckoutParams
+import com.adyen.checkout.core.components.AdditionalDetailsResult
+import com.adyen.checkout.core.components.AdvancedCheckoutCallbacks
+import com.adyen.checkout.core.components.CheckoutAdditionalCallback
+import com.adyen.checkout.core.components.CheckoutConfiguration
+import com.adyen.checkout.core.components.CheckoutTarget
+import com.adyen.checkout.core.components.SubmitResult
+import com.adyen.checkout.core.components.data.model.paymentmethod.GenericPaymentMethod
+import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
+import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethods
+import com.adyen.checkout.core.components.data.model.paymentmethod.StoredBLIKPaymentMethod
+import com.adyen.checkout.core.components.data.model.paymentmethod.UnsupportedPaymentMethod
+import com.adyen.checkout.core.components.internal.ui.PaymentComponent
+import com.adyen.checkout.core.components.internal.ui.TestPaymentComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.Locale
+
+internal class PaymentComponentResolverTest {
+
+    @BeforeEach
+    fun setUp() {
+        PaymentMethodProvider.clear()
+    }
+
+    @Test
+    fun `when payment methods response has no payment methods, then Failure is returned`() = runTest {
+        val result = resolve(
+            target = CheckoutTarget.PaymentMethod("scheme"),
+            paymentMethods = PaymentMethods(paymentMethods = null),
+        )
+
+        assertEquals(PaymentComponentResult.Failure("No payment methods response available."), result)
+    }
+
+    @Test
+    fun `when target payment method is not in the response, then Failure is returned`() = runTest {
+        val result = resolve(
+            target = CheckoutTarget.PaymentMethod("scheme"),
+            paymentMethods = PaymentMethods(
+                paymentMethods = listOf(GenericPaymentMethod(type = "ideal", name = "iDEAL")),
+            ),
+        )
+
+        assertEquals(
+            PaymentComponentResult.Failure(
+                "Payment method 'scheme' was not found in the payment methods response.",
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `when payment method is not supported, then Failure is returned`() = runTest {
+        val result = resolve(
+            target = CheckoutTarget.PaymentMethod("scheme"),
+            paymentMethods = PaymentMethods(
+                paymentMethods = listOf(UnsupportedPaymentMethod(type = "scheme", name = "Card")),
+            ),
+        )
+
+        assertEquals(
+            PaymentComponentResult.Failure(
+                "Payment method 'scheme' is not supported. " +
+                    "Ensure the corresponding module is included in your build dependencies.",
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `when payment methods response has no stored payment methods, then Failure is returned`() = runTest {
+        val result = resolve(
+            target = CheckoutTarget.StoredPaymentMethod("test_id"),
+            paymentMethods = PaymentMethods(storedPaymentMethods = null),
+        )
+
+        assertEquals(PaymentComponentResult.Failure("No payment methods response available."), result)
+    }
+
+    @Test
+    fun `when target stored payment method is not in the response, then Failure is returned`() = runTest {
+        val result = resolve(
+            target = CheckoutTarget.StoredPaymentMethod("test_id"),
+            paymentMethods = PaymentMethods(
+                storedPaymentMethods = listOf(
+                    StoredBLIKPaymentMethod(
+                        type = "blik",
+                        name = "BLIK",
+                        id = "other_id",
+                        supportedShopperInteractions = emptyList(),
+                    ),
+                ),
+            ),
+        )
+
+        assertEquals(
+            PaymentComponentResult.Failure(
+                "Stored payment method with id 'test_id' was not found in the payment methods response.",
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `when stored payment method is not supported, then Failure is returned`() = runTest {
+        val result = resolve(
+            target = CheckoutTarget.StoredPaymentMethod("test_id"),
+            paymentMethods = PaymentMethods(
+                storedPaymentMethods = listOf(
+                    StoredBLIKPaymentMethod(
+                        type = "blik",
+                        name = "BLIK",
+                        id = "test_id",
+                        supportedShopperInteractions = emptyList(),
+                    ),
+                ),
+            ),
+        )
+
+        assertEquals(
+            PaymentComponentResult.Failure(
+                "Stored payment method type 'blik' is not supported. " +
+                    "Ensure the corresponding module is included in your build dependencies.",
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `when checkout target is unknown, then Failure is returned`() = runTest {
+        val result = resolve(
+            target = object : CheckoutTarget {},
+            paymentMethods = PaymentMethods(),
+        )
+
+        assertEquals(PaymentComponentResult.Failure("Unsupported checkout target."), result)
+    }
+
+    @Test
+    fun `when payment method is supported, then Success with the component is returned`() = runTest {
+        val component = TestPaymentComponent()
+        registerFactory(type = "scheme", component = component)
+
+        val result = resolve(
+            target = CheckoutTarget.PaymentMethod("scheme"),
+            paymentMethods = PaymentMethods(
+                paymentMethods = listOf(GenericPaymentMethod(type = "scheme", name = "Card")),
+            ),
+        )
+
+        assertEquals(PaymentComponentResult.Success(component), result)
+    }
+
+    private fun CoroutineScope.resolve(
+        target: CheckoutTarget,
+        paymentMethods: PaymentMethods,
+    ): PaymentComponentResult = PaymentComponentResolver.resolve(
+        target = target,
+        context = advancedContext(paymentMethods),
+        callbacks = advancedCallbacks(),
+        coroutineScope = this,
+        analyticsManager = TestAnalyticsManager(),
+        checkoutParams = checkoutParams(),
+    )
+
+    private fun advancedContext(paymentMethods: PaymentMethods) = CheckoutContext.Advanced(
+        paymentMethods = paymentMethods,
+        checkoutConfiguration = CheckoutConfiguration(
+            environment = Environment.TEST,
+            clientKey = TEST_CLIENT_KEY,
+            shopperLocale = Locale.US,
+        ),
+        checkoutAttemptId = null,
+        publicKey = null,
+    )
+
+    private fun advancedCallbacks() = AdvancedCheckoutCallbacks(
+        onSubmit = { SubmitResult.Completion("") },
+        onAdditionalDetails = { AdditionalDetailsResult.Completion("") },
+        onFailure = {},
+    )
+
+    private fun checkoutParams() = CheckoutParams(
+        shopperLocale = Locale.US,
+        environment = Environment.TEST,
+        clientKey = TEST_CLIENT_KEY,
+        analyticsParams = AnalyticsParams(AnalyticsParamsLevel.ALL),
+        amount = null,
+        showSubmitButton = true,
+        publicKey = "test_publicKey",
+        additionalConfigurations = emptyMap(),
+        additionalSessionParams = null,
+    )
+
+    private fun registerFactory(type: String, component: PaymentComponent) {
+        PaymentMethodProvider.register(
+            type,
+            object : PaymentComponentFactory<PaymentComponent> {
+                override fun create(
+                    paymentMethod: PaymentMethod,
+                    coroutineScope: CoroutineScope,
+                    analyticsManager: AnalyticsManager,
+                    params: CheckoutParams,
+                    additionalCallbacks: Set<CheckoutAdditionalCallback>,
+                ): PaymentComponent = component
+            },
+        )
+    }
+
+    companion object {
+        private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfghjklzxcvbnm"
+    }
+}

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentComponentResolverTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentComponentResolverTest.kt
@@ -8,6 +8,7 @@
 
 package com.adyen.checkout.core.components.internal
 
+import com.adyen.checkout.core.action.data.RedirectAction
 import com.adyen.checkout.core.analytics.internal.AnalyticsManager
 import com.adyen.checkout.core.analytics.internal.TestAnalyticsManager
 import com.adyen.checkout.core.common.CheckoutContext
@@ -23,9 +24,12 @@ import com.adyen.checkout.core.components.data.model.paymentmethod.GenericPaymen
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethods
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredBLIKPaymentMethod
+import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.UnsupportedPaymentMethod
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
 import com.adyen.checkout.core.components.internal.ui.TestPaymentComponent
+import com.adyen.checkout.core.sessions.CheckoutSession
+import com.adyen.checkout.core.sessions.internal.data.model.SessionSetupResponse
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -169,6 +173,63 @@ internal class PaymentComponentResolverTest {
         assertEquals(PaymentComponentResult.Success(component), result)
     }
 
+    @Test
+    fun `when stored payment method is supported, then Success with the component is returned`() = runTest {
+        val component = TestPaymentComponent()
+        registerStoredFactory(type = "blik", component = component)
+
+        val result = resolve(
+            target = CheckoutTarget.StoredPaymentMethod("test_id"),
+            paymentMethods = PaymentMethods(
+                storedPaymentMethods = listOf(
+                    StoredBLIKPaymentMethod(
+                        type = "blik",
+                        name = "BLIK",
+                        id = "test_id",
+                        supportedShopperInteractions = emptyList(),
+                    ),
+                ),
+            ),
+        )
+
+        assertEquals(PaymentComponentResult.Success(component), result)
+    }
+
+    @Test
+    fun `when context is ActionOnly, then Failure is returned`() = runTest {
+        val result = PaymentComponentResolver.resolve(
+            target = CheckoutTarget.PaymentMethod("scheme"),
+            context = actionOnlyContext(),
+            callbacks = advancedCallbacks(),
+            coroutineScope = this,
+            analyticsManager = TestAnalyticsManager(),
+            checkoutParams = checkoutParams(),
+        )
+
+        assertEquals(PaymentComponentResult.Failure("No payment methods response available."), result)
+    }
+
+    @Test
+    fun `when context is Sessions, then payment methods are resolved from the session setup response`() = runTest {
+        val component = TestPaymentComponent()
+        registerFactory(type = "scheme", component = component)
+
+        val result = PaymentComponentResolver.resolve(
+            target = CheckoutTarget.PaymentMethod("scheme"),
+            context = sessionsContext(
+                PaymentMethods(
+                    paymentMethods = listOf(GenericPaymentMethod(type = "scheme", name = "Card")),
+                ),
+            ),
+            callbacks = advancedCallbacks(),
+            coroutineScope = this,
+            analyticsManager = TestAnalyticsManager(),
+            checkoutParams = checkoutParams(),
+        )
+
+        assertEquals(PaymentComponentResult.Success(component), result)
+    }
+
     private fun CoroutineScope.resolve(
         target: CheckoutTarget,
         paymentMethods: PaymentMethods,
@@ -183,6 +244,46 @@ internal class PaymentComponentResolverTest {
 
     private fun advancedContext(paymentMethods: PaymentMethods) = CheckoutContext.Advanced(
         paymentMethods = paymentMethods,
+        checkoutConfiguration = CheckoutConfiguration(
+            environment = Environment.TEST,
+            clientKey = TEST_CLIENT_KEY,
+            shopperLocale = Locale.US,
+        ),
+        checkoutAttemptId = null,
+        publicKey = null,
+    )
+
+    private fun actionOnlyContext() = CheckoutContext.ActionOnly(
+        action = RedirectAction(
+            type = "redirect",
+            paymentData = "test_data",
+            paymentMethodType = "scheme",
+        ),
+        checkoutConfiguration = CheckoutConfiguration(
+            environment = Environment.TEST,
+            clientKey = TEST_CLIENT_KEY,
+            shopperLocale = Locale.US,
+        ),
+        checkoutAttemptId = null,
+        publicKey = null,
+    )
+
+    private fun sessionsContext(paymentMethods: PaymentMethods) = CheckoutContext.Sessions(
+        checkoutSession = CheckoutSession(
+            sessionSetupResponse = SessionSetupResponse(
+                id = "test_session_id",
+                sessionData = "test_session_data",
+                amount = null,
+                expiresAt = "2026-12-31T23:59:59Z",
+                paymentMethods = paymentMethods,
+                returnUrl = null,
+                configuration = null,
+                shopperLocale = null,
+            ),
+            order = null,
+            environment = Environment.TEST,
+            clientKey = TEST_CLIENT_KEY,
+        ),
         checkoutConfiguration = CheckoutConfiguration(
             environment = Environment.TEST,
             clientKey = TEST_CLIENT_KEY,
@@ -220,6 +321,20 @@ internal class PaymentComponentResolverTest {
                     analyticsManager: AnalyticsManager,
                     params: CheckoutParams,
                     additionalCallbacks: Set<CheckoutAdditionalCallback>,
+                ): PaymentComponent = component
+            },
+        )
+    }
+
+    private fun registerStoredFactory(type: String, component: PaymentComponent) {
+        PaymentMethodProvider.register(
+            type,
+            object : StoredPaymentComponentFactory<PaymentComponent> {
+                override fun create(
+                    storedPaymentMethod: StoredPaymentMethod,
+                    coroutineScope: CoroutineScope,
+                    analyticsManager: AnalyticsManager,
+                    params: CheckoutParams,
                 ): PaymentComponent = component
             },
         )


### PR DESCRIPTION
## Description
When a payment component cannot be created, `CheckoutControllerFactory` now notifies the merchant via the `onFailure` callback using the existing `CheckoutError.ErrorCode.PAYMENT_METHOD_FAILURE` code with a descriptive reason, instead of silently doing nothing (no UI, no-op `submit()`, zero feedback).

- Added `PaymentComponentResult` sealed class (`Success` / `Failure`) to carry the resolution outcome.
- Extracted target→component resolution into `PaymentComponentResolver`, covering all failure cases: no payment methods response, payment method / stored payment method not found, payment method / stored payment method not supported, and unknown `CheckoutTarget`.
- `createFullCheckoutController()` dispatches `CheckoutError(PAYMENT_METHOD_FAILURE, reason)` via the component request dispatcher on failure, and still passes `null` to `FullCheckoutFlow` (existing no-op behavior preserved).

No public API changes. No breaking changes.

## Checklist
- [x] Code is unit tested
- [x] Changes are tested manually

## Ticket Number
COSDK-1301