### PR TITLE
v6 - Google Pay - Component and factory wiring

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardFactory.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardFactory.kt
@@ -132,7 +132,8 @@ internal class CardFactory :
 
         return StoredCardComponent(
             // TODO - Remove casting when paymentMethod object is typed
-            storedPaymentMethod = storedPaymentMethod as? StoredCardPaymentMethod ?: error("Incorrect paymentMethod"),
+            storedPaymentMethod = storedPaymentMethod as? StoredCardPaymentMethod
+                ?: throw IllegalArgumentException("Incorrect paymentMethod"),
             analyticsManager = analyticsManager,
             cardEncryptor = cardEncryptor,
             componentParams = cardComponentParams,

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/GooglePayComponent.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/GooglePayComponent.kt
@@ -8,37 +8,88 @@
 
 package com.adyen.checkout.googlepay.internal.ui
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.adyen.checkout.core.analytics.internal.AnalyticsManager
+import com.adyen.checkout.core.common.internal.helper.bufferedChannel
 import com.adyen.checkout.core.components.internal.PaymentComponentEvent
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
+import com.adyen.checkout.core.components.internal.ui.state.ComponentStateFlow
+import com.adyen.checkout.core.components.internal.ui.state.viewState
 import com.adyen.checkout.core.components.paymentmethod.PaymentMethodTypes
+import com.adyen.checkout.googlepay.internal.ui.model.GooglePayComponentParams
+import com.adyen.checkout.googlepay.internal.ui.state.GooglePayComponentStateFactory
+import com.adyen.checkout.googlepay.internal.ui.state.GooglePayComponentStateReducer
+import com.adyen.checkout.googlepay.internal.ui.state.GooglePayComponentStateValidator
+import com.adyen.checkout.googlepay.internal.ui.state.GooglePayIntent
+import com.adyen.checkout.googlepay.internal.ui.state.GooglePayViewStateProducer
+import com.adyen.checkout.googlepay.internal.ui.state.toPaymentComponentState
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
 
-internal class GooglePayComponent : PaymentComponent {
+@Suppress("LongParameterList")
+internal class GooglePayComponent(
+    private val analyticsManager: AnalyticsManager,
+    // TODO - Will be used to build the Google Pay sheet request and availability check.
+    @Suppress("UnusedPrivateProperty", "UnusedPrivateMember")
+    private val componentParams: GooglePayComponentParams,
+    private val sdkDataProvider: SdkDataProvider,
+    private val paymentMethodType: String,
+    private val componentStateValidator: GooglePayComponentStateValidator,
+    componentStateFactory: GooglePayComponentStateFactory,
+    componentStateReducer: GooglePayComponentStateReducer,
+    viewStateProducer: GooglePayViewStateProducer,
+    coroutineScope: CoroutineScope,
+) : PaymentComponent {
 
-    override val eventFlow: Flow<PaymentComponentEvent>
-        get() = TODO("Not yet implemented")
+    private val eventChannel = bufferedChannel<PaymentComponentEvent>()
+    override val eventFlow: Flow<PaymentComponentEvent> = eventChannel.receiveAsFlow()
+
+    private val componentState = ComponentStateFlow(
+        initialState = componentStateFactory.createInitialState(),
+        reducer = componentStateReducer,
+        validator = componentStateValidator,
+        coroutineScope = coroutineScope,
+    )
+
+    internal val viewState = componentState.viewState(viewStateProducer, coroutineScope)
+
+    init {
+        initializeAnalytics(coroutineScope)
+    }
+
+    private fun initializeAnalytics(coroutineScope: CoroutineScope) {
+        analyticsManager.initialize(this, coroutineScope)
+    }
 
     @Composable
     override fun Content(modifier: Modifier) {
-        TODO("Not yet implemented")
+        // TODO - Render the Google Pay button and launch the payment sheet.
+        Box(modifier = modifier)
     }
 
     override fun submit() {
-        TODO("Not yet implemented")
+        // TODO - Launch the Google Pay sheet and handle the result before emitting.
+        if (componentStateValidator.isValid(componentState.value)) {
+            val paymentComponentState = componentState.value.toPaymentComponentState(
+                paymentMethodType = paymentMethodType,
+                sdkDataProvider = sdkDataProvider,
+            )
+            eventChannel.trySend(PaymentComponentEvent.Submit(paymentComponentState))
+        }
     }
 
-    override fun requiresUserInteraction(): Boolean {
-        TODO("Not yet implemented")
-    }
+    override fun requiresUserInteraction(): Boolean = true
 
     override fun setLoading(isLoading: Boolean) {
-        TODO("Not yet implemented")
+        componentState.handleIntent(GooglePayIntent.UpdateLoading(isLoading))
     }
 
     override fun onCleared() {
-        TODO("Not yet implemented")
+        analyticsManager.clear(this)
     }
 
     companion object {

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/GooglePayFactory.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/GooglePayFactory.kt
@@ -11,8 +11,15 @@ package com.adyen.checkout.googlepay.internal.ui
 import com.adyen.checkout.core.analytics.internal.AnalyticsManager
 import com.adyen.checkout.core.common.internal.CheckoutParams
 import com.adyen.checkout.core.components.CheckoutAdditionalCallback
+import com.adyen.checkout.core.components.data.model.paymentmethod.GooglePayPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
 import com.adyen.checkout.core.components.internal.PaymentComponentFactory
+import com.adyen.checkout.core.components.internal.data.provider.DefaultSdkDataProvider
+import com.adyen.checkout.googlepay.internal.ui.model.GooglePayComponentParamsMapper
+import com.adyen.checkout.googlepay.internal.ui.state.GooglePayComponentStateFactory
+import com.adyen.checkout.googlepay.internal.ui.state.GooglePayComponentStateReducer
+import com.adyen.checkout.googlepay.internal.ui.state.GooglePayComponentStateValidator
+import com.adyen.checkout.googlepay.internal.ui.state.GooglePayViewStateProducer
 import kotlinx.coroutines.CoroutineScope
 
 internal class GooglePayFactory : PaymentComponentFactory<GooglePayComponent> {
@@ -23,6 +30,24 @@ internal class GooglePayFactory : PaymentComponentFactory<GooglePayComponent> {
         params: CheckoutParams,
         additionalCallbacks: Set<CheckoutAdditionalCallback>,
     ): GooglePayComponent {
-        return GooglePayComponent()
+        // TODO - Remove casting when paymentMethod object is typed
+        val googlePayPaymentMethod = paymentMethod as? GooglePayPaymentMethod ?: error("Incorrect paymentMethod")
+
+        val componentParams = GooglePayComponentParamsMapper().mapToParams(
+            params = params,
+            paymentMethod = googlePayPaymentMethod,
+        )
+
+        return GooglePayComponent(
+            analyticsManager = analyticsManager,
+            componentParams = componentParams,
+            sdkDataProvider = DefaultSdkDataProvider(analyticsManager),
+            paymentMethodType = googlePayPaymentMethod.type,
+            componentStateValidator = GooglePayComponentStateValidator(),
+            componentStateFactory = GooglePayComponentStateFactory(),
+            componentStateReducer = GooglePayComponentStateReducer(),
+            viewStateProducer = GooglePayViewStateProducer(),
+            coroutineScope = coroutineScope,
+        )
     }
 }

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/GooglePayFactory.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/GooglePayFactory.kt
@@ -31,7 +31,8 @@ internal class GooglePayFactory : PaymentComponentFactory<GooglePayComponent> {
         additionalCallbacks: Set<CheckoutAdditionalCallback>,
     ): GooglePayComponent {
         // TODO - Remove casting when paymentMethod object is typed
-        val googlePayPaymentMethod = paymentMethod as? GooglePayPaymentMethod ?: error("Incorrect paymentMethod")
+        val googlePayPaymentMethod = paymentMethod as? GooglePayPaymentMethod
+            ?: throw IllegalArgumentException("Incorrect paymentMethod")
 
         val componentParams = GooglePayComponentParamsMapper().mapToParams(
             params = params,

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/GooglePayComponentTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/GooglePayComponentTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 23/6/2026.
+ */
+
+package com.adyen.checkout.googlepay.internal.ui
+
+import com.adyen.checkout.core.common.test
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
+import com.adyen.checkout.googlepay.internal.ui.model.GooglePayComponentParams
+import com.adyen.checkout.googlepay.internal.ui.state.GooglePayComponentStateFactory
+import com.adyen.checkout.googlepay.internal.ui.state.GooglePayComponentStateReducer
+import com.adyen.checkout.googlepay.internal.ui.state.GooglePayComponentStateValidator
+import com.adyen.checkout.googlepay.internal.ui.state.GooglePayViewStateProducer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class GooglePayComponentTest {
+
+    @Test
+    fun `when requiresUserInteraction is called, then it returns true`() = runTest {
+        val component = createComponent(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+
+        assertTrue(component.requiresUserInteraction())
+    }
+
+    @Test
+    fun `when setLoading is called with true, then the loading state is updated`() = runTest {
+        val component = createComponent(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+        val viewState = component.viewState.test(testScheduler)
+
+        component.setLoading(true)
+
+        assertTrue(viewState.latestValue.isLoading)
+    }
+
+    private fun createComponent(coroutineScope: CoroutineScope) = GooglePayComponent(
+        analyticsManager = mock(),
+        componentParams = mock<GooglePayComponentParams>(),
+        sdkDataProvider = mock<SdkDataProvider>(),
+        paymentMethodType = "googlepay",
+        componentStateValidator = GooglePayComponentStateValidator(),
+        componentStateFactory = GooglePayComponentStateFactory(),
+        componentStateReducer = GooglePayComponentStateReducer(),
+        viewStateProducer = GooglePayViewStateProducer(),
+        coroutineScope = coroutineScope,
+    )
+}

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/GooglePayFactoryTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/GooglePayFactoryTest.kt
@@ -48,7 +48,7 @@ internal class GooglePayFactoryTest {
 
     @Test
     fun `when create is called with a non GooglePayPaymentMethod, then an error is thrown`() {
-        assertThrows<IllegalStateException> {
+        assertThrows<IllegalArgumentException> {
             factory.create(
                 paymentMethod = mock<PaymentMethod>(),
                 coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/GooglePayFactoryTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/GooglePayFactoryTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 23/6/2026.
+ */
+
+package com.adyen.checkout.googlepay.internal.ui
+
+import com.adyen.checkout.core.common.Environment
+import com.adyen.checkout.core.common.LoggingExtension
+import com.adyen.checkout.core.common.internal.CheckoutParams
+import com.adyen.checkout.core.components.data.model.paymentmethod.GooglePayPaymentMethod
+import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
+import com.adyen.checkout.core.components.internal.AnalyticsParams
+import com.adyen.checkout.core.components.internal.AnalyticsParamsLevel
+import com.adyen.checkout.core.components.paymentmethod.PaymentMethodTypes
+import com.adyen.checkout.googlepay.GooglePayConfiguration
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.kotlin.mock
+import java.util.Locale
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(LoggingExtension::class)
+internal class GooglePayFactoryTest {
+
+    private val factory = GooglePayFactory()
+
+    @Test
+    fun `when create is called with a GooglePayPaymentMethod, then a GooglePayComponent is created`() {
+        val component = factory.create(
+            paymentMethod = createPaymentMethod(),
+            coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+            analyticsManager = mock(),
+            params = createCheckoutParams(),
+            additionalCallbacks = emptySet(),
+        )
+
+        assertNotNull(component)
+    }
+
+    @Test
+    fun `when create is called with a non GooglePayPaymentMethod, then an error is thrown`() {
+        assertThrows<IllegalStateException> {
+            factory.create(
+                paymentMethod = mock<PaymentMethod>(),
+                coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+                analyticsManager = mock(),
+                params = createCheckoutParams(),
+                additionalCallbacks = emptySet(),
+            )
+        }
+    }
+
+    private fun createCheckoutParams() = CheckoutParams(
+        shopperLocale = Locale.US,
+        environment = Environment.TEST,
+        clientKey = TEST_CLIENT_KEY,
+        analyticsParams = AnalyticsParams(AnalyticsParamsLevel.ALL),
+        amount = null,
+        showSubmitButton = false,
+        publicKey = null,
+        additionalConfigurations = mapOf(GooglePayConfiguration::class.java.name to createGooglePayConfiguration()),
+        additionalSessionParams = null,
+    )
+
+    private fun createGooglePayConfiguration() = GooglePayConfiguration(
+        merchantAccount = TEST_GATEWAY_MERCHANT_ID,
+        googlePayEnvironment = null,
+        totalPriceStatus = null,
+        countryCode = null,
+        merchantInfo = null,
+        allowedAuthMethods = null,
+        allowedCardNetworks = null,
+        isAllowPrepaidCards = null,
+        isAllowCreditCards = null,
+        isAssuranceDetailsRequired = null,
+        isEmailRequired = null,
+        isExistingPaymentMethodRequired = null,
+        isShippingAddressRequired = null,
+        shippingAddressParameters = null,
+        isBillingAddressRequired = null,
+        billingAddressParameters = null,
+        checkoutOption = null,
+        googlePayButtonStyling = null,
+    )
+
+    private fun createPaymentMethod() = GooglePayPaymentMethod(
+        type = PaymentMethodTypes.GOOGLE_PAY,
+        name = "Google Pay",
+        brands = emptyList(),
+        configuration = null,
+    )
+
+    companion object {
+        private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
+        private const val TEST_GATEWAY_MERCHANT_ID = "TEST_GATEWAY_MERCHANT_ID"
+    }
+}


### PR DESCRIPTION
## Description
Phase 1 of the Google Pay v6 migration: assemble the component and factory on top of the existing state machine.

- Implement `GooglePayComponent` against `PaymentComponent`: holds the `ComponentStateFlow` + derived view state, initializes analytics, and implements `setLoading()`, `requiresUserInteraction()` (= `true`), and `onCleared()`. `submit()` and `Content` are placeholders — the real sheet launch + result handling land in Phase 2, and the button UI in Phase 4.
- Implement `GooglePayFactory`: builds params via `GooglePayComponentParamsMapper`, and wires `analyticsManager`, `DefaultSdkDataProvider`, `paymentMethodType`, and the state factory/reducer/validator/view-state producer.
- `componentParams` is carried into the component now (forward-looking wiring) and is consumed in Phases 2 & 3.
- Start the component with the Google Pay button hidden (`isButtonVisible = false`) to avoid a flash before the `isReadyToPay` availability check (Phase 3).

### Progress
➡️ **Phase 1 — Component + factory wiring (this PR)**
Phase 2 — Sheet launch + result handling ([#2839](https://github.com/Adyen/adyen-android/pull/2839))
Phase 3 — Availability (`isReadyToPay`) gating
Phase 4 — Google Pay button UI
Phase 5 — Example app integration & on-device verification

## Checklist
- [x] Code is unit tested

## Ticket Number
COSDK-1309