### PR TITLE
v6 - Analytics - Improve SdkDataProvider

### DIFF
--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/BlikFactory.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/BlikFactory.kt
@@ -19,7 +19,7 @@ import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPaymentMethod
 import com.adyen.checkout.core.components.internal.PaymentComponentFactory
 import com.adyen.checkout.core.components.internal.StoredPaymentComponentFactory
-import com.adyen.checkout.core.components.internal.data.provider.DefaultSdkDataProvider
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import kotlinx.coroutines.CoroutineScope
 
 internal class BlikFactory :
@@ -30,12 +30,13 @@ internal class BlikFactory :
         paymentMethod: PaymentMethod,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         params: CheckoutParams,
         additionalCallbacks: Set<CheckoutAdditionalCallback>,
     ): BlikComponent {
         return BlikComponent(
             analyticsManager = analyticsManager,
-            sdkDataProvider = DefaultSdkDataProvider(analyticsManager),
+            sdkDataProvider = sdkDataProvider,
             componentStateFactory = BlikComponentStateFactory(),
             componentStateReducer = BlikComponentStateReducer(),
             componentStateValidator = BlikComponentStateValidator(),
@@ -48,12 +49,13 @@ internal class BlikFactory :
         storedPaymentMethod: StoredPaymentMethod,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         params: CheckoutParams,
     ): StoredBlikComponent {
         return StoredBlikComponent(
             storedPaymentMethod = storedPaymentMethod,
             analyticsManager = analyticsManager,
-            sdkDataProvider = DefaultSdkDataProvider(analyticsManager),
+            sdkDataProvider = sdkDataProvider,
         )
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardFactory.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardFactory.kt
@@ -39,7 +39,7 @@ import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPayment
 import com.adyen.checkout.core.components.getAdditionalCallback
 import com.adyen.checkout.core.components.internal.PaymentComponentFactory
 import com.adyen.checkout.core.components.internal.StoredPaymentComponentFactory
-import com.adyen.checkout.core.components.internal.data.provider.DefaultSdkDataProvider
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.cse.internal.CardEncryptorFactory
 import com.adyen.checkout.cse.internal.GenericEncryptorFactory
 import kotlinx.coroutines.CoroutineScope
@@ -52,6 +52,7 @@ internal class CardFactory :
         paymentMethod: PaymentMethod,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         params: CheckoutParams,
         additionalCallbacks: Set<CheckoutAdditionalCallback>,
     ): CardComponent {
@@ -101,7 +102,7 @@ internal class CardFactory :
             componentStateReducer = componentStateReducer,
             viewStateProducer = viewStateProducer,
             coroutineScope = coroutineScope,
-            sdkDataProvider = DefaultSdkDataProvider(analyticsManager),
+            sdkDataProvider = sdkDataProvider,
             paymentMethodType = paymentMethodType,
             onBinChangeCallback = additionalCallbacks.getAdditionalCallback<OnBinChangeCallback>(),
             onBinLookupCallback = additionalCallbacks.getAdditionalCallback<OnBinLookupCallback>(),
@@ -115,6 +116,7 @@ internal class CardFactory :
         storedPaymentMethod: StoredPaymentMethod,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         params: CheckoutParams,
     ): StoredCardComponent {
         // TODO - Remove casting when paymentMethod object is typed
@@ -145,7 +147,7 @@ internal class CardFactory :
             componentStateReducer = componentStateReducer,
             viewStateProducer = viewStateProducer,
             coroutineScope = coroutineScope,
-            sdkDataProvider = DefaultSdkDataProvider(analyticsManager),
+            sdkDataProvider = sdkDataProvider,
             publicKey = params.publicKey,
         )
     }

--- a/core/src/main/java/com/adyen/checkout/core/analytics/internal/AnalyticsManager.kt
+++ b/core/src/main/java/com/adyen/checkout/core/analytics/internal/AnalyticsManager.kt
@@ -14,6 +14,4 @@ import androidx.annotation.RestrictTo
 interface AnalyticsManager {
 
     fun trackEvent(event: AnalyticsEvent)
-
-    fun getCheckoutAttemptId(): String
 }

--- a/core/src/main/java/com/adyen/checkout/core/analytics/internal/DefaultAnalyticsManager.kt
+++ b/core/src/main/java/com/adyen/checkout/core/analytics/internal/DefaultAnalyticsManager.kt
@@ -97,8 +97,6 @@ internal class DefaultAnalyticsManager(
         )
     }
 
-    override fun getCheckoutAttemptId(): String = checkoutAttemptId
-
     private fun canTrackEvents() = analyticsParams.level.priority > AnalyticsParamsLevel.INITIAL.priority
 
     companion object {

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutControllerFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutControllerFactory.kt
@@ -23,6 +23,8 @@ import com.adyen.checkout.core.components.CheckoutCallbacks
 import com.adyen.checkout.core.components.CheckoutController
 import com.adyen.checkout.core.components.CheckoutTarget
 import com.adyen.checkout.core.components.SessionCheckoutCallbacks
+import com.adyen.checkout.core.components.internal.data.provider.DefaultSdkDataProvider
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.core.error.CheckoutError
 import com.adyen.checkout.core.sessions.internal.data.api.SessionRepository
 import com.adyen.checkout.core.sessions.internal.data.api.SessionService
@@ -92,7 +94,7 @@ internal class CheckoutControllerFactory {
         componentRequestDispatcher: SubmittableComponentRequestDispatcher,
         coroutineScope: CoroutineScope,
     ): CheckoutController {
-        val (checkoutParams, analyticsManager) = createCommonDependencies(context, coroutineScope)
+        val (checkoutParams, analyticsManager, sdkDataProvider) = createCommonDependencies(context, coroutineScope)
         val actionHandler = createActionHandler(
             componentRequestDispatcher = componentRequestDispatcher,
             coroutineScope = coroutineScope,
@@ -106,6 +108,7 @@ internal class CheckoutControllerFactory {
             callbacks = callbacks,
             coroutineScope = coroutineScope,
             analyticsManager = analyticsManager,
+            sdkDataProvider = sdkDataProvider,
             checkoutParams = checkoutParams,
         )
 
@@ -153,7 +156,13 @@ internal class CheckoutControllerFactory {
             coroutineScope = coroutineScope,
         )
 
-        return CommonDependencies(checkoutParams, analyticsManager)
+        val sdkDataProvider = DefaultSdkDataProvider(context.checkoutAttemptId)
+
+        return CommonDependencies(
+            checkoutParams = checkoutParams,
+            analyticsManager = analyticsManager,
+            sdkDataProvider = sdkDataProvider,
+        )
     }
 
     private fun createSessionComponentRequestDispatcher(
@@ -188,5 +197,6 @@ internal class CheckoutControllerFactory {
     private data class CommonDependencies(
         val checkoutParams: CheckoutParams,
         val analyticsManager: AnalyticsManager,
+        val sdkDataProvider: SdkDataProvider,
     )
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentComponentFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentComponentFactory.kt
@@ -13,6 +13,7 @@ import com.adyen.checkout.core.analytics.internal.AnalyticsManager
 import com.adyen.checkout.core.common.internal.CheckoutParams
 import com.adyen.checkout.core.components.CheckoutAdditionalCallback
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
 import kotlinx.coroutines.CoroutineScope
 
@@ -22,10 +23,12 @@ import kotlinx.coroutines.CoroutineScope
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface PaymentComponentFactory<T : PaymentComponent> : ComponentFactory {
 
+    @Suppress("LongParameterList")
     fun create(
         paymentMethod: PaymentMethod,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         params: CheckoutParams,
         additionalCallbacks: Set<CheckoutAdditionalCallback>,
     ): T

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentComponentResolver.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentComponentResolver.kt
@@ -14,6 +14,7 @@ import com.adyen.checkout.core.common.internal.CheckoutParams
 import com.adyen.checkout.core.components.CheckoutCallbacks
 import com.adyen.checkout.core.components.CheckoutTarget
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethods
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import kotlinx.coroutines.CoroutineScope
 
 internal object PaymentComponentResolver {
@@ -25,6 +26,7 @@ internal object PaymentComponentResolver {
         callbacks: CheckoutCallbacks,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         checkoutParams: CheckoutParams,
     ): PaymentComponentResult {
         return when (target) {
@@ -34,6 +36,7 @@ internal object PaymentComponentResolver {
                 callbacks = callbacks,
                 coroutineScope = coroutineScope,
                 analyticsManager = analyticsManager,
+                sdkDataProvider = sdkDataProvider,
                 checkoutParams = checkoutParams,
             )
 
@@ -42,6 +45,7 @@ internal object PaymentComponentResolver {
                 context = context,
                 coroutineScope = coroutineScope,
                 analyticsManager = analyticsManager,
+                sdkDataProvider = sdkDataProvider,
                 checkoutParams = checkoutParams,
             )
 
@@ -56,6 +60,7 @@ internal object PaymentComponentResolver {
         callbacks: CheckoutCallbacks,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         checkoutParams: CheckoutParams,
     ): PaymentComponentResult {
         val paymentMethods = context.getPaymentMethodResponse()?.paymentMethods
@@ -70,6 +75,7 @@ internal object PaymentComponentResolver {
             paymentMethod = paymentMethod,
             coroutineScope = coroutineScope,
             analyticsManager = analyticsManager,
+            sdkDataProvider = sdkDataProvider,
             params = checkoutParams,
             additionalCallbacks = callbacks.additionalCallbacks,
         ) ?: return PaymentComponentResult.Failure(
@@ -80,12 +86,13 @@ internal object PaymentComponentResolver {
         return PaymentComponentResult.Success(component)
     }
 
-    @Suppress("ReturnCount")
+    @Suppress("ReturnCount", "LongParameterList")
     private fun resolveStoredPaymentMethod(
         target: CheckoutTarget.StoredPaymentMethod,
         context: CheckoutContext,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         checkoutParams: CheckoutParams,
     ): PaymentComponentResult {
         val storedPaymentMethods = context.getPaymentMethodResponse()?.storedPaymentMethods
@@ -100,6 +107,7 @@ internal object PaymentComponentResolver {
             storedPaymentMethod = storedPaymentMethod,
             coroutineScope = coroutineScope,
             analyticsManager = analyticsManager,
+            sdkDataProvider = sdkDataProvider,
             params = checkoutParams,
         ) ?: return PaymentComponentResult.Failure(
             "Stored payment method type '${storedPaymentMethod.type}' is not supported. " +

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentMethodProvider.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentMethodProvider.kt
@@ -16,6 +16,7 @@ import com.adyen.checkout.core.components.CheckoutAdditionalCallback
 import com.adyen.checkout.core.components.data.model.paymentmethod.GenericPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPaymentMethod
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.core.components.internal.ui.GenericPaymentComponentFactory
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
 import kotlinx.coroutines.CoroutineScope
@@ -40,10 +41,12 @@ object PaymentMethodProvider {
         }
     }
 
+    @Suppress("LongParameterList")
     fun getPaymentComponent(
         paymentMethod: PaymentMethod,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         params: CheckoutParams,
         additionalCallbacks: Set<CheckoutAdditionalCallback>,
     ): PaymentComponent? {
@@ -59,6 +62,7 @@ object PaymentMethodProvider {
             paymentMethod = paymentMethod,
             coroutineScope = coroutineScope,
             analyticsManager = analyticsManager,
+            sdkDataProvider = sdkDataProvider,
             params = params,
             additionalCallbacks = additionalCallbacks,
         )
@@ -68,6 +72,7 @@ object PaymentMethodProvider {
         storedPaymentMethod: StoredPaymentMethod,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         params: CheckoutParams,
     ): PaymentComponent? {
         val txVariant = storedPaymentMethod.type
@@ -76,6 +81,7 @@ object PaymentMethodProvider {
             storedPaymentMethod = storedPaymentMethod,
             coroutineScope = coroutineScope,
             analyticsManager = analyticsManager,
+            sdkDataProvider = sdkDataProvider,
             params = params,
         )
     }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/StoredPaymentComponentFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/StoredPaymentComponentFactory.kt
@@ -12,6 +12,7 @@ import androidx.annotation.RestrictTo
 import com.adyen.checkout.core.analytics.internal.AnalyticsManager
 import com.adyen.checkout.core.common.internal.CheckoutParams
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPaymentMethod
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
 import kotlinx.coroutines.CoroutineScope
 
@@ -25,6 +26,7 @@ interface StoredPaymentComponentFactory<T : PaymentComponent> : ComponentFactory
         storedPaymentMethod: StoredPaymentMethod,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         params: CheckoutParams,
     ): T
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/data/provider/DefaultSdkDataProvider.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/data/provider/DefaultSdkDataProvider.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.core.components.internal.data.provider
 
 import androidx.annotation.RestrictTo
-import com.adyen.checkout.core.analytics.internal.AnalyticsManager
 import com.adyen.checkout.core.common.AdyenLogLevel
 import com.adyen.checkout.core.common.internal.helper.adyenLog
 import com.adyen.checkout.core.components.internal.data.model.sdkData.Analytics
@@ -27,7 +26,7 @@ import kotlin.io.encoding.ExperimentalEncodingApi
 @OptIn(DirectSdkDataCreation::class)
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class DefaultSdkDataProvider(
-    private val analyticsManager: AnalyticsManager
+    private val checkoutAttemptId: String,
 ) : SdkDataProvider {
 
     @OptIn(ExperimentalEncodingApi::class)
@@ -53,7 +52,7 @@ class DefaultSdkDataProvider(
         return SdkData(
             schemaVersion = SCHEMA_VERSION,
             analytics = Analytics(
-                checkoutAttemptId = analyticsManager.getCheckoutAttemptId(),
+                checkoutAttemptId = checkoutAttemptId,
             ),
             authentication = authentication,
             createdAt = Date().time,

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/GenericPaymentComponentFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/GenericPaymentComponentFactory.kt
@@ -13,7 +13,7 @@ import com.adyen.checkout.core.common.internal.CheckoutParams
 import com.adyen.checkout.core.components.CheckoutAdditionalCallback
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
 import com.adyen.checkout.core.components.internal.PaymentComponentFactory
-import com.adyen.checkout.core.components.internal.data.provider.DefaultSdkDataProvider
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import kotlinx.coroutines.CoroutineScope
 
 internal object GenericPaymentComponentFactory : PaymentComponentFactory<GenericPaymentComponent> {
@@ -22,13 +22,14 @@ internal object GenericPaymentComponentFactory : PaymentComponentFactory<Generic
         paymentMethod: PaymentMethod,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         params: CheckoutParams,
         additionalCallbacks: Set<CheckoutAdditionalCallback>
     ): GenericPaymentComponent {
         return GenericPaymentComponent(
             analyticsManager = analyticsManager,
             paymentMethodType = paymentMethod.type,
-            sdkDataProvider = DefaultSdkDataProvider(analyticsManager),
+            sdkDataProvider = sdkDataProvider,
         )
     }
 }

--- a/core/src/test/java/com/adyen/checkout/core/analytics/internal/DefaultAnalyticsManagerTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/analytics/internal/DefaultAnalyticsManagerTest.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -195,16 +194,6 @@ internal class DefaultAnalyticsManagerTest(
 
             verify(analyticsRepository, times(2)).sendEvents(any())
         }
-    }
-
-    @Test
-    fun `when getCheckoutAttemptId is called, then returns provided id`() = runTest {
-        val analyticsManager = createAnalyticsManager(
-            analyticsParamsLevel = AnalyticsParamsLevel.INITIAL,
-            coroutineScope = backgroundScope,
-        )
-
-        assertEquals("test-id", analyticsManager.getCheckoutAttemptId())
     }
 
     private fun createAnalyticsManager(

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/FullCheckoutFlowTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/FullCheckoutFlowTest.kt
@@ -19,6 +19,7 @@ import com.adyen.checkout.core.components.CheckoutPaymentMethodRoute
 import com.adyen.checkout.core.components.CheckoutSecondaryRoute
 import com.adyen.checkout.core.components.SubmitResult
 import com.adyen.checkout.core.components.data.PaymentComponentData
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
 import com.adyen.checkout.core.components.internal.ui.TestPaymentComponent
 import com.adyen.checkout.core.components.paymentmethod.PaymentComponentState
@@ -233,6 +234,7 @@ internal class FullCheckoutFlowTest(
                     paymentMethod: com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod,
                     coroutineScope: CoroutineScope,
                     analyticsManager: AnalyticsManager,
+                    sdkDataProvider: SdkDataProvider,
                     params: CheckoutParams,
                     additionalCallbacks: Set<CheckoutAdditionalCallback>,
                 ) = component

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentComponentResolverTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentComponentResolverTest.kt
@@ -26,6 +26,8 @@ import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredBLIKPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.UnsupportedPaymentMethod
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
+import com.adyen.checkout.core.components.internal.data.provider.TestSdkDataProvider
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
 import com.adyen.checkout.core.components.internal.ui.TestPaymentComponent
 import com.adyen.checkout.core.sessions.CheckoutSession
@@ -203,6 +205,7 @@ internal class PaymentComponentResolverTest {
             callbacks = advancedCallbacks(),
             coroutineScope = this,
             analyticsManager = TestAnalyticsManager(),
+            sdkDataProvider = TestSdkDataProvider(),
             checkoutParams = checkoutParams(),
         )
 
@@ -224,6 +227,7 @@ internal class PaymentComponentResolverTest {
             callbacks = advancedCallbacks(),
             coroutineScope = this,
             analyticsManager = TestAnalyticsManager(),
+            sdkDataProvider = TestSdkDataProvider(),
             checkoutParams = checkoutParams(),
         )
 
@@ -239,6 +243,7 @@ internal class PaymentComponentResolverTest {
         callbacks = advancedCallbacks(),
         coroutineScope = this,
         analyticsManager = TestAnalyticsManager(),
+        sdkDataProvider = TestSdkDataProvider(),
         checkoutParams = checkoutParams(),
     )
 
@@ -319,6 +324,7 @@ internal class PaymentComponentResolverTest {
                     paymentMethod: PaymentMethod,
                     coroutineScope: CoroutineScope,
                     analyticsManager: AnalyticsManager,
+                    sdkDataProvider: SdkDataProvider,
                     params: CheckoutParams,
                     additionalCallbacks: Set<CheckoutAdditionalCallback>,
                 ): PaymentComponent = component
@@ -334,6 +340,7 @@ internal class PaymentComponentResolverTest {
                     storedPaymentMethod: StoredPaymentMethod,
                     coroutineScope: CoroutineScope,
                     analyticsManager: AnalyticsManager,
+                    sdkDataProvider: SdkDataProvider,
                     params: CheckoutParams,
                 ): PaymentComponent = component
             },

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentMethodProviderTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentMethodProviderTest.kt
@@ -18,6 +18,8 @@ import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredBLIKPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.UnsupportedPaymentMethod
+import com.adyen.checkout.core.components.internal.data.provider.DefaultSdkDataProvider
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.core.components.internal.ui.GenericPaymentComponent
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
 import com.adyen.checkout.core.components.internal.ui.TestPaymentComponent
@@ -113,6 +115,7 @@ internal class PaymentMethodProviderTest {
                 paymentMethod = GenericPaymentMethod(type = "txVariant", name = "name"),
                 coroutineScope = this,
                 analyticsManager = TestAnalyticsManager(),
+                sdkDataProvider = generateSdkDataProvider(),
                 params = generateCheckoutParams(),
                 additionalCallbacks = emptySet(),
             )
@@ -141,6 +144,7 @@ internal class PaymentMethodProviderTest {
                 ),
                 coroutineScope = this,
                 analyticsManager = TestAnalyticsManager(),
+                sdkDataProvider = generateSdkDataProvider(),
                 params = generateCheckoutParams(),
             )
             assertEquals(1, PaymentMethodProvider.getStoredFactoriesCount())
@@ -173,6 +177,7 @@ internal class PaymentMethodProviderTest {
                 paymentMethod = GenericPaymentMethod(type = "txVariant", name = "name"),
                 coroutineScope = this,
                 analyticsManager = TestAnalyticsManager(),
+                sdkDataProvider = generateSdkDataProvider(),
                 params = generateCheckoutParams(),
                 additionalCallbacks = emptySet(),
             )
@@ -194,6 +199,7 @@ internal class PaymentMethodProviderTest {
                 ),
                 coroutineScope = this,
                 analyticsManager = TestAnalyticsManager(),
+                sdkDataProvider = generateSdkDataProvider(),
                 params = generateCheckoutParams(),
             )
             assertEquals(1, PaymentMethodProvider.getStoredFactoriesCount())
@@ -207,6 +213,7 @@ internal class PaymentMethodProviderTest {
                 paymentMethod = GenericPaymentMethod(type = "unregistered_txVariant", name = "name"),
                 coroutineScope = this,
                 analyticsManager = TestAnalyticsManager(),
+                sdkDataProvider = generateSdkDataProvider(),
                 params = generateCheckoutParams(),
                 additionalCallbacks = emptySet(),
             )
@@ -220,6 +227,7 @@ internal class PaymentMethodProviderTest {
                 paymentMethod = UnsupportedPaymentMethod(type = "unregistered_txVariant", name = "name"),
                 coroutineScope = this,
                 analyticsManager = TestAnalyticsManager(),
+                sdkDataProvider = generateSdkDataProvider(),
                 params = generateCheckoutParams(),
                 additionalCallbacks = emptySet(),
             )
@@ -237,6 +245,7 @@ internal class PaymentMethodProviderTest {
             ),
             coroutineScope = this,
             analyticsManager = TestAnalyticsManager(),
+            sdkDataProvider = generateSdkDataProvider(),
             params = generateCheckoutParams(),
         )
         assertNull(actualComponent)
@@ -263,6 +272,7 @@ internal class PaymentMethodProviderTest {
                 paymentMethod: PaymentMethod,
                 coroutineScope: CoroutineScope,
                 analyticsManager: AnalyticsManager,
+                sdkDataProvider: SdkDataProvider,
                 params: CheckoutParams,
                 additionalCallbacks: Set<CheckoutAdditionalCallback>,
             ) = paymentComponent
@@ -275,9 +285,12 @@ internal class PaymentMethodProviderTest {
                 storedPaymentMethod: StoredPaymentMethod,
                 coroutineScope: CoroutineScope,
                 analyticsManager: AnalyticsManager,
+                sdkDataProvider: SdkDataProvider,
                 params: CheckoutParams,
             ) = paymentComponent
         }
+
+    private fun generateSdkDataProvider() = DefaultSdkDataProvider("test-checkout-attempt-id")
 
     private fun generateCheckoutParams() = CheckoutParams(
         shopperLocale = Locale.US,

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/data/provider/DefaultSdkDataProviderTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/data/provider/DefaultSdkDataProviderTest.kt
@@ -8,7 +8,6 @@
 
 package com.adyen.checkout.core.components.internal.data.provider
 
-import com.adyen.checkout.core.analytics.internal.TestAnalyticsManager
 import com.adyen.checkout.core.common.internal.model.getBooleanOrNull
 import com.adyen.checkout.core.common.internal.model.getLongOrNull
 import com.adyen.checkout.core.common.internal.model.getStringOrNull
@@ -24,27 +23,23 @@ import kotlin.io.encoding.ExperimentalEncodingApi
 @OptIn(ExperimentalEncodingApi::class)
 internal class DefaultSdkDataProviderTest {
 
-    private lateinit var analyticsManager: TestAnalyticsManager
     private lateinit var sdkDataProvider: DefaultSdkDataProvider
 
     @BeforeEach
     fun setup() {
-        analyticsManager = TestAnalyticsManager()
-        sdkDataProvider = DefaultSdkDataProvider(analyticsManager)
+        sdkDataProvider = DefaultSdkDataProvider(CHECKOUT_ATTEMPT_ID)
     }
 
     @Test
     fun `when createEncodedSdkData is called, then data is correctly set`() {
-        val checkoutAttemptId = "test_checkout_attempt_id"
         val threeDS2SdkVersion = "2.2.0"
-        analyticsManager.setCheckoutAttemptId(checkoutAttemptId)
 
         val encodedSdkData = sdkDataProvider.createEncodedSdkData(threeDS2SdkVersion)
 
         assertNotNull(encodedSdkData)
         val jsonObject = decodeJsonObject(encodedSdkData!!)
         assertEquals(
-            checkoutAttemptId,
+            CHECKOUT_ATTEMPT_ID,
             jsonObject.optJSONObject("analytics")?.getStringOrNull("checkoutAttemptId"),
         )
         assertEquals(
@@ -57,8 +52,6 @@ internal class DefaultSdkDataProviderTest {
 
     @Test
     fun `when createEncodedSdkData is called without 3DS2 SDK version, then the version is null`() {
-        analyticsManager.setCheckoutAttemptId("test_checkout_attempt_id")
-
         val encodedSdkData = sdkDataProvider.createEncodedSdkData(null)
 
         assertNotNull(encodedSdkData)
@@ -69,5 +62,9 @@ internal class DefaultSdkDataProviderTest {
     private fun decodeJsonObject(encodedString: String): JSONObject {
         val decodedString = Base64.decode(encodedString).toString(Charsets.UTF_8)
         return JSONObject(decodedString)
+    }
+
+    companion object {
+        private const val CHECKOUT_ATTEMPT_ID = "test_checkout_attempt_id"
     }
 }

--- a/core/src/testFixtures/java/com/adyen/checkout/core/analytics/internal/TestAnalyticsManager.kt
+++ b/core/src/testFixtures/java/com/adyen/checkout/core/analytics/internal/TestAnalyticsManager.kt
@@ -49,8 +49,6 @@ class TestAnalyticsManager : AnalyticsManager {
         return re.matches(actual)
     }
 
-    override fun getCheckoutAttemptId(): String = checkoutAttemptId
-
     fun setCheckoutAttemptId(checkoutAttemptId: String) {
         this.checkoutAttemptId = checkoutAttemptId
     }

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/GooglePayFactory.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/GooglePayFactory.kt
@@ -15,7 +15,7 @@ import com.adyen.checkout.core.components.data.model.paymentmethod.GooglePayPaym
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
 import com.adyen.checkout.core.components.internal.ApplicationContextHolder
 import com.adyen.checkout.core.components.internal.PaymentComponentFactory
-import com.adyen.checkout.core.components.internal.data.provider.DefaultSdkDataProvider
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.googlepay.internal.helper.GooglePayAvailabilityCheck
 import com.adyen.checkout.googlepay.internal.ui.model.GooglePayComponentParamsMapper
 import com.adyen.checkout.googlepay.internal.ui.state.GooglePayComponentStateFactory
@@ -29,6 +29,7 @@ internal class GooglePayFactory : PaymentComponentFactory<GooglePayComponent> {
         paymentMethod: PaymentMethod,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         params: CheckoutParams,
         additionalCallbacks: Set<CheckoutAdditionalCallback>,
     ): GooglePayComponent {
@@ -44,7 +45,7 @@ internal class GooglePayFactory : PaymentComponentFactory<GooglePayComponent> {
         return GooglePayComponent(
             analyticsManager = analyticsManager,
             componentParams = componentParams,
-            sdkDataProvider = DefaultSdkDataProvider(analyticsManager),
+            sdkDataProvider = sdkDataProvider,
             googlePayAvailabilityCheck = GooglePayAvailabilityCheck(
                 componentParams = componentParams,
                 applicationContext = ApplicationContextHolder.require(),

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/MBWayFactory.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/MBWayFactory.kt
@@ -13,7 +13,7 @@ import com.adyen.checkout.core.common.internal.CheckoutParams
 import com.adyen.checkout.core.components.CheckoutAdditionalCallback
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
 import com.adyen.checkout.core.components.internal.PaymentComponentFactory
-import com.adyen.checkout.core.components.internal.data.provider.DefaultSdkDataProvider
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.mbway.internal.ui.state.MBWayComponentStateFactory
 import com.adyen.checkout.mbway.internal.ui.state.MBWayComponentStateReducer
 import com.adyen.checkout.mbway.internal.ui.state.MBWayComponentStateValidator
@@ -26,12 +26,13 @@ internal class MBWayFactory : PaymentComponentFactory<MBWayComponent> {
         paymentMethod: PaymentMethod,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
+        sdkDataProvider: SdkDataProvider,
         params: CheckoutParams,
         additionalCallbacks: Set<CheckoutAdditionalCallback>,
     ): MBWayComponent {
         return MBWayComponent(
             analyticsManager = analyticsManager,
-            sdkDataProvider = DefaultSdkDataProvider(analyticsManager),
+            sdkDataProvider = sdkDataProvider,
             componentStateFactory = MBWayComponentStateFactory(params.shopperLocale),
             componentStateReducer = MBWayComponentStateReducer(),
             componentStateValidator = MBWayComponentStateValidator(),


### PR DESCRIPTION
## Description
Decouple `SdkDataProvider` from `AnalyticsManager`

### Key changes

**Decouple `DefaultSdkDataProvider` from `AnalyticsManager`**: `DefaultSdkDataProvider` now takes a `checkoutAttemptId: String` instead of an `AnalyticsManager` reference. The provider is created in `CheckoutControllerFactory` and passed down through `PaymentComponentFactory` / `StoredPaymentComponentFactory` / `PaymentMethodProvider` to individual component factories.

**Remove `getCheckoutAttemptId()` from `AnalyticsManager` interface**: Since `SdkDataProvider` no longer depends on `AnalyticsManager` for the checkout attempt ID, the `getCheckoutAttemptId()` method is removed from the `AnalyticsManager` interface and `DefaultAnalyticsManager`.


## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually