### PR TITLE
v6 - Card - Dual Brand Selection

### DIFF
--- a/card/build.gradle
+++ b/card/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     implementation libs.material
 
     //Tests
+    testImplementation testFixtures(project(':core'))
     testImplementation testFixtures(project(':test-core'))
     testImplementation testFixtures(project(':action-core'))
     testImplementation testFixtures(project(':components-core'))

--- a/card/src/main/java/com/adyen/checkout/card/internal/analytics/DualBrandCardEvents.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/analytics/DualBrandCardEvents.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by temirlan on 29/6/2026.
+ */
+
+package com.adyen.checkout.card.internal.analytics
+
+import com.adyen.checkout.card.internal.ui.state.CardBrandData
+import com.adyen.checkout.core.analytics.internal.GenericEvents
+import com.adyen.checkout.core.common.CardBrand
+
+internal object DualBrandCardEvents {
+
+    fun dualBrandSelectionDisplayed(
+        component: String,
+        selectedBrand: CardBrand,
+        brandOptions: List<CardBrandData>,
+    ) = GenericEvents.displayed(
+        component = component,
+        target = DUAL_BRAND_ANALYTICS_TARGET,
+        brand = selectedBrand.txVariant,
+        configData = mapOf("dualBrands" to brandOptions.joinToString(",") { it.cardBrand.txVariant }),
+    )
+
+    fun brandSelected(
+        component: String,
+        selectedBrand: CardBrand
+    ) = GenericEvents.selected(
+        component = component,
+        target = DUAL_BRAND_ANALYTICS_TARGET,
+        brand = selectedBrand.txVariant,
+    )
+
+    private const val DUAL_BRAND_ANALYTICS_TARGET = "dual_brand_button"
+}

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
@@ -266,13 +266,19 @@ constructor(
     }
 
     private fun subscribeToDualBrandSelectionAppearAnalyticsEvents() {
+        // Fires dualBrandSelectionDisplayed when DualBrandWithShopperSelection appears.
         componentState
             .map { it.cardBrandState }
+            // Compares bucket membership (DualBrandWithShopperSelection vs. anything else) rather
+            // than state equality: suppresses brand-selection changes within the dual brand UI
+            // (same bucket → "equal") while emitting on appear/disappear transitions.
             .distinctUntilChanged { old, new ->
                 val isOldDualBrandWithSelection = old is CardBrandState.DualBrandWithShopperSelection
                 val isNewDualBrandWithSelection = new is CardBrandState.DualBrandWithShopperSelection
                 isOldDualBrandWithSelection == isNewDualBrandWithSelection
             }
+            // Discards the disappear emissions so only appear transitions reach onEach.
+            // WARNING: must come AFTER distinctUntilChanged — reversing them causes the event to never fire.
             .mapNotNull { it as? CardBrandState.DualBrandWithShopperSelection }
             .onEach { cardBrandState ->
                 val event = DualBrandCardEvents.dualBrandSelectionDisplayed(

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
@@ -56,7 +56,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
@@ -268,13 +267,14 @@ constructor(
 
     private fun subscribeToDualBrandAnalyticsEvents() {
         componentState
-            .map { it.cardBrandState is CardBrandState.DualBrandWithShopperSelection }
-            .distinctUntilChanged()
-            .filter { isVisible -> isVisible }
-            .onEach {
-                val cardBrandState = componentState.value.cardBrandState
-                    as? CardBrandState.DualBrandWithShopperSelection ?: return@onEach
-
+            .map { it.cardBrandState }
+            .distinctUntilChanged { old, new ->
+                val isOldDualBrandWithSelection = old is CardBrandState.DualBrandWithShopperSelection
+                val isNewDualBrandWithSelection = new is CardBrandState.DualBrandWithShopperSelection
+                isOldDualBrandWithSelection == isNewDualBrandWithSelection
+            }
+            .mapNotNull { it as? CardBrandState.DualBrandWithShopperSelection }
+            .onEach { cardBrandState ->
                 val event = DualBrandCardEvents.dualBrandSelectionDisplayed(
                     component = paymentMethodType,
                     selectedBrand = cardBrandState.shopperSelectedCardBrandData.cardBrand,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
@@ -14,6 +14,7 @@ import android.content.Intent
 import android.content.IntentSender
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.IntentSenderRequest
+import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.adyen.checkout.card.OnBinChangeCallback
@@ -231,7 +232,8 @@ constructor(
         componentState.handleIntent(intent)
     }
 
-    private fun handleIntent(intent: CardIntent) {
+    @VisibleForTesting
+    internal fun handleIntent(intent: CardIntent) {
         when (intent) {
             is CardIntent.UpdateCardNumber -> onCardNumberChanged(intent.number)
             is CardIntent.SelectBrand -> onBrandSelected(intent)

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
@@ -19,9 +19,11 @@ import androidx.compose.ui.Modifier
 import com.adyen.checkout.card.OnBinChangeCallback
 import com.adyen.checkout.card.OnBinLookupCallback
 import com.adyen.checkout.card.internal.analytics.CardScannerEvents
+import com.adyen.checkout.card.internal.analytics.DualBrandCardEvents
 import com.adyen.checkout.card.internal.data.api.DetectCardTypeRepository
 import com.adyen.checkout.card.internal.helper.toBinLookupData
 import com.adyen.checkout.card.internal.ui.model.CardComponentParams
+import com.adyen.checkout.card.internal.ui.state.CardBrandState
 import com.adyen.checkout.card.internal.ui.state.CardComponentStateFactory
 import com.adyen.checkout.card.internal.ui.state.CardComponentStateReducer
 import com.adyen.checkout.card.internal.ui.state.CardComponentStateValidator
@@ -53,6 +55,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
@@ -97,6 +100,7 @@ constructor(
     private val viewState = componentState.viewState(viewStateProducer, coroutineScope)
 
     init {
+        subscribeToDualBrandAnalyticsEvents()
         onCardBrandDataChanged()
         onBinChanged()
     }
@@ -230,6 +234,7 @@ constructor(
     private fun handleIntent(intent: CardIntent) {
         when (intent) {
             is CardIntent.UpdateCardNumber -> onCardNumberChanged(intent.number)
+            is CardIntent.SelectBrand -> onBrandSelected(intent)
             else -> onIntent(intent)
         }
     }
@@ -243,6 +248,39 @@ constructor(
         detectCardTypeRepository.detectCardTypes(cardNumber).onEach { result ->
             onIntent(CardIntent.UpdateDetectedCardTypes(result))
         }.launchIn(coroutineScope)
+    }
+
+    private fun onBrandSelected(intent: CardIntent.SelectBrand) {
+        val currentBrandState = componentState.value.cardBrandState
+        if (currentBrandState is CardBrandState.DualBrandWithShopperSelection &&
+            currentBrandState.shopperSelectedCardBrandData.cardBrand != intent.cardBrand
+        ) {
+            val event = DualBrandCardEvents.brandSelected(
+                component = paymentMethodType,
+                selectedBrand = intent.cardBrand
+            )
+            analyticsManager.trackEvent(event)
+        }
+        onIntent(intent)
+    }
+
+    private fun subscribeToDualBrandAnalyticsEvents() {
+        componentState
+            .map { it.cardBrandState is CardBrandState.DualBrandWithShopperSelection }
+            .distinctUntilChanged()
+            .filter { isVisible -> isVisible }
+            .onEach {
+                val cardBrandState = componentState.value.cardBrandState
+                    as? CardBrandState.DualBrandWithShopperSelection ?: return@onEach
+
+                val event = DualBrandCardEvents.dualBrandSelectionDisplayed(
+                    component = paymentMethodType,
+                    selectedBrand = cardBrandState.shopperSelectedCardBrandData.cardBrand,
+                    brandOptions = cardBrandState.cardBrandDataList,
+                )
+                analyticsManager.trackEvent(event)
+            }
+            .launchIn(coroutineScope)
     }
 
     private fun onBinChanged() {

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
@@ -100,7 +100,7 @@ constructor(
     private val viewState = componentState.viewState(viewStateProducer, coroutineScope)
 
     init {
-        subscribeToDualBrandAnalyticsEvents()
+        subscribeToDualBrandSelectionAppearAnalyticsEvents()
         onCardBrandDataChanged()
         onBinChanged()
     }
@@ -265,7 +265,7 @@ constructor(
         onIntent(intent)
     }
 
-    private fun subscribeToDualBrandAnalyticsEvents() {
+    private fun subscribeToDualBrandSelectionAppearAnalyticsEvents() {
         componentState
             .map { it.cardBrandState }
             .distinctUntilChanged { old, new ->

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
@@ -35,13 +35,13 @@ internal class CardViewStateProducer : ViewStateProducer<CardComponentState, Car
             is CardBrandState.DualBrandWithShopperSelection -> false
         }
 
-        val cardNumberDescription = getCardNumberDescription(state.cardBrandState)
+        val cardNumberInputDescription = getCardNumberInputDescription(state.cardBrandState)
         val cardBrandViewState = getCardBrandViewState(state.cardBrandState)
         val cardNumberFormat = getCardNumberFormat(state.cardBrandState)
         val isCardScanButtonVisible = state.isCardScanningAvailable && state.cardNumber.text.isEmpty()
 
         return CardViewState(
-            cardNumber = state.cardNumber.copy(description = cardNumberDescription).toViewState(
+            cardNumber = state.cardNumber.copy(description = cardNumberInputDescription).toViewState(
                 trailingIcon = getCardNumberTrailingIcon(state.cardNumber, isCardScanButtonVisible),
             ),
             expiryDate = state.expiryDate.toViewState(
@@ -71,7 +71,7 @@ internal class CardViewStateProducer : ViewStateProducer<CardComponentState, Car
         )
     }
 
-    private fun getCardNumberDescription(cardBrandState: CardBrandState): CheckoutLocalizationKey? {
+    private fun getCardNumberInputDescription(cardBrandState: CardBrandState): CheckoutLocalizationKey? {
         if (cardBrandState is CardBrandState.DualBrandWithShopperSelection) {
             return CheckoutLocalizationKey.CARD_DUAL_BRAND_SELECTOR_DESCRIPTION
         }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
@@ -13,6 +13,7 @@ import com.adyen.checkout.card.internal.ui.model.CardNumberTrailingIcon
 import com.adyen.checkout.card.internal.ui.model.ExpiryDateTrailingIcon
 import com.adyen.checkout.card.internal.ui.model.PostalCodeTrailingIcon
 import com.adyen.checkout.card.internal.ui.model.SecurityCodeTrailingIcon
+import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.components.internal.ui.state.ViewStateProducer
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
 import com.adyen.checkout.core.components.internal.ui.state.model.toViewState
@@ -34,12 +35,13 @@ internal class CardViewStateProducer : ViewStateProducer<CardComponentState, Car
             is CardBrandState.DualBrandWithShopperSelection -> false
         }
 
+        val cardNumberDescription = getCardNumberDescription(state.cardBrandState)
         val cardBrandViewState = getCardBrandViewState(state.cardBrandState)
         val cardNumberFormat = getCardNumberFormat(state.cardBrandState)
         val isCardScanButtonVisible = state.isCardScanningAvailable && state.cardNumber.text.isEmpty()
 
         return CardViewState(
-            cardNumber = state.cardNumber.toViewState(
+            cardNumber = state.cardNumber.copy(description = cardNumberDescription).toViewState(
                 trailingIcon = getCardNumberTrailingIcon(state.cardNumber, isCardScanButtonVisible),
             ),
             expiryDate = state.expiryDate.toViewState(
@@ -67,6 +69,14 @@ internal class CardViewStateProducer : ViewStateProducer<CardComponentState, Car
             isCardScanButtonVisible = isCardScanButtonVisible,
             installmentViewState = state.installmentState.toViewState(),
         )
+    }
+
+    private fun getCardNumberDescription(cardBrandState: CardBrandState): CheckoutLocalizationKey? {
+        if (cardBrandState is CardBrandState.DualBrandWithShopperSelection) {
+            return CheckoutLocalizationKey.CARD_DUAL_BRAND_SELECTOR_DESCRIPTION
+        }
+
+        return null
     }
 
     private fun getCardBrandViewState(cardBrandState: CardBrandState): CardBrandViewState {

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardContent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardContent.kt
@@ -129,7 +129,7 @@ private fun CardDetailsSection(
                 onValueChange = { onIntent(CardIntent.UpdateCardNumber(it)) },
                 onFocusChange = { onIntent(CardIntent.UpdateCardNumberFocus(it)) },
                 onScanButtonClick = onScanButtonClick,
-                onBrandSelected = { onIntent(CardIntent.SelectBrand(it)) },
+                onBrandSelect = { onIntent(CardIntent.SelectBrand(it)) },
             )
         }
         if (viewState.expiryDate != null) {

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardContent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardContent.kt
@@ -129,6 +129,7 @@ private fun CardDetailsSection(
                 onValueChange = { onIntent(CardIntent.UpdateCardNumber(it)) },
                 onFocusChange = { onIntent(CardIntent.UpdateCardNumberFocus(it)) },
                 onScanButtonClick = onScanButtonClick,
+                onBrandSelected = { onIntent(CardIntent.SelectBrand(it)) },
             )
         }
         if (viewState.expiryDate != null) {

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
@@ -275,7 +275,8 @@ private fun CardNumberFieldIcon(
     onBrandSelect: (CardBrand) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val trailingIcon = state.trailingIcon as? CardNumberTrailingIcon
+    // null is not expected for the trailingIcon
+    val trailingIcon = state.trailingIcon as? CardNumberTrailingIcon ?: return
     AnimatedContent(targetState = trailingIcon, modifier = modifier) { trailingIcon ->
         when (trailingIcon) {
             CardNumberTrailingIcon.Warning -> Icon(
@@ -296,7 +297,7 @@ private fun CardNumberFieldIcon(
                 )
             }
 
-            else -> DetectedBrandsList(cardBrandViewState, onBrandSelect)
+            CardNumberTrailingIcon.BrandLogos -> DetectedBrandsList(cardBrandViewState, onBrandSelect)
         }
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -49,8 +50,10 @@ import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParamet
 import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
 import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
 import com.adyen.checkout.ui.internal.helper.getThemedIcon
+import com.adyen.checkout.ui.internal.text.Footnote
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
 import com.adyen.checkout.ui.internal.theme.Dimensions
+import com.adyen.checkout.ui.internal.theme.Dimensions.Spacing
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @Composable
@@ -132,6 +135,16 @@ private fun CardNumberInputField(
             )
         },
     )
+
+    AnimatedVisibility(
+        modifier = Modifier.fillMaxWidth(),
+        visible = cardBrandViewState is CardBrandViewState.SelectableDualBrand,
+    ) {
+        Column {
+            Spacer(modifier = Modifier.size(Spacing.Small))
+            Footnote(resolveString(CheckoutLocalizationKey.CARD_DUAL_BRAND_SELECTOR_DESCRIPTION))
+        }
+    }
 }
 
 @Composable

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
@@ -377,5 +377,51 @@ private fun CardNumberFieldPreview(
             onScanButtonClick = {},
             onBrandSelect = {},
         )
+
+        // Dual brand card logos
+        CardNumberField(
+            cardNumberState = TextInputViewState(
+                text = "5555444433330001",
+            ),
+            supportedCardBrands = emptyList(),
+            isSupportedCardBrandsShown = false,
+            cardBrandViewState = CardBrandViewState.DualBrand(
+                brands = listOf(
+                    CardBrand(CardType.VISA.txVariant),
+                    CardBrand(CardType.MASTERCARD.txVariant),
+                ),
+            ),
+            cardNumberFormat = CardNumberFormat.DEFAULT,
+            onValueChange = {},
+            onFocusChange = {},
+            onScanButtonClick = {},
+            onBrandSelect = {},
+        )
+
+        // Selectable dual brand card logos
+        CardNumberField(
+            cardNumberState = TextInputViewState(
+                text = "5555444433330002",
+            ),
+            supportedCardBrands = emptyList(),
+            isSupportedCardBrandsShown = false,
+            cardBrandViewState = CardBrandViewState.SelectableDualBrand(
+                brands = listOf(
+                    SelectableCardBrandItem(
+                        brand = CardBrand(CardType.VISA.txVariant),
+                        isSelected = true,
+                    ),
+                    SelectableCardBrandItem(
+                        brand = CardBrand(CardType.MASTERCARD.txVariant),
+                        isSelected = false,
+                    ),
+                ),
+            ),
+            cardNumberFormat = CardNumberFormat.DEFAULT,
+            onValueChange = {},
+            onFocusChange = {},
+            onScanButtonClick = {},
+            onBrandSelect = {},
+        )
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
@@ -10,6 +10,8 @@ package com.adyen.checkout.card.internal.ui.view
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
@@ -17,6 +19,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
@@ -31,6 +34,7 @@ import com.adyen.checkout.card.R
 import com.adyen.checkout.card.internal.ui.model.CardNumberTrailingIcon
 import com.adyen.checkout.card.internal.ui.state.CardBrandViewState
 import com.adyen.checkout.card.internal.ui.state.CardNumberFormat
+import com.adyen.checkout.card.internal.ui.state.SelectableCardBrandItem
 import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.common.CardType
 import com.adyen.checkout.core.common.internal.properties.CardNumberProperties.CARD_NUMBER_MAXIMUM_LENGTH
@@ -59,6 +63,7 @@ internal fun CardNumberField(
     onValueChange: (String) -> Unit,
     onFocusChange: (Boolean) -> Unit,
     onScanButtonClick: () -> Unit,
+    onBrandSelected: (CardBrand) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -71,6 +76,7 @@ internal fun CardNumberField(
             onValueChange = onValueChange,
             onFocusChange = onFocusChange,
             onScanButtonClick = onScanButtonClick,
+            onBrandSelected = onBrandSelected,
         )
 
         CardBrandsList(
@@ -88,6 +94,7 @@ private fun CardNumberInputField(
     onValueChange: (String) -> Unit,
     onFocusChange: (Boolean) -> Unit,
     onScanButtonClick: () -> Unit,
+    onBrandSelected: (CardBrand) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val supportingTextCardNumber = cardNumberState.supportingText?.let { resolveString(it) }
@@ -121,6 +128,7 @@ private fun CardNumberInputField(
                 state = cardNumberState,
                 cardBrandViewState = cardBrandViewState,
                 onScanButtonClick = onScanButtonClick,
+                onBrandSelected = onBrandSelected,
             )
         },
     )
@@ -129,6 +137,7 @@ private fun CardNumberInputField(
 @Composable
 private fun DetectedBrandsList(
     cardBrandViewState: CardBrandViewState,
+    onBrandSelected: (CardBrand) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -138,13 +147,65 @@ private fun DetectedBrandsList(
         when (cardBrandViewState) {
             is CardBrandViewState.Placeholder -> BrandLogo(txVariant = null)
             is CardBrandViewState.SingleBrand -> BrandLogo(cardBrandViewState.brand.txVariant)
-            is CardBrandViewState.DualBrand -> cardBrandViewState.brands.forEach { brand ->
-                BrandLogo(brand.txVariant)
-            }
-            // TODO - Co-badged selectable cards [COSDK-1193]
-            is CardBrandViewState.SelectableDualBrand -> cardBrandViewState.brands.forEach { brandItem ->
-                BrandLogo(brandItem.brand.txVariant)
-            }
+            is CardBrandViewState.DualBrand -> DualBrandLogos(cardBrandViewState.brands)
+
+            is CardBrandViewState.SelectableDualBrand -> SelectableDualBrandLogos(
+                selectableBrandItems = cardBrandViewState.brands,
+                onBrandSelected = onBrandSelected,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DualBrandLogos(
+    cardBrands: List<CardBrand>,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .padding(Dimensions.Spacing.ExtraSmall),
+    ) {
+        cardBrands.forEach { brand ->
+            BrandLogo(
+                txVariant = brand.txVariant,
+                modifier = Modifier.padding(Dimensions.Spacing.ExtraSmall),
+            )
+        }
+    }
+}
+
+@Composable
+private fun SelectableDualBrandLogos(
+    selectableBrandItems: List<SelectableCardBrandItem>,
+    onBrandSelected: (CardBrand) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .background(
+                color = CheckoutThemeProvider.colors.container,
+                shape = RoundedCornerShape(Dimensions.CornerRadius),
+            )
+            .padding(Dimensions.Spacing.ExtraSmall),
+    ) {
+        selectableBrandItems.forEach { brandItem ->
+            BrandLogo(
+                txVariant = brandItem.brand.txVariant,
+                modifier = Modifier
+                    .then(
+                        if (brandItem.isSelected) {
+                            Modifier.background(
+                                color = CheckoutThemeProvider.colors.background,
+                                shape = RoundedCornerShape(Dimensions.CornerRadius),
+                            )
+                        } else {
+                            Modifier
+                        },
+                    )
+                    .clickable(onClick = { onBrandSelected(brandItem.brand) })
+                    .padding(Dimensions.Spacing.ExtraSmall),
+            )
         }
     }
 }
@@ -195,6 +256,7 @@ private fun CardNumberFieldIcon(
     state: TextInputViewState,
     cardBrandViewState: CardBrandViewState,
     onScanButtonClick: () -> Unit,
+    onBrandSelected: (CardBrand) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val trailingIcon = state.trailingIcon as? CardNumberTrailingIcon
@@ -218,7 +280,7 @@ private fun CardNumberFieldIcon(
                 )
             }
 
-            else -> DetectedBrandsList(cardBrandViewState)
+            else -> DetectedBrandsList(cardBrandViewState, onBrandSelected)
         }
     }
 }
@@ -246,6 +308,7 @@ private fun CardNumberFieldPreview(
             onValueChange = {},
             onFocusChange = {},
             onScanButtonClick = {},
+            onBrandSelected = {},
         )
 
         CardNumberField(
@@ -263,6 +326,7 @@ private fun CardNumberFieldPreview(
             onValueChange = {},
             onFocusChange = {},
             onScanButtonClick = {},
+            onBrandSelected = {},
         )
 
         CardNumberField(
@@ -279,6 +343,7 @@ private fun CardNumberFieldPreview(
             onValueChange = {},
             onFocusChange = {},
             onScanButtonClick = {},
+            onBrandSelected = {},
         )
 
         CardNumberField(
@@ -294,6 +359,7 @@ private fun CardNumberFieldPreview(
             onValueChange = {},
             onFocusChange = {},
             onScanButtonClick = {},
+            onBrandSelected = {},
         )
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
@@ -11,26 +11,33 @@ package com.adyen.checkout.card.internal.ui.view
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
 import com.adyen.checkout.card.R
 import com.adyen.checkout.card.internal.ui.model.CardNumberTrailingIcon
 import com.adyen.checkout.card.internal.ui.state.CardBrandViewState
@@ -53,7 +60,6 @@ import com.adyen.checkout.ui.internal.helper.getThemedIcon
 import com.adyen.checkout.ui.internal.text.Footnote
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
 import com.adyen.checkout.ui.internal.theme.Dimensions
-import com.adyen.checkout.ui.internal.theme.Dimensions.Spacing
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @Composable
@@ -140,10 +146,10 @@ private fun CardNumberInputField(
         modifier = Modifier.fillMaxWidth(),
         visible = cardBrandViewState is CardBrandViewState.SelectableDualBrand,
     ) {
-        Column {
-            Spacer(modifier = Modifier.size(Spacing.Small))
-            Footnote(resolveString(CheckoutLocalizationKey.CARD_DUAL_BRAND_SELECTOR_DESCRIPTION))
-        }
+        Footnote(
+            text = resolveString(CheckoutLocalizationKey.CARD_DUAL_BRAND_SELECTOR_DESCRIPTION),
+            modifier = Modifier.padding(top = Dimensions.Spacing.Small),
+        )
     }
 }
 
@@ -206,17 +212,28 @@ private fun SelectableDualBrandLogos(
             BrandLogo(
                 txVariant = brandItem.brand.txVariant,
                 modifier = Modifier
+                    .semantics {
+                        role = Role.RadioButton
+                        selected = brandItem.isSelected
+                    }
+                    .clip(RoundedCornerShape(Dimensions.CornerRadius))
                     .then(
                         if (brandItem.isSelected) {
-                            Modifier.background(
-                                color = CheckoutThemeProvider.colors.background,
-                                shape = RoundedCornerShape(Dimensions.CornerRadius),
-                            )
+                            Modifier
+                                .border(
+                                    width = 1.dp,
+                                    color = CheckoutThemeProvider.colors.outline,
+                                    shape = RoundedCornerShape(Dimensions.CornerRadius),
+                                )
+                                .background(color = CheckoutThemeProvider.colors.background)
                         } else {
                             Modifier
                         },
                     )
-                    .clickable(onClick = { onBrandSelected(brandItem.brand) })
+                    .clickable(
+                        interactionSource = null,
+                        indication = ripple(),
+                    ) { onBrandSelected(brandItem.brand) }
                     .padding(Dimensions.Spacing.ExtraSmall),
             )
         }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
@@ -157,7 +157,7 @@ private fun DetectedBrandsList(
             is CardBrandViewState.DualBrand -> DualBrandLogos(cardBrandViewState.brands)
 
             is CardBrandViewState.SelectableDualBrand -> SelectableDualBrandLogos(
-                selectableBrandItems = cardBrandViewState.brands,
+                brands = cardBrandViewState.brands,
                 onBrandSelect = onBrandSelect,
             )
         }
@@ -166,14 +166,14 @@ private fun DetectedBrandsList(
 
 @Composable
 private fun DualBrandLogos(
-    cardBrands: List<CardBrand>,
+    brands: List<CardBrand>,
     modifier: Modifier = Modifier,
 ) {
     Row(
         modifier = modifier
             .padding(Dimensions.Spacing.ExtraSmall),
     ) {
-        cardBrands.forEach { brand ->
+        brands.forEach { brand ->
             BrandLogo(
                 txVariant = brand.txVariant,
                 modifier = Modifier.padding(Dimensions.Spacing.ExtraSmall),
@@ -184,7 +184,7 @@ private fun DualBrandLogos(
 
 @Composable
 private fun SelectableDualBrandLogos(
-    selectableBrandItems: List<SelectableCardBrandItem>,
+    brands: List<SelectableCardBrandItem>,
     onBrandSelect: (CardBrand) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -196,7 +196,7 @@ private fun SelectableDualBrandLogos(
             )
             .padding(Dimensions.Spacing.ExtraSmall),
     ) {
-        selectableBrandItems.forEach { brandItem ->
+        brands.forEach { brandItem ->
             BrandLogo(
                 txVariant = brandItem.brand.txVariant,
                 modifier = Modifier

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -72,7 +71,7 @@ internal fun CardNumberField(
     onValueChange: (String) -> Unit,
     onFocusChange: (Boolean) -> Unit,
     onScanButtonClick: () -> Unit,
-    onBrandSelected: (CardBrand) -> Unit,
+    onBrandSelect: (CardBrand) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -85,7 +84,7 @@ internal fun CardNumberField(
             onValueChange = onValueChange,
             onFocusChange = onFocusChange,
             onScanButtonClick = onScanButtonClick,
-            onBrandSelected = onBrandSelected,
+            onBrandSelect = onBrandSelect,
         )
 
         CardBrandsList(
@@ -103,7 +102,7 @@ private fun CardNumberInputField(
     onValueChange: (String) -> Unit,
     onFocusChange: (Boolean) -> Unit,
     onScanButtonClick: () -> Unit,
-    onBrandSelected: (CardBrand) -> Unit,
+    onBrandSelect: (CardBrand) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val supportingTextCardNumber = cardNumberState.supportingText?.let { resolveString(it) }
@@ -118,45 +117,48 @@ private fun CardNumberInputField(
         CardNumberOutputTransformation(cardNumberFormat = cardNumberFormat)
     }
 
-    CheckoutTextField(
-        modifier = modifier
-            .fillMaxWidth()
-            .onFocusChanged { focusState ->
-                onFocusChange(focusState.isFocused)
+    Column(modifier = modifier) {
+        CheckoutTextField(
+            modifier = Modifier
+                .fillMaxWidth()
+                .onFocusChanged { focusState ->
+                    onFocusChange(focusState.isFocused)
+                },
+            label = resolveString(CheckoutLocalizationKey.CARD_NUMBER),
+            state = rememberTextFieldStateWithCurrentValue(cardNumberState.text),
+            isError = cardNumberState.isError,
+            supportingText = supportingTextCardNumber,
+            onValueChange = onValueChange,
+            inputTransformation = inputTransformation,
+            outputTransformation = outputTransformation,
+            shouldFocus = cardNumberState.isFocused,
+            trailingIcon = {
+                CardNumberFieldIcon(
+                    state = cardNumberState,
+                    cardBrandViewState = cardBrandViewState,
+                    onScanButtonClick = onScanButtonClick,
+                    onBrandSelect = onBrandSelect,
+                )
             },
-        label = resolveString(CheckoutLocalizationKey.CARD_NUMBER),
-        state = rememberTextFieldStateWithCurrentValue(cardNumberState.text),
-        isError = cardNumberState.isError,
-        supportingText = supportingTextCardNumber,
-        onValueChange = onValueChange,
-        inputTransformation = inputTransformation,
-        outputTransformation = outputTransformation,
-        shouldFocus = cardNumberState.isFocused,
-        trailingIcon = {
-            CardNumberFieldIcon(
-                state = cardNumberState,
-                cardBrandViewState = cardBrandViewState,
-                onScanButtonClick = onScanButtonClick,
-                onBrandSelected = onBrandSelected,
-            )
-        },
-    )
-
-    AnimatedVisibility(
-        modifier = Modifier.fillMaxWidth(),
-        visible = cardBrandViewState is CardBrandViewState.SelectableDualBrand,
-    ) {
-        Footnote(
-            text = resolveString(CheckoutLocalizationKey.CARD_DUAL_BRAND_SELECTOR_DESCRIPTION),
-            modifier = Modifier.padding(top = Dimensions.Spacing.Small),
         )
+
+        AnimatedVisibility(
+            visible = cardBrandViewState is CardBrandViewState.SelectableDualBrand,
+        ) {
+            Footnote(
+                text = resolveString(CheckoutLocalizationKey.CARD_DUAL_BRAND_SELECTOR_DESCRIPTION),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = Dimensions.Spacing.Small),
+            )
+        }
     }
 }
 
 @Composable
 private fun DetectedBrandsList(
     cardBrandViewState: CardBrandViewState,
-    onBrandSelected: (CardBrand) -> Unit,
+    onBrandSelect: (CardBrand) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -170,7 +172,7 @@ private fun DetectedBrandsList(
 
             is CardBrandViewState.SelectableDualBrand -> SelectableDualBrandLogos(
                 selectableBrandItems = cardBrandViewState.brands,
-                onBrandSelected = onBrandSelected,
+                onBrandSelect = onBrandSelect,
             )
         }
     }
@@ -197,7 +199,7 @@ private fun DualBrandLogos(
 @Composable
 private fun SelectableDualBrandLogos(
     selectableBrandItems: List<SelectableCardBrandItem>,
-    onBrandSelected: (CardBrand) -> Unit,
+    onBrandSelect: (CardBrand) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -230,10 +232,7 @@ private fun SelectableDualBrandLogos(
                             Modifier
                         },
                     )
-                    .clickable(
-                        interactionSource = null,
-                        indication = ripple(),
-                    ) { onBrandSelected(brandItem.brand) }
+                    .clickable { onBrandSelect(brandItem.brand) }
                     .padding(Dimensions.Spacing.ExtraSmall),
             )
         }
@@ -286,7 +285,7 @@ private fun CardNumberFieldIcon(
     state: TextInputViewState,
     cardBrandViewState: CardBrandViewState,
     onScanButtonClick: () -> Unit,
-    onBrandSelected: (CardBrand) -> Unit,
+    onBrandSelect: (CardBrand) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val trailingIcon = state.trailingIcon as? CardNumberTrailingIcon
@@ -310,7 +309,7 @@ private fun CardNumberFieldIcon(
                 )
             }
 
-            else -> DetectedBrandsList(cardBrandViewState, onBrandSelected)
+            else -> DetectedBrandsList(cardBrandViewState, onBrandSelect)
         }
     }
 }
@@ -338,7 +337,7 @@ private fun CardNumberFieldPreview(
             onValueChange = {},
             onFocusChange = {},
             onScanButtonClick = {},
-            onBrandSelected = {},
+            onBrandSelect = {},
         )
 
         CardNumberField(
@@ -356,7 +355,7 @@ private fun CardNumberFieldPreview(
             onValueChange = {},
             onFocusChange = {},
             onScanButtonClick = {},
-            onBrandSelected = {},
+            onBrandSelect = {},
         )
 
         CardNumberField(
@@ -373,7 +372,7 @@ private fun CardNumberFieldPreview(
             onValueChange = {},
             onFocusChange = {},
             onScanButtonClick = {},
-            onBrandSelected = {},
+            onBrandSelect = {},
         )
 
         CardNumberField(
@@ -389,7 +388,7 @@ private fun CardNumberFieldPreview(
             onValueChange = {},
             onFocusChange = {},
             onScanButtonClick = {},
-            onBrandSelected = {},
+            onBrandSelect = {},
         )
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
@@ -56,7 +56,6 @@ import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParamet
 import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
 import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
 import com.adyen.checkout.ui.internal.helper.getThemedIcon
-import com.adyen.checkout.ui.internal.text.Footnote
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
 import com.adyen.checkout.ui.internal.theme.Dimensions
 import com.adyen.checkout.ui.theme.CheckoutTheme
@@ -117,42 +116,29 @@ private fun CardNumberInputField(
         CardNumberOutputTransformation(cardNumberFormat = cardNumberFormat)
     }
 
-    Column(modifier = modifier) {
-        CheckoutTextField(
-            modifier = Modifier
-                .fillMaxWidth()
-                .onFocusChanged { focusState ->
-                    onFocusChange(focusState.isFocused)
-                },
-            label = resolveString(CheckoutLocalizationKey.CARD_NUMBER),
-            state = rememberTextFieldStateWithCurrentValue(cardNumberState.text),
-            isError = cardNumberState.isError,
-            supportingText = supportingTextCardNumber,
-            onValueChange = onValueChange,
-            inputTransformation = inputTransformation,
-            outputTransformation = outputTransformation,
-            shouldFocus = cardNumberState.isFocused,
-            trailingIcon = {
-                CardNumberFieldIcon(
-                    state = cardNumberState,
-                    cardBrandViewState = cardBrandViewState,
-                    onScanButtonClick = onScanButtonClick,
-                    onBrandSelect = onBrandSelect,
-                )
+    CheckoutTextField(
+        modifier = modifier
+            .fillMaxWidth()
+            .onFocusChanged { focusState ->
+                onFocusChange(focusState.isFocused)
             },
-        )
-
-        AnimatedVisibility(
-            visible = cardBrandViewState is CardBrandViewState.SelectableDualBrand,
-        ) {
-            Footnote(
-                text = resolveString(CheckoutLocalizationKey.CARD_DUAL_BRAND_SELECTOR_DESCRIPTION),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = Dimensions.Spacing.Small),
+        label = resolveString(CheckoutLocalizationKey.CARD_NUMBER),
+        state = rememberTextFieldStateWithCurrentValue(cardNumberState.text),
+        isError = cardNumberState.isError,
+        supportingText = supportingTextCardNumber,
+        onValueChange = onValueChange,
+        inputTransformation = inputTransformation,
+        outputTransformation = outputTransformation,
+        shouldFocus = cardNumberState.isFocused,
+        trailingIcon = {
+            CardNumberFieldIcon(
+                state = cardNumberState,
+                cardBrandViewState = cardBrandViewState,
+                onScanButtonClick = onScanButtonClick,
+                onBrandSelect = onBrandSelect,
             )
-        }
-    }
+        },
+    )
 }
 
 @Composable

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
@@ -233,7 +233,8 @@ private fun SelectableDualBrandLogos(
                         },
                     )
                     .clickable { onBrandSelect(brandItem.brand) }
-                    .padding(Dimensions.Spacing.ExtraSmall),
+                    .padding(Dimensions.Spacing.ExtraSmall)
+                    .clip(RoundedCornerShape(Dimensions.CornerRadius)),
             )
         }
     }

--- a/card/src/test/java/com/adyen/checkout/card/internal/analytics/DualBrandCardEventsTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/analytics/DualBrandCardEventsTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by temirlan on 29/6/2026.
+ */
+
+package com.adyen.checkout.card.internal.analytics
+
+import com.adyen.checkout.card.internal.data.model.Brand
+import com.adyen.checkout.card.internal.ui.state.CardBrandData
+import com.adyen.checkout.core.analytics.internal.AnalyticsEvent
+import com.adyen.checkout.core.analytics.internal.DirectAnalyticsEventCreation
+import com.adyen.checkout.core.common.CardBrand
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+@OptIn(DirectAnalyticsEventCreation::class)
+internal class DualBrandCardEventsTest {
+
+    @Test
+    fun `when dualBrandSelectionDisplayed is called then event has correct type, target, brand and configData`() {
+        // GIVEN
+        val component = "scheme"
+        val selectedBrand = CardBrand("visa")
+        val brandOptions = listOf(
+            createCardBrandData(CardBrand("visa")),
+            createCardBrandData(CardBrand("cartebancaire")),
+        )
+
+        // WHEN
+        val event = DualBrandCardEvents.dualBrandSelectionDisplayed(
+            component = component,
+            selectedBrand = selectedBrand,
+            brandOptions = brandOptions,
+        )
+
+        // THEN
+        val expected = AnalyticsEvent.Info(
+            component = component,
+            type = AnalyticsEvent.Info.Type.DISPLAYED,
+            target = "dual_brand_button",
+            brand = "visa",
+            configData = mapOf("dualBrands" to "visa,cartebancaire"),
+        )
+        assertEquals(expected.component, event.component)
+        assertEquals(expected.type, event.type)
+        assertEquals(expected.target, event.target)
+        assertEquals(expected.brand, event.brand)
+        assertEquals(expected.configData, event.configData)
+    }
+
+    @Test
+    fun `when brandSelected is called then event has correct type, target and brand`() {
+        // GIVEN
+        val component = "scheme"
+        val selectedBrand = CardBrand("cartebancaire")
+
+        // WHEN
+        val event = DualBrandCardEvents.brandSelected(
+            component = component,
+            selectedBrand = selectedBrand,
+        )
+
+        // THEN
+        val expected = AnalyticsEvent.Info(
+            component = component,
+            type = AnalyticsEvent.Info.Type.SELECTED,
+            target = "dual_brand_button",
+            brand = "cartebancaire",
+        )
+        assertEquals(expected.component, event.component)
+        assertEquals(expected.type, event.type)
+        assertEquals(expected.target, event.target)
+        assertEquals(expected.brand, event.brand)
+    }
+
+    private fun createCardBrandData(cardBrand: CardBrand) = CardBrandData(
+        cardBrand = cardBrand,
+        enableLuhnCheck = true,
+        cvcPolicy = Brand.FieldPolicy.REQUIRED,
+        expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
+        panLength = null,
+        paymentMethodVariant = null,
+        localizedBrand = null,
+    )
+}

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/CardComponentTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/CardComponentTest.kt
@@ -70,7 +70,7 @@ internal class CardComponentTest(
         @Test
         fun `then dualBrandSelectionDisplayed event is tracked`() {
             // WHEN
-            component.handleIntent(CardIntent.UpdateDetectedCardTypes(createDetectedSelectableCardBrandList()))
+            component.handleIntent(CardIntent.UpdateDetectedCardTypes(createSelectableDetectedCardBrandList()))
 
             // THEN
             val expected = DualBrandCardEvents.dualBrandSelectionDisplayed(
@@ -87,8 +87,8 @@ internal class CardComponentTest(
         @Test
         fun `and same state is emitted again then event is tracked only once`() {
             // WHEN
-            component.handleIntent(CardIntent.UpdateDetectedCardTypes(createDetectedSelectableCardBrandList()))
-            component.handleIntent(CardIntent.UpdateDetectedCardTypes(createDetectedSelectableCardBrandList()))
+            component.handleIntent(CardIntent.UpdateDetectedCardTypes(createSelectableDetectedCardBrandList()))
+            component.handleIntent(CardIntent.UpdateDetectedCardTypes(createSelectableDetectedCardBrandList()))
 
             // THEN
             val expected = DualBrandCardEvents.dualBrandSelectionDisplayed(
@@ -101,6 +101,65 @@ internal class CardComponentTest(
             )
             analyticsManager.assertEventCount(1, expected)
         }
+
+        @Test
+        fun `and shopper changes brand selection within DualBrandWithShopperSelection then no new event is tracked`() {
+            // GIVEN
+            component.handleIntent(CardIntent.UpdateDetectedCardTypes(createSelectableDetectedCardBrandList()))
+
+            // WHEN - change selection from auto-selected "visa" to "cartebancaire"
+            component.handleIntent(CardIntent.SelectBrand(CardBrand("cartebancaire")))
+
+            // THEN - event is tracked only once (on appear, not on brand selection change)
+            val expected = DualBrandCardEvents.dualBrandSelectionDisplayed(
+                component = PAYMENT_METHOD_TYPE,
+                selectedBrand = CardBrand("visa"),
+                brandOptions = listOf(
+                    createCardBrandData(CardBrand("visa")),
+                    createCardBrandData(CardBrand("cartebancaire")),
+                ),
+            )
+            analyticsManager.assertEventCount(1, expected)
+        }
+
+        @Test
+        fun `and brand state transitions to non-dual-brand then no new event is tracked`() {
+            // GIVEN
+            component.handleIntent(CardIntent.UpdateDetectedCardTypes(createSelectableDetectedCardBrandList()))
+
+            // WHEN - clear detected brands (simulates card number being cleared)
+            component.handleIntent(CardIntent.UpdateDetectedCardTypes(createEmptyDetectedCardTypeList()))
+
+            // THEN - event is tracked only once (on appear, not on disappear)
+            val expected = DualBrandCardEvents.dualBrandSelectionDisplayed(
+                component = PAYMENT_METHOD_TYPE,
+                selectedBrand = CardBrand("visa"),
+                brandOptions = listOf(
+                    createCardBrandData(CardBrand("visa")),
+                    createCardBrandData(CardBrand("cartebancaire")),
+                ),
+            )
+            analyticsManager.assertEventCount(1, expected)
+        }
+
+        @Test
+        fun `and dual brand state disappears and reappears then event is tracked again`() {
+            // WHEN
+            component.handleIntent(CardIntent.UpdateDetectedCardTypes(createSelectableDetectedCardBrandList()))
+            component.handleIntent(CardIntent.UpdateDetectedCardTypes(createEmptyDetectedCardTypeList()))
+            component.handleIntent(CardIntent.UpdateDetectedCardTypes(createSelectableDetectedCardBrandList()))
+
+            // THEN
+            val expected = DualBrandCardEvents.dualBrandSelectionDisplayed(
+                component = PAYMENT_METHOD_TYPE,
+                selectedBrand = CardBrand("visa"),
+                brandOptions = listOf(
+                    createCardBrandData(CardBrand("visa")),
+                    createCardBrandData(CardBrand("cartebancaire")),
+                ),
+            )
+            analyticsManager.assertEventCount(2, expected)
+        }
     }
 
     @Nested
@@ -110,7 +169,7 @@ internal class CardComponentTest(
         @Test
         fun `and brand is different from currently selected then brandSelected event is tracked`() {
             // GIVEN
-            component.handleIntent(CardIntent.UpdateDetectedCardTypes(createDetectedSelectableCardBrandList()))
+            component.handleIntent(CardIntent.UpdateDetectedCardTypes(createSelectableDetectedCardBrandList()))
 
             // WHEN - current selection is "visa" (first brand), selecting "cartebancaire"
             component.handleIntent(CardIntent.SelectBrand(CardBrand("cartebancaire")))
@@ -126,7 +185,7 @@ internal class CardComponentTest(
         @Test
         fun `and brand is same as currently selected then no brandSelected event is tracked`() {
             // GIVEN
-            component.handleIntent(CardIntent.UpdateDetectedCardTypes(createDetectedSelectableCardBrandList()))
+            component.handleIntent(CardIntent.UpdateDetectedCardTypes(createSelectableDetectedCardBrandList()))
 
             // WHEN - current selection is "visa", re-selecting "visa"
             component.handleIntent(CardIntent.SelectBrand(CardBrand("visa")))
@@ -155,7 +214,14 @@ internal class CardComponentTest(
         }
     }
 
-    private fun createDetectedSelectableCardBrandList() = DetectedCardTypeList(
+    private fun createEmptyDetectedCardTypeList() = DetectedCardTypeList(
+        detectedCardTypes = emptyList(),
+        source = DetectedCardTypeList.Source.NETWORK,
+        cardDetectionBin = null,
+        issuingCountryCode = null,
+    )
+
+    private fun createSelectableDetectedCardBrandList() = DetectedCardTypeList(
         detectedCardTypes = listOf(
             createDetectedSelectableCardType().copy(
                 cardBrand = CardBrand("visa"),

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/CardComponentTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/CardComponentTest.kt
@@ -56,13 +56,15 @@ internal class CardComponentTest(
     @Mock private val cardScannerWrapper: CardScannerWrapper,
 ) {
 
-    private val analyticsManager = TestAnalyticsManager()
-    private val cardComponentParams = createCardComponentParams()
+    private lateinit var analyticsManager: TestAnalyticsManager
+    private lateinit var cardComponentParams: CardComponentParams
     private lateinit var coroutineScope: CoroutineScope
     private lateinit var component: CardComponent
 
     @BeforeEach
     fun beforeEach() {
+        analyticsManager = TestAnalyticsManager()
+        cardComponentParams = createCardComponentParams()
         coroutineScope = CoroutineScope(UnconfinedTestDispatcher())
         component = createCardComponent()
     }

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/CardComponentTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/CardComponentTest.kt
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by temirlan on 29/6/2026.
+ */
+
+package com.adyen.checkout.card.internal.ui
+
+import com.adyen.checkout.card.FieldVisibility
+import com.adyen.checkout.card.internal.analytics.DualBrandCardEvents
+import com.adyen.checkout.card.internal.data.api.DetectCardTypeRepository
+import com.adyen.checkout.card.internal.data.model.Brand
+import com.adyen.checkout.card.internal.data.model.DetectedCardType
+import com.adyen.checkout.card.internal.data.model.DetectedCardTypeList
+import com.adyen.checkout.card.internal.helper.DetectCardTypeBinHelper
+import com.adyen.checkout.card.internal.ui.model.CVCVisibility
+import com.adyen.checkout.card.internal.ui.model.CardComponentParams
+import com.adyen.checkout.card.internal.ui.model.StoredCVCVisibility
+import com.adyen.checkout.card.internal.ui.state.CardBrandData
+import com.adyen.checkout.card.internal.ui.state.CardBrandIntentsHandler
+import com.adyen.checkout.card.internal.ui.state.CardComponentStateFactory
+import com.adyen.checkout.card.internal.ui.state.CardComponentStateReducer
+import com.adyen.checkout.card.internal.ui.state.CardComponentStateValidator
+import com.adyen.checkout.card.internal.ui.state.CardIntent
+import com.adyen.checkout.card.internal.ui.state.CardValidationMapper
+import com.adyen.checkout.card.internal.ui.state.CardViewStateProducer
+import com.adyen.checkout.card.internal.util.CardScannerWrapper
+import com.adyen.checkout.core.analytics.internal.TestAnalyticsManager
+import com.adyen.checkout.core.common.CardBrand
+import com.adyen.checkout.core.common.Environment
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
+import com.adyen.checkout.cse.internal.BaseCardEncryptor
+import com.adyen.checkout.cse.internal.BaseGenericEncryptor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(MockitoExtension::class)
+internal class CardComponentTest(
+    @Mock private val cardEncryptor: BaseCardEncryptor,
+    @Mock private val genericEncryptor: BaseGenericEncryptor,
+    @Mock private val detectCardTypeRepository: DetectCardTypeRepository,
+    @Mock private val sdkDataProvider: SdkDataProvider,
+    @Mock private val cardScannerWrapper: CardScannerWrapper,
+) {
+
+    private val analyticsManager = TestAnalyticsManager()
+    private val cardComponentParams = createCardComponentParams()
+    private lateinit var coroutineScope: CoroutineScope
+    private lateinit var component: CardComponent
+
+    @BeforeEach
+    fun beforeEach() {
+        coroutineScope = CoroutineScope(UnconfinedTestDispatcher())
+        component = createCardComponent()
+    }
+
+    @AfterEach
+    fun afterEach() {
+        coroutineScope.cancel()
+    }
+
+    @Nested
+    @DisplayName("when brand state transitions to DualBrandWithShopperSelection")
+    inner class SubscribeToDualBrandAnalyticsEventsTest {
+
+        @Test
+        fun `then dualBrandSelectionDisplayed event is tracked`() {
+            // WHEN
+            component.handleIntent(CardIntent.UpdateDetectedCardTypes(createDualBrandSelectableList()))
+
+            // THEN
+            val expected = DualBrandCardEvents.dualBrandSelectionDisplayed(
+                component = PAYMENT_METHOD_TYPE,
+                selectedBrand = CardBrand("visa"),
+                brandOptions = listOf(
+                    createCardBrandData(CardBrand("visa")),
+                    createCardBrandData(CardBrand("cartebancaire")),
+                ),
+            )
+            analyticsManager.assertHasEventEquals(expected)
+        }
+
+        @Test
+        fun `and same state is emitted again then event is tracked only once`() {
+            // WHEN
+            component.handleIntent(CardIntent.UpdateDetectedCardTypes(createDualBrandSelectableList()))
+            component.handleIntent(CardIntent.UpdateDetectedCardTypes(createDualBrandSelectableList()))
+
+            // THEN - distinctUntilChanged prevents duplicate events for repeated DualBrandWithShopperSelection state
+            val expected = DualBrandCardEvents.dualBrandSelectionDisplayed(
+                component = PAYMENT_METHOD_TYPE,
+                selectedBrand = CardBrand("visa"),
+                brandOptions = listOf(
+                    createCardBrandData(CardBrand("visa")),
+                    createCardBrandData(CardBrand("cartebancaire")),
+                ),
+            )
+            analyticsManager.assertEventCount(1, expected)
+        }
+    }
+
+    @Nested
+    @DisplayName("when intent is SelectBrand")
+    inner class SelectBrandTest {
+
+        @Test
+        fun `and brand is different from currently selected then brandSelected event is tracked`() {
+            // GIVEN
+            setupDualBrandWithShopperSelectionState()
+
+            // WHEN - current selection is "visa" (first brand), selecting "cartebancaire"
+            component.handleIntent(CardIntent.SelectBrand(CardBrand("cartebancaire")))
+
+            // THEN
+            val expected = DualBrandCardEvents.brandSelected(
+                component = PAYMENT_METHOD_TYPE,
+                selectedBrand = CardBrand("cartebancaire"),
+            )
+            analyticsManager.assertLastEventEquals(expected)
+        }
+
+        @Test
+        fun `and brand is same as currently selected then no brandSelected event is tracked`() {
+            // GIVEN
+            setupDualBrandWithShopperSelectionState()
+
+            // WHEN - current selection is "visa", re-selecting "visa"
+            component.handleIntent(CardIntent.SelectBrand(CardBrand("visa")))
+
+            // THEN - last event is the dualBrandSelectionDisplayed event, not a brandSelected event
+            val notExpected = DualBrandCardEvents.brandSelected(
+                component = PAYMENT_METHOD_TYPE,
+                selectedBrand = CardBrand("visa"),
+            )
+            analyticsManager.assertLastEventNotEquals(notExpected)
+        }
+
+        @Test
+        fun `and brand state is not DualBrandWithShopperSelection then no brandSelected event is tracked`() {
+            // GIVEN - initial state is NoBrandsDetected, no setup
+
+            // WHEN
+            component.handleIntent(CardIntent.SelectBrand(CardBrand("visa")))
+
+            // THEN - no events tracked at all
+            val notExpected = DualBrandCardEvents.brandSelected(
+                component = PAYMENT_METHOD_TYPE,
+                selectedBrand = CardBrand("visa"),
+            )
+            analyticsManager.assertLastEventNotEquals(notExpected)
+        }
+    }
+
+    private fun setupDualBrandWithShopperSelectionState() {
+        component.handleIntent(CardIntent.UpdateDetectedCardTypes(createDualBrandSelectableList()))
+    }
+
+    private fun createDualBrandSelectableList() = DetectedCardTypeList(
+        detectedCardTypes = listOf(
+            createDetectedCardType().copy(cardBrand = CardBrand("visa")),
+            createDetectedCardType().copy(
+                cardBrand = CardBrand("cartebancaire"),
+                isShopperSelectionAllowedInDualBranded = true,
+            ),
+        ),
+        source = DetectedCardTypeList.Source.NETWORK,
+        cardDetectionBin = null,
+        issuingCountryCode = null,
+    )
+
+    private fun createCardComponent(): CardComponent {
+        val detectCardTypeBinHelper = DetectCardTypeBinHelper()
+        val cardBrandIntentsHandler = CardBrandIntentsHandler(cardComponentParams, detectCardTypeBinHelper)
+        val reducer = CardComponentStateReducer(cardBrandIntentsHandler)
+        val factory = CardComponentStateFactory(cardComponentParams)
+        val validator = CardComponentStateValidator(CardValidationMapper())
+        return CardComponent(
+            analyticsManager = analyticsManager,
+            cardEncryptor = cardEncryptor,
+            genericEncryptor = genericEncryptor,
+            componentParams = cardComponentParams,
+            detectCardTypeRepository = detectCardTypeRepository,
+            componentStateValidator = validator,
+            componentStateFactory = factory,
+            componentStateReducer = reducer,
+            viewStateProducer = CardViewStateProducer(),
+            coroutineScope = coroutineScope,
+            sdkDataProvider = sdkDataProvider,
+            paymentMethodType = PAYMENT_METHOD_TYPE,
+            onBinChangeCallback = null,
+            onBinLookupCallback = null,
+            cardScannerWrapper = cardScannerWrapper,
+            publicKey = null,
+            environment = Environment.TEST,
+        )
+    }
+
+    private fun createCardComponentParams() = CardComponentParams(
+        showCardholderName = false,
+        supportedCardBrands = emptyList(),
+        showStorePaymentMethod = false,
+        showSupportedCardBrandLogos = true,
+        socialSecurityNumberVisibility = FieldVisibility.HIDE,
+        koreanAuthenticationVisibility = FieldVisibility.HIDE,
+        showPostalCode = false,
+        cvcVisibility = CVCVisibility.ALWAYS_SHOW,
+        storedCVCVisibility = StoredCVCVisibility.SHOW,
+        showCardScanner = false,
+        installmentParams = null,
+    )
+
+    private fun createDetectedCardType() = DetectedCardType(
+        cardBrand = CardBrand("visa"),
+        enableLuhnCheck = true,
+        cvcPolicy = Brand.FieldPolicy.REQUIRED,
+        expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
+        isSupported = true,
+        isHidden = false,
+        isShopperSelectionAllowedInDualBranded = false,
+        panLength = null,
+        paymentMethodVariant = null,
+        localizedBrand = null,
+    )
+
+    private fun createCardBrandData(cardBrand: CardBrand) = CardBrandData(
+        cardBrand = cardBrand,
+        enableLuhnCheck = true,
+        cvcPolicy = Brand.FieldPolicy.REQUIRED,
+        expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
+        panLength = null,
+        paymentMethodVariant = null,
+        localizedBrand = null,
+    )
+
+    companion object {
+        private const val PAYMENT_METHOD_TYPE = "scheme"
+    }
+}

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/CardComponentTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/CardComponentTest.kt
@@ -35,9 +35,7 @@ import com.adyen.checkout.cse.internal.BaseCardEncryptor
 import com.adyen.checkout.cse.internal.BaseGenericEncryptor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -57,31 +55,22 @@ internal class CardComponentTest(
 ) {
 
     private lateinit var analyticsManager: TestAnalyticsManager
-    private lateinit var cardComponentParams: CardComponentParams
-    private lateinit var coroutineScope: CoroutineScope
     private lateinit var component: CardComponent
 
     @BeforeEach
     fun beforeEach() {
         analyticsManager = TestAnalyticsManager()
-        cardComponentParams = createCardComponentParams()
-        coroutineScope = CoroutineScope(UnconfinedTestDispatcher())
-        component = createCardComponent()
-    }
-
-    @AfterEach
-    fun afterEach() {
-        coroutineScope.cancel()
+        component = createComponent()
     }
 
     @Nested
     @DisplayName("when brand state transitions to DualBrandWithShopperSelection")
-    inner class SubscribeToDualBrandAnalyticsEventsTest {
+    inner class SubscribeToDualBrandSelectionAppearAnalyticsEventsTest {
 
         @Test
         fun `then dualBrandSelectionDisplayed event is tracked`() {
             // WHEN
-            component.handleIntent(CardIntent.UpdateDetectedCardTypes(createDualBrandSelectableList()))
+            component.handleIntent(CardIntent.UpdateDetectedCardTypes(createDetectedSelectableCardBrandList()))
 
             // THEN
             val expected = DualBrandCardEvents.dualBrandSelectionDisplayed(
@@ -98,10 +87,10 @@ internal class CardComponentTest(
         @Test
         fun `and same state is emitted again then event is tracked only once`() {
             // WHEN
-            component.handleIntent(CardIntent.UpdateDetectedCardTypes(createDualBrandSelectableList()))
-            component.handleIntent(CardIntent.UpdateDetectedCardTypes(createDualBrandSelectableList()))
+            component.handleIntent(CardIntent.UpdateDetectedCardTypes(createDetectedSelectableCardBrandList()))
+            component.handleIntent(CardIntent.UpdateDetectedCardTypes(createDetectedSelectableCardBrandList()))
 
-            // THEN - distinctUntilChanged prevents duplicate events for repeated DualBrandWithShopperSelection state
+            // THEN
             val expected = DualBrandCardEvents.dualBrandSelectionDisplayed(
                 component = PAYMENT_METHOD_TYPE,
                 selectedBrand = CardBrand("visa"),
@@ -121,7 +110,7 @@ internal class CardComponentTest(
         @Test
         fun `and brand is different from currently selected then brandSelected event is tracked`() {
             // GIVEN
-            setupDualBrandWithShopperSelectionState()
+            component.handleIntent(CardIntent.UpdateDetectedCardTypes(createDetectedSelectableCardBrandList()))
 
             // WHEN - current selection is "visa" (first brand), selecting "cartebancaire"
             component.handleIntent(CardIntent.SelectBrand(CardBrand("cartebancaire")))
@@ -137,12 +126,12 @@ internal class CardComponentTest(
         @Test
         fun `and brand is same as currently selected then no brandSelected event is tracked`() {
             // GIVEN
-            setupDualBrandWithShopperSelectionState()
+            component.handleIntent(CardIntent.UpdateDetectedCardTypes(createDetectedSelectableCardBrandList()))
 
             // WHEN - current selection is "visa", re-selecting "visa"
             component.handleIntent(CardIntent.SelectBrand(CardBrand("visa")))
 
-            // THEN - last event is the dualBrandSelectionDisplayed event, not a brandSelected event
+            // THEN
             val notExpected = DualBrandCardEvents.brandSelected(
                 component = PAYMENT_METHOD_TYPE,
                 selectedBrand = CardBrand("visa"),
@@ -166,16 +155,13 @@ internal class CardComponentTest(
         }
     }
 
-    private fun setupDualBrandWithShopperSelectionState() {
-        component.handleIntent(CardIntent.UpdateDetectedCardTypes(createDualBrandSelectableList()))
-    }
-
-    private fun createDualBrandSelectableList() = DetectedCardTypeList(
+    private fun createDetectedSelectableCardBrandList() = DetectedCardTypeList(
         detectedCardTypes = listOf(
-            createDetectedCardType().copy(cardBrand = CardBrand("visa")),
-            createDetectedCardType().copy(
+            createDetectedSelectableCardType().copy(
+                cardBrand = CardBrand("visa"),
+            ),
+            createDetectedSelectableCardType().copy(
                 cardBrand = CardBrand("cartebancaire"),
-                isShopperSelectionAllowedInDualBranded = true,
             ),
         ),
         source = DetectedCardTypeList.Source.NETWORK,
@@ -183,23 +169,47 @@ internal class CardComponentTest(
         issuingCountryCode = null,
     )
 
-    private fun createCardComponent(): CardComponent {
-        val detectCardTypeBinHelper = DetectCardTypeBinHelper()
-        val cardBrandIntentsHandler = CardBrandIntentsHandler(cardComponentParams, detectCardTypeBinHelper)
-        val reducer = CardComponentStateReducer(cardBrandIntentsHandler)
-        val factory = CardComponentStateFactory(cardComponentParams)
-        val validator = CardComponentStateValidator(CardValidationMapper())
+    private fun createDetectedSelectableCardType() = DetectedCardType(
+        cardBrand = CardBrand(""),
+        enableLuhnCheck = true,
+        cvcPolicy = Brand.FieldPolicy.REQUIRED,
+        expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
+        isSupported = true,
+        isHidden = false,
+        isShopperSelectionAllowedInDualBranded = true,
+        panLength = null,
+        paymentMethodVariant = null,
+        localizedBrand = null,
+    )
+
+    private fun createCardBrandData(cardBrand: CardBrand) = CardBrandData(
+        cardBrand = cardBrand,
+        enableLuhnCheck = true,
+        cvcPolicy = Brand.FieldPolicy.REQUIRED,
+        expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
+        panLength = null,
+        paymentMethodVariant = null,
+        localizedBrand = null,
+    )
+
+    private fun createComponent(
+        cardComponentParams: CardComponentParams = createCardComponentParams()
+    ): CardComponent {
+        val cardBrandIntentsHandler = CardBrandIntentsHandler(
+            componentParams = cardComponentParams,
+            detectCardTypeBinHelper = DetectCardTypeBinHelper(),
+        )
         return CardComponent(
             analyticsManager = analyticsManager,
             cardEncryptor = cardEncryptor,
             genericEncryptor = genericEncryptor,
             componentParams = cardComponentParams,
             detectCardTypeRepository = detectCardTypeRepository,
-            componentStateValidator = validator,
-            componentStateFactory = factory,
-            componentStateReducer = reducer,
+            componentStateValidator = CardComponentStateValidator(CardValidationMapper()),
+            componentStateFactory = CardComponentStateFactory(cardComponentParams),
+            componentStateReducer = CardComponentStateReducer(cardBrandIntentsHandler),
             viewStateProducer = CardViewStateProducer(),
-            coroutineScope = coroutineScope,
+            coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
             sdkDataProvider = sdkDataProvider,
             paymentMethodType = PAYMENT_METHOD_TYPE,
             onBinChangeCallback = null,
@@ -214,37 +224,14 @@ internal class CardComponentTest(
         showCardholderName = false,
         supportedCardBrands = emptyList(),
         showStorePaymentMethod = false,
-        showSupportedCardBrandLogos = true,
+        showSupportedCardBrandLogos = false,
         socialSecurityNumberVisibility = FieldVisibility.HIDE,
         koreanAuthenticationVisibility = FieldVisibility.HIDE,
         showPostalCode = false,
-        cvcVisibility = CVCVisibility.ALWAYS_SHOW,
-        storedCVCVisibility = StoredCVCVisibility.SHOW,
+        cvcVisibility = CVCVisibility.ALWAYS_HIDE,
+        storedCVCVisibility = StoredCVCVisibility.HIDE,
         showCardScanner = false,
         installmentParams = null,
-    )
-
-    private fun createDetectedCardType() = DetectedCardType(
-        cardBrand = CardBrand("visa"),
-        enableLuhnCheck = true,
-        cvcPolicy = Brand.FieldPolicy.REQUIRED,
-        expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
-        isSupported = true,
-        isHidden = false,
-        isShopperSelectionAllowedInDualBranded = false,
-        panLength = null,
-        paymentMethodVariant = null,
-        localizedBrand = null,
-    )
-
-    private fun createCardBrandData(cardBrand: CardBrand) = CardBrandData(
-        cardBrand = cardBrand,
-        enableLuhnCheck = true,
-        cvcPolicy = Brand.FieldPolicy.REQUIRED,
-        expiryDatePolicy = Brand.FieldPolicy.REQUIRED,
-        panLength = null,
-        paymentMethodVariant = null,
-        localizedBrand = null,
     )
 
     companion object {

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandlerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandlerTest.kt
@@ -851,6 +851,38 @@ internal class CardBrandIntentsHandlerTest(
             assertInstanceOf<CardBrandState.DualBrandWithShopperSelection>(actual.cardBrandState)
             assertEquals(carteBancaireCardBrandData, actual.cardBrandState.shopperSelectedCardBrandData)
         }
+
+        @Test
+        fun `and selected brand is not in the brand list then state is unchanged`() {
+            val visaCardBrandData = createCardBrandData().copy(cardBrand = CardBrand("visa"))
+            val mcCardBrandData = createCardBrandData().copy(cardBrand = CardBrand("mc"))
+            val state = createInitialState().copy(
+                cardBrandState = CardBrandState.DualBrandWithShopperSelection(
+                    cardBrandDataList = listOf(visaCardBrandData, mcCardBrandData),
+                    shopperSelectedCardBrandData = visaCardBrandData,
+                ),
+            )
+
+            val actual = cardBrandIntentsHandler.onBrandSelected(state, CardIntent.SelectBrand(CardBrand("amex")))
+
+            assertEquals(state, actual)
+        }
+
+        @Test
+        fun `and brand state is not DualBrandWithShopperSelection then state is unchanged`() {
+            val state = createInitialState().copy(
+                cardBrandState = CardBrandState.DualBrand(
+                    listOf(
+                        createCardBrandData().copy(cardBrand = CardBrand("visa")),
+                        createCardBrandData().copy(cardBrand = CardBrand("mc")),
+                    ),
+                ),
+            )
+
+            val actual = cardBrandIntentsHandler.onBrandSelected(state, CardIntent.SelectBrand(CardBrand("visa")))
+
+            assertEquals(state, actual)
+        }
     }
 
     @Nested

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNull
 
 internal class CardViewStateProducerTest {
 
@@ -223,6 +224,27 @@ internal class CardViewStateProducerTest {
     }
 
     @Test
+    fun `when dual brand with non-amex selected, then cardNumberFormat should be Default`() {
+        // GIVEN
+        val amexBrandData = getCardBrandData().copy(
+            cardBrand = CardBrand("amex"),
+        )
+        val visaBrandData = getCardBrandData().copy(cardBrand = CardBrand("visa"))
+        val componentState = createComponentState(
+            cardBrandState = CardBrandState.DualBrandWithShopperSelection(
+                cardBrandDataList = listOf(amexBrandData, visaBrandData),
+                shopperSelectedCardBrandData = visaBrandData,
+            ),
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertEquals(CardNumberFormat.DEFAULT, viewState.cardNumberFormat)
+    }
+
+    @Test
     fun `when dual brand with shopper selection is detected, then card number supportingText is dual brand selector description`() {
         // GIVEN
         val visaBrandData = getCardBrandData().copy(cardBrand = CardBrand("visa"))
@@ -252,28 +274,7 @@ internal class CardViewStateProducerTest {
         val viewState = producer.produce(componentState)
 
         // THEN
-        assertEquals(null, viewState.cardNumber?.supportingText)
-    }
-
-    @Test
-    fun `when dual brand with non-amex selected, then cardNumberFormat should be Default`() {
-        // GIVEN
-        val amexBrandData = getCardBrandData().copy(
-            cardBrand = CardBrand("amex"),
-        )
-        val visaBrandData = getCardBrandData().copy(cardBrand = CardBrand("visa"))
-        val componentState = createComponentState(
-            cardBrandState = CardBrandState.DualBrandWithShopperSelection(
-                cardBrandDataList = listOf(amexBrandData, visaBrandData),
-                shopperSelectedCardBrandData = visaBrandData,
-            ),
-        )
-
-        // WHEN
-        val viewState = producer.produce(componentState)
-
-        // THEN
-        assertEquals(CardNumberFormat.DEFAULT, viewState.cardNumberFormat)
+        assertNull(viewState.cardNumber?.supportingText)
     }
 
     // UC6: Error Hides Brand Logos

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
@@ -223,6 +223,39 @@ internal class CardViewStateProducerTest {
     }
 
     @Test
+    fun `when dual brand with shopper selection is detected, then card number supportingText is dual brand selector description`() {
+        // GIVEN
+        val visaBrandData = getCardBrandData().copy(cardBrand = CardBrand("visa"))
+        val mcBrandData = getCardBrandData().copy(cardBrand = CardBrand("mc"))
+        val componentState = createComponentState(
+            cardBrandState = CardBrandState.DualBrandWithShopperSelection(
+                cardBrandDataList = listOf(visaBrandData, mcBrandData),
+                shopperSelectedCardBrandData = visaBrandData,
+            ),
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertEquals(CheckoutLocalizationKey.CARD_DUAL_BRAND_SELECTOR_DESCRIPTION, viewState.cardNumber?.supportingText)
+    }
+
+    @Test
+    fun `when no brand is detected, then card number supportingText is null`() {
+        // GIVEN
+        val componentState = createComponentState(
+            cardBrandState = CardBrandState.NoBrandsDetected,
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertEquals(null, viewState.cardNumber?.supportingText)
+    }
+
+    @Test
     fun `when dual brand with non-amex selected, then cardNumberFormat should be Default`() {
         // GIVEN
         val amexBrandData = getCardBrandData().copy(

--- a/core/src/testFixtures/java/com/adyen/checkout/core/analytics/internal/TestAnalyticsManager.kt
+++ b/core/src/testFixtures/java/com/adyen/checkout/core/analytics/internal/TestAnalyticsManager.kt
@@ -8,6 +8,7 @@
 
 package com.adyen.checkout.core.analytics.internal
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.fail
@@ -35,6 +36,11 @@ class TestAnalyticsManager : AnalyticsManager {
     fun assertLastEventNotEquals(expected: AnalyticsEvent) {
         if (events.isEmpty()) return
         assertFalse(areEventsEqual(expected, events.last()))
+    }
+
+    fun assertEventCount(expectedCount: Int, event: AnalyticsEvent) {
+        val actualCount = events.count { areEventsEqual(event, it) }
+        assertEquals(expectedCount, actualCount)
     }
 
     private fun areEventsEqual(expected: AnalyticsEvent, actual: AnalyticsEvent): Boolean {

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/input/CheckoutTextFieldDecorationBox.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/input/CheckoutTextFieldDecorationBox.kt
@@ -98,7 +98,7 @@ internal fun CheckoutTextFieldDecorationBox(
                 .styledBackground(style, isFocused, isError)
                 .fillMaxWidth()
                 .heightIn(Dimensions.MinTouchTarget)
-                .padding(horizontal = Dimensions.Spacing.Large, vertical = Dimensions.Spacing.Medium),
+                .padding(horizontal = Dimensions.Spacing.Large),
         ) {
             prefix?.let {
                 Body(prefix, color = CheckoutThemeProvider.colors.textSecondary)

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/input/CheckoutTextFieldDefaults.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/input/CheckoutTextFieldDefaults.kt
@@ -18,7 +18,7 @@ internal object CheckoutTextFieldDefaults {
         attributes: InternalAttributes,
     ): InternalTextFieldStyle {
         return InternalTextFieldStyle(
-            backgroundColor = colors.container,
+            backgroundColor = colors.background,
             textColor = colors.text,
             activeColor = colors.primary,
             errorColor = colors.destructive,


### PR DESCRIPTION
## Description
[//]: # (Include a short summary of your changes)
[//]: # (If this is a new feature: attach screenshots or a video if applicable)
[//]: # (If this is a bug fix: include a reproduction path)
Adds UI to allow selection of a brand for Dual Branded Cards with Selection and adds corresponding Analytics events.

[Recording](https://github.com/user-attachments/assets/fa2bd1bb-15f7-4657-936b-12a05b1153a6)

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually

## Ticket Number
COSDK-1193

