### PR TITLE
v6 - Analytics - Non Nullable Attempt ID

### DIFF
--- a/core/src/main/java/com/adyen/checkout/core/analytics/internal/AnalyticsManagerFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/analytics/internal/AnalyticsManagerFactory.kt
@@ -30,7 +30,7 @@ internal class AnalyticsManagerFactory {
         params: CheckoutParams,
         source: AnalyticsSource,
         sessionId: String?,
-        checkoutAttemptId: String?,
+        checkoutAttemptId: String,
     ): AnalyticsManager = provide(
         shopperLocale = params.shopperLocale,
         environment = params.environment,
@@ -54,7 +54,7 @@ internal class AnalyticsManagerFactory {
         amount: Amount?,
         source: AnalyticsSource,
         sessionId: String?,
-        checkoutAttemptId: String?,
+        checkoutAttemptId: String,
     ): AnalyticsManager {
         val applicationContext = ApplicationContextHolder.require()
 
@@ -86,6 +86,7 @@ internal class AnalyticsManagerFactory {
                 analyticsTrackRequestProvider = AnalyticsTrackRequestProvider(),
             ),
             analyticsParams = analyticsParams,
+            checkoutAttemptId = checkoutAttemptId,
         )
     }
 

--- a/core/src/main/java/com/adyen/checkout/core/analytics/internal/DefaultAnalyticsManager.kt
+++ b/core/src/main/java/com/adyen/checkout/core/analytics/internal/DefaultAnalyticsManager.kt
@@ -27,10 +27,9 @@ import kotlin.time.Duration.Companion.seconds
 internal class DefaultAnalyticsManager(
     private val analyticsRepository: AnalyticsRepository,
     private val analyticsParams: AnalyticsParams,
+    private val checkoutAttemptId: String,
     private val coroutineDispatcher: CoroutineDispatcher = DispatcherProvider.IO,
 ) : AnalyticsManager {
-
-    private var checkoutAttemptIdState: CheckoutAttemptIdState = CheckoutAttemptIdState.NotAvailable
 
     private var isInitialized: Boolean = false
 
@@ -54,16 +53,11 @@ internal class DefaultAnalyticsManager(
             runSuspendCatching {
                 analyticsRepository.fetchCheckoutAttemptId()
             }.fold(
-                onSuccess = { attemptId ->
-                    checkoutAttemptIdState = attemptId?.let { id ->
-                        CheckoutAttemptIdState.Available(id)
-                    }?.also {
-                        startTimer()
-                    } ?: CheckoutAttemptIdState.Failed
+                onSuccess = {
+                    startTimer()
                 },
                 onFailure = {
                     adyenLog(AdyenLogLevel.WARN, it) { "Failed to fetch checkoutAttemptId." }
-                    checkoutAttemptIdState = CheckoutAttemptIdState.Failed
                 },
             )
         }
@@ -99,7 +93,7 @@ internal class DefaultAnalyticsManager(
         }
         timerJob = coroutineScope?.launch(coroutineDispatcher) {
             while (isActive) {
-                delay(DISPATCH_INTERVAL_MILLIS)
+                delay(DISPATCH_INTERVAL_SECONDS)
                 sendEvents()
             }
         }
@@ -110,14 +104,8 @@ internal class DefaultAnalyticsManager(
     }
 
     private suspend fun sendEvents() {
-        val checkoutAttemptIdState = checkoutAttemptIdState as? CheckoutAttemptIdState.Available
-        if (checkoutAttemptIdState == null) {
-            adyenLog(AdyenLogLevel.WARN) { "checkoutAttemptId should be available at this point." }
-            return
-        }
-
         runSuspendCatching {
-            analyticsRepository.sendEvents(checkoutAttemptIdState.checkoutAttemptId)
+            analyticsRepository.sendEvents(checkoutAttemptId)
         }.fold(
             onSuccess = { /* Not necessary */ },
             onFailure = { throwable ->
@@ -126,11 +114,7 @@ internal class DefaultAnalyticsManager(
         )
     }
 
-    override fun getCheckoutAttemptId(): String = when (val checkoutAttemptIdState = checkoutAttemptIdState) {
-        is CheckoutAttemptIdState.Available -> checkoutAttemptIdState.checkoutAttemptId
-        CheckoutAttemptIdState.Failed -> FAILED_CHECKOUT_ATTEMPT_ID
-        CheckoutAttemptIdState.NotAvailable -> CHECKOUT_ATTEMPT_ID_NOT_FETCHED
-    }
+    override fun getCheckoutAttemptId(): String = checkoutAttemptId
 
     private fun cannotSendEvents() = analyticsParams.level.priority <= AnalyticsParamsLevel.INITIAL.priority
 
@@ -143,7 +127,6 @@ internal class DefaultAnalyticsManager(
         adyenLog(AdyenLogLevel.DEBUG) { "Clearing analytics manager" }
 
         coroutineScope = null
-        checkoutAttemptIdState = CheckoutAttemptIdState.NotAvailable
         ownerReference = null
         isInitialized = false
         stopTimer()
@@ -151,13 +134,8 @@ internal class DefaultAnalyticsManager(
     }
 
     companion object {
-        @VisibleForTesting
-        internal const val CHECKOUT_ATTEMPT_ID_NOT_FETCHED = "checkoutAttemptId-not-fetched"
 
         @VisibleForTesting
-        internal const val FAILED_CHECKOUT_ATTEMPT_ID = "fetch-checkoutAttemptId-failed"
-
-        @VisibleForTesting
-        internal val DISPATCH_INTERVAL_MILLIS = 10.seconds.inWholeMilliseconds
+        internal val DISPATCH_INTERVAL_SECONDS = 10.seconds
     }
 }

--- a/core/src/main/java/com/adyen/checkout/core/analytics/internal/data/remote/DefaultAnalyticsSetupProvider.kt
+++ b/core/src/main/java/com/adyen/checkout/core/analytics/internal/data/remote/DefaultAnalyticsSetupProvider.kt
@@ -26,7 +26,7 @@ internal class DefaultAnalyticsSetupProvider(
     private val amount: Amount?,
     private val source: AnalyticsSource,
     private val sessionId: String?,
-    private val checkoutAttemptId: String?,
+    private val checkoutAttemptId: String,
 ) : AnalyticsSetupProvider {
 
     override fun provide(): AnalyticsSetupRequest {

--- a/core/src/main/java/com/adyen/checkout/core/common/CheckoutContext.kt
+++ b/core/src/main/java/com/adyen/checkout/core/common/CheckoutContext.kt
@@ -25,7 +25,7 @@ sealed interface CheckoutContext : Parcelable {
     data class Sessions internal constructor(
         val checkoutSession: CheckoutSession,
         override val checkoutConfiguration: CheckoutConfiguration,
-        internal val checkoutAttemptId: String?,
+        internal val checkoutAttemptId: String,
         internal val publicKey: String?,
     ) : CheckoutContext
 
@@ -34,7 +34,7 @@ sealed interface CheckoutContext : Parcelable {
     data class Advanced internal constructor(
         val paymentMethods: PaymentMethods,
         override val checkoutConfiguration: CheckoutConfiguration,
-        internal val checkoutAttemptId: String?,
+        internal val checkoutAttemptId: String,
         internal val publicKey: String?,
     ) : CheckoutContext
 
@@ -43,7 +43,7 @@ sealed interface CheckoutContext : Parcelable {
     data class ActionOnly internal constructor(
         internal val action: Action,
         override val checkoutConfiguration: CheckoutConfiguration,
-        internal val checkoutAttemptId: String?,
+        internal val checkoutAttemptId: String,
         internal val publicKey: String?,
     ) : CheckoutContext
 }

--- a/core/src/main/java/com/adyen/checkout/core/common/internal/CheckoutContextExt.kt
+++ b/core/src/main/java/com/adyen/checkout/core/common/internal/CheckoutContextExt.kt
@@ -10,7 +10,7 @@ package com.adyen.checkout.core.common.internal
 
 import com.adyen.checkout.core.common.CheckoutContext
 
-internal val CheckoutContext.checkoutAttemptId: String?
+internal val CheckoutContext.checkoutAttemptId: String
     get() = when (this) {
         is CheckoutContext.Sessions -> checkoutAttemptId
         is CheckoutContext.Advanced -> checkoutAttemptId

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutInitializer.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutInitializer.kt
@@ -118,5 +118,5 @@ object CheckoutInitializer {
 data class InitializationData(
     val checkoutSession: CheckoutSession?,
     val publicKey: String?,
-    val checkoutAttemptId: String?,
+    val checkoutAttemptId: String,
 )

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutInitializer.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutInitializer.kt
@@ -9,6 +9,7 @@
 package com.adyen.checkout.core.components.internal
 
 import androidx.annotation.RestrictTo
+import androidx.annotation.VisibleForTesting
 import com.adyen.checkout.core.analytics.internal.data.remote.api.AnalyticsService
 import com.adyen.checkout.core.analytics.internal.data.remote.model.AnalyticsSetupRequest
 import com.adyen.checkout.core.common.AdyenLogLevel
@@ -26,6 +27,9 @@ import kotlinx.coroutines.supervisorScope
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 object CheckoutInitializer {
+
+    @VisibleForTesting
+    internal const val FAILED_CHECKOUT_ATTEMPT_ID = "fetch-checkoutAttemptId-failed"
 
     suspend fun initialize(
         checkoutConfiguration: CheckoutConfiguration,
@@ -90,23 +94,23 @@ object CheckoutInitializer {
 
     private suspend fun fetchCheckoutAttemptId(
         checkoutConfiguration: CheckoutConfiguration,
-    ): String? {
+    ): String {
         val httpClient = HttpClientFactory.getAnalyticsHttpClient(checkoutConfiguration.environment)
         val analyticsService = AnalyticsService(httpClient)
 
-        analyticsService.fetchCheckoutAttemptId(
+        return analyticsService.fetchCheckoutAttemptId(
             request = AnalyticsSetupRequest(),
             clientKey = checkoutConfiguration.clientKey,
         ).fold(
             onSuccess = { response ->
                 adyenLog(AdyenLogLevel.DEBUG) { "Checkout attempt ID fetched" }
-                return response.checkoutAttemptId
+                response.checkoutAttemptId
             },
             onFailure = {
                 adyenLog(AdyenLogLevel.ERROR) { "Unable to fetch checkout attempt ID" }
-                return null
+                null
             },
-        )
+        ) ?: FAILED_CHECKOUT_ATTEMPT_ID
     }
 }
 

--- a/core/src/test/java/com/adyen/checkout/core/analytics/internal/DefaultAnalyticsManagerTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/analytics/internal/DefaultAnalyticsManagerTest.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -33,11 +32,12 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(ExperimentalCoroutinesApi::class, DirectAnalyticsEventCreation::class)
 @ExtendWith(MockitoExtension::class, LoggingExtension::class, TestDispatcherExtension::class)
 internal class DefaultAnalyticsManagerTest(
-    @Mock private val analyticsRepository: AnalyticsRepository,
+    @param:Mock private val analyticsRepository: AnalyticsRepository,
 ) {
 
     private lateinit var analyticsManager: DefaultAnalyticsManager
@@ -47,45 +47,9 @@ internal class DefaultAnalyticsManagerTest(
         analyticsManager = createAnalyticsManager()
     }
 
-    @Test
-    fun `checkoutAttemptId is not available by default`() {
-        assertEquals(DefaultAnalyticsManager.CHECKOUT_ATTEMPT_ID_NOT_FETCHED, analyticsManager.getCheckoutAttemptId())
-    }
-
     @Nested
     @DisplayName("when initializing and")
     inner class InitializeTest {
-
-        @Test
-        fun `fetching checkoutAttemptId succeeds, then it is set`() = runTest {
-            whenever(analyticsRepository.fetchCheckoutAttemptId()) doReturn "test value"
-
-            analyticsManager.initialize(this@InitializeTest, this)
-
-            assertEquals("test value", analyticsManager.getCheckoutAttemptId())
-            analyticsManager.clear(this@InitializeTest)
-        }
-
-        @Test
-        fun `analytics level is initial, then checkoutAttemptId is still set`() = runTest {
-            analyticsManager = createAnalyticsManager(AnalyticsParamsLevel.INITIAL)
-            whenever(analyticsRepository.fetchCheckoutAttemptId()) doReturn "test value"
-
-            analyticsManager.initialize(this@InitializeTest, this)
-
-            assertEquals("test value", analyticsManager.getCheckoutAttemptId())
-            analyticsManager.clear(this@InitializeTest)
-        }
-
-        @Test
-        fun `fetching checkoutAttemptId fails, then checkoutAttemptId is failed`() = runTest {
-            whenever(analyticsRepository.fetchCheckoutAttemptId()) doAnswer { error("test") }
-
-            analyticsManager.initialize(this@InitializeTest, this)
-
-            assertEquals(DefaultAnalyticsManager.FAILED_CHECKOUT_ATTEMPT_ID, analyticsManager.getCheckoutAttemptId())
-            analyticsManager.clear(this@InitializeTest)
-        }
 
         @Test
         fun `initialize is called twice, then the second time is ignored`() = runTest {
@@ -161,36 +125,6 @@ internal class DefaultAnalyticsManagerTest(
             verify(analyticsRepository, never()).sendEvents(any())
             analyticsManager.clear(this@SendEventTest)
         }
-
-        @Test
-        fun `checkoutAttemptId is null when fetching, then events are not sent`() = runTest {
-            whenever(analyticsRepository.fetchCheckoutAttemptId()) doReturn null
-            analyticsManager.initialize(this@SendEventTest, this)
-            val event = AnalyticsEvent.Info(
-                component = "test",
-                shouldForceSend = true,
-            )
-
-            analyticsManager.trackEvent(event)
-
-            verify(analyticsRepository, never()).sendEvents(any())
-            analyticsManager.clear(this@SendEventTest)
-        }
-
-        @Test
-        fun `checkoutAttemptId has failed fetching, then events are not sent`() = runTest {
-            whenever(analyticsRepository.fetchCheckoutAttemptId()) doAnswer { error("test") }
-            analyticsManager.initialize(this@SendEventTest, this)
-            val event = AnalyticsEvent.Info(
-                component = "test",
-                shouldForceSend = true,
-            )
-
-            analyticsManager.trackEvent(event)
-
-            verify(analyticsRepository, never()).sendEvents(any())
-            analyticsManager.clear(this@SendEventTest)
-        }
     }
 
     @Test
@@ -202,7 +136,7 @@ internal class DefaultAnalyticsManagerTest(
         analyticsManager.initialize(this@DefaultAnalyticsManagerTest, this)
 
         analyticsManager.trackEvent(GenericEvents.rendered("dropin", false))
-        testScheduler.advanceTimeBy(DefaultAnalyticsManager.DISPATCH_INTERVAL_MILLIS + 1)
+        testScheduler.advanceTimeBy(DefaultAnalyticsManager.DISPATCH_INTERVAL_SECONDS + 1.milliseconds)
 
         verify(analyticsRepository, times(1)).sendEvents(any())
         analyticsManager.clear(this@DefaultAnalyticsManagerTest)
@@ -214,6 +148,7 @@ internal class DefaultAnalyticsManagerTest(
     ) = DefaultAnalyticsManager(
         analyticsRepository = analyticsRepository,
         analyticsParams = AnalyticsParams(analyticsParamsLevel),
+        checkoutAttemptId = "test-id",
         coroutineDispatcher = coroutineDispatcher,
     )
 }

--- a/core/src/test/java/com/adyen/checkout/core/analytics/internal/data/remote/DefaultAnalyticsSetupProviderTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/analytics/internal/data/remote/DefaultAnalyticsSetupProviderTest.kt
@@ -112,7 +112,7 @@ internal class DefaultAnalyticsSetupProviderTest {
         amount: Amount? = Amount("USD", 123),
         source: AnalyticsSource = AnalyticsSource.PaymentComponent("scheme"),
         sessionId: String? = "sessionId",
-        checkoutAttemptId: String? = "checkoutAttemptId",
+        checkoutAttemptId: String = "checkoutAttemptId",
     ) = DefaultAnalyticsSetupProvider(
         shopperLocale = shopperLocale,
         isCreatedByDropIn = isCreatedByDropIn,

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentComponentResolverTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentComponentResolverTest.kt
@@ -249,7 +249,7 @@ internal class PaymentComponentResolverTest {
             clientKey = TEST_CLIENT_KEY,
             shopperLocale = Locale.US,
         ),
-        checkoutAttemptId = null,
+        checkoutAttemptId = "",
         publicKey = null,
     )
 
@@ -264,7 +264,7 @@ internal class PaymentComponentResolverTest {
             clientKey = TEST_CLIENT_KEY,
             shopperLocale = Locale.US,
         ),
-        checkoutAttemptId = null,
+        checkoutAttemptId = "",
         publicKey = null,
     )
 
@@ -289,7 +289,7 @@ internal class PaymentComponentResolverTest {
             clientKey = TEST_CLIENT_KEY,
             shopperLocale = Locale.US,
         ),
-        checkoutAttemptId = null,
+        checkoutAttemptId = "",
         publicKey = null,
     )
 


### PR DESCRIPTION
## Description
Make `checkoutAttemptId` non-nullable across the SDK by resolving it eagerly during initialization.

Previously, `checkoutAttemptId` was nullable (`String?`) throughout `CheckoutContext`, `DefaultAnalyticsManager`, and related classes. The analytics manager maintained its own `CheckoutAttemptIdState` sealed class to track fetching/failed/available states, and fetched the attempt ID during initialize().

This PR:
- Moves the `checkoutAttemptId` fetch to `CheckoutInitializer`, falling back to "fetch-checkoutAttemptId-failed" on failure instead of returning null.
- Makes `checkoutAttemptId` a non-nullable String in `CheckoutContext` (Sessions, Advanced, ActionOnly), `InitializationData`, `AnalyticsManagerFactory`, and `DefaultAnalyticsSetupProvider`.
- Injects checkoutAttemptId directly into `DefaultAnalyticsManager` via constructor, removing the internal `CheckoutAttemptIdState` state machine and simplifying `getCheckoutAttemptId()` to a direct property access.
- Removes now-unnecessary tests for null/failed checkoutAttemptId states in `DefaultAnalyticsManagerTest`.
- Renames `DISPATCH_INTERVAL_MILLIS` to `DISPATCH_INTERVAL_SECONDS` using `kotlin.time.Duration` directly.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually