### PR TITLE
v6 - KDoc - Core - common, localization & validators

### DIFF
--- a/core/src/main/java/com/adyen/checkout/core/common/AdyenLogLevel.kt
+++ b/core/src/main/java/com/adyen/checkout/core/common/AdyenLogLevel.kt
@@ -10,6 +10,14 @@ package com.adyen.checkout.core.common
 
 import android.util.Log
 
+/**
+ * The severity levels used by the Adyen logger, ordered from most to least verbose.
+ *
+ * Use these values with [AdyenLogger.setLogLevel] to control the minimum level that gets logged.
+ * [NONE] disables logging entirely.
+ *
+ * @param priority The underlying Android [Log] priority for this level.
+ */
 enum class AdyenLogLevel(
     val priority: Int,
 ) {

--- a/core/src/main/java/com/adyen/checkout/core/common/AdyenLogger.kt
+++ b/core/src/main/java/com/adyen/checkout/core/common/AdyenLogger.kt
@@ -16,10 +16,30 @@ import com.adyen.checkout.core.common.internal.helper.LogcatLogger
  */
 interface AdyenLogger {
 
+    /**
+     * Returns whether a message logged at the given [level] should be emitted, based on the
+     * currently configured minimum log level.
+     *
+     * @param level The level of the message to be logged.
+     * @return `true` if the message should be logged, `false` otherwise.
+     */
     fun shouldLog(level: AdyenLogLevel): Boolean
 
+    /**
+     * Sets the minimum [AdyenLogLevel] to be logged. Messages below this level are ignored.
+     *
+     * @param level The minimum level to be logged.
+     */
     fun setLogLevel(level: AdyenLogLevel)
 
+    /**
+     * Logs a message with the given [level].
+     *
+     * @param level The severity level of the message.
+     * @param tag The tag identifying the source of the message.
+     * @param message The message to be logged.
+     * @param throwable An optional [Throwable] to log alongside the message.
+     */
     fun log(
         level: AdyenLogLevel,
         tag: String,

--- a/core/src/main/java/com/adyen/checkout/core/common/CheckoutContext.kt
+++ b/core/src/main/java/com/adyen/checkout/core/common/CheckoutContext.kt
@@ -10,16 +10,30 @@ package com.adyen.checkout.core.common
 
 import android.os.Parcelable
 import com.adyen.checkout.core.action.data.Action
+import com.adyen.checkout.core.components.Checkout
 import com.adyen.checkout.core.components.CheckoutConfiguration
+import com.adyen.checkout.core.components.CheckoutController
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethods
 import com.adyen.checkout.core.sessions.CheckoutSession
 import kotlinx.parcelize.Parcelize
 
-// TODO - Kdocs
+/**
+ * Holds the initialized state of a checkout flow.
+ *
+ * An instance is created by one of the [Checkout.setup] functions and then passed to a
+ * [CheckoutController] to drive the payment. Each subtype represents a specific integration flow.
+ */
 sealed interface CheckoutContext : Parcelable {
 
+    /**
+     * The [CheckoutConfiguration] used to set up this checkout.
+     */
     val checkoutConfiguration: CheckoutConfiguration
 
+    /**
+     * Checkout context for the sessions flow, created from a session response returned by the
+     * `/sessions` endpoint.
+     */
     @Parcelize
     @ConsistentCopyVisibility
     data class Sessions internal constructor(
@@ -29,6 +43,10 @@ sealed interface CheckoutContext : Parcelable {
         internal val publicKey: String?,
     ) : CheckoutContext
 
+    /**
+     * Checkout context for the advanced flow, created from the available payment
+     * methods returned by the `/paymentMethods` endpoint.
+     */
     @Parcelize
     @ConsistentCopyVisibility
     data class Advanced internal constructor(
@@ -38,6 +56,10 @@ sealed interface CheckoutContext : Parcelable {
         internal val publicKey: String?,
     ) : CheckoutContext
 
+    /**
+     * Checkout context for the action-only flow, created from a standalone [Action] that needs to
+     * be handled.
+     */
     @Parcelize
     @ConsistentCopyVisibility
     data class ActionOnly internal constructor(

--- a/core/src/main/java/com/adyen/checkout/core/common/helper/CardExpiryDateValidator.kt
+++ b/core/src/main/java/com/adyen/checkout/core/common/helper/CardExpiryDateValidator.kt
@@ -13,6 +13,12 @@ import com.adyen.checkout.core.common.internal.helper.DateUtils
 import java.util.Calendar
 import java.util.GregorianCalendar
 
+/**
+ * Validates card expiry dates.
+ *
+ * Use this when building a custom card UI to validate the expiry date independently of the built-in
+ * card component.
+ */
 object CardExpiryDateValidator {
     /**
      * Expiry date.

--- a/core/src/main/java/com/adyen/checkout/core/common/helper/CardNumberValidator.kt
+++ b/core/src/main/java/com/adyen/checkout/core/common/helper/CardNumberValidator.kt
@@ -12,6 +12,12 @@ import com.adyen.checkout.core.common.internal.helper.StringUtil
 import com.adyen.checkout.core.common.internal.properties.CardNumberProperties.CARD_NUMBER_MAXIMUM_LENGTH
 import com.adyen.checkout.core.common.internal.properties.CardNumberProperties.CARD_NUMBER_MINIMUM_LENGTH
 
+/**
+ * Validates card numbers.
+ *
+ * Use this when building a custom card UI to validate the card number independently of the built-in
+ * card component.
+ */
 object CardNumberValidator {
 
     // Luhn Check

--- a/core/src/main/java/com/adyen/checkout/core/common/helper/CardSecurityCodeValidator.kt
+++ b/core/src/main/java/com/adyen/checkout/core/common/helper/CardSecurityCodeValidator.kt
@@ -14,6 +14,12 @@ import com.adyen.checkout.core.common.internal.helper.StringUtil
 import com.adyen.checkout.core.common.internal.properties.SecurityCodeProperties.SECURITY_CODE_MAX_LENGTH_AMEX
 import com.adyen.checkout.core.common.internal.properties.SecurityCodeProperties.SECURITY_CODE_MAX_LENGTH_DEFAULT
 
+/**
+ * Validates card security codes (CVV/CVC).
+ *
+ * Use this when building a custom card UI to validate the security code independently of the
+ * built-in card component.
+ */
 object CardSecurityCodeValidator {
 
     /**

--- a/core/src/main/java/com/adyen/checkout/core/common/localization/CheckoutLocalizationKey.kt
+++ b/core/src/main/java/com/adyen/checkout/core/common/localization/CheckoutLocalizationKey.kt
@@ -8,6 +8,12 @@
 
 package com.adyen.checkout.core.common.localization
 
+/**
+ * Identifies a piece of user-facing text displayed by the checkout UI.
+ *
+ * Each key maps to a localized string that can be overridden through a
+ * [CheckoutLocalizationProvider], allowing you to customize the copy shown to the shopper.
+ */
 enum class CheckoutLocalizationKey {
     AWAIT_LOADING,
     CARD_NUMBER,

--- a/core/src/main/java/com/adyen/checkout/core/common/localization/CheckoutLocalizationProvider.kt
+++ b/core/src/main/java/com/adyen/checkout/core/common/localization/CheckoutLocalizationProvider.kt
@@ -11,10 +11,31 @@ package com.adyen.checkout.core.common.localization
 import android.content.Context
 import java.util.Locale
 
+/**
+ * Supplies the localized text shown by the checkout UI, allowing you to override the default copy.
+ *
+ * Provide your own implementation to fully control the strings displayed to the shopper, or use
+ * [StringResourceLocalizationProvider] to map keys to Android string resources.
+ */
 interface CheckoutLocalizationProvider {
+    /**
+     * Returns the localized string for the given [key], or `null` to fall back to the default text.
+     *
+     * @param context A [Context] used to resolve string resources.
+     * @param locale The shopper [Locale] the text should be localized for.
+     * @param key The [CheckoutLocalizationKey] identifying the text to resolve.
+     * @return The localized string, or `null` if no override is provided for this key.
+     */
     fun getLocalizedString(context: Context, locale: Locale, key: CheckoutLocalizationKey): String?
 }
 
+/**
+ * A [CheckoutLocalizationProvider] that resolves each [CheckoutLocalizationKey] to an Android string
+ * resource.
+ *
+ * @param localizations A map from localization keys to their corresponding string resource IDs.
+ * Keys that are not present in the map fall back to the default text.
+ */
 class StringResourceLocalizationProvider(
     private val localizations: Map<CheckoutLocalizationKey, Int>,
 ) : CheckoutLocalizationProvider {


### PR DESCRIPTION
## Description
Adds KDoc to the public API of the v6 `core.common` package, localization, and the standalone
card validators. Documentation-only change; no behavior or public API surface changes.

Covered declarations:
- `common/CheckoutContext.kt` — interface + `Sessions` / `Advanced` / `ActionOnly` and `checkoutConfiguration`
- `common/AdyenLogLevel.kt` — enum type-level doc
- `common/AdyenLogger.kt` — `shouldLog` / `setLogLevel` / `log`
- `common/localization/CheckoutLocalizationKey.kt` — enum type-level doc
- `common/localization/CheckoutLocalizationProvider.kt` — interface + `StringResourceLocalizationProvider`
- `common/helper/CardExpiryDateValidator.kt`, `CardNumberValidator.kt`, `CardSecurityCodeValidator.kt` — type-level docs

### Progress
✅ Phase 1 — Core components entry points (#2880)
✅ Phase 2 — Config DSLs (card / authentication / Google Pay) (#2881)
➡️ **Phase 3 - core.common + localization + validators**

## Ticket Number
COSDK-481