### PR TITLE
docs: refresh Android v6 migration guide examples

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -238,12 +238,80 @@ CheckoutPaymentFlow(
 - Locale selection still starts from `shopperLocale` on `CheckoutConfiguration`.
 - Targeted string overrides move to `CheckoutLocalizationProvider` or `StringResourceLocalizationProvider` passed to `CheckoutPaymentFlow(...)`.
 
+### Google Pay
+
+#### Configuration object
+
+##### Before (v5)
+
+```kotlin
+val checkoutConfiguration = CheckoutConfiguration(
+    environment = environment,
+    clientKey = clientKey,
+    amount = amount,
+) {
+    googlePay {
+        setCountryCode("US")
+        setCheckoutOption("COMPLETE_IMMEDIATE_PURCHASE")
+        setGooglePayEnvironment(WalletConstants.ENVIRONMENT_TEST)
+    }
+}
+```
+
+##### After (v6)
+
+```kotlin
+val configuration = CheckoutConfiguration(
+    environment = Environment.TEST,
+    clientKey = clientKey,
+    amount = amount,
+) {
+    googlePay(
+        countryCode = "US",
+        checkoutOption = "COMPLETE_IMMEDIATE_PURCHASE",
+    )
+}
+```
+
+#### Flow migration
+
+Google Pay now follows the same `Checkout.setup(...)` + `CheckoutController(...)` + `CheckoutPaymentFlow(...)` host pattern as the other public v6 payment methods.
+
+```kotlin
+lifecycleScope.launch {
+    when (val result = Checkout.setup(paymentMethods = paymentMethods, configuration = configuration)) {
+        is Checkout.Result.Error -> showError(result.error.message.orEmpty())
+        is Checkout.Result.Success -> {
+            val controller = CheckoutController(
+                target = CheckoutTarget.PaymentMethod(PaymentMethodTypes.GOOGLE_PAY),
+                context = result.checkoutContext,
+                callbacks = AdvancedCheckoutCallbacks(
+                    onSubmit = { data ->
+                        callPayments(data)
+                    },
+                    onAdditionalDetails = { data ->
+                        callDetails(data)
+                    },
+                    onFailure = { error ->
+                        showError(error.message.orEmpty())
+                    },
+                ),
+                coroutineScope = lifecycleScope,
+            )
+        }
+    }
+}
+```
+
+If your payment-method response still returns `googlepay_legacy`, target `PaymentMethodTypes.GOOGLE_PAY_LEGACY` instead.
+
 #### Package migration guide
 
 | v5 style | v6 style |
 | --- | --- |
 | `com.adyen.checkout.components.core.CheckoutConfiguration` | `com.adyen.checkout.core.components.CheckoutConfiguration` |
 | `com.adyen.checkout.card.*` | `com.adyen.checkout.card.*` (package unchanged) |
+| `com.adyen.checkout.googlepay.old.googlePay` | `com.adyen.checkout.googlepay.googlePay` |
 | `CheckoutSessionProvider.createSession(...)` | `Checkout.setup(sessionResponse = ..., configuration = ...)` |
 | `ComponentCallback<CardComponentState>` | `AdvancedCheckoutCallbacks` |
 | `SessionComponentCallback<CardComponentState>` | `SessionCheckoutCallbacks` |

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -47,7 +47,7 @@ val configuration = CheckoutConfiguration(
     shopperLocale = shopperLocale,
 ) {
     card(showCardholderName = true)
-    threeDS2(threeDSRequestorAppURL = "https://your-app.example/adyen")
+    authentication(threeDSRequestorAppURL = "https://your-app.example/adyen")
 }
 
 lifecycleScope.launch {
@@ -134,7 +134,7 @@ class CardActivity : AppCompatActivity() {
                             onAdditionalDetails = { data ->
                                 callDetails(data)
                             },
-                            onError = { error ->
+                            onFailure = { error ->
                                 showError(error.message.orEmpty())
                             },
                         ) {

--- a/docs/v6/README.md
+++ b/docs/v6/README.md
@@ -2,7 +2,7 @@
 
 This guide covers the v6 checkout entry points and the shared concepts used by the Android v6 alpha documentation set.
 
-For card-specific configuration and flow guides, see [card.md](card.md), [card-session-flow.md](card-session-flow.md), and [card-advanced-flow.md](card-advanced-flow.md). For Compose theme customization, see [theme.md](theme.md). For migration notes, see [../../MIGRATION.md](../../MIGRATION.md).
+For card-specific configuration and flow guides, see [card.md](card.md), [card-session-flow.md](card-session-flow.md), and [card-advanced-flow.md](card-advanced-flow.md). For Compose theme customization, see [theme.md](theme.md). For migration notes, including Google Pay migration notes, see [../../MIGRATION.md](../../MIGRATION.md).
 
 ## Alpha status
 
@@ -33,6 +33,7 @@ import androidx.compose.runtime.Composable
 import androidx.lifecycle.lifecycleScope
 import com.adyen.checkout.card.BillingAddressMode
 import com.adyen.checkout.card.card
+import com.adyen.checkout.authentication.authentication
 import com.adyen.checkout.core.common.Environment
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.StringResourceLocalizationProvider
@@ -44,7 +45,6 @@ import com.adyen.checkout.core.components.CheckoutConfiguration
 import com.adyen.checkout.core.components.CheckoutController
 import com.adyen.checkout.core.components.CheckoutPaymentFlow
 import com.adyen.checkout.core.components.data.model.Amount
-import com.adyen.checkout.threeds2.threeDS2
 import com.adyen.checkout.ui.theme.CheckoutTheme
 import java.util.Locale
 import kotlinx.coroutines.launch
@@ -57,7 +57,7 @@ import kotlinx.coroutines.launch
 - environment and client key
 - optional shopper locale, amount, analytics, and submit-button behavior
 - payment-method configuration registered through the builder block
-- action configuration such as 3D Secure 2
+- action configuration such as authentication
 
 ```kotlin
 val configuration = CheckoutConfiguration(
@@ -76,7 +76,7 @@ val configuration = CheckoutConfiguration(
         showStorePaymentMethod = true,
     )
 
-    threeDS2(
+    authentication(
         threeDSRequestorAppURL = "https://your-app.example/adyen",
     )
 }

--- a/docs/v6/card-advanced-flow.md
+++ b/docs/v6/card-advanced-flow.md
@@ -23,7 +23,7 @@ val configuration = CheckoutConfiguration(
         showSecurityCode = true,
         showStorePaymentMethod = true,
     )
-    threeDS2(threeDSRequestorAppURL = "https://your-app.example/adyen")
+    authentication(threeDSRequestorAppURL = "https://your-app.example/adyen")
 }
 
 lifecycleScope.launch {
@@ -42,7 +42,7 @@ lifecycleScope.launch {
                     onAdditionalDetails = { data ->
                         callDetails(data)
                     },
-                    onError = { error ->
+                    onFailure = { error ->
                         showError(error.message.orEmpty())
                     },
                 ) {

--- a/docs/v6/card-session-flow.md
+++ b/docs/v6/card-session-flow.md
@@ -20,7 +20,7 @@ val configuration = CheckoutConfiguration(
         showCardholderName = true,
         showSecurityCode = true,
     )
-    threeDS2(threeDSRequestorAppURL = "https://your-app.example/adyen")
+    authentication(threeDSRequestorAppURL = "https://your-app.example/adyen")
 }
 
 lifecycleScope.launch {
@@ -33,10 +33,10 @@ lifecycleScope.launch {
                 target = CheckoutTarget.PaymentMethod(PaymentMethodTypes.SCHEME),
                 context = result.checkoutContext,
                 callbacks = SessionCheckoutCallbacks(
-                    onFinished = {
-                        showSuccess()
+                    onComplete = { checkoutResult ->
+                        showSuccess(checkoutResult.resultCode.value)
                     },
-                    onError = { error ->
+                    onFailure = { error ->
                         showError(error.message.orEmpty())
                     },
                 ) {

--- a/docs/v6/card.md
+++ b/docs/v6/card.md
@@ -17,12 +17,12 @@ import com.adyen.checkout.card.FieldVisibility
 import com.adyen.checkout.card.OnBinChangeCallback
 import com.adyen.checkout.card.OnBinLookupCallback
 import com.adyen.checkout.card.card
+import com.adyen.checkout.authentication.authentication
 import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.common.Environment
 import com.adyen.checkout.core.components.AdvancedCheckoutCallbacks
 import com.adyen.checkout.core.components.CheckoutConfiguration
 import com.adyen.checkout.core.components.data.model.Amount
-import com.adyen.checkout.threeds2.threeDS2
 ```
 
 ## Configure the card component
@@ -85,7 +85,7 @@ Register card-specific callbacks through the checkout callbacks block:
 val callbacks = AdvancedCheckoutCallbacks(
     onSubmit = { data -> callPayments(data) },
     onAdditionalDetails = { data -> callDetails(data) },
-    onError = { error -> showError(error.message.orEmpty()) },
+    onFailure = { error -> showError(error.message.orEmpty()) },
 ) {
     card(
         onBinChange = OnBinChangeCallback { bin ->
@@ -107,7 +107,7 @@ val callbacks = AdvancedCheckoutCallbacks(
 
 ## 3D Secure configuration
 
-3DS2-specific settings are configured with `threeDS2(...)`, not `card(...)`:
+3DS2-specific settings are configured with `authentication(...)`, not `card(...)`:
 
 ```kotlin
 val configuration = CheckoutConfiguration(
@@ -115,7 +115,7 @@ val configuration = CheckoutConfiguration(
     clientKey = clientKey,
 ) {
     card(showCardholderName = true)
-    threeDS2(
+    authentication(
         threeDSRequestorAppURL = "https://your-app.example/adyen",
     )
 }


### PR DESCRIPTION
## Summary
- update Android v6 migration and guide snippets to match current public APIs
- add compact Google Pay v5 to v6 migration coverage in `MIGRATION.md`
- keep README and v6 guide references aligned with the migration notes

COSDK-1122