### PR TITLE
v6 - Submit guard

### DIFF
--- a/core/src/main/java/com/adyen/checkout/core/components/internal/FullCheckoutFlow.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/FullCheckoutFlow.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import java.util.concurrent.atomic.AtomicBoolean
 
 internal class FullCheckoutFlow(
     private val componentRequestDispatcher: SubmittableComponentRequestDispatcher,
@@ -38,8 +39,7 @@ internal class FullCheckoutFlow(
     )
     override val navigation: Flow<CheckoutRoute> = navigationFlow.asSharedFlow()
 
-    @Volatile
-    private var canSubmit = true
+    private val canSubmit = AtomicBoolean(true)
 
     init {
         paymentComponent.eventFlow
@@ -67,8 +67,7 @@ internal class FullCheckoutFlow(
     }
 
     override fun submit() {
-        if (!canSubmit) return
-        canSubmit = false
+        if (!canSubmit.compareAndSet(true, false)) return
         paymentComponent.submit()
         paymentComponent.setLoading(true)
     }
@@ -88,7 +87,7 @@ internal class FullCheckoutFlow(
             }
 
             is SubmitResult.Retry -> {
-                canSubmit = true
+                canSubmit.set(true)
                 paymentComponent.setLoading(false)
             }
 

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/FullCheckoutFlow.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/FullCheckoutFlow.kt
@@ -38,15 +38,16 @@ internal class FullCheckoutFlow(
     )
     override val navigation: Flow<CheckoutRoute> = navigationFlow.asSharedFlow()
 
+    @Volatile
+    private var canSubmit = true
+
     init {
         paymentComponent?.eventFlow
             ?.onEach { event ->
                 when (event) {
                     is PaymentComponentEvent.Submit -> {
-                        paymentComponent.setLoading(true)
                         val result = componentRequestDispatcher.submit(event.state.data)
                         handleResult(result)
-                        paymentComponent.setLoading(false)
                     }
 
                     is PaymentComponentEvent.Error -> {
@@ -65,9 +66,11 @@ internal class FullCheckoutFlow(
             ?.launchIn(coroutineScope)
     }
 
-    // TODO - Ensure we are not handling an action
     override fun submit() {
+        if (!canSubmit) return
+        canSubmit = false
         paymentComponent?.submit()
+        paymentComponent?.setLoading(true)
     }
 
     override fun requiresUserInteraction(): Boolean =
@@ -85,7 +88,8 @@ internal class FullCheckoutFlow(
             }
 
             is SubmitResult.Retry -> {
-                // No-op: there is nothing we should do in these cases
+                canSubmit = true
+                paymentComponent?.setLoading(false)
             }
 
             is SubmitResult.PartialPayment -> {

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/FullCheckoutFlow.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/FullCheckoutFlow.kt
@@ -46,6 +46,7 @@ internal class FullCheckoutFlow(
             .onEach { event ->
                 when (event) {
                     is PaymentComponentEvent.Submit -> {
+                        paymentComponent.setLoading(true)
                         val result = componentRequestDispatcher.submit(event.state.data)
                         handleResult(result)
                     }
@@ -69,7 +70,6 @@ internal class FullCheckoutFlow(
     override fun submit() {
         if (!canSubmit.compareAndSet(true, false)) return
         paymentComponent.submit()
-        paymentComponent.setLoading(true)
     }
 
     override fun requiresUserInteraction(): Boolean =

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/FullCheckoutFlow.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/FullCheckoutFlow.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.flow.onEach
 internal class FullCheckoutFlow(
     private val componentRequestDispatcher: SubmittableComponentRequestDispatcher,
     coroutineScope: CoroutineScope,
-    override val paymentComponent: PaymentComponent?,
+    override val paymentComponent: PaymentComponent,
     private val actionHandler: ActionHandler,
 ) : CheckoutFlow {
 
@@ -42,8 +42,8 @@ internal class FullCheckoutFlow(
     private var canSubmit = true
 
     init {
-        paymentComponent?.eventFlow
-            ?.onEach { event ->
+        paymentComponent.eventFlow
+            .onEach { event ->
                 when (event) {
                     is PaymentComponentEvent.Submit -> {
                         val result = componentRequestDispatcher.submit(event.state.data)
@@ -63,18 +63,18 @@ internal class FullCheckoutFlow(
                     }
                 }
             }
-            ?.launchIn(coroutineScope)
+            .launchIn(coroutineScope)
     }
 
     override fun submit() {
         if (!canSubmit) return
         canSubmit = false
-        paymentComponent?.submit()
-        paymentComponent?.setLoading(true)
+        paymentComponent.submit()
+        paymentComponent.setLoading(true)
     }
 
     override fun requiresUserInteraction(): Boolean =
-        actionComponent == null && paymentComponent?.requiresUserInteraction() == true
+        actionComponent == null && paymentComponent.requiresUserInteraction()
 
     private fun handleResult(submitResult: SubmitResult) {
         when (submitResult) {
@@ -89,7 +89,7 @@ internal class FullCheckoutFlow(
 
             is SubmitResult.Retry -> {
                 canSubmit = true
-                paymentComponent?.setLoading(false)
+                paymentComponent.setLoading(false)
             }
 
             is SubmitResult.PartialPayment -> {

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/FullCheckoutFlowTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/FullCheckoutFlowTest.kt
@@ -138,16 +138,6 @@ internal class FullCheckoutFlowTest(
         }
 
         @Test
-        fun `when payment component is null, then returns false`() = runTest {
-            val flow = createFullCheckoutFlow(
-                coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
-                component = null,
-            )
-
-            assertFalse(flow.requiresUserInteraction())
-        }
-
-        @Test
         fun `when payment component does not require user interaction, then returns false`() = runTest {
             val flow = createFullCheckoutFlow(
                 coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
@@ -329,9 +319,9 @@ internal class FullCheckoutFlowTest(
     private fun createFullCheckoutFlow(
         coroutineScope: CoroutineScope,
         requiresUserInteraction: Boolean = true,
-        component: PaymentComponent? = TestPaymentComponent(eventFlow, requiresUserInteraction),
+        component: PaymentComponent = TestPaymentComponent(eventFlow, requiresUserInteraction),
     ): FullCheckoutFlow {
-        component?.let { registerComponent(it) }
+        registerComponent(component)
 
         return FullCheckoutFlow(
             componentRequestDispatcher = componentRequestDispatcher,

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/FullCheckoutFlowTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/FullCheckoutFlowTest.kt
@@ -165,19 +165,6 @@ internal class FullCheckoutFlowTest(
         }
 
         @Test
-        fun `when submit is called, then loading is set to true`() = runTest {
-            val component = TestPaymentComponent(eventFlow)
-            val flow = createFullCheckoutFlow(
-                coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
-                component = component,
-            )
-
-            flow.submit()
-
-            assertTrue(component.isLoading)
-        }
-
-        @Test
         fun `when submit is called twice, then payment component submit is called only once`() = runTest {
             val component = TestPaymentComponent(eventFlow)
             val flow = createFullCheckoutFlow(
@@ -261,6 +248,20 @@ internal class FullCheckoutFlowTest(
             flow.submit()
 
             assertEquals(1, component.submitCount)
+        }
+
+        @Test
+        fun `when submit event is received, then loading is set to true`() = runTest {
+            whenever(componentRequestDispatcher.submit(any())) doReturn SubmitResult.Completion("Authorised")
+            val component = TestPaymentComponent(eventFlow)
+            createFullCheckoutFlow(
+                coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+                component = component,
+            )
+
+            eventFlow.emit(PaymentComponentEvent.Submit(createPaymentComponentState()))
+
+            assertTrue(component.isLoading)
         }
     }
 

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/FullCheckoutFlowTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/FullCheckoutFlowTest.kt
@@ -159,6 +159,122 @@ internal class FullCheckoutFlowTest(
     }
 
     @Nested
+    inner class SubmitTest {
+
+        @Test
+        fun `when submit is called, then payment component submit is called`() = runTest {
+            val component = TestPaymentComponent(eventFlow)
+            val flow = createFullCheckoutFlow(
+                coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+                component = component,
+            )
+
+            flow.submit()
+
+            assertEquals(1, component.submitCount)
+        }
+
+        @Test
+        fun `when submit is called, then loading is set to true`() = runTest {
+            val component = TestPaymentComponent(eventFlow)
+            val flow = createFullCheckoutFlow(
+                coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+                component = component,
+            )
+
+            flow.submit()
+
+            assertTrue(component.isLoading)
+        }
+
+        @Test
+        fun `when submit is called twice, then payment component submit is called only once`() = runTest {
+            val component = TestPaymentComponent(eventFlow)
+            val flow = createFullCheckoutFlow(
+                coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+                component = component,
+            )
+
+            flow.submit()
+            flow.submit()
+
+            assertEquals(1, component.submitCount)
+        }
+
+        @Test
+        fun `when submit results in Retry and submit is called again, then payment component submit is called twice`() =
+            runTest {
+                whenever(componentRequestDispatcher.submit(any())) doReturn SubmitResult.Retry()
+
+                val component = TestPaymentComponent(eventFlow)
+                val flow = createFullCheckoutFlow(
+                    coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+                    component = component,
+                )
+
+                flow.submit()
+                eventFlow.emit(PaymentComponentEvent.Submit(createPaymentComponentState()))
+
+                flow.submit()
+
+                assertEquals(2, component.submitCount)
+            }
+
+        @Test
+        fun `when submit results in Retry, then loading is set to false`() = runTest {
+            whenever(componentRequestDispatcher.submit(any())) doReturn SubmitResult.Retry()
+
+            val component = TestPaymentComponent(eventFlow)
+            val flow = createFullCheckoutFlow(
+                coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+                component = component,
+            )
+
+            flow.submit()
+            eventFlow.emit(PaymentComponentEvent.Submit(createPaymentComponentState()))
+
+            assertFalse(component.isLoading)
+        }
+
+        @Test
+        fun `when submit results in Completion, then submit cannot be called again`() = runTest {
+            whenever(componentRequestDispatcher.submit(any())) doReturn SubmitResult.Completion("Authorised")
+
+            val component = TestPaymentComponent(eventFlow)
+            val flow = createFullCheckoutFlow(
+                coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+                component = component,
+            )
+
+            flow.submit()
+            eventFlow.emit(PaymentComponentEvent.Submit(createPaymentComponentState()))
+
+            flow.submit()
+
+            assertEquals(1, component.submitCount)
+        }
+
+        @Test
+        fun `when submit results in Action, then submit cannot be called again`() = runTest {
+            val action = RedirectAction(type = "redirect", paymentData = "test_data", paymentMethodType = "scheme")
+            whenever(componentRequestDispatcher.submit(any())) doReturn SubmitResult.Action(action)
+
+            val component = TestPaymentComponent(eventFlow)
+            val flow = createFullCheckoutFlow(
+                coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+                component = component,
+            )
+
+            flow.submit()
+            eventFlow.emit(PaymentComponentEvent.Submit(createPaymentComponentState()))
+
+            flow.submit()
+
+            assertEquals(1, component.submitCount)
+        }
+    }
+
+    @Nested
     inner class HandleResultTest {
 
         @Test

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/ui/TestPaymentComponent.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/ui/TestPaymentComponent.kt
@@ -19,14 +19,24 @@ internal class TestPaymentComponent(
     private val requiresUserInteraction: Boolean = true,
 ) : PaymentComponent {
 
+    var submitCount = 0
+        private set
+
+    var isLoading = false
+        private set
+
     @Composable
     override fun Content(modifier: Modifier) = Unit
 
-    override fun submit() = Unit
+    override fun submit() {
+        submitCount++
+    }
 
     override fun requiresUserInteraction(): Boolean = requiresUserInteraction
 
-    override fun setLoading(isLoading: Boolean) = Unit
+    override fun setLoading(isLoading: Boolean) {
+        this.isLoading = isLoading
+    }
 
     override fun onCleared() = Unit
 }


### PR DESCRIPTION
## Description
Add a canSubmit guard to FullCheckoutFlow.submit() to prevent duplicate payment submissions when the method is called multiple times while an async request is in-flight or when an action component is shown.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Code is unit tested
- [x] Changes are tested manually