### PR TITLE
v6 - Google Pay - Default button theme & previews

### DIFF
--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/view/GooglePayButton.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/view/GooglePayButton.kt
@@ -12,10 +12,18 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import com.adyen.checkout.googlepay.GooglePayButtonStyling
+import com.adyen.checkout.googlepay.GooglePayButtonTheme
+import com.adyen.checkout.googlepay.GooglePayButtonType
 import com.adyen.checkout.googlepay.internal.ui.state.GooglePayButtonViewState
+import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.helper.isDark
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
+import com.adyen.checkout.ui.theme.CheckoutTheme
 import com.google.pay.button.ButtonTheme
 import com.google.pay.button.ButtonType
 import com.google.pay.button.PayButton
@@ -44,3 +52,62 @@ internal fun GooglePayButton(
 }
 
 private val DEFAULT_CORNER_RADIUS = 100.dp
+
+@Preview(showBackground = true)
+@Composable
+private fun GooglePayButtonPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemeWrapper(theme) {
+        GooglePayButton(
+            buttonViewState = GooglePayButtonViewState(
+                allowedPaymentMethods = "[]",
+                buttonStyling = null,
+                isLoading = false,
+            ),
+            onClick = {},
+        )
+        GooglePayButton(
+            buttonViewState = GooglePayButtonViewState(
+                allowedPaymentMethods = "[]",
+                buttonStyling = GooglePayButtonStyling(
+                    buttonType = GooglePayButtonType.PAY,
+                    cornerRadius = 8,
+                ),
+                isLoading = false,
+            ),
+            onClick = {},
+        )
+        GooglePayButton(
+            buttonViewState = GooglePayButtonViewState(
+                allowedPaymentMethods = "[]",
+                buttonStyling = GooglePayButtonStyling(
+                    buttonType = GooglePayButtonType.CHECKOUT,
+                    cornerRadius = 0,
+                ),
+                isLoading = true,
+            ),
+            onClick = {},
+        )
+        GooglePayButton(
+            buttonViewState = GooglePayButtonViewState(
+                allowedPaymentMethods = "[]",
+                buttonStyling = GooglePayButtonStyling(
+                    buttonTheme = GooglePayButtonTheme.LIGHT,
+                ),
+                isLoading = false,
+            ),
+            onClick = {},
+        )
+        GooglePayButton(
+            buttonViewState = GooglePayButtonViewState(
+                allowedPaymentMethods = "[]",
+                buttonStyling = GooglePayButtonStyling(
+                    buttonTheme = GooglePayButtonTheme.DARK,
+                ),
+                isLoading = false,
+            ),
+            onClick = {},
+        )
+    }
+}

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/view/GooglePayButton.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/view/GooglePayButton.kt
@@ -10,9 +10,14 @@ package com.adyen.checkout.googlepay.internal.ui.view
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.adyen.checkout.googlepay.internal.ui.state.GooglePayButtonViewState
+import com.adyen.checkout.ui.internal.helper.isDark
+import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
+import com.google.pay.button.ButtonTheme
+import com.google.pay.button.ButtonType
 import com.google.pay.button.PayButton
 
 @Composable
@@ -22,12 +27,17 @@ internal fun GooglePayButton(
     modifier: Modifier = Modifier,
 ) {
     val buttonStyling = buttonViewState.buttonStyling
+    val backgroundColor = CheckoutThemeProvider.colors.background
+    val defaultButtonTheme = remember(backgroundColor) {
+        if (backgroundColor.isDark()) ButtonTheme.Light else ButtonTheme.Dark
+    }
+
     PayButton(
         onClick = onClick,
         allowedPaymentMethods = buttonViewState.allowedPaymentMethods,
         modifier = modifier.fillMaxWidth(),
-        theme = buttonStyling?.buttonTheme.toButtonTheme(),
-        type = buttonStyling?.buttonType.toButtonType(),
+        theme = buttonStyling?.buttonTheme?.toButtonTheme() ?: defaultButtonTheme,
+        type = buttonStyling?.buttonType?.toButtonType() ?: ButtonType.Buy,
         radius = buttonStyling?.cornerRadius?.dp ?: DEFAULT_CORNER_RADIUS,
         enabled = !buttonViewState.isLoading,
     )

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/view/GooglePayButtonStylingMapper.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/view/GooglePayButtonStylingMapper.kt
@@ -13,13 +13,12 @@ import com.adyen.checkout.googlepay.GooglePayButtonType
 import com.google.pay.button.ButtonTheme
 import com.google.pay.button.ButtonType
 
-internal fun GooglePayButtonTheme?.toButtonTheme(): ButtonTheme = when (this) {
+internal fun GooglePayButtonTheme.toButtonTheme(): ButtonTheme = when (this) {
     GooglePayButtonTheme.LIGHT -> ButtonTheme.Light
-    GooglePayButtonTheme.DARK,
-    null -> ButtonTheme.Dark
+    GooglePayButtonTheme.DARK -> ButtonTheme.Dark
 }
 
-internal fun GooglePayButtonType?.toButtonType(): ButtonType = when (this) {
+internal fun GooglePayButtonType.toButtonType(): ButtonType = when (this) {
     GooglePayButtonType.BOOK -> ButtonType.Book
     GooglePayButtonType.CHECKOUT -> ButtonType.Checkout
     GooglePayButtonType.DONATE -> ButtonType.Donate
@@ -27,6 +26,5 @@ internal fun GooglePayButtonType?.toButtonType(): ButtonType = when (this) {
     GooglePayButtonType.PAY -> ButtonType.Pay
     GooglePayButtonType.SUBSCRIBE -> ButtonType.Subscribe
     GooglePayButtonType.PLAIN -> ButtonType.Plain
-    GooglePayButtonType.BUY,
-    null -> ButtonType.Buy
+    GooglePayButtonType.BUY -> ButtonType.Buy
 }

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/view/GooglePayContent.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/view/GooglePayContent.kt
@@ -15,10 +15,8 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.adyen.checkout.googlepay.internal.ui.GooglePayViewEvent
-import com.adyen.checkout.googlepay.internal.ui.state.GooglePayButtonViewState
 import com.adyen.checkout.googlepay.internal.ui.state.GooglePayViewState
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.wallet.PaymentData
@@ -71,19 +69,4 @@ private fun GooglePayContent(
             modifier = modifier,
         )
     }
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun GooglePayContentPreview() {
-    GooglePayContent(
-        viewState = GooglePayViewState(
-            buttonViewState = GooglePayButtonViewState(
-                allowedPaymentMethods = "[]",
-                buttonStyling = null,
-                isLoading = false,
-            ),
-        ),
-        onSubmit = {},
-    )
 }

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/view/GooglePayButtonStylingMapperTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/view/GooglePayButtonStylingMapperTest.kt
@@ -28,13 +28,7 @@ internal class GooglePayButtonStylingMapperTest {
     }
 
     @Test
-    fun `when toButtonTheme is called with null, then it defaults to ButtonTheme Dark`() {
-        assertEquals(ButtonTheme.Dark, (null as GooglePayButtonTheme?).toButtonTheme())
-    }
-
-    @Test
     fun `when toButtonType is called with each type, then it maps to the matching ButtonType`() {
-        assertEquals(ButtonType.Buy, GooglePayButtonType.BUY.toButtonType())
         assertEquals(ButtonType.Book, GooglePayButtonType.BOOK.toButtonType())
         assertEquals(ButtonType.Checkout, GooglePayButtonType.CHECKOUT.toButtonType())
         assertEquals(ButtonType.Donate, GooglePayButtonType.DONATE.toButtonType())
@@ -42,10 +36,6 @@ internal class GooglePayButtonStylingMapperTest {
         assertEquals(ButtonType.Pay, GooglePayButtonType.PAY.toButtonType())
         assertEquals(ButtonType.Subscribe, GooglePayButtonType.SUBSCRIBE.toButtonType())
         assertEquals(ButtonType.Plain, GooglePayButtonType.PLAIN.toButtonType())
-    }
-
-    @Test
-    fun `when toButtonType is called with null, then it defaults to ButtonType Buy`() {
-        assertEquals(ButtonType.Buy, (null as GooglePayButtonType?).toButtonType())
+        assertEquals(ButtonType.Buy, GooglePayButtonType.BUY.toButtonType())
     }
 }


### PR DESCRIPTION
## Description
Two follow-ups to the v6 Google Pay button:

- **Default button theme follows the checkout theme.** When the merchant does not set a `buttonTheme`, the button now derives it from the checkout theme background — a light button on a dark background and a dark button on a light background — mirroring the v5 day/night default. A merchant-provided `buttonTheme` still takes precedence.

  Note: the v6 SDK has no direct reference to system dark/light mode (the `CheckoutTheme` defaults to light unless the merchant configures otherwise), so the default is derived from the theme background luminance. This reuses the same approach already used for picking themed icons (`getThemedIcon` / `Color.isDark()` on the background).
- **Extensive previews.** Added parameterized (light/dark) `@Preview`s for `GooglePayButton`: default styling, `PAY` (radius 8), `CHECKOUT` (radius 0, loading), and explicit `LIGHT`/`DARK` theme overrides.

Note: Google's `PayButton` may render as a placeholder in Android Studio previews since it relies on Play Services.

## Checklist
- [x] Changes are tested manually

## Ticket Number
COSDK-1309