### PR TITLE
v5 - Renovate - Group v5 dependency updates into a single quarterly PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,17 @@
       "matchPackageNames": [
         "*"
       ]
+    },
+    {
+      "matchBaseBranches": [
+        "v5"
+      ],
+      "groupName": "All v5 dependencies",
+      "groupSlug": "all-v5",
+      "separateMajorMinor": false,
+      "schedule": [
+        "* * 1 */3 *"
+      ]
     }
   ],
   "rebaseWhen": "never"


### PR DESCRIPTION
## Description
Adds a `v5`-only Renovate package rule so that all dependency updates on the `v5` branch are combined into a single PR, opened once per quarter.

- `matchBaseBranches: ["v5"]` scopes the rule to the `v5` branch only.
- `groupName` / `groupSlug` collapse every update (including the existing
  Kotlin groups) into one branch/PR on `v5`.
- `separateMajorMinor: false` keeps major updates in the same combined PR.
- The `main` branch update cadence and grouping are intentionally unchanged.

## Checklist
- [ ] Changes are tested manually