### PR TITLE
v6 - Google Pay - Example app integration

### DIFF
--- a/core/src/main/java/com/adyen/checkout/core/components/paymentmethod/PaymentMethodDetails.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/paymentmethod/PaymentMethodDetails.kt
@@ -87,8 +87,8 @@ abstract class PaymentMethodDetails : ModelObject() {
 //                PaymentMethodTypes.PAY_BY_BANK_US -> PayByBankUSPaymentMethod.SERIALIZER
 //                PayEasyPaymentMethod.PAYMENT_METHOD_TYPE -> PayEasyPaymentMethod.SERIALIZER
 //                PayToPaymentMethod.PAYMENT_METHOD_TYPE -> PayToPaymentMethod.SERIALIZER
-//                PaymentMethodTypes.GOOGLE_PAY,
-//                PaymentMethodTypes.GOOGLE_PAY_LEGACY -> GooglePayPaymentMethod.SERIALIZER
+                PaymentMethodTypes.GOOGLE_PAY,
+                PaymentMethodTypes.GOOGLE_PAY_LEGACY -> GooglePayDetails.SERIALIZER
 //
 //                PaymentMethodTypes.MOLPAY_MALAYSIA,
 //                PaymentMethodTypes.MOLPAY_THAILAND,

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/configuration/CheckoutConfigurationProvider.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/configuration/CheckoutConfigurationProvider.kt
@@ -24,6 +24,7 @@ import com.adyen.checkout.example.data.storage.CardAddressMode
 import com.adyen.checkout.example.data.storage.CardInstallmentOptionsMode
 import com.adyen.checkout.example.data.storage.KeyValueStorage
 import com.adyen.checkout.giftcard.giftCard
+import com.adyen.checkout.googlepay.googlePay
 import com.adyen.checkout.googlepay.old.googlePay
 import com.adyen.checkout.instant.instantPayment
 import com.adyen.checkout.mealvoucherfr.mealVoucherFR
@@ -121,6 +122,11 @@ internal class CheckoutConfigurationProvider @Inject constructor(
             card(
                 billingAddressMode = getBillingAddressMode(),
                 installmentConfiguration = getInstallmentConfiguration(),
+            )
+
+            googlePay(
+                countryCode = keyValueStorage.getCountry(),
+                checkoutOption = "COMPLETE_IMMEDIATE_PURCHASE",
             )
 
             threeDS2(

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/v6/CheckoutContextExt.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/v6/CheckoutContextExt.kt
@@ -16,6 +16,8 @@ import com.adyen.checkout.core.components.paymentmethod.PaymentMethodTypes
 
 private val SUPPORTED_V6_PAYMENT_METHODS = listOf(
     PaymentMethodTypes.BLIK,
+    PaymentMethodTypes.GOOGLE_PAY,
+    PaymentMethodTypes.GOOGLE_PAY_LEGACY,
     PaymentMethodTypes.MB_WAY,
     PaymentMethodTypes.SCHEME,
 )


### PR DESCRIPTION
## Description
Enables Google Pay in the v6 example app so the component can be exercised end-to-end.

- Adds `GOOGLE_PAY` and `GOOGLE_PAY_LEGACY` to the v6 sample's supported payment methods (`CheckoutContextExt.kt`). Both type strings map to the same component, matching v5.
- Adds a v6 `googlePay(countryCode, checkoutOption)` block to the example's `checkoutConfig` (`CheckoutConfigurationProvider.kt`), mirroring the old sample's relevant settings.

### Progress

✅ Component and factory wiring — #2837
✅ Sheet launch and result handling — #2839
✅ Availability gating — #2845
✅ Button — #2847
➡️ **Example app integration (this PR)**

## Checklist
- [x] Changes are tested manually

## Ticket Number
COSDK-1309