### PR TITLE
v6 - Analytics - Checkout Controller

### DIFF
--- a/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutControllerFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutControllerFactory.kt
@@ -24,7 +24,6 @@ import com.adyen.checkout.core.components.CheckoutController
 import com.adyen.checkout.core.components.CheckoutTarget
 import com.adyen.checkout.core.components.SessionCheckoutCallbacks
 import com.adyen.checkout.core.components.internal.data.provider.DefaultSdkDataProvider
-import com.adyen.checkout.core.error.CheckoutError
 import com.adyen.checkout.core.sessions.internal.data.api.SessionRepository
 import com.adyen.checkout.core.sessions.internal.data.api.SessionService
 import kotlinx.coroutines.CoroutineScope
@@ -71,8 +70,10 @@ internal class CheckoutControllerFactory {
         callbacks: ActionOnlyCheckoutCallbacks,
         coroutineScope: CoroutineScope,
     ): CheckoutController {
+        val checkoutParams = createCheckoutParams(context)
         // TODO - what should be the payment method type for action only?
-        val (checkoutParams, analyticsManager) = createCommonDependencies(
+        val analyticsManager = createAnalyticsManager(
+            checkoutParams = checkoutParams,
             paymentMethodType = "NONE",
             context = context,
             coroutineScope = coroutineScope,
@@ -102,20 +103,16 @@ internal class CheckoutControllerFactory {
         componentRequestDispatcher: SubmittableComponentRequestDispatcher,
         coroutineScope: CoroutineScope,
     ): CheckoutController {
-        val paymentMethod = PaymentMethodResolver.resolve(target, context)
+        val checkoutParams = createCheckoutParams(context)
 
-        if (paymentMethod == null) {
-            componentRequestDispatcher.failure(
-                CheckoutError(
-                    code = CheckoutError.ErrorCode.PAYMENT_METHOD_FAILURE,
-                    message = "Payment method for target '${target}' was not found in the payment methods response.",
-                ),
-            )
-            //TODO - gracefully fail
-            error("")
-        }
+        val paymentMethod = PaymentMethodResolver.resolve(target, context) ?: return createFailedCheckoutController(
+            errorMessage = "Payment method for target '$target' was not found in the payment methods response.",
+            componentRequestDispatcher = componentRequestDispatcher,
+            checkoutParams = checkoutParams,
+        )
 
-        val (checkoutParams, analyticsManager) = createCommonDependencies(
+        val analyticsManager = createAnalyticsManager(
+            checkoutParams = checkoutParams,
             paymentMethodType = paymentMethod.type,
             context = context,
             coroutineScope = coroutineScope,
@@ -136,57 +133,54 @@ internal class CheckoutControllerFactory {
             checkoutParams = checkoutParams,
         )
 
-        val paymentComponent = when (paymentComponentResult) {
-            is PaymentComponentResult.Success -> paymentComponentResult.component
-            is PaymentComponentResult.Failure -> {
-                componentRequestDispatcher.failure(
-                    CheckoutError(
-                        code = CheckoutError.ErrorCode.PAYMENT_METHOD_FAILURE,
-                        message = paymentComponentResult.message,
-                    ),
+        return when (paymentComponentResult) {
+            is PaymentComponentResult.Success -> {
+                val flow = FullCheckoutFlow(
+                    componentRequestDispatcher = componentRequestDispatcher,
+                    coroutineScope = coroutineScope,
+                    paymentComponent = paymentComponentResult.component,
+                    actionHandler = actionHandler,
                 )
-                null
+
+                CheckoutController(
+                    flow = flow,
+                    environment = checkoutParams.environment,
+                    shopperLocale = checkoutParams.shopperLocale,
+                )
+            }
+
+            is PaymentComponentResult.Failure -> {
+                createFailedCheckoutController(
+                    errorMessage = paymentComponentResult.message,
+                    componentRequestDispatcher = componentRequestDispatcher,
+                    checkoutParams = checkoutParams,
+                )
             }
         }
-
-        val flow = FullCheckoutFlow(
-            componentRequestDispatcher = componentRequestDispatcher,
-            coroutineScope = coroutineScope,
-            paymentComponent = paymentComponent,
-            actionHandler = actionHandler,
-        )
-
-        return CheckoutController(
-            flow = flow,
-            environment = checkoutParams.environment,
-            shopperLocale = checkoutParams.shopperLocale,
-        )
     }
 
-    private fun createCommonDependencies(
-        paymentMethodType: String,
-        context: CheckoutContext,
-        coroutineScope: CoroutineScope,
-    ): CommonDependencies {
+    private fun createCheckoutParams(context: CheckoutContext): CheckoutParams {
         val session = (context as? CheckoutContext.Sessions)?.checkoutSession
-
-        val checkoutParams = CheckoutParamsFactory().create(
+        return CheckoutParamsFactory().create(
             configuration = context.checkoutConfiguration,
             session = session,
             publicKey = context.publicKey,
         )
+    }
 
-        val analyticsManager = AnalyticsManagerFactory().provide(
+    private fun createAnalyticsManager(
+        checkoutParams: CheckoutParams,
+        paymentMethodType: String,
+        context: CheckoutContext,
+        coroutineScope: CoroutineScope,
+    ): AnalyticsManager {
+        val session = (context as? CheckoutContext.Sessions)?.checkoutSession
+        return AnalyticsManagerFactory().provide(
             params = checkoutParams,
             source = AnalyticsSource.PaymentComponent(paymentMethodType),
             sessionId = session?.sessionSetupResponse?.id,
             checkoutAttemptId = context.checkoutAttemptId,
             coroutineScope = coroutineScope,
-        )
-
-        return CommonDependencies(
-            checkoutParams = checkoutParams,
-            analyticsManager = analyticsManager,
         )
     }
 
@@ -219,8 +213,19 @@ internal class CheckoutControllerFactory {
         params = params,
     )
 
-    private data class CommonDependencies(
-        val checkoutParams: CheckoutParams,
-        val analyticsManager: AnalyticsManager,
-    )
+    private fun createFailedCheckoutController(
+        errorMessage: String,
+        componentRequestDispatcher: ComponentRequestDispatcher,
+        checkoutParams: CheckoutParams,
+    ): CheckoutController {
+        val flow = FailureCheckoutFlow(
+            errorMessage = errorMessage,
+            componentRequestDispatcher = componentRequestDispatcher,
+        )
+        return CheckoutController(
+            flow = flow,
+            environment = checkoutParams.environment,
+            shopperLocale = checkoutParams.shopperLocale,
+        )
+    }
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutControllerFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutControllerFactory.kt
@@ -24,7 +24,6 @@ import com.adyen.checkout.core.components.CheckoutController
 import com.adyen.checkout.core.components.CheckoutTarget
 import com.adyen.checkout.core.components.SessionCheckoutCallbacks
 import com.adyen.checkout.core.components.internal.data.provider.DefaultSdkDataProvider
-import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.core.error.CheckoutError
 import com.adyen.checkout.core.sessions.internal.data.api.SessionRepository
 import com.adyen.checkout.core.sessions.internal.data.api.SessionService
@@ -72,7 +71,12 @@ internal class CheckoutControllerFactory {
         callbacks: ActionOnlyCheckoutCallbacks,
         coroutineScope: CoroutineScope,
     ): CheckoutController {
-        val (checkoutParams, analyticsManager) = createCommonDependencies(context, coroutineScope)
+        // TODO - what should be the payment method type for action only?
+        val (checkoutParams, analyticsManager) = createCommonDependencies(
+            paymentMethodType = "NONE",
+            context = context,
+            coroutineScope = coroutineScope,
+        )
         val componentRequestDispatcher = ActionOnlyComponentRequestDispatcher(callbacks)
         val actionHandler = createActionHandler(
             componentRequestDispatcher = componentRequestDispatcher,
@@ -98,17 +102,33 @@ internal class CheckoutControllerFactory {
         componentRequestDispatcher: SubmittableComponentRequestDispatcher,
         coroutineScope: CoroutineScope,
     ): CheckoutController {
-        val (checkoutParams, analyticsManager, sdkDataProvider) = createCommonDependencies(context, coroutineScope)
+        val paymentMethod = PaymentMethodResolver.resolve(target, context)
+
+        if (paymentMethod == null) {
+            componentRequestDispatcher.failure(
+                CheckoutError(
+                    code = CheckoutError.ErrorCode.PAYMENT_METHOD_FAILURE,
+                    message = "Payment method for target '${target}' was not found in the payment methods response.",
+                ),
+            )
+            //TODO - gracefully fail
+            error("")
+        }
+
+        val (checkoutParams, analyticsManager) = createCommonDependencies(
+            paymentMethodType = paymentMethod.type,
+            context = context,
+            coroutineScope = coroutineScope,
+        )
         val actionHandler = createActionHandler(
             componentRequestDispatcher = componentRequestDispatcher,
             coroutineScope = coroutineScope,
             analyticsManager = analyticsManager,
             params = checkoutParams,
         )
-
+        val sdkDataProvider = DefaultSdkDataProvider(context.checkoutAttemptId)
         val paymentComponentResult = PaymentComponentResolver.resolve(
-            target = target,
-            context = context,
+            paymentMethod = paymentMethod,
             callbacks = callbacks,
             coroutineScope = coroutineScope,
             analyticsManager = analyticsManager,
@@ -144,6 +164,7 @@ internal class CheckoutControllerFactory {
     }
 
     private fun createCommonDependencies(
+        paymentMethodType: String,
         context: CheckoutContext,
         coroutineScope: CoroutineScope,
     ): CommonDependencies {
@@ -157,19 +178,15 @@ internal class CheckoutControllerFactory {
 
         val analyticsManager = AnalyticsManagerFactory().provide(
             params = checkoutParams,
-            // TODO - Analytics: Pass the correct paymentMethod type
-            source = AnalyticsSource.PaymentComponent("paymentMethod.type"),
+            source = AnalyticsSource.PaymentComponent(paymentMethodType),
             sessionId = session?.sessionSetupResponse?.id,
             checkoutAttemptId = context.checkoutAttemptId,
             coroutineScope = coroutineScope,
         )
 
-        val sdkDataProvider = DefaultSdkDataProvider(context.checkoutAttemptId)
-
         return CommonDependencies(
             checkoutParams = checkoutParams,
             analyticsManager = analyticsManager,
-            sdkDataProvider = sdkDataProvider,
         )
     }
 
@@ -205,6 +222,5 @@ internal class CheckoutControllerFactory {
     private data class CommonDependencies(
         val checkoutParams: CheckoutParams,
         val analyticsManager: AnalyticsManager,
-        val sdkDataProvider: SdkDataProvider,
     )
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/FailureCheckoutFlow.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/FailureCheckoutFlow.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 23/6/2026.
+ */
+
+package com.adyen.checkout.core.components.internal
+
+import android.content.Intent
+import com.adyen.checkout.core.action.internal.ActionComponent
+import com.adyen.checkout.core.common.AdyenLogLevel
+import com.adyen.checkout.core.common.internal.helper.adyenLog
+import com.adyen.checkout.core.components.CheckoutRoute
+import com.adyen.checkout.core.components.internal.ui.PaymentComponent
+import com.adyen.checkout.core.error.CheckoutError
+import com.adyen.checkout.core.error.CheckoutError.ErrorCode.PAYMENT_METHOD_FAILURE
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+
+internal class FailureCheckoutFlow(
+    errorMessage: String,
+    componentRequestDispatcher: ComponentRequestDispatcher,
+) : CheckoutFlow {
+
+    override val paymentComponent: PaymentComponent? = null
+    override val actionComponent: ActionComponent? = null
+    override val navigation: Flow<CheckoutRoute> = emptyFlow()
+
+    init {
+        val error = CheckoutError(
+            code = PAYMENT_METHOD_FAILURE,
+            message = errorMessage,
+        )
+        componentRequestDispatcher.failure(error)
+    }
+
+    override fun submit() {
+        adyenLog(AdyenLogLevel.WARN) { "Ignoring submit() call, flow has already failed" }
+    }
+
+    override fun handleReturn(intent: Intent) {
+        adyenLog(AdyenLogLevel.WARN) { "Ignoring handleReturn() call, flow has already failed" }
+    }
+
+    override fun requiresUserInteraction(): Boolean {
+        return false
+    }
+}

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentComponentResolver.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentComponentResolver.kt
@@ -9,30 +9,27 @@
 package com.adyen.checkout.core.components.internal
 
 import com.adyen.checkout.core.analytics.internal.AnalyticsManager
-import com.adyen.checkout.core.common.CheckoutContext
 import com.adyen.checkout.core.common.internal.CheckoutParams
 import com.adyen.checkout.core.components.CheckoutCallbacks
-import com.adyen.checkout.core.components.CheckoutTarget
-import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethods
+import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
+import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethodResponse
+import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPaymentMethod
 import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import kotlinx.coroutines.CoroutineScope
 
 internal object PaymentComponentResolver {
 
-    @Suppress("LongParameterList")
     fun resolve(
-        target: CheckoutTarget,
-        context: CheckoutContext,
+        paymentMethod: PaymentMethodResponse,
         callbacks: CheckoutCallbacks,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
         sdkDataProvider: SdkDataProvider,
         checkoutParams: CheckoutParams,
     ): PaymentComponentResult {
-        return when (target) {
-            is CheckoutTarget.PaymentMethod -> resolvePaymentMethod(
-                target = target,
-                context = context,
+        return when (paymentMethod) {
+            is PaymentMethod -> resolvePaymentMethod(
+                paymentMethod = paymentMethod,
                 callbacks = callbacks,
                 coroutineScope = coroutineScope,
                 analyticsManager = analyticsManager,
@@ -40,37 +37,26 @@ internal object PaymentComponentResolver {
                 checkoutParams = checkoutParams,
             )
 
-            is CheckoutTarget.StoredPaymentMethod -> resolveStoredPaymentMethod(
-                target = target,
-                context = context,
+            is StoredPaymentMethod -> resolveStoredPaymentMethod(
+                paymentMethod = paymentMethod,
                 coroutineScope = coroutineScope,
                 analyticsManager = analyticsManager,
                 sdkDataProvider = sdkDataProvider,
                 checkoutParams = checkoutParams,
             )
 
-            else -> PaymentComponentResult.Failure("Unsupported checkout target.")
+            else -> PaymentComponentResult.Failure("Unsupported payment method response type.")
         }
     }
 
-    @Suppress("LongParameterList", "ReturnCount")
     private fun resolvePaymentMethod(
-        target: CheckoutTarget.PaymentMethod,
-        context: CheckoutContext,
+        paymentMethod: PaymentMethod,
         callbacks: CheckoutCallbacks,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
         sdkDataProvider: SdkDataProvider,
         checkoutParams: CheckoutParams,
     ): PaymentComponentResult {
-        val paymentMethods = context.getPaymentMethodResponse()?.paymentMethods
-            ?: return PaymentComponentResult.Failure("No payment methods response available.")
-
-        val paymentMethod = paymentMethods.find { it.type == target.type }
-            ?: return PaymentComponentResult.Failure(
-                "Payment method '${target.type}' was not found in the payment methods response.",
-            )
-
         val component = PaymentMethodProvider.getPaymentComponent(
             paymentMethod = paymentMethod,
             coroutineScope = coroutineScope,
@@ -79,49 +65,31 @@ internal object PaymentComponentResolver {
             params = checkoutParams,
             additionalCallbacks = callbacks.additionalCallbacks,
         ) ?: return PaymentComponentResult.Failure(
-            "Payment method '${target.type}' is not supported. " +
+            "Payment method '${paymentMethod.type}' is not supported. " +
                 "Ensure the corresponding module is included in your build dependencies.",
         )
 
         return PaymentComponentResult.Success(component)
     }
 
-    @Suppress("ReturnCount", "LongParameterList")
     private fun resolveStoredPaymentMethod(
-        target: CheckoutTarget.StoredPaymentMethod,
-        context: CheckoutContext,
+        paymentMethod: StoredPaymentMethod,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
         sdkDataProvider: SdkDataProvider,
         checkoutParams: CheckoutParams,
     ): PaymentComponentResult {
-        val storedPaymentMethods = context.getPaymentMethodResponse()?.storedPaymentMethods
-            ?: return PaymentComponentResult.Failure("No payment methods response available.")
-
-        val storedPaymentMethod = storedPaymentMethods.find { it.id == target.id }
-            ?: return PaymentComponentResult.Failure(
-                "Stored payment method with id '${target.id}' was not found in the payment methods response.",
-            )
-
         val component = PaymentMethodProvider.getStoredPaymentComponent(
-            storedPaymentMethod = storedPaymentMethod,
+            storedPaymentMethod = paymentMethod,
             coroutineScope = coroutineScope,
             analyticsManager = analyticsManager,
             sdkDataProvider = sdkDataProvider,
             params = checkoutParams,
         ) ?: return PaymentComponentResult.Failure(
-            "Stored payment method type '${storedPaymentMethod.type}' is not supported. " +
+            "Stored payment method type '${paymentMethod.type}' is not supported. " +
                 "Ensure the corresponding module is included in your build dependencies.",
         )
 
         return PaymentComponentResult.Success(component)
-    }
-
-    private fun CheckoutContext.getPaymentMethodResponse(): PaymentMethods? {
-        return when (this) {
-            is CheckoutContext.Advanced -> paymentMethods
-            is CheckoutContext.Sessions -> checkoutSession.sessionSetupResponse.paymentMethods
-            is CheckoutContext.ActionOnly -> null
-        }
     }
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentComponentResolver.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentComponentResolver.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.CoroutineScope
 
 internal object PaymentComponentResolver {
 
+    @Suppress("LongParameterList")
     fun resolve(
         paymentMethod: PaymentMethodResponse,
         callbacks: CheckoutCallbacks,
@@ -49,6 +50,7 @@ internal object PaymentComponentResolver {
         }
     }
 
+    @Suppress("LongParameterList")
     private fun resolvePaymentMethod(
         paymentMethod: PaymentMethod,
         callbacks: CheckoutCallbacks,

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentMethodResolver.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/PaymentMethodResolver.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 23/6/2026.
+ */
+
+package com.adyen.checkout.core.components.internal
+
+import com.adyen.checkout.core.common.AdyenLogLevel
+import com.adyen.checkout.core.common.CheckoutContext
+import com.adyen.checkout.core.common.internal.helper.adyenLog
+import com.adyen.checkout.core.components.CheckoutTarget
+import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethodResponse
+import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethods
+
+internal object PaymentMethodResolver {
+
+    fun resolve(
+        target: CheckoutTarget,
+        context: CheckoutContext,
+    ): PaymentMethodResponse? {
+        return when (target) {
+            is CheckoutTarget.PaymentMethod -> resolvePaymentMethod(
+                target = target,
+                context = context,
+            )
+
+            is CheckoutTarget.StoredPaymentMethod -> resolveStoredPaymentMethod(
+                target = target,
+                context = context,
+            )
+
+            else -> {
+                adyenLog(AdyenLogLevel.WARN) { "Invalid target: $target" }
+                null
+            }
+        }
+    }
+
+    private fun resolvePaymentMethod(
+        target: CheckoutTarget.PaymentMethod,
+        context: CheckoutContext,
+    ): PaymentMethodResponse? {
+        val paymentMethods = context.getPaymentMethodResponse()?.paymentMethods
+        return paymentMethods?.find { it.type == target.type }
+    }
+
+    private fun resolveStoredPaymentMethod(
+        target: CheckoutTarget.StoredPaymentMethod,
+        context: CheckoutContext,
+    ): PaymentMethodResponse? {
+        val storedPaymentMethods = context.getPaymentMethodResponse()?.storedPaymentMethods
+        return storedPaymentMethods?.find { it.id == target.id }
+    }
+
+    private fun CheckoutContext.getPaymentMethodResponse(): PaymentMethods? {
+        return when (this) {
+            is CheckoutContext.Advanced -> paymentMethods
+            is CheckoutContext.Sessions -> checkoutSession.sessionSetupResponse.paymentMethods
+            is CheckoutContext.ActionOnly -> null
+        }
+    }
+}

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/FailureCheckoutFlowTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/FailureCheckoutFlowTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 23/6/2026.
+ */
+
+package com.adyen.checkout.core.components.internal
+
+import com.adyen.checkout.core.error.CheckoutError
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+internal class FailureCheckoutFlowTest {
+
+    @Nested
+    inner class InitTest {
+
+        @Test
+        fun `when created, then failure is emitted with the error message`() {
+            val dispatcher = TestComponentRequestDispatcher()
+
+            FailureCheckoutFlow(
+                errorMessage = "test error",
+                componentRequestDispatcher = dispatcher,
+            )
+
+            assertEquals(
+                CheckoutError(
+                    code = CheckoutError.ErrorCode.PAYMENT_METHOD_FAILURE,
+                    message = "test error",
+                ),
+                dispatcher.lastFailure,
+            )
+        }
+    }
+
+    @Nested
+    inner class PropertiesTest {
+
+        @Test
+        fun `when created, then paymentComponent is null`() {
+            val flow = createFailedCheckoutFlow()
+
+            assertNull(flow.paymentComponent)
+        }
+
+        @Test
+        fun `when created, then actionComponent is null`() {
+            val flow = createFailedCheckoutFlow()
+
+            assertNull(flow.actionComponent)
+        }
+
+        @Test
+        fun `when created, then navigation emits nothing`() = runTest {
+            val flow = createFailedCheckoutFlow()
+
+            val result = runCatching { flow.navigation.first() }
+
+            assertFalse(result.isSuccess)
+        }
+    }
+
+    @Nested
+    inner class RequiresUserInteractionTest {
+
+        @Test
+        fun `when requiresUserInteraction is called, then false is returned`() {
+            val flow = createFailedCheckoutFlow()
+
+            assertFalse(flow.requiresUserInteraction())
+        }
+    }
+
+    private fun createFailedCheckoutFlow(
+        errorMessage: String = "test error",
+    ) = FailureCheckoutFlow(
+        errorMessage = errorMessage,
+        componentRequestDispatcher = TestComponentRequestDispatcher(),
+    )
+
+    private class TestComponentRequestDispatcher : ComponentRequestDispatcher {
+
+        var lastFailure: CheckoutError? = null
+
+        override suspend fun additionalDetails(
+            data: com.adyen.checkout.core.action.data.ActionComponentData,
+        ) = com.adyen.checkout.core.components.AdditionalDetailsResult.Completion("")
+
+        override fun complete(resultCode: com.adyen.checkout.core.common.CheckoutResultCode) = Unit
+
+        override fun failure(error: CheckoutError) {
+            lastFailure = error
+        }
+    }
+}

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentComponentResolverTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentComponentResolverTest.kt
@@ -8,30 +8,25 @@
 
 package com.adyen.checkout.core.components.internal
 
-import com.adyen.checkout.core.action.data.RedirectAction
+import android.os.Parcel
 import com.adyen.checkout.core.analytics.internal.AnalyticsManager
 import com.adyen.checkout.core.analytics.internal.TestAnalyticsManager
-import com.adyen.checkout.core.common.CheckoutContext
 import com.adyen.checkout.core.common.Environment
 import com.adyen.checkout.core.common.internal.CheckoutParams
 import com.adyen.checkout.core.components.AdditionalDetailsResult
 import com.adyen.checkout.core.components.AdvancedCheckoutCallbacks
 import com.adyen.checkout.core.components.CheckoutAdditionalCallback
-import com.adyen.checkout.core.components.CheckoutConfiguration
-import com.adyen.checkout.core.components.CheckoutTarget
 import com.adyen.checkout.core.components.SubmitResult
+import com.adyen.checkout.core.components.data.model.paymentmethod.CardPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.GenericPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
-import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethods
+import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethodResponse
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredBLIKPaymentMethod
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPaymentMethod
-import com.adyen.checkout.core.components.data.model.paymentmethod.UnsupportedPaymentMethod
 import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
 import com.adyen.checkout.core.components.internal.data.provider.TestSdkDataProvider
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
 import com.adyen.checkout.core.components.internal.ui.TestPaymentComponent
-import com.adyen.checkout.core.sessions.CheckoutSession
-import com.adyen.checkout.core.sessions.internal.data.model.SessionSetupResponse
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -47,40 +42,14 @@ internal class PaymentComponentResolverTest {
     }
 
     @Test
-    fun `when payment methods response has no payment methods, then Failure is returned`() = runTest {
-        val result = resolve(
-            target = CheckoutTarget.PaymentMethod("scheme"),
-            paymentMethods = PaymentMethods(paymentMethods = null),
-        )
-
-        assertEquals(PaymentComponentResult.Failure("No payment methods response available."), result)
-    }
-
-    @Test
-    fun `when target payment method is not in the response, then Failure is returned`() = runTest {
-        val result = resolve(
-            target = CheckoutTarget.PaymentMethod("scheme"),
-            paymentMethods = PaymentMethods(
-                paymentMethods = listOf(GenericPaymentMethod(type = "ideal", name = "iDEAL")),
-            ),
-        )
-
-        assertEquals(
-            PaymentComponentResult.Failure(
-                "Payment method 'scheme' was not found in the payment methods response.",
-            ),
-            result,
-        )
-    }
-
-    @Test
     fun `when payment method is not supported, then Failure is returned`() = runTest {
-        val result = resolve(
-            target = CheckoutTarget.PaymentMethod("scheme"),
-            paymentMethods = PaymentMethods(
-                paymentMethods = listOf(UnsupportedPaymentMethod(type = "scheme", name = "Card")),
-            ),
+        val paymentMethod = CardPaymentMethod(
+            type = "scheme",
+            name = "Card",
+            brands = emptyList(),
+            fundingSource = null,
         )
+        val result = resolve(paymentMethod)
 
         assertEquals(
             PaymentComponentResult.Failure(
@@ -92,52 +61,13 @@ internal class PaymentComponentResolverTest {
     }
 
     @Test
-    fun `when payment methods response has no stored payment methods, then Failure is returned`() = runTest {
-        val result = resolve(
-            target = CheckoutTarget.StoredPaymentMethod("test_id"),
-            paymentMethods = PaymentMethods(storedPaymentMethods = null),
-        )
-
-        assertEquals(PaymentComponentResult.Failure("No payment methods response available."), result)
-    }
-
-    @Test
-    fun `when target stored payment method is not in the response, then Failure is returned`() = runTest {
-        val result = resolve(
-            target = CheckoutTarget.StoredPaymentMethod("test_id"),
-            paymentMethods = PaymentMethods(
-                storedPaymentMethods = listOf(
-                    StoredBLIKPaymentMethod(
-                        type = "blik",
-                        name = "BLIK",
-                        id = "other_id",
-                        supportedShopperInteractions = emptyList(),
-                    ),
-                ),
-            ),
-        )
-
-        assertEquals(
-            PaymentComponentResult.Failure(
-                "Stored payment method with id 'test_id' was not found in the payment methods response.",
-            ),
-            result,
-        )
-    }
-
-    @Test
     fun `when stored payment method is not supported, then Failure is returned`() = runTest {
         val result = resolve(
-            target = CheckoutTarget.StoredPaymentMethod("test_id"),
-            paymentMethods = PaymentMethods(
-                storedPaymentMethods = listOf(
-                    StoredBLIKPaymentMethod(
-                        type = "blik",
-                        name = "BLIK",
-                        id = "test_id",
-                        supportedShopperInteractions = emptyList(),
-                    ),
-                ),
+            StoredBLIKPaymentMethod(
+                type = "blik",
+                name = "BLIK",
+                id = "test_id",
+                supportedShopperInteractions = emptyList(),
             ),
         )
 
@@ -151,13 +81,19 @@ internal class PaymentComponentResolverTest {
     }
 
     @Test
-    fun `when checkout target is unknown, then Failure is returned`() = runTest {
+    fun `when payment method response type is unsupported, then Failure is returned`() = runTest {
         val result = resolve(
-            target = object : CheckoutTarget {},
-            paymentMethods = PaymentMethods(),
+            object : PaymentMethodResponse() {
+                override val type: String = "unknown"
+                override val name: String = "Unknown"
+                override fun writeToParcel(dest: Parcel, flags: Int) = Unit
+            },
         )
 
-        assertEquals(PaymentComponentResult.Failure("Unsupported checkout target."), result)
+        assertEquals(
+            PaymentComponentResult.Failure("Unsupported payment method response type."),
+            result,
+        )
     }
 
     @Test
@@ -165,12 +101,7 @@ internal class PaymentComponentResolverTest {
         val component = TestPaymentComponent()
         registerFactory(type = "scheme", component = component)
 
-        val result = resolve(
-            target = CheckoutTarget.PaymentMethod("scheme"),
-            paymentMethods = PaymentMethods(
-                paymentMethods = listOf(GenericPaymentMethod(type = "scheme", name = "Card")),
-            ),
-        )
+        val result = resolve(GenericPaymentMethod(type = "scheme", name = "Card"))
 
         assertEquals(PaymentComponentResult.Success(component), result)
     }
@@ -181,121 +112,26 @@ internal class PaymentComponentResolverTest {
         registerStoredFactory(type = "blik", component = component)
 
         val result = resolve(
-            target = CheckoutTarget.StoredPaymentMethod("test_id"),
-            paymentMethods = PaymentMethods(
-                storedPaymentMethods = listOf(
-                    StoredBLIKPaymentMethod(
-                        type = "blik",
-                        name = "BLIK",
-                        id = "test_id",
-                        supportedShopperInteractions = emptyList(),
-                    ),
-                ),
+            StoredBLIKPaymentMethod(
+                type = "blik",
+                name = "BLIK",
+                id = "test_id",
+                supportedShopperInteractions = emptyList(),
             ),
-        )
-
-        assertEquals(PaymentComponentResult.Success(component), result)
-    }
-
-    @Test
-    fun `when context is ActionOnly, then Failure is returned`() = runTest {
-        val result = PaymentComponentResolver.resolve(
-            target = CheckoutTarget.PaymentMethod("scheme"),
-            context = actionOnlyContext(),
-            callbacks = advancedCallbacks(),
-            coroutineScope = this,
-            analyticsManager = TestAnalyticsManager(),
-            sdkDataProvider = TestSdkDataProvider(),
-            checkoutParams = checkoutParams(),
-        )
-
-        assertEquals(PaymentComponentResult.Failure("No payment methods response available."), result)
-    }
-
-    @Test
-    fun `when context is Sessions, then payment methods are resolved from the session setup response`() = runTest {
-        val component = TestPaymentComponent()
-        registerFactory(type = "scheme", component = component)
-
-        val result = PaymentComponentResolver.resolve(
-            target = CheckoutTarget.PaymentMethod("scheme"),
-            context = sessionsContext(
-                PaymentMethods(
-                    paymentMethods = listOf(GenericPaymentMethod(type = "scheme", name = "Card")),
-                ),
-            ),
-            callbacks = advancedCallbacks(),
-            coroutineScope = this,
-            analyticsManager = TestAnalyticsManager(),
-            sdkDataProvider = TestSdkDataProvider(),
-            checkoutParams = checkoutParams(),
         )
 
         assertEquals(PaymentComponentResult.Success(component), result)
     }
 
     private fun CoroutineScope.resolve(
-        target: CheckoutTarget,
-        paymentMethods: PaymentMethods,
+        paymentMethod: PaymentMethodResponse,
     ): PaymentComponentResult = PaymentComponentResolver.resolve(
-        target = target,
-        context = advancedContext(paymentMethods),
+        paymentMethod = paymentMethod,
         callbacks = advancedCallbacks(),
         coroutineScope = this,
         analyticsManager = TestAnalyticsManager(),
         sdkDataProvider = TestSdkDataProvider(),
         checkoutParams = checkoutParams(),
-    )
-
-    private fun advancedContext(paymentMethods: PaymentMethods) = CheckoutContext.Advanced(
-        paymentMethods = paymentMethods,
-        checkoutConfiguration = CheckoutConfiguration(
-            environment = Environment.TEST,
-            clientKey = TEST_CLIENT_KEY,
-            shopperLocale = Locale.US,
-        ),
-        checkoutAttemptId = "",
-        publicKey = null,
-    )
-
-    private fun actionOnlyContext() = CheckoutContext.ActionOnly(
-        action = RedirectAction(
-            type = "redirect",
-            paymentData = "test_data",
-            paymentMethodType = "scheme",
-        ),
-        checkoutConfiguration = CheckoutConfiguration(
-            environment = Environment.TEST,
-            clientKey = TEST_CLIENT_KEY,
-            shopperLocale = Locale.US,
-        ),
-        checkoutAttemptId = "",
-        publicKey = null,
-    )
-
-    private fun sessionsContext(paymentMethods: PaymentMethods) = CheckoutContext.Sessions(
-        checkoutSession = CheckoutSession(
-            sessionSetupResponse = SessionSetupResponse(
-                id = "test_session_id",
-                sessionData = "test_session_data",
-                amount = null,
-                expiresAt = "2026-12-31T23:59:59Z",
-                paymentMethods = paymentMethods,
-                returnUrl = null,
-                configuration = null,
-                shopperLocale = null,
-            ),
-            order = null,
-            environment = Environment.TEST,
-            clientKey = TEST_CLIENT_KEY,
-        ),
-        checkoutConfiguration = CheckoutConfiguration(
-            environment = Environment.TEST,
-            clientKey = TEST_CLIENT_KEY,
-            shopperLocale = Locale.US,
-        ),
-        checkoutAttemptId = "",
-        publicKey = null,
     )
 
     private fun advancedCallbacks() = AdvancedCheckoutCallbacks(

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentMethodResolverTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentMethodResolverTest.kt
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by oscars on 23/6/2026.
+ */
+
+package com.adyen.checkout.core.components.internal
+
+import com.adyen.checkout.core.action.data.RedirectAction
+import com.adyen.checkout.core.common.CheckoutContext
+import com.adyen.checkout.core.common.Environment
+import com.adyen.checkout.core.components.CheckoutConfiguration
+import com.adyen.checkout.core.components.CheckoutTarget
+import com.adyen.checkout.core.components.data.model.paymentmethod.GenericPaymentMethod
+import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethods
+import com.adyen.checkout.core.components.data.model.paymentmethod.StoredUnsupportedPaymentMethod
+import com.adyen.checkout.core.sessions.CheckoutSession
+import com.adyen.checkout.core.sessions.internal.data.model.SessionSetupResponse
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.Locale
+
+internal class PaymentMethodResolverTest {
+
+    @Nested
+    inner class PaymentMethodTargetTest {
+
+        @Test
+        fun `when payment method is found, then it is returned`() {
+            val expected = GenericPaymentMethod(type = "scheme", name = "Card")
+            val context = advancedContext(
+                PaymentMethods(paymentMethods = listOf(expected)),
+            )
+
+            val result = PaymentMethodResolver.resolve(
+                target = CheckoutTarget.PaymentMethod("scheme"),
+                context = context,
+            )
+
+            assertEquals(expected, result)
+        }
+
+        @Test
+        fun `when payment method is not found, then null is returned`() {
+            val context = advancedContext(
+                PaymentMethods(
+                    paymentMethods = listOf(GenericPaymentMethod(type = "ideal", name = "iDEAL")),
+                ),
+            )
+
+            val result = PaymentMethodResolver.resolve(
+                target = CheckoutTarget.PaymentMethod("scheme"),
+                context = context,
+            )
+
+            assertNull(result)
+        }
+
+        @Test
+        fun `when payment methods list is null, then null is returned`() {
+            val context = advancedContext(
+                PaymentMethods(paymentMethods = null),
+            )
+
+            val result = PaymentMethodResolver.resolve(
+                target = CheckoutTarget.PaymentMethod("scheme"),
+                context = context,
+            )
+
+            assertNull(result)
+        }
+
+        @Test
+        fun `when multiple payment methods exist, then the matching one is returned`() {
+            val expected = GenericPaymentMethod(type = "scheme", name = "Card")
+            val context = advancedContext(
+                PaymentMethods(
+                    paymentMethods = listOf(
+                        GenericPaymentMethod(type = "ideal", name = "iDEAL"),
+                        expected,
+                        GenericPaymentMethod(type = "paypal", name = "PayPal"),
+                    ),
+                ),
+            )
+
+            val result = PaymentMethodResolver.resolve(
+                target = CheckoutTarget.PaymentMethod("scheme"),
+                context = context,
+            )
+
+            assertEquals(expected, result)
+        }
+    }
+
+    @Nested
+    inner class StoredPaymentMethodTargetTest {
+
+        @Test
+        fun `when stored payment method is found, then it is returned`() {
+            val expected = StoredUnsupportedPaymentMethod(
+                type = "scheme",
+                name = "Card",
+                id = "test_id",
+                supportedShopperInteractions = emptyList(),
+            )
+            val context = advancedContext(
+                PaymentMethods(storedPaymentMethods = listOf(expected)),
+            )
+
+            val result = PaymentMethodResolver.resolve(
+                target = CheckoutTarget.StoredPaymentMethod("test_id"),
+                context = context,
+            )
+
+            assertEquals(expected, result)
+        }
+
+        @Test
+        fun `when stored payment method is not found, then null is returned`() {
+            val context = advancedContext(
+                PaymentMethods(
+                    storedPaymentMethods = listOf(
+                        StoredUnsupportedPaymentMethod(
+                            type = "scheme",
+                            name = "Card",
+                            id = "other_id",
+                            supportedShopperInteractions = emptyList(),
+                        ),
+                    ),
+                ),
+            )
+
+            val result = PaymentMethodResolver.resolve(
+                target = CheckoutTarget.StoredPaymentMethod("test_id"),
+                context = context,
+            )
+
+            assertNull(result)
+        }
+
+        @Test
+        fun `when stored payment methods list is null, then null is returned`() {
+            val context = advancedContext(
+                PaymentMethods(storedPaymentMethods = null),
+            )
+
+            val result = PaymentMethodResolver.resolve(
+                target = CheckoutTarget.StoredPaymentMethod("test_id"),
+                context = context,
+            )
+
+            assertNull(result)
+        }
+
+        @Test
+        fun `when multiple stored payment methods exist, then the matching one is returned`() {
+            val expected = StoredUnsupportedPaymentMethod(
+                type = "scheme",
+                name = "Card",
+                id = "test_id",
+                supportedShopperInteractions = emptyList(),
+            )
+            val context = advancedContext(
+                PaymentMethods(
+                    storedPaymentMethods = listOf(
+                        StoredUnsupportedPaymentMethod(
+                            type = "blik",
+                            name = "BLIK",
+                            id = "other_id",
+                            supportedShopperInteractions = emptyList(),
+                        ),
+                        expected,
+                    ),
+                ),
+            )
+
+            val result = PaymentMethodResolver.resolve(
+                target = CheckoutTarget.StoredPaymentMethod("test_id"),
+                context = context,
+            )
+
+            assertEquals(expected, result)
+        }
+    }
+
+    @Nested
+    inner class UnknownTargetTest {
+
+        @Test
+        fun `when target is unknown, then null is returned`() {
+            val context = advancedContext(PaymentMethods())
+
+            val result = PaymentMethodResolver.resolve(
+                target = object : CheckoutTarget {},
+                context = context,
+            )
+
+            assertNull(result)
+        }
+    }
+
+    @Nested
+    inner class CheckoutContextTest {
+
+        @Test
+        fun `when context is ActionOnly, then null is returned`() {
+            val result = PaymentMethodResolver.resolve(
+                target = CheckoutTarget.PaymentMethod("scheme"),
+                context = actionOnlyContext(),
+            )
+
+            assertNull(result)
+        }
+
+        @Test
+        fun `when context is Sessions, then payment method is resolved from session setup response`() {
+            val expected = GenericPaymentMethod(type = "scheme", name = "Card")
+            val context = sessionsContext(
+                PaymentMethods(paymentMethods = listOf(expected)),
+            )
+
+            val result = PaymentMethodResolver.resolve(
+                target = CheckoutTarget.PaymentMethod("scheme"),
+                context = context,
+            )
+
+            assertEquals(expected, result)
+        }
+
+        @Test
+        fun `when context is Sessions, then stored payment method is resolved from session setup response`() {
+            val expected = StoredUnsupportedPaymentMethod(
+                type = "scheme",
+                name = "Card",
+                id = "test_id",
+                supportedShopperInteractions = emptyList(),
+            )
+            val context = sessionsContext(
+                PaymentMethods(storedPaymentMethods = listOf(expected)),
+            )
+
+            val result = PaymentMethodResolver.resolve(
+                target = CheckoutTarget.StoredPaymentMethod("test_id"),
+                context = context,
+            )
+
+            assertEquals(expected, result)
+        }
+
+        @Test
+        fun `when context is Sessions and payment methods are null, then null is returned`() {
+            val context = sessionsContext(paymentMethods = null)
+
+            val result = PaymentMethodResolver.resolve(
+                target = CheckoutTarget.PaymentMethod("scheme"),
+                context = context,
+            )
+
+            assertNull(result)
+        }
+    }
+
+    private fun advancedContext(paymentMethods: PaymentMethods) = CheckoutContext.Advanced(
+        paymentMethods = paymentMethods,
+        checkoutConfiguration = CheckoutConfiguration(
+            environment = Environment.TEST,
+            clientKey = TEST_CLIENT_KEY,
+            shopperLocale = Locale.US,
+        ),
+        checkoutAttemptId = "",
+        publicKey = null,
+    )
+
+    private fun actionOnlyContext() = CheckoutContext.ActionOnly(
+        action = RedirectAction(
+            type = "redirect",
+            paymentData = "test_data",
+            paymentMethodType = "scheme",
+        ),
+        checkoutConfiguration = CheckoutConfiguration(
+            environment = Environment.TEST,
+            clientKey = TEST_CLIENT_KEY,
+            shopperLocale = Locale.US,
+        ),
+        checkoutAttemptId = "",
+        publicKey = null,
+    )
+
+    private fun sessionsContext(paymentMethods: PaymentMethods?) = CheckoutContext.Sessions(
+        checkoutSession = CheckoutSession(
+            sessionSetupResponse = SessionSetupResponse(
+                id = "test_session_id",
+                sessionData = "test_session_data",
+                amount = null,
+                expiresAt = "2026-12-31T23:59:59Z",
+                paymentMethods = paymentMethods,
+                returnUrl = null,
+                configuration = null,
+                shopperLocale = null,
+            ),
+            order = null,
+            environment = Environment.TEST,
+            clientKey = TEST_CLIENT_KEY,
+        ),
+        checkoutConfiguration = CheckoutConfiguration(
+            environment = Environment.TEST,
+            clientKey = TEST_CLIENT_KEY,
+            shopperLocale = Locale.US,
+        ),
+        checkoutAttemptId = "",
+        publicKey = null,
+    )
+
+    companion object {
+        private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfghjklzxcvbnm"
+    }
+}


### PR DESCRIPTION
## Description

Refactor checkout controller creation to resolve payment methods earlier,  handle errors more gracefully and extract payment method resolution into a dedicated class.

### Key changes

**Extract `PaymentMethodResolver`**: Payment method lookup logic (finding a `PaymentMethod` or `StoredPaymentMethod` from the `CheckoutContext`) was moved out of `PaymentComponentResolver` into a new `PaymentMethodResolver` object. This allows `CheckoutControllerFactory` to resolve the payment method response object earlier in the flow, before creating common dependencies like the `AnalyticsManager`.

**Resolve payment method type before analytics creation**: `CheckoutControllerFactory` now resolves the payment method *before* calling `createCommonDependencies`, passing the actual `paymentMethodType` to `AnalyticsSource.PaymentComponent` instead of the previous hardcoded `"paymentMethod.type"` placeholder.

**Introduce `FailureCheckoutFlow`**: Instead of emitting a failure and passing `null` to `FullCheckoutFlow`, errors during component resolution now produce a `FailureCheckoutFlow` that immediately dispatches a `CheckoutError` with `PAYMENT_METHOD_FAILURE` and returns no-ops for `submit()` and navigation flows.

**Simplify `PaymentComponentResolver`**: No longer responsible for finding payment methods in the response — it receives a resolved `PaymentMethodResponse` directly and only handles factory dispatch.

**Add tests**: New `FailureCheckoutFlowTest`, `PaymentMethodResolverTest`, updated `PaymentMethodProviderTest`, and simplified `PaymentComponentResolverTest`.


## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually