### PR TITLE
v6 - KDoc - Config DSLs (card / authentication / Google Pay)

### DIFF
--- a/authentication/src/main/java/com/adyen/checkout/authentication/AuthenticationConfiguration.kt
+++ b/authentication/src/main/java/com/adyen/checkout/authentication/AuthenticationConfiguration.kt
@@ -17,6 +17,12 @@ internal class AuthenticationConfiguration internal constructor(
     val threeDSRequestorAppURL: String?,
 ) : Configuration
 
+/**
+ * Adds an authentication configuration to this [CheckoutConfiguration] to configure 3D Secure 2 authentication.
+ *
+ * @param threeDSRequestorAppURL The URL of the requestor app, used by the issuer's ACS app to redirect the shopper
+ * back to your app after out-of-band (OOB) authentication.
+ */
 @JvmOverloads
 fun CheckoutConfiguration.authentication(
     threeDSRequestorAppURL: String? = null,

--- a/card/src/main/java/com/adyen/checkout/card/CardCallbackExt.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardCallbackExt.kt
@@ -10,6 +10,12 @@ package com.adyen.checkout.card
 
 import com.adyen.checkout.core.components.CheckoutCallbacks
 
+/**
+ * Registers card-specific callbacks on this [CheckoutCallbacks].
+ *
+ * @param onBinChange Called when the first digits (BIN) of the card number change. See [OnBinChangeCallback].
+ * @param onBinLookup Called when a BIN lookup completes for the entered card number. See [OnBinLookupCallback].
+ */
 @JvmOverloads
 fun CheckoutCallbacks.card(
     onBinChange: OnBinChangeCallback? = null,

--- a/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
+++ b/card/src/main/java/com/adyen/checkout/card/CardConfiguration.kt
@@ -13,6 +13,9 @@ import com.adyen.checkout.core.components.CheckoutConfiguration
 import com.adyen.checkout.core.components.internal.Configuration
 import kotlinx.parcelize.Parcelize
 
+/**
+ * Configuration for the card payment method. Create it by calling [CheckoutConfiguration.card].
+ */
 @Parcelize
 @Suppress("LongParameterList")
 class CardConfiguration internal constructor(
@@ -29,6 +32,27 @@ class CardConfiguration internal constructor(
     val installmentConfiguration: InstallmentConfiguration?,
 ) : Configuration
 
+/**
+ * Adds a [CardConfiguration] to this [CheckoutConfiguration] to configure the card payment method.
+ *
+ * @param billingAddressMode The type of billing address form to show to the shopper.
+ * @param koreanAuthenticationVisibility Whether the security fields for Korean cards should be shown.
+ * @param showCardholderName Whether the cardholder name should be shown as an input field.
+ * @param showSecurityCode Whether the security code (CVC/CVV) field should be shown and requested from the shopper on
+ * a regular payment. Note that hiding it might have implications for the risk of the transaction; talk to Adyen
+ * Support before changing this.
+ * @param showSecurityCodeForStoredCard Whether the security code (CVC/CVV) field should be shown and requested from
+ * the shopper on a stored card payment.
+ * @param showStorePaymentMethod Whether the option to store the card for future payments should be shown as an input
+ * field. Not applicable for the sessions flow.
+ * @param showSupportedCardBrandLogos Whether the logos of the supported card brands should be shown.
+ * @param socialSecurityNumberVisibility Whether the CPF/CNPJ field for Brazilian shoppers should be shown.
+ * @param supportedCardBrands The supported card brands, shown as the shopper inputs the card number. Defaults to the
+ * brands from the `/paymentMethods` response if available.
+ * @param showCardScanner Whether the card scanner should be shown.
+ * @param installmentConfiguration The configuration of the installment options shown to the shopper. Not applicable
+ * for the sessions flow.
+ */
 @Suppress("LongParameterList")
 @JvmOverloads
 fun CheckoutConfiguration.card(

--- a/card/src/main/java/com/adyen/checkout/card/OnBinChangeCallback.kt
+++ b/card/src/main/java/com/adyen/checkout/card/OnBinChangeCallback.kt
@@ -9,8 +9,19 @@
 package com.adyen.checkout.card
 
 import com.adyen.checkout.core.components.CheckoutAdditionalCallback
+import com.adyen.checkout.core.components.CheckoutCallbacks
 
+/**
+ * Callback invoked when the first digits (BIN) of the card number entered by the shopper change.
+ *
+ * Register it through [CheckoutCallbacks.card] on your [CheckoutCallbacks].
+ */
 fun interface OnBinChangeCallback : CheckoutAdditionalCallback {
 
+    /**
+     * Called when the BIN of the entered card number changes.
+     *
+     * @param binValue The current BIN (the leading digits of the card number).
+     */
     fun onBinChange(binValue: String)
 }

--- a/card/src/main/java/com/adyen/checkout/card/OnBinLookupCallback.kt
+++ b/card/src/main/java/com/adyen/checkout/card/OnBinLookupCallback.kt
@@ -9,8 +9,23 @@
 package com.adyen.checkout.card
 
 import com.adyen.checkout.core.components.CheckoutAdditionalCallback
+import com.adyen.checkout.core.components.CheckoutCallbacks
 
+/**
+ * Callback invoked when a BIN lookup completes for the card number entered by the shopper.
+ *
+ * It fires once the shopper has entered at least 11 digits and the SDK receives a `/binLookup` response (including
+ * responses served from the SDK's internal cache), exposing all detected brands without any SDK-side filtering. It
+ * does not fire for the client-side regex-based brand detection used while fewer digits are entered.
+ *
+ * Register it through [CheckoutCallbacks.card] on your [CheckoutCallbacks].
+ */
 fun interface OnBinLookupCallback : CheckoutAdditionalCallback {
 
+    /**
+     * Called when a BIN lookup completes.
+     *
+     * @param data The result of the BIN lookup, containing the issuing country and the detected brands.
+     */
     fun onBinLookup(data: BinLookupData)
 }

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/GooglePayConfiguration.kt
@@ -12,6 +12,9 @@ import com.adyen.checkout.core.components.CheckoutConfiguration
 import com.adyen.checkout.core.components.internal.Configuration
 import kotlinx.parcelize.Parcelize
 
+/**
+ * Configuration for the Google Pay payment method. Create it by calling [CheckoutConfiguration.googlePay].
+ */
 @Parcelize
 @Suppress("LongParameterList")
 class GooglePayConfiguration internal constructor(
@@ -29,6 +32,29 @@ class GooglePayConfiguration internal constructor(
     val googlePayButtonStyling: GooglePayButtonStyling?,
 ) : Configuration
 
+/**
+ * Adds a [GooglePayConfiguration] to this [CheckoutConfiguration] to configure the Google Pay payment method.
+ *
+ * Most parameters map to fields of the Google Pay request objects. See the
+ * [Google Pay docs](https://developers.google.com/pay/api/android/reference/request-objects) for more details.
+ *
+ * @param merchantAccount The merchant account to be put in the payment token from Google to Adyen. If not set, the
+ * value from the `/paymentMethods` response is used.
+ * @param googlePayEnvironment The Google Pay environment, either `WalletConstants.ENVIRONMENT_TEST` or
+ * `WalletConstants.ENVIRONMENT_PRODUCTION`. Defaults to the value of the Adyen environment.
+ * @param totalPriceStatus The status of the total price used. Defaults to `"FINAL"`.
+ * @param countryCode The ISO 3166-1 alpha-2 country code where the transaction is processed.
+ * @param merchantInfo Information about the merchant requesting the payment.
+ * @param allowedPaymentMethods The payment methods offered through Google Pay and their parameters. See
+ * [GooglePayAllowedPaymentMethods]. Defaults to a single card payment method when null.
+ * @param isEmailRequired Whether an email address is required.
+ * @param isExistingPaymentMethodRequired Whether an existing payment method is required for the shopper to be
+ * considered ready to pay.
+ * @param isShippingAddressRequired Whether a shipping address is required.
+ * @param shippingAddressParameters The required shipping address details.
+ * @param checkoutOption The checkout option, which affects the submit button text shown in the Google Pay sheet.
+ * @param googlePayButtonStyling The customization of the Google Pay button.
+ */
 @Suppress("LongParameterList")
 fun CheckoutConfiguration.googlePay(
     merchantAccount: String? = null,


### PR DESCRIPTION
## Description
Adds KDoc to the v6 payment-method configuration entry points.
Documentation only — no behavioral or public API changes.

Covered:
- `card`: `CardConfiguration` + `CheckoutConfiguration.card(...)`, `CheckoutCallbacks.card(...)`, `OnBinLookupCallback`, `OnBinChangeCallback`.
- `authentication`: `CheckoutConfiguration.authentication(...)`.
- `googlepay`: `GooglePayConfiguration` + `CheckoutConfiguration.googlePay(...)`.


### Progress
✅ Phase 1 — core.components entry points (#2880)
➡️ **Phase 2 — config DSLs (card / authentication / Google Pay)**
Phase 3 — core.common + localization + validators

## Ticket Number
COSDK-481