### PR TITLE
v6 - 3DS2 - Pass checkout theme as UiCustomization

### DIFF
--- a/3ds2/api/3ds2.api
+++ b/3ds2/api/3ds2.api
@@ -9,8 +9,7 @@ public final class com/adyen/checkout/adyen3ds2/BuildConfig {
 public final class com/adyen/checkout/threeds2/ThreeDS2ConfigurationKt {
 	public static final fun threeDS2 (Lcom/adyen/checkout/core/components/CheckoutConfiguration;)Lcom/adyen/checkout/core/components/CheckoutConfiguration;
 	public static final fun threeDS2 (Lcom/adyen/checkout/core/components/CheckoutConfiguration;Ljava/lang/String;)Lcom/adyen/checkout/core/components/CheckoutConfiguration;
-	public static final fun threeDS2 (Lcom/adyen/checkout/core/components/CheckoutConfiguration;Ljava/lang/String;Lcom/adyen/threeds2/customization/UiCustomization;)Lcom/adyen/checkout/core/components/CheckoutConfiguration;
-	public static synthetic fun threeDS2$default (Lcom/adyen/checkout/core/components/CheckoutConfiguration;Ljava/lang/String;Lcom/adyen/threeds2/customization/UiCustomization;ILjava/lang/Object;)Lcom/adyen/checkout/core/components/CheckoutConfiguration;
+	public static synthetic fun threeDS2$default (Lcom/adyen/checkout/core/components/CheckoutConfiguration;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/core/components/CheckoutConfiguration;
 }
 
 public final class com/adyen/checkout/threeds2/old/Adyen3DS2Component : androidx/lifecycle/ViewModel, com/adyen/checkout/components/core/RedirectableActionComponent, com/adyen/checkout/components/core/internal/ActionComponent, com/adyen/checkout/components/core/internal/IntentHandlingComponent, com/adyen/checkout/ui/core/old/internal/ui/ViewableComponent {

--- a/3ds2/build.gradle
+++ b/3ds2/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     // Dependencies
     api libs.adyen3ds2
     implementation libs.androidx.startup
+    implementation libs.compose.activity
 
     //Tests
     testImplementation testFixtures(project(':test-core'))

--- a/3ds2/src/main/java/com/adyen/checkout/threeds2/ThreeDS2Configuration.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/threeds2/ThreeDS2Configuration.kt
@@ -10,23 +10,19 @@ package com.adyen.checkout.threeds2
 
 import com.adyen.checkout.core.components.CheckoutConfiguration
 import com.adyen.checkout.core.components.internal.Configuration
-import com.adyen.threeds2.customization.UiCustomization
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal class ThreeDS2Configuration internal constructor(
     val threeDSRequestorAppURL: String?,
-    val uiCustomization: UiCustomization?,
 ) : Configuration
 
 @JvmOverloads
 fun CheckoutConfiguration.threeDS2(
     threeDSRequestorAppURL: String? = null,
-    uiCustomization: UiCustomization? = null,
 ): CheckoutConfiguration {
     val config = ThreeDS2Configuration(
         threeDSRequestorAppURL = threeDSRequestorAppURL,
-        uiCustomization = uiCustomization,
     )
     addConfiguration(config)
     return this

--- a/3ds2/src/main/java/com/adyen/checkout/threeds2/internal/ui/ThreeDS2Component.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/threeds2/internal/ui/ThreeDS2Component.kt
@@ -10,7 +10,6 @@ package com.adyen.checkout.threeds2.internal.ui
 
 import android.app.Activity
 import android.app.Application
-import android.content.Context
 import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -109,8 +108,8 @@ internal class ThreeDS2Component(
         threeDsEventChannel.trySend(ThreeDS2Event.HandleAction)
     }
 
-    private fun handleAction(context: Context, uiCustomization: UiCustomization) {
-        handleAction(action, context as Activity, uiCustomization)
+    private fun handleAction(activity: Activity, uiCustomization: UiCustomization) {
+        handleAction(action, activity, uiCustomization)
     }
 
     private fun handleAction(action: Action, activity: Activity, uiCustomization: UiCustomization) {

--- a/3ds2/src/main/java/com/adyen/checkout/threeds2/internal/ui/ThreeDS2Component.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/threeds2/internal/ui/ThreeDS2Component.kt
@@ -46,6 +46,7 @@ import com.adyen.threeds2.InitializeResult
 import com.adyen.threeds2.ThreeDS2Service
 import com.adyen.threeds2.Transaction
 import com.adyen.threeds2.TransactionResult
+import com.adyen.threeds2.customization.UiCustomization
 import com.adyen.threeds2.exception.InvalidInputException
 import com.adyen.threeds2.exception.SDKNotInitializedException
 import com.adyen.threeds2.exception.SDKRuntimeException
@@ -108,11 +109,11 @@ internal class ThreeDS2Component(
         threeDsEventChannel.trySend(ThreeDS2Event.HandleAction)
     }
 
-    private fun handleAction(context: Context) {
-        handleAction(action, context as Activity)
+    private fun handleAction(context: Context, uiCustomization: UiCustomization) {
+        handleAction(action, context as Activity, uiCustomization)
     }
 
-    private fun handleAction(action: Action, activity: Activity) {
+    private fun handleAction(action: Action, activity: Activity, uiCustomization: UiCustomization) {
         if (action !is Threeds2Action) {
             emitError(
                 GenericError("Unsupported action"),
@@ -122,13 +123,14 @@ internal class ThreeDS2Component(
 
         val paymentData = action.paymentData
         paymentDataRepository.paymentData = paymentData
-        handleThreeds2Action(action, activity)
+        handleThreeds2Action(action, activity, uiCustomization)
     }
 
     private fun handleThreeds2ActionSubtype(
         action: Threeds2Action,
         activity: Activity,
         subtype: Threeds2Action.SubType,
+        uiCustomization: UiCustomization,
     ) {
         val token = action.token
         if (token.isNullOrEmpty()) {
@@ -159,6 +161,7 @@ internal class ThreeDS2Component(
                     activity = activity,
                     encodedFingerprintToken = token,
                     submitFingerprintAutomatically = true,
+                    uiCustomization = uiCustomization,
                 )
             }
 
@@ -173,6 +176,7 @@ internal class ThreeDS2Component(
     private fun handleThreeds2Action(
         action: Threeds2Action,
         activity: Activity,
+        uiCustomization: UiCustomization,
     ) {
         if (action.subtype == null) {
             emitError(
@@ -181,7 +185,7 @@ internal class ThreeDS2Component(
             return
         }
         val subtype = Threeds2Action.SubType.parse(action.subtype.orEmpty())
-        handleThreeds2ActionSubtype(action, activity, subtype)
+        handleThreeds2ActionSubtype(action, activity, subtype, uiCustomization)
     }
 
     @Suppress("LongMethod", "TooGenericExceptionCaught")
@@ -190,6 +194,7 @@ internal class ThreeDS2Component(
         activity: Activity,
         encodedFingerprintToken: String,
         submitFingerprintAutomatically: Boolean,
+        uiCustomization: UiCustomization,
     ) {
         adyenLog(AdyenLogLevel.DEBUG) {
             "identifyShopper - submitFingerprintAutomatically: $submitFingerprintAutomatically"
@@ -243,7 +248,7 @@ internal class ThreeDS2Component(
                     activity,
                     configParameters,
                     null,
-                    componentParams.uiCustomization,
+                    uiCustomization,
                 )
 
             if (initializeResult is InitializeResult.Failure) {
@@ -272,7 +277,7 @@ internal class ThreeDS2Component(
             val encodedFingerprint = createEncodedFingerprint(authenticationRequestParameters)
 
             if (submitFingerprintAutomatically) {
-                submitFingerprintAutomatically(activity, encodedFingerprint)
+                submitFingerprintAutomatically(activity, encodedFingerprint, uiCustomization)
             } else {
                 emitDetails(threeDS2Serializer.createFingerprintDetails(encodedFingerprint), shouldClearState = false)
             }
@@ -401,6 +406,7 @@ internal class ThreeDS2Component(
     private suspend fun submitFingerprintAutomatically(
         activity: Activity,
         encodedFingerprint: String,
+        uiCustomization: UiCustomization,
     ) {
         submitFingerprintRepository.submitFingerprint(
             encodedFingerprint = encodedFingerprint,
@@ -408,7 +414,7 @@ internal class ThreeDS2Component(
             paymentData = paymentDataRepository.paymentData,
         )
             .fold(
-                onSuccess = { result -> onSubmitFingerprintResult(result, activity) },
+                onSuccess = { result -> onSubmitFingerprintResult(result, activity, uiCustomization) },
                 onFailure = { e ->
                     trackFingerprintErrorEvent(ErrorEvent.API_THREEDS2)
                     emitError(
@@ -421,7 +427,11 @@ internal class ThreeDS2Component(
             )
     }
 
-    private fun onSubmitFingerprintResult(result: SubmitFingerprintResult, activity: Activity) {
+    private fun onSubmitFingerprintResult(
+        result: SubmitFingerprintResult,
+        activity: Activity,
+        uiCustomization: UiCustomization,
+    ) {
         // This flow (calling the internal submitFingerprint endpoint) requires that we do not send paymentData
         // back to the merchant. Setting it to null ensures that when the flow ends and notifyDetails is called,
         // paymentData will not be included in the response.
@@ -440,7 +450,7 @@ internal class ThreeDS2Component(
 
             is SubmitFingerprintResult.Threeds2 -> {
                 trackFingerprintCompletedEvent(ThreeDS2Events.Result.THREEDS2)
-                handleAction(result.action, activity)
+                handleAction(result.action, activity, uiCustomization)
             }
         }
     }

--- a/3ds2/src/main/java/com/adyen/checkout/threeds2/internal/ui/ThreeDS2EventEffect.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/threeds2/internal/ui/ThreeDS2EventEffect.kt
@@ -8,11 +8,12 @@
 
 package com.adyen.checkout.threeds2.internal.ui
 
-import android.content.Context
+import android.app.Activity
+import androidx.activity.compose.LocalActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
-import androidx.compose.ui.platform.LocalContext
+import com.adyen.checkout.core.error.internal.GenericError
 import com.adyen.checkout.core.error.internal.InternalCheckoutError
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
 import com.adyen.threeds2.customization.UiCustomization
@@ -20,18 +21,24 @@ import kotlinx.coroutines.flow.Flow
 
 @Composable
 internal fun ThreeDS2EventEffect(
-    handleAction: (Context, UiCustomization) -> Unit,
+    handleAction: (Activity, UiCustomization) -> Unit,
     viewEventFlow: Flow<ThreeDS2Event>,
     onError: (InternalCheckoutError) -> Unit,
 ) {
-    val context = LocalContext.current
+    val activity = LocalActivity.current
     val colors = CheckoutThemeProvider.colors
     val attributes = CheckoutThemeProvider.attributes
     val uiCustomization = remember(colors, attributes) { mapToUiCustomization(colors, attributes) }
-    LaunchedEffect(handleAction, viewEventFlow, onError, uiCustomization) {
+    LaunchedEffect(handleAction, viewEventFlow, onError, uiCustomization, activity) {
         viewEventFlow.collect { event ->
             when (event) {
-                is ThreeDS2Event.HandleAction -> handleAction(context, uiCustomization)
+                is ThreeDS2Event.HandleAction -> {
+                    if (activity == null) {
+                        onError(GenericError("Activity is not available."))
+                    } else {
+                        handleAction(activity, uiCustomization)
+                    }
+                }
             }
         }
     }

--- a/3ds2/src/main/java/com/adyen/checkout/threeds2/internal/ui/ThreeDS2EventEffect.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/threeds2/internal/ui/ThreeDS2EventEffect.kt
@@ -29,7 +29,8 @@ internal fun ThreeDS2EventEffect(
     val colors = CheckoutThemeProvider.colors
     val attributes = CheckoutThemeProvider.attributes
     val uiCustomization = remember(colors, attributes) { mapToUiCustomization(colors, attributes) }
-    LaunchedEffect(handleAction, viewEventFlow, onError, uiCustomization, activity) {
+
+    LaunchedEffect(viewEventFlow, activity, uiCustomization) {
         viewEventFlow.collect { event ->
             when (event) {
                 is ThreeDS2Event.HandleAction -> {

--- a/3ds2/src/main/java/com/adyen/checkout/threeds2/internal/ui/ThreeDS2EventEffect.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/threeds2/internal/ui/ThreeDS2EventEffect.kt
@@ -11,21 +11,27 @@ package com.adyen.checkout.threeds2.internal.ui
 import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import com.adyen.checkout.core.error.internal.InternalCheckoutError
+import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
+import com.adyen.threeds2.customization.UiCustomization
 import kotlinx.coroutines.flow.Flow
 
 @Composable
 internal fun ThreeDS2EventEffect(
-    handleAction: (Context) -> Unit,
+    handleAction: (Context, UiCustomization) -> Unit,
     viewEventFlow: Flow<ThreeDS2Event>,
     onError: (InternalCheckoutError) -> Unit,
 ) {
     val context = LocalContext.current
-    LaunchedEffect(handleAction, viewEventFlow, onError) {
+    val colors = CheckoutThemeProvider.colors
+    val attributes = CheckoutThemeProvider.attributes
+    val uiCustomization = remember(colors, attributes) { mapToUiCustomization(colors, attributes) }
+    LaunchedEffect(handleAction, viewEventFlow, onError, uiCustomization) {
         viewEventFlow.collect { event ->
             when (event) {
-                is ThreeDS2Event.HandleAction -> handleAction(context)
+                is ThreeDS2Event.HandleAction -> handleAction(context, uiCustomization)
             }
         }
     }

--- a/3ds2/src/main/java/com/adyen/checkout/threeds2/internal/ui/UiCustomizationMapper.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/threeds2/internal/ui/UiCustomizationMapper.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 19/6/2026.
+ */
+
+package com.adyen.checkout.threeds2.internal.ui
+
+import com.adyen.checkout.ui.internal.helper.toHex
+import com.adyen.checkout.ui.internal.theme.InternalAttributes
+import com.adyen.checkout.ui.internal.theme.InternalColors
+import com.adyen.threeds2.customization.ButtonCustomization
+import com.adyen.threeds2.customization.ExpandableInfoCustomization
+import com.adyen.threeds2.customization.LabelCustomization
+import com.adyen.threeds2.customization.ScreenCustomization
+import com.adyen.threeds2.customization.SelectionItemCustomization
+import com.adyen.threeds2.customization.TextBoxCustomization
+import com.adyen.threeds2.customization.ToolbarCustomization
+import com.adyen.threeds2.customization.UiCustomization
+import com.adyen.threeds2.customization.UiCustomization.ButtonType
+
+internal fun mapToUiCustomization(
+    colors: InternalColors,
+    attributes: InternalAttributes,
+): UiCustomization = UiCustomization().apply {
+    screenCustomization = ScreenCustomization().apply {
+        backgroundColor = colors.background.toHex()
+    }
+
+    toolbarCustomization = ToolbarCustomization().apply {
+        textColor = colors.text.toHex()
+        backgroundColor = colors.container.toHex()
+    }
+
+    labelCustomization = LabelCustomization().apply {
+        textColor = colors.text.toHex()
+        headingTextColor = colors.text.toHex()
+        inputLabelTextColor = colors.textSecondary.toHex()
+    }
+
+    selectionItemCustomization = SelectionItemCustomization().apply {
+        textColor = colors.text.toHex()
+        selectionIndicatorTintColor = colors.primary.toHex()
+        highlightedBackgroundColor = colors.containerOutline.toHex()
+        borderColor = colors.outline.toHex()
+    }
+
+    textBoxCustomization = TextBoxCustomization().apply {
+        textColor = colors.text.toHex()
+        borderColor = colors.containerOutline.toHex()
+        cornerRadius = attributes.cornerRadius
+    }
+
+    val primaryButtonCustomization = ButtonCustomization().apply {
+        textColor = colors.textOnPrimary.toHex()
+        backgroundColor = colors.primary.toHex()
+        cornerRadius = attributes.cornerRadius
+    }
+    setButtonCustomization(primaryButtonCustomization, ButtonType.VERIFY)
+    setButtonCustomization(primaryButtonCustomization, ButtonType.CONTINUE)
+    setButtonCustomization(primaryButtonCustomization, ButtonType.NEXT)
+
+    val secondaryButtonCustomization = ButtonCustomization().apply {
+        textColor = colors.primary.toHex()
+        cornerRadius = attributes.cornerRadius
+    }
+    setButtonCustomization(secondaryButtonCustomization, ButtonType.CANCEL)
+    setButtonCustomization(secondaryButtonCustomization, ButtonType.RESEND)
+    setButtonCustomization(secondaryButtonCustomization, ButtonType.OPEN_OOB_APP)
+
+    expandableInfoCustomization = ExpandableInfoCustomization().apply {
+        textColor = colors.text.toHex()
+        headingTextColor = colors.textSecondary.toHex()
+        setExpandStateIndicatorColor(colors.primary.toHex())
+        highlightedBackgroundColor = colors.containerOutline.toHex()
+        borderColor = colors.outline.toHex()
+    }
+}

--- a/3ds2/src/main/java/com/adyen/checkout/threeds2/internal/ui/model/ThreeDS2ComponentParams.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/threeds2/internal/ui/model/ThreeDS2ComponentParams.kt
@@ -8,10 +8,7 @@
 
 package com.adyen.checkout.threeds2.internal.ui.model
 
-import com.adyen.threeds2.customization.UiCustomization
-
 internal data class ThreeDS2ComponentParams(
-    val uiCustomization: UiCustomization?,
     val threeDSRequestorAppURL: String?,
     val deviceParameterBlockList: Set<String>?,
 )

--- a/3ds2/src/main/java/com/adyen/checkout/threeds2/internal/ui/model/ThreeDS2ComponentParamsMapper.kt
+++ b/3ds2/src/main/java/com/adyen/checkout/threeds2/internal/ui/model/ThreeDS2ComponentParamsMapper.kt
@@ -19,7 +19,6 @@ internal class ThreeDS2ComponentParamsMapper {
     ): ThreeDS2ComponentParams {
         val adyen3ds2Configuration = params.getConfiguration<ThreeDS2Configuration>()
         return ThreeDS2ComponentParams(
-            uiCustomization = adyen3ds2Configuration?.uiCustomization,
             threeDSRequestorAppURL = adyen3ds2Configuration?.threeDSRequestorAppURL,
             // Hardcoded for now, but in the feature we could make this configurable
             deviceParameterBlockList = DEVICE_PARAMETER_BLOCK_LIST,

--- a/3ds2/src/test/java/com/adyen/checkout/threeds2/internal/ui/UiCustomizationMapperTest.kt
+++ b/3ds2/src/test/java/com/adyen/checkout/threeds2/internal/ui/UiCustomizationMapperTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 19/6/2026.
+ */
+
+package com.adyen.checkout.threeds2.internal.ui
+
+import androidx.compose.ui.graphics.Color
+import com.adyen.checkout.ui.internal.theme.InternalAttributes
+import com.adyen.checkout.ui.internal.theme.InternalColors
+import com.adyen.threeds2.customization.UiCustomization.ButtonType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class UiCustomizationMapperTest {
+
+    @Test
+    fun `when mapping colors and attributes then ui customization is created with the correct values`() {
+        val uiCustomization = mapToUiCustomization(COLORS, ATTRIBUTES)
+
+        assertEquals(BACKGROUND, uiCustomization.screenCustomization.backgroundColor)
+
+        with(uiCustomization.toolbarCustomization) {
+            assertEquals(TEXT, textColor)
+            assertEquals(CONTAINER, backgroundColor)
+        }
+
+        with(uiCustomization.labelCustomization) {
+            assertEquals(TEXT, textColor)
+            assertEquals(TEXT, headingTextColor)
+            assertEquals(TEXT_SECONDARY, inputLabelTextColor)
+        }
+
+        with(uiCustomization.selectionItemCustomization) {
+            assertEquals(TEXT, textColor)
+            assertEquals(PRIMARY, selectionIndicatorTintColor)
+            assertEquals(CONTAINER_OUTLINE, highlightedBackgroundColor)
+            assertEquals(OUTLINE, borderColor)
+        }
+
+        with(uiCustomization.textBoxCustomization) {
+            assertEquals(TEXT, textColor)
+            assertEquals(CONTAINER_OUTLINE, borderColor)
+            assertEquals(CORNER_RADIUS, cornerRadius)
+        }
+
+        with(uiCustomization.expandableInfoCustomization) {
+            assertEquals(TEXT, textColor)
+            assertEquals(TEXT_SECONDARY, headingTextColor)
+            assertEquals(CONTAINER_OUTLINE, highlightedBackgroundColor)
+            assertEquals(OUTLINE, borderColor)
+        }
+    }
+
+    @Test
+    fun `when mapping then primary buttons use primary colors and corner radius`() {
+        val uiCustomization = mapToUiCustomization(COLORS, ATTRIBUTES)
+
+        listOf(ButtonType.VERIFY, ButtonType.CONTINUE, ButtonType.NEXT).forEach { buttonType ->
+            with(uiCustomization.getButtonCustomization(buttonType)) {
+                assertEquals(TEXT_ON_PRIMARY, textColor)
+                assertEquals(PRIMARY, backgroundColor)
+                assertEquals(CORNER_RADIUS, cornerRadius)
+            }
+        }
+    }
+
+    @Test
+    fun `when mapping then secondary buttons use primary text color and corner radius`() {
+        val uiCustomization = mapToUiCustomization(COLORS, ATTRIBUTES)
+
+        listOf(ButtonType.CANCEL, ButtonType.RESEND, ButtonType.OPEN_OOB_APP).forEach { buttonType ->
+            with(uiCustomization.getButtonCustomization(buttonType)) {
+                assertEquals(PRIMARY, textColor)
+                assertEquals(CORNER_RADIUS, cornerRadius)
+            }
+        }
+    }
+
+    companion object {
+        private const val BACKGROUND = "#010203"
+        private const val CONTAINER = "#040506"
+        private const val CONTAINER_OUTLINE = "#070809"
+        private const val PRIMARY = "#0A0B0C"
+        private const val TEXT_ON_PRIMARY = "#0D0E0F"
+        private const val OUTLINE = "#1F2021"
+        private const val TEXT = "#222324"
+        private const val TEXT_SECONDARY = "#252627"
+        private const val CORNER_RADIUS = 12
+
+        private val COLORS = InternalColors(
+            background = Color(0xFF010203),
+            container = Color(0xFF040506),
+            containerOutline = Color(0xFF070809),
+            primary = Color(0xFF0A0B0C),
+            textOnPrimary = Color(0xFF0D0E0F),
+            highlight = Color(0xFF101112),
+            destructive = Color(0xFF131415),
+            textOnDestructive = Color(0xFF161718),
+            disabled = Color(0xFF191A1B),
+            textOnDisabled = Color(0xFF1C1D1E),
+            outline = Color(0xFF1F2021),
+            text = Color(0xFF222324),
+            textSecondary = Color(0xFF252627),
+        )
+
+        private val ATTRIBUTES = InternalAttributes(cornerRadius = CORNER_RADIUS)
+    }
+}

--- a/3ds2/src/test/java/com/adyen/checkout/threeds2/internal/ui/model/ThreeDS2ComponentParamsMapperTest.kt
+++ b/3ds2/src/test/java/com/adyen/checkout/threeds2/internal/ui/model/ThreeDS2ComponentParamsMapperTest.kt
@@ -27,7 +27,6 @@ internal class ThreeDS2ComponentParamsMapperTest {
     fun `when 3ds2 configuration is set then params should match the configuration`() {
         val configuration = ThreeDS2Configuration(
             threeDSRequestorAppURL = TEST_APP_URL,
-            uiCustomization = null,
         )
         val params = mapper.mapToParams(checkoutParams(configuration))
 

--- a/3ds2/src/test/java/com/adyen/checkout/threeds2/internal/ui/model/ThreeDS2ComponentParamsMapperTest.kt
+++ b/3ds2/src/test/java/com/adyen/checkout/threeds2/internal/ui/model/ThreeDS2ComponentParamsMapperTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 19/6/2026.
+ */
+
+package com.adyen.checkout.threeds2.internal.ui.model
+
+import com.adyen.checkout.core.common.Environment
+import com.adyen.checkout.core.common.internal.CheckoutParams
+import com.adyen.checkout.core.components.internal.AnalyticsParams
+import com.adyen.checkout.core.components.internal.AnalyticsParamsLevel
+import com.adyen.checkout.core.components.internal.Configuration
+import com.adyen.checkout.threeds2.ThreeDS2Configuration
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.util.Locale
+
+internal class ThreeDS2ComponentParamsMapperTest {
+
+    private val mapper = ThreeDS2ComponentParamsMapper()
+
+    @Test
+    fun `when 3ds2 configuration is set then params should match the configuration`() {
+        val configuration = ThreeDS2Configuration(
+            threeDSRequestorAppURL = TEST_APP_URL,
+            uiCustomization = null,
+        )
+        val params = mapper.mapToParams(checkoutParams(configuration))
+
+        assertEquals(TEST_APP_URL, params.threeDSRequestorAppURL)
+        assertEquals(ThreeDS2ComponentParamsMapper.DEVICE_PARAMETER_BLOCK_LIST, params.deviceParameterBlockList)
+    }
+
+    @Test
+    fun `when no 3ds2 configuration is set then threeDSRequestorAppURL should be null`() {
+        val params = mapper.mapToParams(checkoutParams(configuration = null))
+
+        assertNull(params.threeDSRequestorAppURL)
+        assertEquals(ThreeDS2ComponentParamsMapper.DEVICE_PARAMETER_BLOCK_LIST, params.deviceParameterBlockList)
+    }
+
+    private fun checkoutParams(configuration: ThreeDS2Configuration?) = CheckoutParams(
+        shopperLocale = Locale.US,
+        environment = Environment.TEST,
+        clientKey = TEST_CLIENT_KEY,
+        analyticsParams = AnalyticsParams(AnalyticsParamsLevel.ALL),
+        amount = null,
+        showSubmitButton = true,
+        publicKey = null,
+        additionalConfigurations = configuration?.let {
+            mapOf<String, Configuration>(ThreeDS2Configuration::class.java.name to it)
+        }.orEmpty(),
+        additionalSessionParams = null,
+    )
+
+    companion object {
+        private const val TEST_APP_URL = "https://adyen.com"
+        private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfghjklzxcvbnm"
+    }
+}

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/helper/ColorExt.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/helper/ColorExt.kt
@@ -11,7 +11,14 @@ package com.adyen.checkout.ui.internal.helper
 import androidx.annotation.RestrictTo
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.graphics.toArgb
+import java.util.Locale
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun Color.isDark() = luminance() < LUMINANCE_THRESHOLD
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun Color.toHex(): String = String.format(Locale.ROOT, "#%06X", RGB_MASK and toArgb())
+
 private const val LUMINANCE_THRESHOLD = 0.5f
+private const val RGB_MASK = 0xFFFFFF


### PR DESCRIPTION
## Description
Passes the merchant-provided `CheckoutTheme` from `CheckoutPaymentFlow` down to the 3DS2 component and maps it internally to a 3DS2 `UiCustomization`, which is supplied to `ThreeDS2Service.initialize(...)`.

The theme is read from the already-resolved `CheckoutThemeProvider` inside `ThreeDS2EventEffect` (mirroring how the activity is obtained from composition) and threaded through the action-handling flow as a function argument. `uiCustomization` is removed from the public `threeDS2(...)` configuration — it is now derived from the theme internally.

Note: this removes the public `uiCustomization` parameter from the `threeDS2(...)` configuration.

## Checklist
- [x] Code is unit tested
- [x] Changes are tested manually
- [x] Aligned public API changes with other platforms (if applicable)

## Ticket Number
COSDK-1124