### PR TITLE
v6 - Card - Rename onBinValue callback to onBinChange

### DIFF
--- a/card/api/card.api
+++ b/card/api/card.api
@@ -58,9 +58,9 @@ public final class com/adyen/checkout/card/BuildConfig {
 
 public final class com/adyen/checkout/card/CardCallbackExtKt {
 	public static final fun card (Lcom/adyen/checkout/core/components/CheckoutCallbacks;)V
-	public static final fun card (Lcom/adyen/checkout/core/components/CheckoutCallbacks;Lcom/adyen/checkout/card/OnBinValueCallback;)V
-	public static final fun card (Lcom/adyen/checkout/core/components/CheckoutCallbacks;Lcom/adyen/checkout/card/OnBinValueCallback;Lcom/adyen/checkout/card/OnBinLookupCallback;)V
-	public static synthetic fun card$default (Lcom/adyen/checkout/core/components/CheckoutCallbacks;Lcom/adyen/checkout/card/OnBinValueCallback;Lcom/adyen/checkout/card/OnBinLookupCallback;ILjava/lang/Object;)V
+	public static final fun card (Lcom/adyen/checkout/core/components/CheckoutCallbacks;Lcom/adyen/checkout/card/OnBinChangeCallback;)V
+	public static final fun card (Lcom/adyen/checkout/core/components/CheckoutCallbacks;Lcom/adyen/checkout/card/OnBinChangeCallback;Lcom/adyen/checkout/card/OnBinLookupCallback;)V
+	public static synthetic fun card$default (Lcom/adyen/checkout/core/components/CheckoutCallbacks;Lcom/adyen/checkout/card/OnBinChangeCallback;Lcom/adyen/checkout/card/OnBinLookupCallback;ILjava/lang/Object;)V
 }
 
 public final class com/adyen/checkout/card/CardConfiguration : com/adyen/checkout/core/components/internal/Configuration {
@@ -152,12 +152,12 @@ public final class com/adyen/checkout/card/InstallmentOptions$Plan : java/lang/E
 	public static fun values ()[Lcom/adyen/checkout/card/InstallmentOptions$Plan;
 }
 
-public abstract interface class com/adyen/checkout/card/OnBinLookupCallback : com/adyen/checkout/core/components/CheckoutAdditionalCallback {
-	public abstract fun onBinLookup (Lcom/adyen/checkout/card/BinLookupData;)V
+public abstract interface class com/adyen/checkout/card/OnBinChangeCallback : com/adyen/checkout/core/components/CheckoutAdditionalCallback {
+	public abstract fun onBinChange (Ljava/lang/String;)V
 }
 
-public abstract interface class com/adyen/checkout/card/OnBinValueCallback : com/adyen/checkout/core/components/CheckoutAdditionalCallback {
-	public abstract fun onBinValue (Ljava/lang/String;)V
+public abstract interface class com/adyen/checkout/card/OnBinLookupCallback : com/adyen/checkout/core/components/CheckoutAdditionalCallback {
+	public abstract fun onBinLookup (Lcom/adyen/checkout/card/BinLookupData;)V
 }
 
 public abstract class com/adyen/checkout/card/old/AddressConfiguration : android/os/Parcelable {

--- a/card/src/main/java/com/adyen/checkout/card/CardCallbackExt.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardCallbackExt.kt
@@ -12,9 +12,9 @@ import com.adyen.checkout.core.components.CheckoutCallbacks
 
 @JvmOverloads
 fun CheckoutCallbacks.card(
-    onBinValue: OnBinValueCallback? = null,
+    onBinChange: OnBinChangeCallback? = null,
     onBinLookup: OnBinLookupCallback? = null,
 ) {
-    onBinValue?.let { addAdditionalCallback(it) }
+    onBinChange?.let { addAdditionalCallback(it) }
     onBinLookup?.let { addAdditionalCallback(it) }
 }

--- a/card/src/main/java/com/adyen/checkout/card/OnBinChangeCallback.kt
+++ b/card/src/main/java/com/adyen/checkout/card/OnBinChangeCallback.kt
@@ -3,14 +3,14 @@
  *
  * This file is open source and available under the MIT license. See the LICENSE file for more info.
  *
- * Created by ozgur on 18/11/2025.
+ * Created by ararat on 18/07/2026.
  */
 
 package com.adyen.checkout.card
 
 import com.adyen.checkout.core.components.CheckoutAdditionalCallback
 
-fun interface OnBinValueCallback : CheckoutAdditionalCallback {
+fun interface OnBinChangeCallback : CheckoutAdditionalCallback {
 
-    fun onBinValue(binValue: String)
+    fun onBinChange(binValue: String)
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
@@ -279,20 +279,22 @@ constructor(
     }
 
     private fun onBinChanged() {
+        val callback = onBinChangeCallback ?: return
         componentState
             .map { it.binValue }
             .distinctUntilChanged()
             .drop(1)
-            .onEach { newBinValue -> onBinChangeCallback?.onBinChange(newBinValue) }
+            .onEach { newBinValue -> callback.onBinChange(newBinValue) }
             .launchIn(coroutineScope)
     }
 
     private fun onCardBrandDataChanged() {
+        val callback = onBinLookupCallback ?: return
         componentState
             .map { it.networkBinLookupState }
             .distinctUntilChanged()
             .mapNotNull { it?.toBinLookupData() }
-            .onEach { onBinLookupCallback?.onBinLookup(it) }
+            .onEach { binLookupData -> callback.onBinLookup(binLookupData) }
             .launchIn(coroutineScope)
     }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
@@ -22,8 +22,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.adyen.checkout.card.OnBinChangeCallback
 import com.adyen.checkout.card.OnBinLookupCallback
-import com.adyen.checkout.card.OnBinValueCallback
 import com.adyen.checkout.card.internal.analytics.CardScannerEvents
 import com.adyen.checkout.card.internal.data.api.DetectCardTypeRepository
 import com.adyen.checkout.card.internal.helper.toBinLookupData
@@ -81,7 +81,7 @@ constructor(
     private val coroutineScope: CoroutineScope,
     private val sdkDataProvider: SdkDataProvider,
     private val paymentMethodType: String,
-    private val onBinValueCallback: OnBinValueCallback?,
+    private val onBinChangeCallback: OnBinChangeCallback?,
     private val onBinLookupCallback: OnBinLookupCallback?,
     private val cardScannerWrapper: CardScannerWrapper,
     private val publicKey: String?,
@@ -283,7 +283,7 @@ constructor(
             .map { it.binValue }
             .distinctUntilChanged()
             .drop(1)
-            .onEach { newBinValue -> onBinValueCallback?.onBinValue(newBinValue) }
+            .onEach { newBinValue -> onBinChangeCallback?.onBinChange(newBinValue) }
             .launchIn(coroutineScope)
     }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardFactory.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardFactory.kt
@@ -8,8 +8,8 @@
 
 package com.adyen.checkout.card.internal.ui
 
+import com.adyen.checkout.card.OnBinChangeCallback
 import com.adyen.checkout.card.OnBinLookupCallback
-import com.adyen.checkout.card.OnBinValueCallback
 import com.adyen.checkout.card.internal.data.api.BinLookupCache
 import com.adyen.checkout.card.internal.data.api.BinLookupService
 import com.adyen.checkout.card.internal.data.api.DefaultDetectCardTypeRepository
@@ -103,7 +103,7 @@ internal class CardFactory :
             coroutineScope = coroutineScope,
             sdkDataProvider = DefaultSdkDataProvider(analyticsManager),
             paymentMethodType = paymentMethodType,
-            onBinValueCallback = additionalCallbacks.getAdditionalCallback<OnBinValueCallback>(),
+            onBinChangeCallback = additionalCallbacks.getAdditionalCallback<OnBinChangeCallback>(),
             onBinLookupCallback = additionalCallbacks.getAdditionalCallback<OnBinLookupCallback>(),
             cardScannerWrapper = CardScannerWrapper(),
             publicKey = params.publicKey,

--- a/docs/v6/card-advanced-flow.md
+++ b/docs/v6/card-advanced-flow.md
@@ -47,7 +47,7 @@ lifecycleScope.launch {
                     },
                 ) {
                     card(
-                        onBinValue = OnBinValueCallback { bin ->
+                        onBinChange = OnBinChangeCallback { bin ->
                             println("BIN: $bin")
                         },
                         onBinLookup = OnBinLookupCallback { data ->

--- a/docs/v6/card-session-flow.md
+++ b/docs/v6/card-session-flow.md
@@ -42,7 +42,7 @@ lifecycleScope.launch {
                     },
                 ) {
                     card(
-                        onBinValue = OnBinValueCallback { bin ->
+                        onBinChange = OnBinChangeCallback { bin ->
                             println("BIN: $bin")
                         },
                         onBinLookup = OnBinLookupCallback { data ->

--- a/docs/v6/card.md
+++ b/docs/v6/card.md
@@ -14,8 +14,8 @@ Import the APIs used by the card guides:
 ```kotlin
 import com.adyen.checkout.card.BillingAddressMode
 import com.adyen.checkout.card.FieldVisibility
+import com.adyen.checkout.card.OnBinChangeCallback
 import com.adyen.checkout.card.OnBinLookupCallback
-import com.adyen.checkout.card.OnBinValueCallback
 import com.adyen.checkout.card.card
 import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.common.Environment
@@ -85,7 +85,7 @@ val callbacks = AdvancedCheckoutCallbacks(
     onError = { error -> showError(error.message.orEmpty()) },
 ) {
     card(
-        onBinValue = OnBinValueCallback { bin ->
+        onBinChange = OnBinChangeCallback { bin ->
             println("BIN: $bin")
         },
         onBinLookup = OnBinLookupCallback { data ->
@@ -99,7 +99,7 @@ val callbacks = AdvancedCheckoutCallbacks(
 
 | API | Purpose |
 | --- | --- |
-| `OnBinValueCallback` | Receives BIN updates while the shopper types. |
+| `OnBinChangeCallback` | Receives BIN updates while the shopper types. |
 | `OnBinLookupCallback` | Receives the card-brand lookup result for the current input. |
 
 ## 3D Secure configuration

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6SessionsViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6SessionsViewModel.kt
@@ -97,7 +97,7 @@ internal class V6SessionsViewModel @Inject constructor(
         }
     }
 
-    private fun onBinValue(binValue: String) {
+    private fun onBinChange(binValue: String) {
         Log.d(TAG, "Bin value received: $binValue")
     }
 
@@ -146,7 +146,7 @@ internal class V6SessionsViewModel @Inject constructor(
                 onComplete = ::onComplete,
             ) {
                 card(
-                    onBinValue = ::onBinValue,
+                    onBinChange = ::onBinChange,
                     onBinLookup = ::onBinLookup,
                 )
             },

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6ViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6ViewModel.kt
@@ -104,7 +104,7 @@ internal class V6ViewModel @Inject constructor(
         }
     }
 
-    private fun onBinValue(binValue: String) {
+    private fun onBinChange(binValue: String) {
         Log.d(TAG, "Bin value received: $binValue")
     }
 
@@ -206,7 +206,7 @@ internal class V6ViewModel @Inject constructor(
                 onComplete = ::onComplete,
             ) {
                 card(
-                    onBinValue = ::onBinValue,
+                    onBinChange = ::onBinChange,
                     onBinLookup = ::onBinLookup,
                 )
             },


### PR DESCRIPTION
## Description
Renames the v6 card BIN callback to align with the cross-platform alignment spec.

- Renamed `fun interface OnBinValueCallback` → `OnBinChangeCallback` and its method `onBinValue(binValue)` → `onBinChange(binValue)`.
- Renamed the `card()` callbacks DSL parameter `onBinValue` → `onBinChange`.
- Updated `CardComponent` / `CardFactory` wiring.
- Updated the v6 docs and example-app v6 view models.
- Regenerated `card.api`.

Behavior is unchanged and already matches the spec (6-digit BIN, extends to 8 on a valid 16+ digit PAN, deduplicated emissions).

## Checklist
- [x] Changes are tested manually
- [x] Aligned public API changes with other platforms (if applicable)
- [x] Related issues are linked

## Ticket Number
COSDK-1296