### PR TITLE
v6 - KDoc - Core - Components entry points

### DIFF
--- a/core/src/main/java/com/adyen/checkout/core/components/ActionOnlyCheckoutCallbacks.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/ActionOnlyCheckoutCallbacks.kt
@@ -11,6 +11,16 @@ package com.adyen.checkout.core.components
 import com.adyen.checkout.core.action.data.ActionComponentData
 import com.adyen.checkout.core.error.CheckoutError
 
+/**
+ * Callbacks used when only handling an action, without collecting payment details first.
+ *
+ * @param onAdditionalDetails Called when additional details are required to complete the action. Make a network call
+ * to the `/payments/details` endpoint of the Checkout API through your server, and return the result as an
+ * [AdditionalDetailsResult].
+ * @param onFailure Called when an error occurs.
+ * @param onComplete Called when the payment is completed.
+ * @param additionalCallbacksBlock An optional block to register payment-method-specific [CheckoutAdditionalCallback]s.
+ */
 class ActionOnlyCheckoutCallbacks(
     internal val onAdditionalDetails: suspend (data: ActionComponentData) -> AdditionalDetailsResult,
     internal val onFailure: (CheckoutError) -> Unit,

--- a/core/src/main/java/com/adyen/checkout/core/components/AdvancedCheckoutCallbacks.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/AdvancedCheckoutCallbacks.kt
@@ -12,6 +12,18 @@ import com.adyen.checkout.core.action.data.ActionComponentData
 import com.adyen.checkout.core.components.data.PaymentComponentData
 import com.adyen.checkout.core.error.CheckoutError
 
+/**
+ * Callbacks used during a payment using the advanced flow.
+ *
+ * @param onSubmit Called after component validation, when the shopper submits the payment. Make a network call to the
+ * `/payments` endpoint of the Checkout API through your server, and return the result as a [SubmitResult].
+ * @param onAdditionalDetails Called when additional details are required to complete the payment (for example after
+ * an action). Make a network call to the `/payments/details` endpoint of the Checkout API through your server, and
+ * return the result as an [AdditionalDetailsResult].
+ * @param onFailure Called when an error occurs.
+ * @param onComplete Called when the payment is completed.
+ * @param additionalCallbacksBlock An optional block to register payment-method-specific [CheckoutAdditionalCallback]s.
+ */
 class AdvancedCheckoutCallbacks(
     internal val onSubmit: suspend (data: PaymentComponentData<*>) -> SubmitResult,
     internal val onAdditionalDetails: suspend (data: ActionComponentData) -> AdditionalDetailsResult,

--- a/core/src/main/java/com/adyen/checkout/core/components/Checkout.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/Checkout.kt
@@ -16,8 +16,24 @@ import com.adyen.checkout.core.components.internal.validate
 import com.adyen.checkout.core.error.CheckoutError
 import com.adyen.checkout.core.sessions.SessionResponse
 
+/**
+ * Entry point to set up a checkout.
+ *
+ * Use one of the [setup] methods to initialize the SDK for a specific integration flow and obtain a
+ * [CheckoutContext] that can then be passed to a [CheckoutController].
+ */
 object Checkout {
 
+    /**
+     * Sets up a checkout using the sessions flow.
+     *
+     * You only need to integrate with the `/sessions` endpoint to create a session and the SDK will
+     * automatically handle the rest of the payment flow.
+     *
+     * @param sessionResponse The response of the `/sessions` endpoint, deserialized into a [SessionResponse].
+     * @param configuration The [CheckoutConfiguration] to use for this checkout.
+     * @return A [Result.Success] with a [CheckoutContext.Sessions] on success, or a [Result.Error] on failure.
+     */
     suspend fun setup(
         sessionResponse: SessionResponse,
         configuration: CheckoutConfiguration,
@@ -50,6 +66,16 @@ object Checkout {
         }
     }
 
+    /**
+     * Sets up a checkout using the advanced flow.
+     *
+     * With the advanced flow you make the network calls to the Checkout API yourself, through the callbacks
+     * provided to the [CheckoutController].
+     *
+     * @param paymentMethods The available payment methods, from the `/paymentMethods` endpoint.
+     * @param configuration The [CheckoutConfiguration] to use for this checkout.
+     * @return A [Result.Success] with a [CheckoutContext.Advanced] on success, or a [Result.Error] on failure.
+     */
     suspend fun setup(
         paymentMethods: PaymentMethods,
         configuration: CheckoutConfiguration,
@@ -73,6 +99,13 @@ object Checkout {
         )
     }
 
+    /**
+     * Sets up a checkout that only handles an action, without collecting payment details first.
+     *
+     * @param action The [Action] to be handled.
+     * @param configuration The [CheckoutConfiguration] to use for this checkout.
+     * @return A [Result.Success] with a [CheckoutContext.ActionOnly] on success, or a [Result.Error] on failure.
+     */
     suspend fun setup(
         action: Action,
         configuration: CheckoutConfiguration,
@@ -96,8 +129,22 @@ object Checkout {
         )
     }
 
+    /**
+     * The result of a [setup] call.
+     */
     sealed interface Result<T : CheckoutContext> {
+        /**
+         * The setup succeeded.
+         *
+         * @param checkoutContext The resulting [CheckoutContext] to pass to a [CheckoutController].
+         */
         data class Success<T : CheckoutContext>(val checkoutContext: T) : Result<T>
+
+        /**
+         * The setup failed.
+         *
+         * @param error The [CheckoutError] describing what went wrong.
+         */
         data class Error<T : CheckoutContext>(val error: CheckoutError) : Result<T>
     }
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/CheckoutAction.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/CheckoutAction.kt
@@ -15,6 +15,17 @@ import com.adyen.checkout.core.common.localization.CheckoutLocalizationProvider
 import com.adyen.checkout.ui.internal.theme.InternalCheckoutTheme
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
+/**
+ * A [Composable] that displays the UI of an action being handled by the given [controller].
+ *
+ * Use this when you want to render the action screen yourself. To render the whole flow
+ * (payment method, action and secondary screens) automatically, use [CheckoutPaymentFlow] instead.
+ *
+ * @param controller The [CheckoutController] driving this flow.
+ * @param modifier The [Modifier] to be applied to the action UI.
+ * @param theme The [CheckoutTheme] used to style the UI.
+ * @param localizationProvider An optional [CheckoutLocalizationProvider] to override the displayed strings.
+ */
 @Composable
 fun CheckoutAction(
     controller: CheckoutController,

--- a/core/src/main/java/com/adyen/checkout/core/components/CheckoutCallbacks.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/CheckoutCallbacks.kt
@@ -10,6 +10,14 @@ package com.adyen.checkout.core.components
 
 import androidx.annotation.RestrictTo
 
+/**
+ * Base class for the callbacks used to interact with a [CheckoutController].
+ *
+ * Use one of the subclasses that matches your flow: [SessionCheckoutCallbacks], [AdvancedCheckoutCallbacks] or
+ * [ActionOnlyCheckoutCallbacks].
+ *
+ * @param additionalCallbacksBlock An optional block to register payment-method-specific [CheckoutAdditionalCallback]s.
+ */
 abstract class CheckoutCallbacks(
     additionalCallbacksBlock: CheckoutCallbacks.() -> Unit,
 ) {
@@ -41,4 +49,7 @@ inline fun <reified T : CheckoutAdditionalCallback> Set<CheckoutAdditionalCallba
     return find { it is T } as? T
 }
 
+/**
+ * Marker interface for payment-method-specific callbacks that can be registered through [CheckoutCallbacks].
+ */
 interface CheckoutAdditionalCallback

--- a/core/src/main/java/com/adyen/checkout/core/components/CheckoutController.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/CheckoutController.kt
@@ -19,6 +19,15 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import java.util.Locale
 
+/**
+ * Creates a [CheckoutController] for the advanced flow.
+ *
+ * @param target The [CheckoutTarget] indicating which payment method (or stored payment method) to use.
+ * @param context The [CheckoutContext.Advanced] obtained from [Checkout.setup].
+ * @param callbacks The [AdvancedCheckoutCallbacks] used to handle the payment flow.
+ * @param coroutineScope The [CoroutineScope] tied to the lifecycle that owns this controller.
+ * @return A [CheckoutController] instance.
+ */
 fun CheckoutController(
     target: CheckoutTarget,
     context: CheckoutContext.Advanced,
@@ -33,6 +42,15 @@ fun CheckoutController(
     )
 }
 
+/**
+ * Creates a [CheckoutController] for the sessions flow.
+ *
+ * @param target The [CheckoutTarget] indicating which payment method (or stored payment method) to use.
+ * @param context The [CheckoutContext.Sessions] obtained from [Checkout.setup].
+ * @param callbacks The [SessionCheckoutCallbacks] used to observe the payment flow.
+ * @param coroutineScope The [CoroutineScope] tied to the lifecycle that owns this controller.
+ * @return A [CheckoutController] instance.
+ */
 fun CheckoutController(
     target: CheckoutTarget,
     context: CheckoutContext.Sessions,
@@ -47,6 +65,14 @@ fun CheckoutController(
     )
 }
 
+/**
+ * Creates a [CheckoutController] for the action-only flow.
+ *
+ * @param context The [CheckoutContext.ActionOnly] obtained from [Checkout.setup].
+ * @param callbacks The [ActionOnlyCheckoutCallbacks] used to handle the action flow.
+ * @param coroutineScope The [CoroutineScope] tied to the lifecycle that owns this controller.
+ * @return A [CheckoutController] instance.
+ */
 fun CheckoutController(
     context: CheckoutContext.ActionOnly,
     callbacks: ActionOnlyCheckoutCallbacks,
@@ -59,6 +85,12 @@ fun CheckoutController(
     )
 }
 
+/**
+ * Controls a checkout flow.
+ *
+ * Create an instance using one of the [CheckoutController] factory functions, then drive the flow through
+ * [submit] and [handleReturn], and observe navigation changes if necessary through [navigation].
+ */
 class CheckoutController internal constructor(
     private val flow: CheckoutFlow,
     internal val environment: Environment,

--- a/core/src/main/java/com/adyen/checkout/core/components/CheckoutPaymentFlow.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/CheckoutPaymentFlow.kt
@@ -22,6 +22,15 @@ import com.adyen.checkout.core.common.internal.helper.adyenLog
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationProvider
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
+/**
+ * A [Composable] that renders the full checkout flow for the given [controller], automatically switching
+ * between the payment method input, action, and secondary screens as the flow progresses.
+ *
+ * @param controller The [CheckoutController] driving this flow.
+ * @param modifier The [Modifier] to be applied to the checkout UI.
+ * @param theme The [CheckoutTheme] used to style the UI.
+ * @param localizationProvider An optional [CheckoutLocalizationProvider] to override the displayed strings.
+ */
 @Composable
 fun CheckoutPaymentFlow(
     controller: CheckoutController,

--- a/core/src/main/java/com/adyen/checkout/core/components/CheckoutPaymentMethod.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/CheckoutPaymentMethod.kt
@@ -15,6 +15,17 @@ import com.adyen.checkout.core.common.localization.CheckoutLocalizationProvider
 import com.adyen.checkout.ui.internal.theme.InternalCheckoutTheme
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
+/**
+ * A [Composable] that displays the payment method input UI for the given [controller].
+ *
+ * Use this when you want to render the payment method screen yourself. To render the whole flow
+ * (payment method, action and secondary screens) automatically, use [CheckoutPaymentFlow] instead.
+ *
+ * @param controller The [CheckoutController] driving this flow.
+ * @param modifier The [Modifier] to be applied to the payment method UI.
+ * @param theme The [CheckoutTheme] used to style the UI.
+ * @param localizationProvider An optional [CheckoutLocalizationProvider] to override the displayed strings.
+ */
 @Composable
 fun CheckoutPaymentMethod(
     controller: CheckoutController,

--- a/core/src/main/java/com/adyen/checkout/core/components/CheckoutSecondary.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/CheckoutSecondary.kt
@@ -16,6 +16,18 @@ import com.adyen.checkout.core.components.internal.ui.SecondaryScreenComponent
 import com.adyen.checkout.ui.internal.theme.InternalCheckoutTheme
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
+/**
+ * A [Composable] that displays a secondary screen of the payment method handled by the given [controller].
+ *
+ * A secondary screen is shown when a payment method requires an additional step (identified by [identifier]).
+ * The available identifiers are provided through [CheckoutRoute.Secondary].
+ *
+ * @param identifier The identifier of the secondary screen to display.
+ * @param controller The [CheckoutController] driving this flow.
+ * @param modifier The [Modifier] to be applied to the secondary UI.
+ * @param theme The [CheckoutTheme] used to style the UI.
+ * @param localizationProvider An optional [CheckoutLocalizationProvider] to override the displayed strings.
+ */
 @Composable
 fun CheckoutSecondary(
     identifier: String,

--- a/core/src/main/java/com/adyen/checkout/core/components/CheckoutTarget.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/CheckoutTarget.kt
@@ -8,7 +8,22 @@
 
 package com.adyen.checkout.core.components
 
+/**
+ * Identifies which payment method a [CheckoutController] should be created for.
+ */
 interface CheckoutTarget {
+
+    /**
+     * Targets a regular payment method by its type.
+     *
+     * @param type The payment method type, as it appears in the `/paymentMethods` response.
+     */
     data class PaymentMethod(val type: String) : CheckoutTarget
+
+    /**
+     * Targets a stored payment method by its id.
+     *
+     * @param id The id of the stored payment method, as it appears in the `/paymentMethods` response.
+     */
     data class StoredPaymentMethod(val id: String) : CheckoutTarget
 }


### PR DESCRIPTION
## Description
Adds KDoc to the v6 public entry points in `core.components`).
Documentation only — no behavioral or public API changes.

Covered: `Checkout` + `setup(...)` overloads + `Result`, `CheckoutController` (factories + class),
`CheckoutPaymentFlow`/`CheckoutPaymentMethod`/`CheckoutAction`/`CheckoutSecondary`, `CheckoutCallbacks`
+ `AdvancedCheckoutCallbacks` + `ActionOnlyCheckoutCallbacks` + `CheckoutAdditionalCallback`, and `CheckoutTarget`.
Callback wording is adapted/reused from the v5 `ComponentCallback`/`SessionComponentCallback` docs where semantics map.

### Progress
➡️ **Phase 1 — core.components entry points**
Phase 2 — config DSLs (card / authentication / googlepay)
Phase 3 — core.common + localization + validators

## Ticket Number
COSDK-481