### PR TITLE
Fix Editor crashes by gating flow observations with lifecycle

### DIFF
--- a/bacs/src/main/java/com/adyen/checkout/bacs/internal/ui/view/BacsDirectDebitInputView.kt
+++ b/bacs/src/main/java/com/adyen/checkout/bacs/internal/ui/view/BacsDirectDebitInputView.kt
@@ -35,6 +35,7 @@ import com.adyen.checkout.ui.core.old.internal.util.showError
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import com.adyen.checkout.ui.core.old.internal.util.collectWithLifecycle
 import com.adyen.checkout.ui.core.R as UICoreR
 
 @Suppress("TooManyFunctions")
@@ -161,8 +162,7 @@ internal class BacsDirectDebitInputView @JvmOverloads constructor(
 
     private fun observeDelegate(delegate: BacsDirectDebitDelegate, coroutineScope: CoroutineScope) {
         delegate.outputDataFlow
-            .onEach { outputDataChanged(it) }
-            .launchIn(coroutineScope)
+            .collectWithLifecycle(this, coroutineScope) { outputDataChanged(it) }
     }
 
     private fun outputDataChanged(bacsDirectDebitOutputData: BacsDirectDebitOutputData) {

--- a/card/src/main/java/com/adyen/checkout/card/old/internal/ui/view/CardView.kt
+++ b/card/src/main/java/com/adyen/checkout/card/old/internal/ui/view/CardView.kt
@@ -54,6 +54,7 @@ import com.adyen.checkout.ui.core.old.internal.util.showError
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import com.adyen.checkout.ui.core.old.internal.util.collectWithLifecycle
 import com.adyen.checkout.ui.core.R as UICoreR
 
 /**
@@ -192,8 +193,7 @@ class CardView @JvmOverloads constructor(
 
     private fun observeDelegate(delegate: CardDelegate, coroutineScope: CoroutineScope) {
         delegate.outputDataFlow
-            .onEach { outputDataChanged(it) }
-            .launchIn(coroutineScope)
+            .collectWithLifecycle(this, coroutineScope) { outputDataChanged(it) }
     }
 
     private fun outputDataChanged(cardOutputData: CardOutputData) {

--- a/card/src/main/java/com/adyen/checkout/card/old/internal/ui/view/StoredCardView.kt
+++ b/card/src/main/java/com/adyen/checkout/card/old/internal/ui/view/StoredCardView.kt
@@ -36,6 +36,7 @@ import com.adyen.checkout.ui.core.old.internal.util.showError
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import com.adyen.checkout.ui.core.old.internal.util.collectWithLifecycle
 import com.adyen.checkout.ui.core.R as UICoreR
 
 /**
@@ -110,8 +111,7 @@ internal class StoredCardView @JvmOverloads constructor(
 
     private fun observeDelegate(delegate: CardDelegate, coroutineScope: CoroutineScope) {
         delegate.outputDataFlow
-            .onEach { outputDataChanged(it) }
-            .launchIn(coroutineScope)
+            .collectWithLifecycle(this, coroutineScope) { outputDataChanged(it) }
     }
 
     private fun initSecurityCodeInput() {

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/old/internal/ui/view/AddressFormInput.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/old/internal/ui/view/AddressFormInput.kt
@@ -33,6 +33,7 @@ import com.google.android.material.textfield.TextInputLayout
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import com.adyen.checkout.ui.core.old.internal.util.collectWithLifecycle
 
 /**
  * AddressFormInput to be used in other modules.
@@ -140,10 +141,10 @@ class AddressFormInput @JvmOverloads constructor(
     }
 
     private fun subscribeCountryAndStateList(coroutineScope: CoroutineScope) {
-        delegate.addressOutputDataFlow.onEach { addressOutputData ->
+        delegate.addressOutputDataFlow.collectWithLifecycle(this, coroutineScope) { addressOutputData ->
             updateCountries(addressOutputData.countryOptions)
             updateStates(addressOutputData.stateOptions)
-        }.launchIn(coroutineScope)
+        }
     }
 
     fun initLocalizedContext(localizedContext: Context) {

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/old/internal/ui/view/AddressLookupView.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/old/internal/ui/view/AddressLookupView.kt
@@ -33,6 +33,7 @@ import com.adyen.checkout.ui.core.old.internal.util.showKeyboard
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import com.adyen.checkout.ui.core.old.internal.util.collectWithLifecycle
 
 @Suppress("TooManyFunctions")
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -84,11 +85,10 @@ class AddressLookupView @JvmOverloads constructor(
 
     private fun observeDelegate(delegate: AddressLookupDelegate, coroutineScope: CoroutineScope) {
         delegate.addressLookupStateFlow
-            .onEach { outputDataChanged(it) }
-            .launchIn(coroutineScope)
+            .collectWithLifecycle(this, coroutineScope) { outputDataChanged(it) }
 
         delegate.addressLookupErrorPopupFlow
-            .onEach { message ->
+            .collectWithLifecycle(this, coroutineScope) { message ->
                 val errorMessage =
                     message ?: localizedContext.getString(R.string.component_error)
                 AlertDialog.Builder(context)
@@ -97,7 +97,6 @@ class AddressLookupView @JvmOverloads constructor(
                     .setPositiveButton(R.string.error_dialog_button) { dialog, _ -> dialog.dismiss() }
                     .show()
             }
-            .launchIn(coroutineScope)
     }
 
     private fun initLocalizedStrings(localizedContext: Context) {

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/old/internal/util/FlowExtensions.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/old/internal/util/FlowExtensions.kt
@@ -49,7 +49,7 @@ fun <T> Flow<T>.collectWithLifecycle(
     coroutineScope: CoroutineScope,
     action: (T) -> Unit
 ): Job {
-    return coroutineScope.launch {
+    return coroutineScope.launch(kotlinx.coroutines.Dispatchers.Main.immediate) {
         if (view.findViewTreeLifecycleOwner() == null) {
             view.awaitAttach()
         }
@@ -58,7 +58,20 @@ fun <T> Flow<T>.collectWithLifecycle(
             this@collectWithLifecycle.flowWithLifecycle(lifecycleOwner.lifecycle)
                 .collect { action(it) }
         } else {
-            this@collectWithLifecycle.collect { action(it) }
+            val collectJob = launch {
+                this@collectWithLifecycle.collect { action(it) }
+            }
+            val listener = object : View.OnAttachStateChangeListener {
+                override fun onViewAttachedToWindow(v: View) {}
+                override fun onViewDetachedFromWindow(v: View) {
+                    collectJob.cancel()
+                    view.removeOnAttachStateChangeListener(this)
+                }
+            }
+            view.addOnAttachStateChangeListener(listener)
+            collectJob.invokeOnCompletion {
+                view.removeOnAttachStateChangeListener(listener)
+            }
         }
     }
 }

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/old/internal/util/FlowExtensions.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/old/internal/util/FlowExtensions.kt
@@ -8,14 +8,20 @@
 
 package com.adyen.checkout.ui.core.old.internal.util
 
+import android.view.View
 import androidx.annotation.RestrictTo
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.flowWithLifecycle
 import com.adyen.checkout.components.core.internal.util.mergeStateFlows
 import com.adyen.checkout.ui.core.old.internal.ui.ComponentViewType
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun mergeViewFlows(
@@ -32,3 +38,21 @@ fun mergeViewFlows(
     // genericActionViewFlow's initial value is null. We don't need this value as it breaks the desired behaviour.
     flows = arrayOf(paymentMethodViewFlow, genericActionViewFlow.drop(1)),
 )
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun <T> Flow<T>.collectWithLifecycle(
+    view: View,
+    coroutineScope: CoroutineScope,
+    action: (T) -> Unit
+): Job {
+    val lifecycleOwner = view.findViewTreeLifecycleOwner()
+    return if (lifecycleOwner != null) {
+        this.flowWithLifecycle(lifecycleOwner.lifecycle)
+            .onEach { action(it) }
+            .launchIn(coroutineScope)
+    } else {
+        this.onEach { action(it) }
+            .launchIn(coroutineScope)
+    }
+}
+

--- a/ui-core/src/main/java/com/adyen/checkout/ui/core/old/internal/util/FlowExtensions.kt
+++ b/ui-core/src/main/java/com/adyen/checkout/ui/core/old/internal/util/FlowExtensions.kt
@@ -19,9 +19,13 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun mergeViewFlows(
@@ -45,14 +49,35 @@ fun <T> Flow<T>.collectWithLifecycle(
     coroutineScope: CoroutineScope,
     action: (T) -> Unit
 ): Job {
-    val lifecycleOwner = view.findViewTreeLifecycleOwner()
-    return if (lifecycleOwner != null) {
-        this.flowWithLifecycle(lifecycleOwner.lifecycle)
-            .onEach { action(it) }
-            .launchIn(coroutineScope)
-    } else {
-        this.onEach { action(it) }
-            .launchIn(coroutineScope)
+    return coroutineScope.launch {
+        if (view.findViewTreeLifecycleOwner() == null) {
+            view.awaitAttach()
+        }
+        val lifecycleOwner = view.findViewTreeLifecycleOwner()
+        if (lifecycleOwner != null) {
+            this@collectWithLifecycle.flowWithLifecycle(lifecycleOwner.lifecycle)
+                .collect { action(it) }
+        } else {
+            this@collectWithLifecycle.collect { action(it) }
+        }
+    }
+}
+
+private suspend fun View.awaitAttach() {
+    if (isAttachedToWindow) return
+    suspendCancellableCoroutine<Unit> { continuation ->
+        val listener = object : View.OnAttachStateChangeListener {
+            override fun onViewAttachedToWindow(v: View) {
+                removeOnAttachStateChangeListener(this)
+                continuation.resume(Unit)
+            }
+
+            override fun onViewDetachedFromWindow(v: View) {}
+        }
+        addOnAttachStateChangeListener(listener)
+        continuation.invokeOnCancellation {
+            removeOnAttachStateChangeListener(listener)
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #2820. Gates delegate flow observations in views with lifecycle to prevent UI mutations while the lifecycle is stopped.