### PR TITLE
v6 - Analytics - Checkout Controller

### DIFF
--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/BlikComponent.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/BlikComponent.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 
 @Suppress("LongParameterList")
 internal class BlikComponent(
-    private val analyticsManager: AnalyticsManager,
+    @Suppress("unused") private val analyticsManager: AnalyticsManager,
     private val sdkDataProvider: SdkDataProvider,
     private val componentStateValidator: BlikComponentStateValidator,
     componentStateFactory: BlikComponentStateFactory,

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/BlikFactory.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/BlikFactory.kt
@@ -19,7 +19,7 @@ import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPaymentMethod
 import com.adyen.checkout.core.components.internal.PaymentComponentFactory
 import com.adyen.checkout.core.components.internal.StoredPaymentComponentFactory
-import com.adyen.checkout.core.components.internal.data.provider.DefaultSdkDataProvider
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import kotlinx.coroutines.CoroutineScope
 
 internal class BlikFactory :
@@ -30,12 +30,13 @@ internal class BlikFactory :
         paymentMethod: PaymentMethod,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         params: CheckoutParams,
         additionalCallbacks: Set<CheckoutAdditionalCallback>,
     ): BlikComponent {
         return BlikComponent(
             analyticsManager = analyticsManager,
-            sdkDataProvider = DefaultSdkDataProvider(analyticsManager),
+            sdkDataProvider = sdkDataProvider,
             componentStateFactory = BlikComponentStateFactory(),
             componentStateReducer = BlikComponentStateReducer(),
             componentStateValidator = BlikComponentStateValidator(),
@@ -48,12 +49,13 @@ internal class BlikFactory :
         storedPaymentMethod: StoredPaymentMethod,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         params: CheckoutParams,
     ): StoredBlikComponent {
         return StoredBlikComponent(
             storedPaymentMethod = storedPaymentMethod,
             analyticsManager = analyticsManager,
-            sdkDataProvider = DefaultSdkDataProvider(analyticsManager),
+            sdkDataProvider = sdkDataProvider,
         )
     }
 }

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/StoredBlikComponent.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/StoredBlikComponent.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 
 internal class StoredBlikComponent(
     private val storedPaymentMethod: StoredPaymentMethod,
-    private val analyticsManager: AnalyticsManager,
+    @Suppress("unused") private val analyticsManager: AnalyticsManager,
     private val sdkDataProvider: SdkDataProvider,
 ) : PaymentComponent {
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardFactory.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardFactory.kt
@@ -39,7 +39,7 @@ import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPayment
 import com.adyen.checkout.core.components.getAdditionalCallback
 import com.adyen.checkout.core.components.internal.PaymentComponentFactory
 import com.adyen.checkout.core.components.internal.StoredPaymentComponentFactory
-import com.adyen.checkout.core.components.internal.data.provider.DefaultSdkDataProvider
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.cse.internal.CardEncryptorFactory
 import com.adyen.checkout.cse.internal.GenericEncryptorFactory
 import kotlinx.coroutines.CoroutineScope
@@ -52,6 +52,7 @@ internal class CardFactory :
         paymentMethod: PaymentMethod,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         params: CheckoutParams,
         additionalCallbacks: Set<CheckoutAdditionalCallback>,
     ): CardComponent {
@@ -101,7 +102,7 @@ internal class CardFactory :
             componentStateReducer = componentStateReducer,
             viewStateProducer = viewStateProducer,
             coroutineScope = coroutineScope,
-            sdkDataProvider = DefaultSdkDataProvider(analyticsManager),
+            sdkDataProvider = sdkDataProvider,
             paymentMethodType = paymentMethodType,
             onBinChangeCallback = additionalCallbacks.getAdditionalCallback<OnBinChangeCallback>(),
             onBinLookupCallback = additionalCallbacks.getAdditionalCallback<OnBinLookupCallback>(),
@@ -115,6 +116,7 @@ internal class CardFactory :
         storedPaymentMethod: StoredPaymentMethod,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         params: CheckoutParams,
     ): StoredCardComponent {
         val cardComponentParams = CardComponentParamsMapper().mapToParams(
@@ -142,7 +144,7 @@ internal class CardFactory :
             componentStateReducer = componentStateReducer,
             viewStateProducer = viewStateProducer,
             coroutineScope = coroutineScope,
-            sdkDataProvider = DefaultSdkDataProvider(analyticsManager),
+            sdkDataProvider = sdkDataProvider,
             publicKey = params.publicKey,
         )
     }

--- a/core/src/main/java/com/adyen/checkout/core/analytics/internal/AnalyticsManager.kt
+++ b/core/src/main/java/com/adyen/checkout/core/analytics/internal/AnalyticsManager.kt
@@ -14,6 +14,4 @@ import androidx.annotation.RestrictTo
 interface AnalyticsManager {
 
     fun trackEvent(event: AnalyticsEvent)
-
-    fun getCheckoutAttemptId(): String
 }

--- a/core/src/main/java/com/adyen/checkout/core/analytics/internal/DefaultAnalyticsManager.kt
+++ b/core/src/main/java/com/adyen/checkout/core/analytics/internal/DefaultAnalyticsManager.kt
@@ -98,8 +98,6 @@ internal class DefaultAnalyticsManager(
         )
     }
 
-    override fun getCheckoutAttemptId(): String = checkoutAttemptId
-
     private fun canTrackEvents() = analyticsParams.level.priority > AnalyticsParamsLevel.INITIAL.priority
 
     companion object {

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutControllerFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutControllerFactory.kt
@@ -24,7 +24,6 @@ import com.adyen.checkout.core.components.CheckoutController
 import com.adyen.checkout.core.components.CheckoutTarget
 import com.adyen.checkout.core.components.SessionCheckoutCallbacks
 import com.adyen.checkout.core.components.internal.data.provider.DefaultSdkDataProvider
-import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.core.error.CheckoutError
 import com.adyen.checkout.core.sessions.internal.data.api.SessionRepository
 import com.adyen.checkout.core.sessions.internal.data.api.SessionService
@@ -72,7 +71,12 @@ internal class CheckoutControllerFactory {
         callbacks: ActionOnlyCheckoutCallbacks,
         coroutineScope: CoroutineScope,
     ): CheckoutController {
-        val (checkoutParams, analyticsManager) = createCommonDependencies(context, coroutineScope)
+        // TODO - what should be the payment method type for action only?
+        val (checkoutParams, analyticsManager) = createCommonDependencies(
+            paymentMethodType = "NONE",
+            context = context,
+            coroutineScope = coroutineScope,
+        )
         val componentRequestDispatcher = ActionOnlyComponentRequestDispatcher(callbacks)
         val actionHandler = createActionHandler(
             componentRequestDispatcher = componentRequestDispatcher,
@@ -94,17 +98,33 @@ internal class CheckoutControllerFactory {
         componentRequestDispatcher: SubmittableComponentRequestDispatcher,
         coroutineScope: CoroutineScope,
     ): CheckoutController {
-        val (checkoutParams, analyticsManager, sdkDataProvider) = createCommonDependencies(context, coroutineScope)
+        val paymentMethod = PaymentMethodResolver.resolve(target, context)
+
+        if (paymentMethod == null) {
+            componentRequestDispatcher.failure(
+                CheckoutError(
+                    code = CheckoutError.ErrorCode.PAYMENT_METHOD_FAILURE,
+                    message = "Payment method for target '${target}' was not found in the payment methods response.",
+                ),
+            )
+            //TODO - gracefully fail
+            error("")
+        }
+
+        val (checkoutParams, analyticsManager) = createCommonDependencies(
+            paymentMethodType = paymentMethod.type,
+            context = context,
+            coroutineScope = coroutineScope,
+        )
         val actionHandler = createActionHandler(
             componentRequestDispatcher = componentRequestDispatcher,
             coroutineScope = coroutineScope,
             analyticsManager = analyticsManager,
             params = checkoutParams,
         )
-
+        val sdkDataProvider = DefaultSdkDataProvider(context.checkoutAttemptId)
         val paymentComponentResult = PaymentComponentResolver.resolve(
-            target = target,
-            context = context,
+            paymentMethod = paymentMethod,
             callbacks = callbacks,
             coroutineScope = coroutineScope,
             analyticsManager = analyticsManager,
@@ -136,6 +156,7 @@ internal class CheckoutControllerFactory {
     }
 
     private fun createCommonDependencies(
+        paymentMethodType: String,
         context: CheckoutContext,
         coroutineScope: CoroutineScope,
     ): CommonDependencies {
@@ -149,19 +170,15 @@ internal class CheckoutControllerFactory {
 
         val analyticsManager = AnalyticsManagerFactory().provide(
             params = checkoutParams,
-            // TODO - Analytics: Pass the correct paymentMethod type
-            source = AnalyticsSource.PaymentComponent("paymentMethod.type"),
+            source = AnalyticsSource.PaymentComponent(paymentMethodType),
             sessionId = session?.sessionSetupResponse?.id,
             checkoutAttemptId = context.checkoutAttemptId,
             coroutineScope = coroutineScope,
         )
 
-        val sdkDataProvider = DefaultSdkDataProvider(context.checkoutAttemptId)
-
         return CommonDependencies(
             checkoutParams = checkoutParams,
             analyticsManager = analyticsManager,
-            sdkDataProvider = sdkDataProvider,
         )
     }
 
@@ -197,6 +214,5 @@ internal class CheckoutControllerFactory {
     private data class CommonDependencies(
         val checkoutParams: CheckoutParams,
         val analyticsManager: AnalyticsManager,
-        val sdkDataProvider: SdkDataProvider,
     )
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutControllerFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutControllerFactory.kt
@@ -23,6 +23,8 @@ import com.adyen.checkout.core.components.CheckoutCallbacks
 import com.adyen.checkout.core.components.CheckoutController
 import com.adyen.checkout.core.components.CheckoutTarget
 import com.adyen.checkout.core.components.SessionCheckoutCallbacks
+import com.adyen.checkout.core.components.internal.data.provider.DefaultSdkDataProvider
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.core.error.CheckoutError
 import com.adyen.checkout.core.sessions.internal.data.api.SessionRepository
 import com.adyen.checkout.core.sessions.internal.data.api.SessionService
@@ -92,7 +94,7 @@ internal class CheckoutControllerFactory {
         componentRequestDispatcher: SubmittableComponentRequestDispatcher,
         coroutineScope: CoroutineScope,
     ): CheckoutController {
-        val (checkoutParams, analyticsManager) = createCommonDependencies(context, coroutineScope)
+        val (checkoutParams, analyticsManager, sdkDataProvider) = createCommonDependencies(context, coroutineScope)
         val actionHandler = createActionHandler(
             componentRequestDispatcher = componentRequestDispatcher,
             coroutineScope = coroutineScope,
@@ -106,6 +108,7 @@ internal class CheckoutControllerFactory {
             callbacks = callbacks,
             coroutineScope = coroutineScope,
             analyticsManager = analyticsManager,
+            sdkDataProvider = sdkDataProvider,
             checkoutParams = checkoutParams,
         )
 
@@ -153,7 +156,13 @@ internal class CheckoutControllerFactory {
             coroutineScope = coroutineScope,
         )
 
-        return CommonDependencies(checkoutParams, analyticsManager)
+        val sdkDataProvider = DefaultSdkDataProvider(context.checkoutAttemptId)
+
+        return CommonDependencies(
+            checkoutParams = checkoutParams,
+            analyticsManager = analyticsManager,
+            sdkDataProvider = sdkDataProvider,
+        )
     }
 
     private fun createSessionComponentRequestDispatcher(
@@ -188,5 +197,6 @@ internal class CheckoutControllerFactory {
     private data class CommonDependencies(
         val checkoutParams: CheckoutParams,
         val analyticsManager: AnalyticsManager,
+        val sdkDataProvider: SdkDataProvider,
     )
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutControllerFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutControllerFactory.kt
@@ -24,7 +24,6 @@ import com.adyen.checkout.core.components.CheckoutController
 import com.adyen.checkout.core.components.CheckoutTarget
 import com.adyen.checkout.core.components.SessionCheckoutCallbacks
 import com.adyen.checkout.core.components.internal.data.provider.DefaultSdkDataProvider
-import com.adyen.checkout.core.error.CheckoutError
 import com.adyen.checkout.core.sessions.internal.data.api.SessionRepository
 import com.adyen.checkout.core.sessions.internal.data.api.SessionService
 import kotlinx.coroutines.CoroutineScope
@@ -98,18 +97,10 @@ internal class CheckoutControllerFactory {
         componentRequestDispatcher: SubmittableComponentRequestDispatcher,
         coroutineScope: CoroutineScope,
     ): CheckoutController {
-        val paymentMethod = PaymentMethodResolver.resolve(target, context)
-
-        if (paymentMethod == null) {
-            componentRequestDispatcher.failure(
-                CheckoutError(
-                    code = CheckoutError.ErrorCode.PAYMENT_METHOD_FAILURE,
-                    message = "Payment method for target '${target}' was not found in the payment methods response.",
-                ),
-            )
-            //TODO - gracefully fail
-            error("")
-        }
+        val paymentMethod = PaymentMethodResolver.resolve(target, context) ?: return createFailedCheckoutController(
+            errorMessage = "Payment method for target '${target}' was not found in the payment methods response.",
+            componentRequestDispatcher = componentRequestDispatcher,
+        )
 
         val (checkoutParams, analyticsManager) = createCommonDependencies(
             paymentMethodType = paymentMethod.type,
@@ -132,27 +123,25 @@ internal class CheckoutControllerFactory {
             checkoutParams = checkoutParams,
         )
 
-        val paymentComponent = when (paymentComponentResult) {
-            is PaymentComponentResult.Success -> paymentComponentResult.component
-            is PaymentComponentResult.Failure -> {
-                componentRequestDispatcher.failure(
-                    CheckoutError(
-                        code = CheckoutError.ErrorCode.PAYMENT_METHOD_FAILURE,
-                        message = paymentComponentResult.message,
-                    ),
+        return when (paymentComponentResult) {
+            is PaymentComponentResult.Success -> {
+                val flow = FullCheckoutFlow(
+                    componentRequestDispatcher = componentRequestDispatcher,
+                    coroutineScope = coroutineScope,
+                    paymentComponent = paymentComponentResult.component,
+                    actionHandler = actionHandler,
                 )
-                null
+
+                CheckoutController(flow = flow)
+            }
+
+            is PaymentComponentResult.Failure -> {
+                createFailedCheckoutController(
+                    errorMessage = paymentComponentResult.message,
+                    componentRequestDispatcher = componentRequestDispatcher,
+                )
             }
         }
-
-        val flow = FullCheckoutFlow(
-            componentRequestDispatcher = componentRequestDispatcher,
-            coroutineScope = coroutineScope,
-            paymentComponent = paymentComponent,
-            actionHandler = actionHandler,
-        )
-
-        return CheckoutController(flow = flow)
     }
 
     private fun createCommonDependencies(
@@ -210,6 +199,17 @@ internal class CheckoutControllerFactory {
         analyticsManager = analyticsManager,
         params = params,
     )
+
+    private fun createFailedCheckoutController(
+        errorMessage: String,
+        componentRequestDispatcher: ComponentRequestDispatcher,
+    ): CheckoutController {
+        val flow = FailureCheckoutFlow(
+            errorMessage = errorMessage,
+            componentRequestDispatcher = componentRequestDispatcher,
+        )
+        return CheckoutController(flow)
+    }
 
     private data class CommonDependencies(
         val checkoutParams: CheckoutParams,

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutControllerFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutControllerFactory.kt
@@ -98,7 +98,7 @@ internal class CheckoutControllerFactory {
         coroutineScope: CoroutineScope,
     ): CheckoutController {
         val paymentMethod = PaymentMethodResolver.resolve(target, context) ?: return createFailedCheckoutController(
-            errorMessage = "Payment method for target '${target}' was not found in the payment methods response.",
+            errorMessage = "Payment method for target '$target' was not found in the payment methods response.",
             componentRequestDispatcher = componentRequestDispatcher,
         )
 

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/FailureCheckoutFlow.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/FailureCheckoutFlow.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 23/6/2026.
+ */
+
+package com.adyen.checkout.core.components.internal
+
+import com.adyen.checkout.core.action.internal.ActionComponent
+import com.adyen.checkout.core.components.CheckoutPaymentMethodRoute
+import com.adyen.checkout.core.components.CheckoutSecondaryRoute
+import com.adyen.checkout.core.components.internal.ui.PaymentComponent
+import com.adyen.checkout.core.error.CheckoutError
+import com.adyen.checkout.core.error.CheckoutError.ErrorCode.PAYMENT_METHOD_FAILURE
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+
+internal class FailureCheckoutFlow(
+    private val errorMessage: String,
+    private val componentRequestDispatcher: ComponentRequestDispatcher,
+) : CheckoutFlow {
+
+    override val paymentComponent: PaymentComponent? = null
+    override val actionComponent: ActionComponent? = null
+    override val paymentMethodNavigation: Flow<CheckoutPaymentMethodRoute> = emptyFlow()
+    override val secondaryNavigation: Flow<CheckoutSecondaryRoute> = emptyFlow()
+
+    init {
+        emitFailure(errorMessage)
+    }
+
+    override fun submit() {
+        emitFailure("Cannot submit: $errorMessage")
+    }
+
+    private fun emitFailure(errorMessage: String) {
+        val error = CheckoutError(
+            code = PAYMENT_METHOD_FAILURE,
+            message = errorMessage,
+        )
+        componentRequestDispatcher.failure(error)
+    }
+
+    override fun requiresUserInteraction(): Boolean {
+        return false
+    }
+}

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentComponentFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentComponentFactory.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.CoroutineScope
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface PaymentComponentFactory<T : PaymentComponent> : ComponentFactory {
 
+    @Suppress("LongParameterList")
     fun create(
         paymentMethod: PaymentMethod,
         coroutineScope: CoroutineScope,

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentComponentFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentComponentFactory.kt
@@ -13,6 +13,7 @@ import com.adyen.checkout.core.analytics.internal.AnalyticsManager
 import com.adyen.checkout.core.common.internal.CheckoutParams
 import com.adyen.checkout.core.components.CheckoutAdditionalCallback
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
 import kotlinx.coroutines.CoroutineScope
 
@@ -26,6 +27,7 @@ interface PaymentComponentFactory<T : PaymentComponent> : ComponentFactory {
         paymentMethod: PaymentMethod,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         params: CheckoutParams,
         additionalCallbacks: Set<CheckoutAdditionalCallback>,
     ): T

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentComponentResolver.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentComponentResolver.kt
@@ -9,30 +9,27 @@
 package com.adyen.checkout.core.components.internal
 
 import com.adyen.checkout.core.analytics.internal.AnalyticsManager
-import com.adyen.checkout.core.common.CheckoutContext
 import com.adyen.checkout.core.common.internal.CheckoutParams
 import com.adyen.checkout.core.components.CheckoutCallbacks
-import com.adyen.checkout.core.components.CheckoutTarget
-import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethods
+import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
+import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethodResponse
+import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPaymentMethod
 import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import kotlinx.coroutines.CoroutineScope
 
 internal object PaymentComponentResolver {
 
-    @Suppress("LongParameterList")
     fun resolve(
-        target: CheckoutTarget,
-        context: CheckoutContext,
+        paymentMethod: PaymentMethodResponse,
         callbacks: CheckoutCallbacks,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
         sdkDataProvider: SdkDataProvider,
         checkoutParams: CheckoutParams,
     ): PaymentComponentResult {
-        return when (target) {
-            is CheckoutTarget.PaymentMethod -> resolvePaymentMethod(
-                target = target,
-                context = context,
+        return when (paymentMethod) {
+            is PaymentMethod -> resolvePaymentMethod(
+                paymentMethod = paymentMethod,
                 callbacks = callbacks,
                 coroutineScope = coroutineScope,
                 analyticsManager = analyticsManager,
@@ -40,37 +37,26 @@ internal object PaymentComponentResolver {
                 checkoutParams = checkoutParams,
             )
 
-            is CheckoutTarget.StoredPaymentMethod -> resolveStoredPaymentMethod(
-                target = target,
-                context = context,
+            is StoredPaymentMethod -> resolveStoredPaymentMethod(
+                paymentMethod = paymentMethod,
                 coroutineScope = coroutineScope,
                 analyticsManager = analyticsManager,
                 sdkDataProvider = sdkDataProvider,
                 checkoutParams = checkoutParams,
             )
 
-            else -> PaymentComponentResult.Failure("Unsupported checkout target.")
+            else -> PaymentComponentResult.Failure("Unsupported payment method response type.")
         }
     }
 
-    @Suppress("LongParameterList", "ReturnCount")
     private fun resolvePaymentMethod(
-        target: CheckoutTarget.PaymentMethod,
-        context: CheckoutContext,
+        paymentMethod: PaymentMethod,
         callbacks: CheckoutCallbacks,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
         sdkDataProvider: SdkDataProvider,
         checkoutParams: CheckoutParams,
     ): PaymentComponentResult {
-        val paymentMethods = context.getPaymentMethodResponse()?.paymentMethods
-            ?: return PaymentComponentResult.Failure("No payment methods response available.")
-
-        val paymentMethod = paymentMethods.find { it.type == target.type }
-            ?: return PaymentComponentResult.Failure(
-                "Payment method '${target.type}' was not found in the payment methods response.",
-            )
-
         val component = PaymentMethodProvider.getPaymentComponent(
             paymentMethod = paymentMethod,
             coroutineScope = coroutineScope,
@@ -79,49 +65,31 @@ internal object PaymentComponentResolver {
             params = checkoutParams,
             additionalCallbacks = callbacks.additionalCallbacks,
         ) ?: return PaymentComponentResult.Failure(
-            "Payment method '${target.type}' is not supported. " +
+            "Payment method '${paymentMethod.type}' is not supported. " +
                 "Ensure the corresponding module is included in your build dependencies.",
         )
 
         return PaymentComponentResult.Success(component)
     }
 
-    @Suppress("ReturnCount")
     private fun resolveStoredPaymentMethod(
-        target: CheckoutTarget.StoredPaymentMethod,
-        context: CheckoutContext,
+        paymentMethod: StoredPaymentMethod,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
         sdkDataProvider: SdkDataProvider,
         checkoutParams: CheckoutParams,
     ): PaymentComponentResult {
-        val storedPaymentMethods = context.getPaymentMethodResponse()?.storedPaymentMethods
-            ?: return PaymentComponentResult.Failure("No payment methods response available.")
-
-        val storedPaymentMethod = storedPaymentMethods.find { it.id == target.id }
-            ?: return PaymentComponentResult.Failure(
-                "Stored payment method with id '${target.id}' was not found in the payment methods response.",
-            )
-
         val component = PaymentMethodProvider.getStoredPaymentComponent(
-            storedPaymentMethod = storedPaymentMethod,
+            storedPaymentMethod = paymentMethod,
             coroutineScope = coroutineScope,
             analyticsManager = analyticsManager,
             sdkDataProvider = sdkDataProvider,
             params = checkoutParams,
         ) ?: return PaymentComponentResult.Failure(
-            "Stored payment method type '${storedPaymentMethod.type}' is not supported. " +
+            "Stored payment method type '${paymentMethod.type}' is not supported. " +
                 "Ensure the corresponding module is included in your build dependencies.",
         )
 
         return PaymentComponentResult.Success(component)
-    }
-
-    private fun CheckoutContext.getPaymentMethodResponse(): PaymentMethods? {
-        return when (this) {
-            is CheckoutContext.Advanced -> paymentMethods
-            is CheckoutContext.Sessions -> checkoutSession.sessionSetupResponse.paymentMethods
-            is CheckoutContext.ActionOnly -> null
-        }
     }
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentComponentResolver.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentComponentResolver.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.CoroutineScope
 
 internal object PaymentComponentResolver {
 
+    @Suppress("LongParameterList")
     fun resolve(
         paymentMethod: PaymentMethodResponse,
         callbacks: CheckoutCallbacks,
@@ -49,6 +50,7 @@ internal object PaymentComponentResolver {
         }
     }
 
+    @Suppress("LongParameterList")
     private fun resolvePaymentMethod(
         paymentMethod: PaymentMethod,
         callbacks: CheckoutCallbacks,

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentComponentResolver.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentComponentResolver.kt
@@ -14,6 +14,7 @@ import com.adyen.checkout.core.common.internal.CheckoutParams
 import com.adyen.checkout.core.components.CheckoutCallbacks
 import com.adyen.checkout.core.components.CheckoutTarget
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethods
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import kotlinx.coroutines.CoroutineScope
 
 internal object PaymentComponentResolver {
@@ -25,6 +26,7 @@ internal object PaymentComponentResolver {
         callbacks: CheckoutCallbacks,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         checkoutParams: CheckoutParams,
     ): PaymentComponentResult {
         return when (target) {
@@ -34,6 +36,7 @@ internal object PaymentComponentResolver {
                 callbacks = callbacks,
                 coroutineScope = coroutineScope,
                 analyticsManager = analyticsManager,
+                sdkDataProvider = sdkDataProvider,
                 checkoutParams = checkoutParams,
             )
 
@@ -42,6 +45,7 @@ internal object PaymentComponentResolver {
                 context = context,
                 coroutineScope = coroutineScope,
                 analyticsManager = analyticsManager,
+                sdkDataProvider = sdkDataProvider,
                 checkoutParams = checkoutParams,
             )
 
@@ -56,6 +60,7 @@ internal object PaymentComponentResolver {
         callbacks: CheckoutCallbacks,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         checkoutParams: CheckoutParams,
     ): PaymentComponentResult {
         val paymentMethods = context.getPaymentMethodResponse()?.paymentMethods
@@ -70,6 +75,7 @@ internal object PaymentComponentResolver {
             paymentMethod = paymentMethod,
             coroutineScope = coroutineScope,
             analyticsManager = analyticsManager,
+            sdkDataProvider = sdkDataProvider,
             params = checkoutParams,
             additionalCallbacks = callbacks.additionalCallbacks,
         ) ?: return PaymentComponentResult.Failure(
@@ -86,6 +92,7 @@ internal object PaymentComponentResolver {
         context: CheckoutContext,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         checkoutParams: CheckoutParams,
     ): PaymentComponentResult {
         val storedPaymentMethods = context.getPaymentMethodResponse()?.storedPaymentMethods
@@ -100,6 +107,7 @@ internal object PaymentComponentResolver {
             storedPaymentMethod = storedPaymentMethod,
             coroutineScope = coroutineScope,
             analyticsManager = analyticsManager,
+            sdkDataProvider = sdkDataProvider,
             params = checkoutParams,
         ) ?: return PaymentComponentResult.Failure(
             "Stored payment method type '${storedPaymentMethod.type}' is not supported. " +

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentMethodProvider.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentMethodProvider.kt
@@ -16,6 +16,7 @@ import com.adyen.checkout.core.components.CheckoutAdditionalCallback
 import com.adyen.checkout.core.components.data.model.paymentmethod.GenericPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPaymentMethod
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.core.components.internal.ui.GenericPaymentComponentFactory
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
 import kotlinx.coroutines.CoroutineScope
@@ -44,6 +45,7 @@ object PaymentMethodProvider {
         paymentMethod: PaymentMethod,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         params: CheckoutParams,
         additionalCallbacks: Set<CheckoutAdditionalCallback>,
     ): PaymentComponent? {
@@ -59,6 +61,7 @@ object PaymentMethodProvider {
             paymentMethod = paymentMethod,
             coroutineScope = coroutineScope,
             analyticsManager = analyticsManager,
+            sdkDataProvider = sdkDataProvider,
             params = params,
             additionalCallbacks = additionalCallbacks,
         )
@@ -68,6 +71,7 @@ object PaymentMethodProvider {
         storedPaymentMethod: StoredPaymentMethod,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         params: CheckoutParams,
     ): PaymentComponent? {
         val txVariant = storedPaymentMethod.type
@@ -76,6 +80,7 @@ object PaymentMethodProvider {
             storedPaymentMethod = storedPaymentMethod,
             coroutineScope = coroutineScope,
             analyticsManager = analyticsManager,
+            sdkDataProvider = sdkDataProvider,
             params = params,
         )
     }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentMethodProvider.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentMethodProvider.kt
@@ -41,6 +41,7 @@ object PaymentMethodProvider {
         }
     }
 
+    @Suppress("LongParameterList")
     fun getPaymentComponent(
         paymentMethod: PaymentMethod,
         coroutineScope: CoroutineScope,

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentMethodResolver.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentMethodResolver.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 23/6/2026.
+ */
+
+package com.adyen.checkout.core.components.internal
+
+import com.adyen.checkout.core.common.AdyenLogLevel
+import com.adyen.checkout.core.common.CheckoutContext
+import com.adyen.checkout.core.common.internal.helper.adyenLog
+import com.adyen.checkout.core.components.CheckoutTarget
+import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethodResponse
+import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethods
+
+internal object PaymentMethodResolver {
+
+    fun resolve(
+        target: CheckoutTarget,
+        context: CheckoutContext,
+    ): PaymentMethodResponse? {
+        return when (target) {
+            is CheckoutTarget.PaymentMethod -> resolvePaymentMethod(
+                target = target,
+                context = context,
+            )
+
+            is CheckoutTarget.StoredPaymentMethod -> resolveStoredPaymentMethod(
+                target = target,
+                context = context,
+            )
+
+            else -> {
+                adyenLog(AdyenLogLevel.WARN) { "Invalid target: $target" }
+                null
+            }
+        }
+    }
+
+    private fun resolvePaymentMethod(
+        target: CheckoutTarget.PaymentMethod,
+        context: CheckoutContext,
+    ): PaymentMethodResponse? {
+        val paymentMethods = context.getPaymentMethodResponse()?.paymentMethods
+        return paymentMethods?.find { it.type == target.type }
+    }
+
+    private fun resolveStoredPaymentMethod(
+        target: CheckoutTarget.StoredPaymentMethod,
+        context: CheckoutContext,
+    ): PaymentMethodResponse? {
+        val storedPaymentMethods = context.getPaymentMethodResponse()?.storedPaymentMethods
+        return storedPaymentMethods?.find { it.id == target.id }
+    }
+
+    private fun CheckoutContext.getPaymentMethodResponse(): PaymentMethods? {
+        return when (this) {
+            is CheckoutContext.Advanced -> paymentMethods
+            is CheckoutContext.Sessions -> checkoutSession.sessionSetupResponse.paymentMethods
+            is CheckoutContext.ActionOnly -> null
+        }
+    }
+}

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/StoredPaymentComponentFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/StoredPaymentComponentFactory.kt
@@ -12,6 +12,7 @@ import androidx.annotation.RestrictTo
 import com.adyen.checkout.core.analytics.internal.AnalyticsManager
 import com.adyen.checkout.core.common.internal.CheckoutParams
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPaymentMethod
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
 import kotlinx.coroutines.CoroutineScope
 
@@ -25,6 +26,7 @@ interface StoredPaymentComponentFactory<T : PaymentComponent> : ComponentFactory
         storedPaymentMethod: StoredPaymentMethod,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         params: CheckoutParams,
     ): T
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/data/provider/DefaultSdkDataProvider.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/data/provider/DefaultSdkDataProvider.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.core.components.internal.data.provider
 
 import androidx.annotation.RestrictTo
-import com.adyen.checkout.core.analytics.internal.AnalyticsManager
 import com.adyen.checkout.core.common.AdyenLogLevel
 import com.adyen.checkout.core.common.internal.helper.adyenLog
 import com.adyen.checkout.core.components.internal.data.model.sdkData.Analytics
@@ -27,7 +26,7 @@ import kotlin.io.encoding.ExperimentalEncodingApi
 @OptIn(DirectSdkDataCreation::class)
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class DefaultSdkDataProvider(
-    private val analyticsManager: AnalyticsManager
+    private val checkoutAttemptId: String,
 ) : SdkDataProvider {
 
     @OptIn(ExperimentalEncodingApi::class)
@@ -53,7 +52,7 @@ class DefaultSdkDataProvider(
         return SdkData(
             schemaVersion = SCHEMA_VERSION,
             analytics = Analytics(
-                checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
+                checkoutAttemptId = checkoutAttemptId,
             ),
             authentication = authentication,
             createdAt = Date().time,

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/GenericPaymentComponent.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/GenericPaymentComponent.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.receiveAsFlow
 
 internal class GenericPaymentComponent(
-    private val analyticsManager: AnalyticsManager,
+    @Suppress("unused") private val analyticsManager: AnalyticsManager,
     private val paymentMethodType: String,
     private val sdkDataProvider: SdkDataProvider,
 ) : PaymentComponent {

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/GenericPaymentComponentFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/GenericPaymentComponentFactory.kt
@@ -13,7 +13,7 @@ import com.adyen.checkout.core.common.internal.CheckoutParams
 import com.adyen.checkout.core.components.CheckoutAdditionalCallback
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
 import com.adyen.checkout.core.components.internal.PaymentComponentFactory
-import com.adyen.checkout.core.components.internal.data.provider.DefaultSdkDataProvider
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import kotlinx.coroutines.CoroutineScope
 
 internal object GenericPaymentComponentFactory : PaymentComponentFactory<GenericPaymentComponent> {
@@ -22,13 +22,14 @@ internal object GenericPaymentComponentFactory : PaymentComponentFactory<Generic
         paymentMethod: PaymentMethod,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         params: CheckoutParams,
         additionalCallbacks: Set<CheckoutAdditionalCallback>
     ): GenericPaymentComponent {
         return GenericPaymentComponent(
             analyticsManager = analyticsManager,
             paymentMethodType = paymentMethod.type,
-            sdkDataProvider = DefaultSdkDataProvider(analyticsManager),
+            sdkDataProvider = sdkDataProvider,
         )
     }
 }

--- a/core/src/test/java/com/adyen/checkout/core/analytics/internal/DefaultAnalyticsManagerTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/analytics/internal/DefaultAnalyticsManagerTest.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -186,13 +185,6 @@ internal class DefaultAnalyticsManagerTest(
 
             verify(analyticsRepository, times(2)).sendEvents(any())
         }
-    }
-
-    @Test
-    fun `when getCheckoutAttemptId is called, then returns provided id`() = runTest {
-        val analyticsManager = createAnalyticsManager(analyticsParamsLevel = AnalyticsParamsLevel.INITIAL)
-
-        assertEquals("test-id", analyticsManager.getCheckoutAttemptId())
     }
 
     private fun createAnalyticsManager(

--- a/core/src/test/java/com/adyen/checkout/core/analytics/internal/TestAnalyticsManager.kt
+++ b/core/src/test/java/com/adyen/checkout/core/analytics/internal/TestAnalyticsManager.kt
@@ -49,8 +49,6 @@ class TestAnalyticsManager : AnalyticsManager {
         return re.matches(actual)
     }
 
-    override fun getCheckoutAttemptId(): String = checkoutAttemptId
-
     fun setCheckoutAttemptId(checkoutAttemptId: String) {
         this.checkoutAttemptId = checkoutAttemptId
     }

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/FailureCheckoutFlowTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/FailureCheckoutFlowTest.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 23/6/2026.
+ */
+
+package com.adyen.checkout.core.components.internal
+
+import com.adyen.checkout.core.error.CheckoutError
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+internal class FailureCheckoutFlowTest {
+
+    @Nested
+    inner class InitTest {
+
+        @Test
+        fun `when created, then failure is emitted with the error message`() {
+            val dispatcher = TestComponentRequestDispatcher()
+
+            FailureCheckoutFlow(
+                errorMessage = "test error",
+                componentRequestDispatcher = dispatcher,
+            )
+
+            assertEquals(
+                CheckoutError(
+                    code = CheckoutError.ErrorCode.PAYMENT_METHOD_FAILURE,
+                    message = "test error",
+                ),
+                dispatcher.lastFailure,
+            )
+        }
+    }
+
+    @Nested
+    inner class PropertiesTest {
+
+        @Test
+        fun `when created, then paymentComponent is null`() {
+            val flow = createFailedCheckoutFlow()
+
+            assertNull(flow.paymentComponent)
+        }
+
+        @Test
+        fun `when created, then actionComponent is null`() {
+            val flow = createFailedCheckoutFlow()
+
+            assertNull(flow.actionComponent)
+        }
+
+        @Test
+        fun `when created, then paymentMethodNavigation emits nothing`() = runTest {
+            val flow = createFailedCheckoutFlow()
+
+            val result = runCatching { flow.paymentMethodNavigation.first() }
+
+            assertFalse(result.isSuccess)
+        }
+
+        @Test
+        fun `when created, then secondaryNavigation emits nothing`() = runTest {
+            val flow = createFailedCheckoutFlow()
+
+            val result = runCatching { flow.secondaryNavigation.first() }
+
+            assertFalse(result.isSuccess)
+        }
+    }
+
+    @Nested
+    inner class SubmitTest {
+
+        @Test
+        fun `when submit is called, then failure is emitted with cannot submit message`() {
+            val dispatcher = TestComponentRequestDispatcher()
+            val flow = FailureCheckoutFlow(
+                errorMessage = "test error",
+                componentRequestDispatcher = dispatcher,
+            )
+            dispatcher.lastFailure = null
+
+            flow.submit()
+
+            assertEquals(
+                CheckoutError(
+                    code = CheckoutError.ErrorCode.PAYMENT_METHOD_FAILURE,
+                    message = "Cannot submit: test error",
+                ),
+                dispatcher.lastFailure,
+            )
+        }
+    }
+
+    @Nested
+    inner class RequiresUserInteractionTest {
+
+        @Test
+        fun `when requiresUserInteraction is called, then false is returned`() {
+            val flow = createFailedCheckoutFlow()
+
+            assertFalse(flow.requiresUserInteraction())
+        }
+    }
+
+    private fun createFailedCheckoutFlow(
+        errorMessage: String = "test error",
+    ) = FailureCheckoutFlow(
+        errorMessage = errorMessage,
+        componentRequestDispatcher = TestComponentRequestDispatcher(),
+    )
+
+    private class TestComponentRequestDispatcher : ComponentRequestDispatcher {
+
+        var lastFailure: CheckoutError? = null
+
+        override suspend fun additionalDetails(
+            data: com.adyen.checkout.core.action.data.ActionComponentData,
+        ) = com.adyen.checkout.core.components.AdditionalDetailsResult.Completion("")
+
+        override fun complete(resultCode: com.adyen.checkout.core.common.CheckoutResultCode) = Unit
+
+        override fun failure(error: CheckoutError) {
+            lastFailure = error
+        }
+    }
+}

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/FullCheckoutFlowTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/FullCheckoutFlowTest.kt
@@ -19,6 +19,7 @@ import com.adyen.checkout.core.components.CheckoutPaymentMethodRoute
 import com.adyen.checkout.core.components.CheckoutSecondaryRoute
 import com.adyen.checkout.core.components.SubmitResult
 import com.adyen.checkout.core.components.data.PaymentComponentData
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
 import com.adyen.checkout.core.components.internal.ui.TestPaymentComponent
 import com.adyen.checkout.core.components.paymentmethod.PaymentComponentState
@@ -233,6 +234,7 @@ internal class FullCheckoutFlowTest(
                     paymentMethod: com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod,
                     coroutineScope: CoroutineScope,
                     analyticsManager: AnalyticsManager,
+                    sdkDataProvider: SdkDataProvider,
                     params: CheckoutParams,
                     additionalCallbacks: Set<CheckoutAdditionalCallback>,
                 ) = component

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentComponentResolverTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentComponentResolverTest.kt
@@ -8,30 +8,25 @@
 
 package com.adyen.checkout.core.components.internal
 
-import com.adyen.checkout.core.action.data.RedirectAction
+import android.os.Parcel
 import com.adyen.checkout.core.analytics.internal.AnalyticsManager
 import com.adyen.checkout.core.analytics.internal.TestAnalyticsManager
-import com.adyen.checkout.core.common.CheckoutContext
 import com.adyen.checkout.core.common.Environment
 import com.adyen.checkout.core.common.internal.CheckoutParams
 import com.adyen.checkout.core.components.AdditionalDetailsResult
 import com.adyen.checkout.core.components.AdvancedCheckoutCallbacks
 import com.adyen.checkout.core.components.CheckoutAdditionalCallback
-import com.adyen.checkout.core.components.CheckoutConfiguration
-import com.adyen.checkout.core.components.CheckoutTarget
 import com.adyen.checkout.core.components.SubmitResult
+import com.adyen.checkout.core.components.data.model.paymentmethod.CardPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.GenericPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
-import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethods
+import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethodResponse
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredBLIKPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPaymentMethod
-import com.adyen.checkout.core.components.data.model.paymentmethod.UnsupportedPaymentMethod
 import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.core.components.internal.data.provider.TestSdkDataProvider
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
 import com.adyen.checkout.core.components.internal.ui.TestPaymentComponent
-import com.adyen.checkout.core.sessions.CheckoutSession
-import com.adyen.checkout.core.sessions.internal.data.model.SessionSetupResponse
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -47,40 +42,14 @@ internal class PaymentComponentResolverTest {
     }
 
     @Test
-    fun `when payment methods response has no payment methods, then Failure is returned`() = runTest {
-        val result = resolve(
-            target = CheckoutTarget.PaymentMethod("scheme"),
-            paymentMethods = PaymentMethods(paymentMethods = null),
-        )
-
-        assertEquals(PaymentComponentResult.Failure("No payment methods response available."), result)
-    }
-
-    @Test
-    fun `when target payment method is not in the response, then Failure is returned`() = runTest {
-        val result = resolve(
-            target = CheckoutTarget.PaymentMethod("scheme"),
-            paymentMethods = PaymentMethods(
-                paymentMethods = listOf(GenericPaymentMethod(type = "ideal", name = "iDEAL")),
-            ),
-        )
-
-        assertEquals(
-            PaymentComponentResult.Failure(
-                "Payment method 'scheme' was not found in the payment methods response.",
-            ),
-            result,
-        )
-    }
-
-    @Test
     fun `when payment method is not supported, then Failure is returned`() = runTest {
-        val result = resolve(
-            target = CheckoutTarget.PaymentMethod("scheme"),
-            paymentMethods = PaymentMethods(
-                paymentMethods = listOf(UnsupportedPaymentMethod(type = "scheme", name = "Card")),
-            ),
+        val paymentMethod = CardPaymentMethod(
+            type = "scheme",
+            name = "Card",
+            brands = emptyList(),
+            fundingSource = null,
         )
+        val result = resolve(paymentMethod)
 
         assertEquals(
             PaymentComponentResult.Failure(
@@ -92,52 +61,13 @@ internal class PaymentComponentResolverTest {
     }
 
     @Test
-    fun `when payment methods response has no stored payment methods, then Failure is returned`() = runTest {
-        val result = resolve(
-            target = CheckoutTarget.StoredPaymentMethod("test_id"),
-            paymentMethods = PaymentMethods(storedPaymentMethods = null),
-        )
-
-        assertEquals(PaymentComponentResult.Failure("No payment methods response available."), result)
-    }
-
-    @Test
-    fun `when target stored payment method is not in the response, then Failure is returned`() = runTest {
-        val result = resolve(
-            target = CheckoutTarget.StoredPaymentMethod("test_id"),
-            paymentMethods = PaymentMethods(
-                storedPaymentMethods = listOf(
-                    StoredBLIKPaymentMethod(
-                        type = "blik",
-                        name = "BLIK",
-                        id = "other_id",
-                        supportedShopperInteractions = emptyList(),
-                    ),
-                ),
-            ),
-        )
-
-        assertEquals(
-            PaymentComponentResult.Failure(
-                "Stored payment method with id 'test_id' was not found in the payment methods response.",
-            ),
-            result,
-        )
-    }
-
-    @Test
     fun `when stored payment method is not supported, then Failure is returned`() = runTest {
         val result = resolve(
-            target = CheckoutTarget.StoredPaymentMethod("test_id"),
-            paymentMethods = PaymentMethods(
-                storedPaymentMethods = listOf(
-                    StoredBLIKPaymentMethod(
-                        type = "blik",
-                        name = "BLIK",
-                        id = "test_id",
-                        supportedShopperInteractions = emptyList(),
-                    ),
-                ),
+            StoredBLIKPaymentMethod(
+                type = "blik",
+                name = "BLIK",
+                id = "test_id",
+                supportedShopperInteractions = emptyList(),
             ),
         )
 
@@ -151,13 +81,19 @@ internal class PaymentComponentResolverTest {
     }
 
     @Test
-    fun `when checkout target is unknown, then Failure is returned`() = runTest {
+    fun `when payment method response type is unsupported, then Failure is returned`() = runTest {
         val result = resolve(
-            target = object : CheckoutTarget {},
-            paymentMethods = PaymentMethods(),
+            object : PaymentMethodResponse() {
+                override val type: String = "unknown"
+                override val name: String = "Unknown"
+                override fun writeToParcel(dest: Parcel, flags: Int) = Unit
+            },
         )
 
-        assertEquals(PaymentComponentResult.Failure("Unsupported checkout target."), result)
+        assertEquals(
+            PaymentComponentResult.Failure("Unsupported payment method response type."),
+            result,
+        )
     }
 
     @Test
@@ -165,12 +101,7 @@ internal class PaymentComponentResolverTest {
         val component = TestPaymentComponent()
         registerFactory(type = "scheme", component = component)
 
-        val result = resolve(
-            target = CheckoutTarget.PaymentMethod("scheme"),
-            paymentMethods = PaymentMethods(
-                paymentMethods = listOf(GenericPaymentMethod(type = "scheme", name = "Card")),
-            ),
-        )
+        val result = resolve(GenericPaymentMethod(type = "scheme", name = "Card"))
 
         assertEquals(PaymentComponentResult.Success(component), result)
     }
@@ -181,121 +112,26 @@ internal class PaymentComponentResolverTest {
         registerStoredFactory(type = "blik", component = component)
 
         val result = resolve(
-            target = CheckoutTarget.StoredPaymentMethod("test_id"),
-            paymentMethods = PaymentMethods(
-                storedPaymentMethods = listOf(
-                    StoredBLIKPaymentMethod(
-                        type = "blik",
-                        name = "BLIK",
-                        id = "test_id",
-                        supportedShopperInteractions = emptyList(),
-                    ),
-                ),
+            StoredBLIKPaymentMethod(
+                type = "blik",
+                name = "BLIK",
+                id = "test_id",
+                supportedShopperInteractions = emptyList(),
             ),
-        )
-
-        assertEquals(PaymentComponentResult.Success(component), result)
-    }
-
-    @Test
-    fun `when context is ActionOnly, then Failure is returned`() = runTest {
-        val result = PaymentComponentResolver.resolve(
-            target = CheckoutTarget.PaymentMethod("scheme"),
-            context = actionOnlyContext(),
-            callbacks = advancedCallbacks(),
-            coroutineScope = this,
-            analyticsManager = TestAnalyticsManager(),
-            sdkDataProvider = TestSdkDataProvider(),
-            checkoutParams = checkoutParams(),
-        )
-
-        assertEquals(PaymentComponentResult.Failure("No payment methods response available."), result)
-    }
-
-    @Test
-    fun `when context is Sessions, then payment methods are resolved from the session setup response`() = runTest {
-        val component = TestPaymentComponent()
-        registerFactory(type = "scheme", component = component)
-
-        val result = PaymentComponentResolver.resolve(
-            target = CheckoutTarget.PaymentMethod("scheme"),
-            context = sessionsContext(
-                PaymentMethods(
-                    paymentMethods = listOf(GenericPaymentMethod(type = "scheme", name = "Card")),
-                ),
-            ),
-            callbacks = advancedCallbacks(),
-            coroutineScope = this,
-            analyticsManager = TestAnalyticsManager(),
-            sdkDataProvider = TestSdkDataProvider(),
-            checkoutParams = checkoutParams(),
         )
 
         assertEquals(PaymentComponentResult.Success(component), result)
     }
 
     private fun CoroutineScope.resolve(
-        target: CheckoutTarget,
-        paymentMethods: PaymentMethods,
+        paymentMethod: PaymentMethodResponse,
     ): PaymentComponentResult = PaymentComponentResolver.resolve(
-        target = target,
-        context = advancedContext(paymentMethods),
+        paymentMethod = paymentMethod,
         callbacks = advancedCallbacks(),
         coroutineScope = this,
         analyticsManager = TestAnalyticsManager(),
         sdkDataProvider = TestSdkDataProvider(),
         checkoutParams = checkoutParams(),
-    )
-
-    private fun advancedContext(paymentMethods: PaymentMethods) = CheckoutContext.Advanced(
-        paymentMethods = paymentMethods,
-        checkoutConfiguration = CheckoutConfiguration(
-            environment = Environment.TEST,
-            clientKey = TEST_CLIENT_KEY,
-            shopperLocale = Locale.US,
-        ),
-        checkoutAttemptId = "",
-        publicKey = null,
-    )
-
-    private fun actionOnlyContext() = CheckoutContext.ActionOnly(
-        action = RedirectAction(
-            type = "redirect",
-            paymentData = "test_data",
-            paymentMethodType = "scheme",
-        ),
-        checkoutConfiguration = CheckoutConfiguration(
-            environment = Environment.TEST,
-            clientKey = TEST_CLIENT_KEY,
-            shopperLocale = Locale.US,
-        ),
-        checkoutAttemptId = "",
-        publicKey = null,
-    )
-
-    private fun sessionsContext(paymentMethods: PaymentMethods) = CheckoutContext.Sessions(
-        checkoutSession = CheckoutSession(
-            sessionSetupResponse = SessionSetupResponse(
-                id = "test_session_id",
-                sessionData = "test_session_data",
-                amount = null,
-                expiresAt = "2026-12-31T23:59:59Z",
-                paymentMethods = paymentMethods,
-                returnUrl = null,
-                configuration = null,
-                shopperLocale = null,
-            ),
-            order = null,
-            environment = Environment.TEST,
-            clientKey = TEST_CLIENT_KEY,
-        ),
-        checkoutConfiguration = CheckoutConfiguration(
-            environment = Environment.TEST,
-            clientKey = TEST_CLIENT_KEY,
-            shopperLocale = Locale.US,
-        ),
-        checkoutAttemptId = "",
-        publicKey = null,
     )
 
     private fun advancedCallbacks() = AdvancedCheckoutCallbacks(

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentComponentResolverTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentComponentResolverTest.kt
@@ -26,6 +26,8 @@ import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredBLIKPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.UnsupportedPaymentMethod
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
+import com.adyen.checkout.core.components.internal.data.provider.TestSdkDataProvider
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
 import com.adyen.checkout.core.components.internal.ui.TestPaymentComponent
 import com.adyen.checkout.core.sessions.CheckoutSession
@@ -203,6 +205,7 @@ internal class PaymentComponentResolverTest {
             callbacks = advancedCallbacks(),
             coroutineScope = this,
             analyticsManager = TestAnalyticsManager(),
+            sdkDataProvider = TestSdkDataProvider(),
             checkoutParams = checkoutParams(),
         )
 
@@ -224,6 +227,7 @@ internal class PaymentComponentResolverTest {
             callbacks = advancedCallbacks(),
             coroutineScope = this,
             analyticsManager = TestAnalyticsManager(),
+            sdkDataProvider = TestSdkDataProvider(),
             checkoutParams = checkoutParams(),
         )
 
@@ -239,6 +243,7 @@ internal class PaymentComponentResolverTest {
         callbacks = advancedCallbacks(),
         coroutineScope = this,
         analyticsManager = TestAnalyticsManager(),
+        sdkDataProvider = TestSdkDataProvider(),
         checkoutParams = checkoutParams(),
     )
 
@@ -319,6 +324,7 @@ internal class PaymentComponentResolverTest {
                     paymentMethod: PaymentMethod,
                     coroutineScope: CoroutineScope,
                     analyticsManager: AnalyticsManager,
+                    sdkDataProvider: SdkDataProvider,
                     params: CheckoutParams,
                     additionalCallbacks: Set<CheckoutAdditionalCallback>,
                 ): PaymentComponent = component
@@ -334,6 +340,7 @@ internal class PaymentComponentResolverTest {
                     storedPaymentMethod: StoredPaymentMethod,
                     coroutineScope: CoroutineScope,
                     analyticsManager: AnalyticsManager,
+                    sdkDataProvider: SdkDataProvider,
                     params: CheckoutParams,
                 ): PaymentComponent = component
             },

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentMethodProviderTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentMethodProviderTest.kt
@@ -18,6 +18,8 @@ import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredBLIKPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.UnsupportedPaymentMethod
+import com.adyen.checkout.core.components.internal.data.provider.DefaultSdkDataProvider
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.core.components.internal.ui.GenericPaymentComponent
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
 import com.adyen.checkout.core.components.internal.ui.TestPaymentComponent
@@ -113,6 +115,7 @@ internal class PaymentMethodProviderTest {
                 paymentMethod = GenericPaymentMethod(type = "txVariant", name = "name"),
                 coroutineScope = this,
                 analyticsManager = TestAnalyticsManager(),
+                sdkDataProvider = generateSdkDataProvider(),
                 params = generateCheckoutParams(),
                 additionalCallbacks = emptySet(),
             )
@@ -141,6 +144,7 @@ internal class PaymentMethodProviderTest {
                 ),
                 coroutineScope = this,
                 analyticsManager = TestAnalyticsManager(),
+                sdkDataProvider = generateSdkDataProvider(),
                 params = generateCheckoutParams(),
             )
             assertEquals(1, PaymentMethodProvider.getStoredFactoriesCount())
@@ -173,6 +177,7 @@ internal class PaymentMethodProviderTest {
                 paymentMethod = GenericPaymentMethod(type = "txVariant", name = "name"),
                 coroutineScope = this,
                 analyticsManager = TestAnalyticsManager(),
+                sdkDataProvider = generateSdkDataProvider(),
                 params = generateCheckoutParams(),
                 additionalCallbacks = emptySet(),
             )
@@ -194,6 +199,7 @@ internal class PaymentMethodProviderTest {
                 ),
                 coroutineScope = this,
                 analyticsManager = TestAnalyticsManager(),
+                sdkDataProvider = generateSdkDataProvider(),
                 params = generateCheckoutParams(),
             )
             assertEquals(1, PaymentMethodProvider.getStoredFactoriesCount())
@@ -207,6 +213,7 @@ internal class PaymentMethodProviderTest {
                 paymentMethod = GenericPaymentMethod(type = "unregistered_txVariant", name = "name"),
                 coroutineScope = this,
                 analyticsManager = TestAnalyticsManager(),
+                sdkDataProvider = generateSdkDataProvider(),
                 params = generateCheckoutParams(),
                 additionalCallbacks = emptySet(),
             )
@@ -220,6 +227,7 @@ internal class PaymentMethodProviderTest {
                 paymentMethod = UnsupportedPaymentMethod(type = "unregistered_txVariant", name = "name"),
                 coroutineScope = this,
                 analyticsManager = TestAnalyticsManager(),
+                sdkDataProvider = generateSdkDataProvider(),
                 params = generateCheckoutParams(),
                 additionalCallbacks = emptySet(),
             )
@@ -237,6 +245,7 @@ internal class PaymentMethodProviderTest {
             ),
             coroutineScope = this,
             analyticsManager = TestAnalyticsManager(),
+            sdkDataProvider = generateSdkDataProvider(),
             params = generateCheckoutParams(),
         )
         assertNull(actualComponent)
@@ -263,6 +272,7 @@ internal class PaymentMethodProviderTest {
                 paymentMethod: PaymentMethod,
                 coroutineScope: CoroutineScope,
                 analyticsManager: AnalyticsManager,
+                sdkDataProvider: SdkDataProvider,
                 params: CheckoutParams,
                 additionalCallbacks: Set<CheckoutAdditionalCallback>,
             ) = paymentComponent
@@ -275,9 +285,12 @@ internal class PaymentMethodProviderTest {
                 storedPaymentMethod: StoredPaymentMethod,
                 coroutineScope: CoroutineScope,
                 analyticsManager: AnalyticsManager,
+                sdkDataProvider: SdkDataProvider,
                 params: CheckoutParams,
             ) = paymentComponent
         }
+
+    private fun generateSdkDataProvider() = DefaultSdkDataProvider("test-checkout-attempt-id")
 
     private fun generateCheckoutParams() = CheckoutParams(
         shopperLocale = Locale.US,

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentMethodResolverTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentMethodResolverTest.kt
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 23/6/2026.
+ */
+
+package com.adyen.checkout.core.components.internal
+
+import com.adyen.checkout.core.action.data.RedirectAction
+import com.adyen.checkout.core.common.CheckoutContext
+import com.adyen.checkout.core.common.Environment
+import com.adyen.checkout.core.components.CheckoutConfiguration
+import com.adyen.checkout.core.components.CheckoutTarget
+import com.adyen.checkout.core.components.data.model.paymentmethod.GenericPaymentMethod
+import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethods
+import com.adyen.checkout.core.components.data.model.paymentmethod.StoredUnsupportedPaymentMethod
+import com.adyen.checkout.core.sessions.CheckoutSession
+import com.adyen.checkout.core.sessions.internal.data.model.SessionSetupResponse
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.Locale
+
+internal class PaymentMethodResolverTest {
+
+    @Nested
+    inner class PaymentMethodTargetTest {
+
+        @Test
+        fun `when payment method is found, then it is returned`() {
+            val expected = GenericPaymentMethod(type = "scheme", name = "Card")
+            val context = advancedContext(
+                PaymentMethods(paymentMethods = listOf(expected)),
+            )
+
+            val result = PaymentMethodResolver.resolve(
+                target = CheckoutTarget.PaymentMethod("scheme"),
+                context = context,
+            )
+
+            assertEquals(expected, result)
+        }
+
+        @Test
+        fun `when payment method is not found, then null is returned`() {
+            val context = advancedContext(
+                PaymentMethods(
+                    paymentMethods = listOf(GenericPaymentMethod(type = "ideal", name = "iDEAL")),
+                ),
+            )
+
+            val result = PaymentMethodResolver.resolve(
+                target = CheckoutTarget.PaymentMethod("scheme"),
+                context = context,
+            )
+
+            assertNull(result)
+        }
+
+        @Test
+        fun `when payment methods list is null, then null is returned`() {
+            val context = advancedContext(
+                PaymentMethods(paymentMethods = null),
+            )
+
+            val result = PaymentMethodResolver.resolve(
+                target = CheckoutTarget.PaymentMethod("scheme"),
+                context = context,
+            )
+
+            assertNull(result)
+        }
+
+        @Test
+        fun `when multiple payment methods exist, then the matching one is returned`() {
+            val expected = GenericPaymentMethod(type = "scheme", name = "Card")
+            val context = advancedContext(
+                PaymentMethods(
+                    paymentMethods = listOf(
+                        GenericPaymentMethod(type = "ideal", name = "iDEAL"),
+                        expected,
+                        GenericPaymentMethod(type = "paypal", name = "PayPal"),
+                    ),
+                ),
+            )
+
+            val result = PaymentMethodResolver.resolve(
+                target = CheckoutTarget.PaymentMethod("scheme"),
+                context = context,
+            )
+
+            assertEquals(expected, result)
+        }
+    }
+
+    @Nested
+    inner class StoredPaymentMethodTargetTest {
+
+        @Test
+        fun `when stored payment method is found, then it is returned`() {
+            val expected = StoredUnsupportedPaymentMethod(
+                type = "scheme",
+                name = "Card",
+                id = "test_id",
+                supportedShopperInteractions = emptyList(),
+            )
+            val context = advancedContext(
+                PaymentMethods(storedPaymentMethods = listOf(expected)),
+            )
+
+            val result = PaymentMethodResolver.resolve(
+                target = CheckoutTarget.StoredPaymentMethod("test_id"),
+                context = context,
+            )
+
+            assertEquals(expected, result)
+        }
+
+        @Test
+        fun `when stored payment method is not found, then null is returned`() {
+            val context = advancedContext(
+                PaymentMethods(
+                    storedPaymentMethods = listOf(
+                        StoredUnsupportedPaymentMethod(
+                            type = "scheme",
+                            name = "Card",
+                            id = "other_id",
+                            supportedShopperInteractions = emptyList(),
+                        ),
+                    ),
+                ),
+            )
+
+            val result = PaymentMethodResolver.resolve(
+                target = CheckoutTarget.StoredPaymentMethod("test_id"),
+                context = context,
+            )
+
+            assertNull(result)
+        }
+
+        @Test
+        fun `when stored payment methods list is null, then null is returned`() {
+            val context = advancedContext(
+                PaymentMethods(storedPaymentMethods = null),
+            )
+
+            val result = PaymentMethodResolver.resolve(
+                target = CheckoutTarget.StoredPaymentMethod("test_id"),
+                context = context,
+            )
+
+            assertNull(result)
+        }
+
+        @Test
+        fun `when multiple stored payment methods exist, then the matching one is returned`() {
+            val expected = StoredUnsupportedPaymentMethod(
+                type = "scheme",
+                name = "Card",
+                id = "test_id",
+                supportedShopperInteractions = emptyList(),
+            )
+            val context = advancedContext(
+                PaymentMethods(
+                    storedPaymentMethods = listOf(
+                        StoredUnsupportedPaymentMethod(
+                            type = "blik",
+                            name = "BLIK",
+                            id = "other_id",
+                            supportedShopperInteractions = emptyList(),
+                        ),
+                        expected,
+                    ),
+                ),
+            )
+
+            val result = PaymentMethodResolver.resolve(
+                target = CheckoutTarget.StoredPaymentMethod("test_id"),
+                context = context,
+            )
+
+            assertEquals(expected, result)
+        }
+    }
+
+    @Nested
+    inner class UnknownTargetTest {
+
+        @Test
+        fun `when target is unknown, then null is returned`() {
+            val context = advancedContext(PaymentMethods())
+
+            val result = PaymentMethodResolver.resolve(
+                target = object : CheckoutTarget {},
+                context = context,
+            )
+
+            assertNull(result)
+        }
+    }
+
+    @Nested
+    inner class CheckoutContextTest {
+
+        @Test
+        fun `when context is ActionOnly, then null is returned`() {
+            val result = PaymentMethodResolver.resolve(
+                target = CheckoutTarget.PaymentMethod("scheme"),
+                context = actionOnlyContext(),
+            )
+
+            assertNull(result)
+        }
+
+        @Test
+        fun `when context is Sessions, then payment method is resolved from session setup response`() {
+            val expected = GenericPaymentMethod(type = "scheme", name = "Card")
+            val context = sessionsContext(
+                PaymentMethods(paymentMethods = listOf(expected)),
+            )
+
+            val result = PaymentMethodResolver.resolve(
+                target = CheckoutTarget.PaymentMethod("scheme"),
+                context = context,
+            )
+
+            assertEquals(expected, result)
+        }
+
+        @Test
+        fun `when context is Sessions, then stored payment method is resolved from session setup response`() {
+            val expected = StoredUnsupportedPaymentMethod(
+                type = "scheme",
+                name = "Card",
+                id = "test_id",
+                supportedShopperInteractions = emptyList(),
+            )
+            val context = sessionsContext(
+                PaymentMethods(storedPaymentMethods = listOf(expected)),
+            )
+
+            val result = PaymentMethodResolver.resolve(
+                target = CheckoutTarget.StoredPaymentMethod("test_id"),
+                context = context,
+            )
+
+            assertEquals(expected, result)
+        }
+
+        @Test
+        fun `when context is Sessions and payment methods are null, then null is returned`() {
+            val context = sessionsContext(paymentMethods = null)
+
+            val result = PaymentMethodResolver.resolve(
+                target = CheckoutTarget.PaymentMethod("scheme"),
+                context = context,
+            )
+
+            assertNull(result)
+        }
+    }
+
+    private fun advancedContext(paymentMethods: PaymentMethods) = CheckoutContext.Advanced(
+        paymentMethods = paymentMethods,
+        checkoutConfiguration = CheckoutConfiguration(
+            environment = Environment.TEST,
+            clientKey = TEST_CLIENT_KEY,
+            shopperLocale = Locale.US,
+        ),
+        checkoutAttemptId = "",
+        publicKey = null,
+    )
+
+    private fun actionOnlyContext() = CheckoutContext.ActionOnly(
+        action = RedirectAction(
+            type = "redirect",
+            paymentData = "test_data",
+            paymentMethodType = "scheme",
+        ),
+        checkoutConfiguration = CheckoutConfiguration(
+            environment = Environment.TEST,
+            clientKey = TEST_CLIENT_KEY,
+            shopperLocale = Locale.US,
+        ),
+        checkoutAttemptId = "",
+        publicKey = null,
+    )
+
+    private fun sessionsContext(paymentMethods: PaymentMethods?) = CheckoutContext.Sessions(
+        checkoutSession = CheckoutSession(
+            sessionSetupResponse = SessionSetupResponse(
+                id = "test_session_id",
+                sessionData = "test_session_data",
+                amount = null,
+                expiresAt = "2026-12-31T23:59:59Z",
+                paymentMethods = paymentMethods,
+                returnUrl = null,
+                configuration = null,
+                shopperLocale = null,
+            ),
+            order = null,
+            environment = Environment.TEST,
+            clientKey = TEST_CLIENT_KEY,
+        ),
+        checkoutConfiguration = CheckoutConfiguration(
+            environment = Environment.TEST,
+            clientKey = TEST_CLIENT_KEY,
+            shopperLocale = Locale.US,
+        ),
+        checkoutAttemptId = "",
+        publicKey = null,
+    )
+
+    companion object {
+        private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfghjklzxcvbnm"
+    }
+}

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/data/provider/DefaultSdkDataProviderTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/data/provider/DefaultSdkDataProviderTest.kt
@@ -8,7 +8,6 @@
 
 package com.adyen.checkout.core.components.internal.data.provider
 
-import com.adyen.checkout.core.analytics.internal.TestAnalyticsManager
 import com.adyen.checkout.core.common.internal.model.getBooleanOrNull
 import com.adyen.checkout.core.common.internal.model.getLongOrNull
 import com.adyen.checkout.core.common.internal.model.getStringOrNull
@@ -24,27 +23,23 @@ import kotlin.io.encoding.ExperimentalEncodingApi
 @OptIn(ExperimentalEncodingApi::class)
 internal class DefaultSdkDataProviderTest {
 
-    private lateinit var analyticsManager: TestAnalyticsManager
     private lateinit var sdkDataProvider: DefaultSdkDataProvider
 
     @BeforeEach
     fun setup() {
-        analyticsManager = TestAnalyticsManager()
-        sdkDataProvider = DefaultSdkDataProvider(analyticsManager)
+        sdkDataProvider = DefaultSdkDataProvider(CHECKOUT_ATTEMPT_ID)
     }
 
     @Test
     fun `when createEncodedSdkData is called, then data is correctly set`() {
-        val checkoutAttemptId = "test_checkout_attempt_id"
         val threeDS2SdkVersion = "2.2.0"
-        analyticsManager.setCheckoutAttemptId(checkoutAttemptId)
 
         val encodedSdkData = sdkDataProvider.createEncodedSdkData(threeDS2SdkVersion)
 
         assertNotNull(encodedSdkData)
         val jsonObject = decodeJsonObject(encodedSdkData!!)
         assertEquals(
-            checkoutAttemptId,
+            CHECKOUT_ATTEMPT_ID,
             jsonObject.optJSONObject("analytics")?.getStringOrNull("checkoutAttemptId"),
         )
         assertEquals(
@@ -57,8 +52,6 @@ internal class DefaultSdkDataProviderTest {
 
     @Test
     fun `when createEncodedSdkData is called without 3DS2 SDK version, then the version is null`() {
-        analyticsManager.setCheckoutAttemptId("test_checkout_attempt_id")
-
         val encodedSdkData = sdkDataProvider.createEncodedSdkData(null)
 
         assertNotNull(encodedSdkData)
@@ -69,5 +62,9 @@ internal class DefaultSdkDataProviderTest {
     private fun decodeJsonObject(encodedString: String): JSONObject {
         val decodedString = Base64.decode(encodedString).toString(Charsets.UTF_8)
         return JSONObject(decodedString)
+    }
+
+    companion object {
+        private const val CHECKOUT_ATTEMPT_ID = "test_checkout_attempt_id"
     }
 }

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/GooglePayFactory.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/GooglePayFactory.kt
@@ -14,7 +14,7 @@ import com.adyen.checkout.core.components.CheckoutAdditionalCallback
 import com.adyen.checkout.core.components.data.model.paymentmethod.GooglePayPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
 import com.adyen.checkout.core.components.internal.PaymentComponentFactory
-import com.adyen.checkout.core.components.internal.data.provider.DefaultSdkDataProvider
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.googlepay.internal.ui.model.GooglePayComponentParamsMapper
 import com.adyen.checkout.googlepay.internal.ui.state.GooglePayComponentStateFactory
 import com.adyen.checkout.googlepay.internal.ui.state.GooglePayComponentStateReducer
@@ -27,6 +27,7 @@ internal class GooglePayFactory : PaymentComponentFactory<GooglePayComponent> {
         paymentMethod: PaymentMethod,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         params: CheckoutParams,
         additionalCallbacks: Set<CheckoutAdditionalCallback>,
     ): GooglePayComponent {
@@ -42,7 +43,7 @@ internal class GooglePayFactory : PaymentComponentFactory<GooglePayComponent> {
         return GooglePayComponent(
             analyticsManager = analyticsManager,
             componentParams = componentParams,
-            sdkDataProvider = DefaultSdkDataProvider(analyticsManager),
+            sdkDataProvider = sdkDataProvider,
             paymentMethodType = googlePayPaymentMethod.type,
             componentStateValidator = GooglePayComponentStateValidator(),
             componentStateFactory = GooglePayComponentStateFactory(),

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/MBWayComponent.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/MBWayComponent.kt
@@ -34,7 +34,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 
 @Suppress("LongParameterList")
 internal class MBWayComponent(
-    private val analyticsManager: AnalyticsManager,
+    @Suppress("unused") private val analyticsManager: AnalyticsManager,
     private val sdkDataProvider: SdkDataProvider,
     private val componentStateValidator: MBWayComponentStateValidator,
     componentStateFactory: MBWayComponentStateFactory,

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/MBWayFactory.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/MBWayFactory.kt
@@ -13,7 +13,7 @@ import com.adyen.checkout.core.common.internal.CheckoutParams
 import com.adyen.checkout.core.components.CheckoutAdditionalCallback
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
 import com.adyen.checkout.core.components.internal.PaymentComponentFactory
-import com.adyen.checkout.core.components.internal.data.provider.DefaultSdkDataProvider
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.mbway.internal.ui.state.MBWayComponentStateFactory
 import com.adyen.checkout.mbway.internal.ui.state.MBWayComponentStateReducer
 import com.adyen.checkout.mbway.internal.ui.state.MBWayComponentStateValidator
@@ -26,12 +26,13 @@ internal class MBWayFactory : PaymentComponentFactory<MBWayComponent> {
         paymentMethod: PaymentMethod,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         params: CheckoutParams,
         additionalCallbacks: Set<CheckoutAdditionalCallback>,
     ): MBWayComponent {
         return MBWayComponent(
             analyticsManager = analyticsManager,
-            sdkDataProvider = DefaultSdkDataProvider(analyticsManager),
+            sdkDataProvider = sdkDataProvider,
             componentStateFactory = MBWayComponentStateFactory(params.shopperLocale),
             componentStateReducer = MBWayComponentStateReducer(),
             componentStateValidator = MBWayComponentStateValidator(),


### PR DESCRIPTION
## Description

Refactor checkout controller creation to resolve payment methods earlier, decouple `SdkDataProvider` from `AnalyticsManager`, handle errors more gracefully, and extract payment method resolution into a dedicated class.

### Key changes

**Extract `PaymentMethodResolver`**: Payment method lookup logic (finding a `PaymentMethod` or `StoredPaymentMethod` from the `CheckoutContext`) was moved out of `PaymentComponentResolver` into a new `PaymentMethodResolver` object. This allows `CheckoutControllerFactory` to resolve the payment method response object earlier in the flow, before creating common dependencies like the `AnalyticsManager`.

**Resolve payment method type before analytics creation**: `CheckoutControllerFactory` now resolves the payment method *before* calling `createCommonDependencies`, passing the actual `paymentMethodType` to `AnalyticsSource.PaymentComponent` instead of the previous hardcoded `"paymentMethod.type"` placeholder.

**Introduce `FailureCheckoutFlow`**: Instead of emitting a failure and passing `null` to `FullCheckoutFlow`, errors during component resolution now produce a `FailureCheckoutFlow` that immediately dispatches a `CheckoutError` with `PAYMENT_METHOD_FAILURE` and returns no-ops for `submit()` and navigation flows.

**Decouple `DefaultSdkDataProvider` from `AnalyticsManager`**: `DefaultSdkDataProvider` now takes a `checkoutAttemptId: String` instead of an `AnalyticsManager` reference. The provider is created in `CheckoutControllerFactory` and passed down through `PaymentComponentFactory` / `StoredPaymentComponentFactory` / `PaymentMethodProvider` to individual component factories.

**Remove `getCheckoutAttemptId()` from `AnalyticsManager` interface**: Since `SdkDataProvider` no longer depends on `AnalyticsManager` for the checkout attempt ID, the `getCheckoutAttemptId()` method is removed from the `AnalyticsManager` interface and `DefaultAnalyticsManager`.

**Suppress unused `analyticsManager` in components**: `GenericPaymentComponent`, `MBWayComponent`, and `BlikComponent`/`StoredBlikComponent` now annotate `analyticsManager` with `@Suppress("unused")` since they no longer call any methods on it directly (tracking is handled upstream).

**Simplify `PaymentComponentResolver`**: No longer responsible for finding payment methods in the response — it receives a resolved `PaymentMethodResponse` directly and only handles factory dispatch.

**Add tests**: New `FailureCheckoutFlowTest`, `PaymentMethodResolverTest`, updated `PaymentMethodProviderTest`, and simplified `PaymentComponentResolverTest`.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually