### PR TITLE
v6 - Core - Clean up error handling TODOs

### DIFF
--- a/authentication/src/main/java/com/adyen/checkout/authentication/internal/ui/AuthenticationComponent.kt
+++ b/authentication/src/main/java/com/adyen/checkout/authentication/internal/ui/AuthenticationComponent.kt
@@ -67,7 +67,7 @@ import kotlin.io.encoding.ExperimentalEncodingApi
 internal class AuthenticationComponent
 @Suppress("LongParameterList")
 constructor(
-    private val action: Action,
+    private val action: Threeds2Action,
     private val componentParams: AuthenticationComponentParams,
     override val savedStateHandle: SavedStateHandle,
     private val analyticsManager: AnalyticsManager,
@@ -115,14 +115,7 @@ constructor(
         handleAction(action, activity, uiCustomization)
     }
 
-    private fun handleAction(action: Action, activity: Activity, uiCustomization: UiCustomization) {
-        if (action !is Threeds2Action) {
-            emitError(
-                GenericError("Unsupported action"),
-            )
-            return
-        }
-
+    private fun handleAction(action: Threeds2Action, activity: Activity, uiCustomization: UiCustomization) {
         val paymentData = action.paymentData
         paymentDataRepository.paymentData = paymentData
         handleThreeds2Action(action, activity, uiCustomization)
@@ -663,7 +656,7 @@ constructor(
     private fun trackActionEvent(action: Action, message: String) {
         val event = GenericEvents.action(
             component = action.paymentMethodType.orEmpty(),
-            subType = action.type.orEmpty(),
+            subType = action.type,
             message = message,
         )
         analyticsManager.trackEvent(event)
@@ -696,7 +689,7 @@ constructor(
 
     private fun makeDetails(transactionStatus: String, errorDetails: String? = null): JSONObject {
         // Check whether authorizationToken was set and create the corresponding details object
-        val token = (action as? Threeds2Action)?.authorisationToken
+        val token = action.authorisationToken
         return if (token == null) {
             authenticationSerializer.createChallengeDetails(
                 transactionStatus = transactionStatus,

--- a/authentication/src/main/java/com/adyen/checkout/authentication/internal/ui/AuthenticationFactory.kt
+++ b/authentication/src/main/java/com/adyen/checkout/authentication/internal/ui/AuthenticationFactory.kt
@@ -14,7 +14,7 @@ import com.adyen.checkout.authentication.internal.data.api.SubmitFingerprintRepo
 import com.adyen.checkout.authentication.internal.data.api.SubmitFingerprintService
 import com.adyen.checkout.authentication.internal.data.model.AuthenticationSerializer
 import com.adyen.checkout.authentication.internal.ui.model.AuthenticationComponentParamsMapper
-import com.adyen.checkout.core.action.data.Action
+import com.adyen.checkout.core.action.data.Threeds2Action
 import com.adyen.checkout.core.action.internal.ActionFactory
 import com.adyen.checkout.core.analytics.internal.AnalyticsManager
 import com.adyen.checkout.core.common.internal.CheckoutParams
@@ -25,10 +25,12 @@ import com.adyen.checkout.core.redirect.internal.DefaultRedirectHandler
 import com.adyen.threeds2.ThreeDS2Service
 import kotlinx.coroutines.CoroutineScope
 
-internal class AuthenticationFactory(private val application: Application) : ActionFactory<AuthenticationComponent> {
+internal class AuthenticationFactory(
+    private val application: Application,
+) : ActionFactory<Threeds2Action, AuthenticationComponent> {
 
     override fun create(
-        action: Action,
+        action: Threeds2Action,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
         params: CheckoutParams,

--- a/authentication/src/test/java/com/adyen/checkout/authentication/internal/data/api/SubmitFingerprintRepositoryTest.kt
+++ b/authentication/src/test/java/com/adyen/checkout/authentication/internal/data/api/SubmitFingerprintRepositoryTest.kt
@@ -73,7 +73,14 @@ internal class SubmitFingerprintRepositoryTest(
     @Test
     fun `when response type is action with RedirectAction then result is Redirect`() = runTest {
         // GIVEN
-        val redirectAction = RedirectAction(url = "https://redirect.url")
+        val redirectAction = RedirectAction(
+            type = RedirectAction.ACTION_TYPE,
+            paymentData = null,
+            paymentMethodType = null,
+            method = null,
+            url = "https://redirect.url",
+            nativeRedirectData = null,
+        )
         val response = SubmitFingerprintResponse(
             action = redirectAction,
             type = "action",
@@ -94,7 +101,14 @@ internal class SubmitFingerprintRepositoryTest(
     @Test
     fun `when response type is action with Threeds2Action then result is Threeds2`() = runTest {
         // GIVEN
-        val threeds2Action = Threeds2Action(token = "test-token")
+        val threeds2Action = Threeds2Action(
+            type = Threeds2Action.ACTION_TYPE,
+            paymentData = null,
+            paymentMethodType = null,
+            token = "test-token",
+            subtype = null,
+            authorisationToken = null,
+        )
         val response = SubmitFingerprintResponse(
             action = threeds2Action,
             type = "action",

--- a/authentication/src/test/java/com/adyen/checkout/authentication/internal/ui/AuthenticationComponentTest.kt
+++ b/authentication/src/test/java/com/adyen/checkout/authentication/internal/ui/AuthenticationComponentTest.kt
@@ -18,7 +18,6 @@ import com.adyen.checkout.authentication.internal.data.api.SubmitFingerprintRepo
 import com.adyen.checkout.authentication.internal.data.model.AuthenticationSerializer
 import com.adyen.checkout.authentication.internal.data.model.SubmitFingerprintResult
 import com.adyen.checkout.authentication.internal.ui.model.AuthenticationComponentParams
-import com.adyen.checkout.core.action.data.Action
 import com.adyen.checkout.core.action.data.ActionComponentData
 import com.adyen.checkout.core.action.data.RedirectAction
 import com.adyen.checkout.core.action.data.Threeds2Action
@@ -100,7 +99,7 @@ internal class AuthenticationComponentTest(
     }
 
     private fun createComponent(
-        action: Action = Threeds2Action(
+        action: Threeds2Action = threeds2Action(
             subtype = Threeds2Action.SubType.FINGERPRINT.value,
             token = Base64.encode(TEST_FINGERPRINT_TOKEN.toByteArray()),
         ),
@@ -130,25 +129,9 @@ internal class AuthenticationComponentTest(
     inner class HandleActionTest {
 
         @Test
-        fun `action is not Threeds2Action, then an error is emitted`() = runTest {
-            // GIVEN
-            val redirectAction = RedirectAction(url = "https://redirect.url")
-            component = createComponent(action = redirectAction)
-            component.initialize(this)
-            val eventFlow = component.eventFlow.test(testScheduler)
-
-            // WHEN
-            component.handleAction(Activity(), mock())
-
-            // THEN
-            val event = assertInstanceOf<ActionComponentEvent.Error>(eventFlow.latestValue)
-            assertEquals("Unsupported action", event.error.message)
-        }
-
-        @Test
         fun `subtype is null, then an error is emitted`() = runTest {
             // GIVEN
-            val action = Threeds2Action(subtype = null, token = "token")
+            val action = threeds2Action(subtype = null, token = "token")
             component = createComponent(action = action)
             component.initialize(this)
             val eventFlow = component.eventFlow.test(testScheduler)
@@ -164,7 +147,7 @@ internal class AuthenticationComponentTest(
         @Test
         fun `token is null for fingerprint subtype, then an error is emitted`() = runTest {
             // GIVEN
-            val action = Threeds2Action(
+            val action = threeds2Action(
                 subtype = Threeds2Action.SubType.FINGERPRINT.value,
                 token = null,
             )
@@ -183,7 +166,7 @@ internal class AuthenticationComponentTest(
         @Test
         fun `token is null for challenge subtype, then an error is emitted`() = runTest {
             // GIVEN
-            val action = Threeds2Action(
+            val action = threeds2Action(
                 subtype = Threeds2Action.SubType.CHALLENGE.value,
                 token = null,
             )
@@ -202,7 +185,7 @@ internal class AuthenticationComponentTest(
         @Test
         fun `action has paymentData, then paymentData is stored`() = runTest {
             // GIVEN
-            val action = Threeds2Action(
+            val action = threeds2Action(
                 subtype = Threeds2Action.SubType.FINGERPRINT.value,
                 token = Base64.encode(TEST_FINGERPRINT_TOKEN.toByteArray()),
                 paymentData = "test_payment_data",
@@ -384,7 +367,7 @@ internal class AuthenticationComponentTest(
             // GIVEN
             threeDS2Service.transactionResult =
                 TransactionResult.Success(TestTransaction(getAuthenticationRequestParams()))
-            val redirectAction = RedirectAction(url = "https://redirect.url")
+            val redirectAction = redirectAction(url = "https://redirect.url")
             val submitResult = SubmitFingerprintResult.Redirect(redirectAction)
             whenever(submitFingerprintRepository.submitFingerprint(any(), any(), anyOrNull())) doReturn
                 Result.success(submitResult)
@@ -423,7 +406,7 @@ internal class AuthenticationComponentTest(
             // GIVEN
             threeDS2Service.transactionResult =
                 TransactionResult.Success(TestTransaction(getAuthenticationRequestParams()))
-            val threeds2Action = Threeds2Action(subtype = null)
+            val threeds2Action = threeds2Action(subtype = null)
             val submitResult = SubmitFingerprintResult.Threeds2(threeds2Action)
             whenever(submitFingerprintRepository.submitFingerprint(any(), any(), anyOrNull())) doReturn
                 Result.success(submitResult)
@@ -444,7 +427,7 @@ internal class AuthenticationComponentTest(
             // GIVEN
             threeDS2Service.transactionResult =
                 TransactionResult.Success(TestTransaction(getAuthenticationRequestParams()))
-            val redirectAction = RedirectAction(url = "https://redirect.url")
+            val redirectAction = redirectAction(url = "https://redirect.url")
             val submitResult = SubmitFingerprintResult.Redirect(redirectAction)
             whenever(submitFingerprintRepository.submitFingerprint(any(), any(), anyOrNull())) doReturn
                 Result.success(submitResult)
@@ -673,7 +656,7 @@ internal class AuthenticationComponentTest(
         @Test
         fun `completed with authorisationToken, then threeDsResult details are used`() = runTest {
             // GIVEN
-            val action = Threeds2Action(
+            val action = threeds2Action(
                 subtype = Threeds2Action.SubType.FINGERPRINT.value,
                 token = Base64.encode(TEST_FINGERPRINT_TOKEN.toByteArray()),
                 authorisationToken = "test-auth-token",
@@ -710,7 +693,7 @@ internal class AuthenticationComponentTest(
         @Test
         fun `handleAction is called with fingerprint subtype, then action event is tracked`() {
             // GIVEN
-            val action = Threeds2Action(
+            val action = threeds2Action(
                 paymentMethodType = TEST_PAYMENT_METHOD_TYPE,
                 type = TEST_ACTION_TYPE,
                 subtype = Threeds2Action.SubType.FINGERPRINT.value,
@@ -734,7 +717,7 @@ internal class AuthenticationComponentTest(
         @Test
         fun `handleAction is called with challenge subtype, then action event is tracked`() {
             // GIVEN
-            val action = Threeds2Action(
+            val action = threeds2Action(
                 paymentMethodType = TEST_PAYMENT_METHOD_TYPE,
                 type = TEST_ACTION_TYPE,
                 subtype = Threeds2Action.SubType.CHALLENGE.value,
@@ -843,7 +826,7 @@ internal class AuthenticationComponentTest(
         @Test
         fun `token is null for fingerprint, then fingerprint error event is tracked`() = runTest {
             // GIVEN
-            val action = Threeds2Action(
+            val action = threeds2Action(
                 subtype = Threeds2Action.SubType.FINGERPRINT.value,
                 token = null,
             )
@@ -863,7 +846,7 @@ internal class AuthenticationComponentTest(
         @Test
         fun `token is null for challenge, then challenge error event is tracked`() = runTest {
             // GIVEN
-            val action = Threeds2Action(
+            val action = threeds2Action(
                 subtype = Threeds2Action.SubType.CHALLENGE.value,
                 token = null,
             )
@@ -1108,11 +1091,11 @@ internal class AuthenticationComponentTest(
                 AuthenticationEvents.Result.COMPLETED,
             ),
             Arguments.arguments(
-                SubmitFingerprintResult.Redirect(RedirectAction()),
+                SubmitFingerprintResult.Redirect(redirectAction()),
                 AuthenticationEvents.Result.REDIRECT,
             ),
             Arguments.arguments(
-                SubmitFingerprintResult.Threeds2(Threeds2Action()),
+                SubmitFingerprintResult.Threeds2(threeds2Action()),
                 AuthenticationEvents.Result.THREEDS2,
             ),
         )
@@ -1135,6 +1118,40 @@ internal class AuthenticationComponentTest(
                 ChallengeResult.Timeout("transactionStatus", "additionalDetails"),
                 AuthenticationEvents.Result.TIMEOUT,
             ),
+        )
+
+        @Suppress("LongParameterList")
+        private fun threeds2Action(
+            type: String = Threeds2Action.ACTION_TYPE,
+            paymentData: String? = null,
+            paymentMethodType: String? = null,
+            token: String? = null,
+            subtype: String? = null,
+            authorisationToken: String? = null,
+        ) = Threeds2Action(
+            type = type,
+            paymentData = paymentData,
+            paymentMethodType = paymentMethodType,
+            token = token,
+            subtype = subtype,
+            authorisationToken = authorisationToken,
+        )
+
+        @Suppress("LongParameterList")
+        private fun redirectAction(
+            type: String = RedirectAction.ACTION_TYPE,
+            paymentData: String? = null,
+            paymentMethodType: String? = null,
+            method: String? = null,
+            url: String? = null,
+            nativeRedirectData: String? = null,
+        ) = RedirectAction(
+            type = type,
+            paymentData = paymentData,
+            paymentMethodType = paymentMethodType,
+            method = method,
+            url = url,
+            nativeRedirectData = nativeRedirectData,
         )
     }
 }

--- a/await/src/main/java/com/adyen/checkout/await/internal/ui/AwaitComponent.kt
+++ b/await/src/main/java/com/adyen/checkout/await/internal/ui/AwaitComponent.kt
@@ -77,7 +77,7 @@ internal class AwaitComponent(
 
         val event = GenericEvents.action(
             component = action.paymentMethodType.orEmpty(),
-            subType = action.type.orEmpty(),
+            subType = action.type,
         )
         analyticsManager.trackEvent(event)
 

--- a/await/src/main/java/com/adyen/checkout/await/internal/ui/AwaitFactory.kt
+++ b/await/src/main/java/com/adyen/checkout/await/internal/ui/AwaitFactory.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.await.internal.ui
 
 import androidx.lifecycle.SavedStateHandle
-import com.adyen.checkout.core.action.data.Action
 import com.adyen.checkout.core.action.data.AwaitAction
 import com.adyen.checkout.core.action.internal.ActionFactory
 import com.adyen.checkout.core.analytics.internal.AnalyticsManager
@@ -21,22 +20,15 @@ import com.adyen.checkout.core.components.internal.data.api.StatusService
 import com.adyen.checkout.core.redirect.internal.DefaultRedirectHandler
 import kotlinx.coroutines.CoroutineScope
 
-internal class AwaitFactory : ActionFactory<AwaitComponent> {
+internal class AwaitFactory : ActionFactory<AwaitAction, AwaitComponent> {
 
-    @Suppress("TooGenericExceptionThrown")
     override fun create(
-        action: Action,
+        action: AwaitAction,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
         params: CheckoutParams,
         savedStateHandle: SavedStateHandle,
     ): AwaitComponent {
-        if (action !is AwaitAction) {
-//          TODO - Error Propagation
-//          throw ComponentException("Unsupported action")
-            throw RuntimeException("Unsupported action")
-        }
-
         val redirectHandler = DefaultRedirectHandler()
         val httpClient = HttpClientFactory.getHttpClient(params.environment)
         val statusService = StatusService(httpClient)

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -118,12 +118,23 @@ public final class com/adyen/checkout/core/action/data/Threeds2Action : com/adye
 	public static final field Companion Lcom/adyen/checkout/core/action/data/Threeds2Action$Companion;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/common/internal/model/ModelObject$Serializer;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/adyen/checkout/core/action/data/Threeds2Action;
+	public static synthetic fun copy$default (Lcom/adyen/checkout/core/action/data/Threeds2Action;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/core/action/data/Threeds2Action;
+	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAuthorisationToken ()Ljava/lang/String;
 	public fun getPaymentData ()Ljava/lang/String;
 	public fun getPaymentMethodType ()Ljava/lang/String;
 	public final fun getSubtype ()Ljava/lang/String;
 	public final fun getToken ()Ljava/lang/String;
 	public fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 	public final fun writeToParcel (Landroid/os/Parcel;I)V
 }
 

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -87,9 +87,7 @@ public final class com/adyen/checkout/core/action/data/RedirectAction : com/adye
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/adyen/checkout/core/action/data/RedirectAction$Companion;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/common/internal/model/ModelObject$Serializer;
-	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
@@ -119,9 +117,7 @@ public final class com/adyen/checkout/core/action/data/Threeds2Action : com/adye
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/adyen/checkout/core/action/data/Threeds2Action$Companion;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/common/internal/model/ModelObject$Serializer;
-	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAuthorisationToken ()Ljava/lang/String;
 	public fun getPaymentData ()Ljava/lang/String;
 	public fun getPaymentMethodType ()Ljava/lang/String;
@@ -2258,7 +2254,6 @@ public final class com/adyen/checkout/core/components/paymentmethod/GooglePayDet
 	public static final field Companion Lcom/adyen/checkout/core/components/paymentmethod/GooglePayDetails$Companion;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/common/internal/model/ModelObject$Serializer;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
@@ -2287,7 +2282,6 @@ public final class com/adyen/checkout/core/components/paymentmethod/MBWayDetails
 	public static final field PAYMENT_METHOD_TYPE Ljava/lang/String;
 	public static final field SERIALIZER Lcom/adyen/checkout/core/common/internal/model/ModelObject$Serializer;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;

--- a/core/src/main/java/com/adyen/checkout/core/action/data/Action.kt
+++ b/core/src/main/java/com/adyen/checkout/core/action/data/Action.kt
@@ -8,7 +8,8 @@
 package com.adyen.checkout.core.action.data
 
 import com.adyen.checkout.core.common.internal.model.ModelObject
-import com.adyen.checkout.core.common.internal.model.getStringOrNull
+import com.adyen.checkout.core.error.CheckoutError
+import com.adyen.checkout.core.error.CheckoutException
 import org.json.JSONObject
 
 /**
@@ -21,7 +22,7 @@ import org.json.JSONObject
  * exact type of the subclass.
  */
 abstract class Action : ModelObject() {
-    abstract val type: String?
+    abstract val type: String
     abstract val paymentData: String?
     abstract val paymentMethodType: String?
 
@@ -34,35 +35,28 @@ abstract class Action : ModelObject() {
         @JvmField
         val SERIALIZER: Serializer<Action> = object : Serializer<Action> {
             override fun serialize(modelObject: Action): JSONObject {
-                val actionType = modelObject.type
-                if (actionType.isNullOrEmpty()) {
-                    // TODO - Error Propagation
-                    // throw CheckoutException("Action type not found")
-                    throw RuntimeException("Action type not found")
-                }
-                return getChildSerializer(actionType).serialize(modelObject)
+                return getChildSerializer(modelObject.type).serialize(modelObject)
             }
 
             override fun deserialize(jsonObject: JSONObject): Action {
-                val actionType = jsonObject.getStringOrNull(TYPE)
-                    // TODO - Error Propagation
-                    // ?: throw CheckoutException("Action type not found")
-                    ?: throw RuntimeException("Action type not found")
+                val actionType = jsonObject.getString(TYPE)
                 val serializer = getChildSerializer(actionType)
                 return serializer.deserialize(jsonObject)
             }
         }
 
-        @Suppress("TooGenericExceptionThrown")
         fun getChildSerializer(actionType: String): Serializer<Action> {
             val childSerializer = when (actionType) {
                 AwaitAction.ACTION_TYPE -> AwaitAction.SERIALIZER
                 RedirectAction.ACTION_TYPE -> RedirectAction.SERIALIZER
                 Threeds2Action.ACTION_TYPE -> Threeds2Action.SERIALIZER
-                else ->
-                    // TODO - Error Propagation
-                    // throw CheckoutException("Action type not found - $actionType")
-                    throw RuntimeException("Action type not found - $actionType")
+                else -> {
+                    val error = CheckoutError(
+                        code = CheckoutError.ErrorCode.GENERIC,
+                        message = "Action type not found - $actionType",
+                    )
+                    throw CheckoutException(error)
+                }
             }
             @Suppress("UNCHECKED_CAST")
             return childSerializer as Serializer<Action>

--- a/core/src/main/java/com/adyen/checkout/core/action/data/AwaitAction.kt
+++ b/core/src/main/java/com/adyen/checkout/core/action/data/AwaitAction.kt
@@ -13,7 +13,7 @@ import org.json.JSONObject
 
 @Parcelize
 data class AwaitAction(
-    override val type: String?,
+    override val type: String,
     override val paymentData: String?,
     override val paymentMethodType: String?,
     val url: String?,
@@ -36,7 +36,7 @@ data class AwaitAction(
 
             override fun deserialize(jsonObject: JSONObject): AwaitAction {
                 return AwaitAction(
-                    type = jsonObject.getStringOrNull(TYPE),
+                    type = jsonObject.getString(TYPE),
                     paymentData = jsonObject.getStringOrNull(PAYMENT_DATA),
                     paymentMethodType = jsonObject.getStringOrNull(PAYMENT_METHOD_TYPE),
                     url = jsonObject.getStringOrNull(URL),

--- a/core/src/main/java/com/adyen/checkout/core/action/data/RedirectAction.kt
+++ b/core/src/main/java/com/adyen/checkout/core/action/data/RedirectAction.kt
@@ -13,12 +13,12 @@ import org.json.JSONObject
 
 @Parcelize
 data class RedirectAction(
-    override val type: String? = null,
-    override val paymentData: String? = null,
-    override val paymentMethodType: String? = null,
-    val method: String? = null,
-    val url: String? = null,
-    val nativeRedirectData: String? = null,
+    override val type: String,
+    override val paymentData: String?,
+    override val paymentMethodType: String?,
+    val method: String?,
+    val url: String?,
+    val nativeRedirectData: String?,
 ) : Action() {
 
     companion object {
@@ -42,7 +42,7 @@ data class RedirectAction(
 
             override fun deserialize(jsonObject: JSONObject): RedirectAction {
                 return RedirectAction(
-                    type = jsonObject.getStringOrNull(TYPE),
+                    type = jsonObject.getString(TYPE),
                     paymentData = jsonObject.getStringOrNull(PAYMENT_DATA),
                     paymentMethodType = jsonObject.getStringOrNull(PAYMENT_METHOD_TYPE),
                     method = jsonObject.getStringOrNull(METHOD),

--- a/core/src/main/java/com/adyen/checkout/core/action/data/Threeds2Action.kt
+++ b/core/src/main/java/com/adyen/checkout/core/action/data/Threeds2Action.kt
@@ -12,7 +12,7 @@ import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 
 @Parcelize
-class Threeds2Action(
+data class Threeds2Action(
     override val type: String,
     override val paymentData: String?,
     override val paymentMethodType: String?,

--- a/core/src/main/java/com/adyen/checkout/core/action/data/Threeds2Action.kt
+++ b/core/src/main/java/com/adyen/checkout/core/action/data/Threeds2Action.kt
@@ -13,12 +13,12 @@ import org.json.JSONObject
 
 @Parcelize
 class Threeds2Action(
-    override val type: String? = null,
-    override val paymentData: String? = null,
-    override val paymentMethodType: String? = null,
-    val token: String? = null,
-    val subtype: String? = null,
-    val authorisationToken: String? = null
+    override val type: String,
+    override val paymentData: String?,
+    override val paymentMethodType: String?,
+    val token: String?,
+    val subtype: String?,
+    val authorisationToken: String?,
 ) : Action() {
 
     companion object {
@@ -43,10 +43,10 @@ class Threeds2Action(
 
             override fun deserialize(jsonObject: JSONObject): Threeds2Action {
                 return Threeds2Action(
+                    type = jsonObject.getString(TYPE),
                     token = jsonObject.getStringOrNull(TOKEN),
                     subtype = jsonObject.getStringOrNull(SUBTYPE),
                     authorisationToken = jsonObject.getStringOrNull(AUTHORISATION_TOKEN),
-                    type = jsonObject.getStringOrNull(TYPE),
                     paymentData = jsonObject.getStringOrNull(PAYMENT_DATA),
                     paymentMethodType = jsonObject.getStringOrNull(PAYMENT_METHOD_TYPE),
                 )

--- a/core/src/main/java/com/adyen/checkout/core/action/internal/ActionComponentProvider.kt
+++ b/core/src/main/java/com/adyen/checkout/core/action/internal/ActionComponentProvider.kt
@@ -20,11 +20,11 @@ import java.util.concurrent.ConcurrentHashMap
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 object ActionComponentProvider {
 
-    private val factories = ConcurrentHashMap<String, ActionFactory<*>>()
+    private val factories = ConcurrentHashMap<String, ActionFactory<*, *>>()
 
     fun register(
         actionType: String,
-        factory: ActionFactory<*>,
+        factory: ActionFactory<*, *>,
     ) {
         factories[actionType] = factory
     }
@@ -36,7 +36,9 @@ object ActionComponentProvider {
         params: CheckoutParams,
         savedStateHandle: SavedStateHandle,
     ): ActionComponent {
-        return factories[action.type]?.create(
+        @Suppress("UNCHECKED_CAST")
+        val factory = factories[action.type] as? ActionFactory<Action, *>
+        return factory?.create(
             action = action,
             coroutineScope = coroutineScope,
             analyticsManager = analyticsManager,

--- a/core/src/main/java/com/adyen/checkout/core/action/internal/ActionFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/action/internal/ActionFactory.kt
@@ -16,10 +16,10 @@ import com.adyen.checkout.core.common.internal.CheckoutParams
 import kotlinx.coroutines.CoroutineScope
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-interface ActionFactory<T : ActionComponent> {
+interface ActionFactory<A : Action, T : ActionComponent> {
 
     fun create(
-        action: Action,
+        action: A,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
         params: CheckoutParams,

--- a/core/src/main/java/com/adyen/checkout/core/common/internal/api/OkHttpClient.kt
+++ b/core/src/main/java/com/adyen/checkout/core/common/internal/api/OkHttpClient.kt
@@ -11,7 +11,7 @@ package com.adyen.checkout.core.common.internal.api
 import com.adyen.checkout.core.common.internal.model.ErrorResponseBody
 import com.adyen.checkout.core.error.internal.HttpError
 import okhttp3.Headers.Companion.toHeaders
-import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -57,12 +57,8 @@ internal class OkHttpClient(
         return executeRequest(request, path)
     }
 
-    @Suppress("TooGenericExceptionThrown")
     private fun buildURL(path: String, queryParameters: Map<String, String>): String {
-        val builder = (baseUrl + path).toHttpUrlOrNull()?.newBuilder()
-            ?: throw Exception("Failed to parse URL.")
-        // TODO - Errors
-//            ?: throw CheckoutException("Failed to parse URL.")
+        val builder = (baseUrl + path).toHttpUrl().newBuilder()
 
         queryParameters.forEach { entry ->
             builder.addQueryParameter(entry.key, entry.value)
@@ -106,7 +102,7 @@ internal class OkHttpClient(
     private fun Response.getHttpError(): HttpError {
         val stringBody = try {
             body?.string()
-        } catch (e: IOException) {
+        } catch (_: IOException) {
             null
         }
 
@@ -114,7 +110,7 @@ internal class OkHttpClient(
             stringBody
                 ?.let { JSONObject(it) }
                 ?.let { ErrorResponseBody.SERIALIZER.deserialize(it) }
-        } catch (e: JSONException) {
+        } catch (_: JSONException) {
             null
         }
 

--- a/core/src/main/java/com/adyen/checkout/core/components/data/model/paymentmethod/PaymentMethod.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/data/model/paymentmethod/PaymentMethod.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.core.components.data.model.paymentmethod
 
 import androidx.annotation.RestrictTo
-import com.adyen.checkout.core.common.internal.model.getStringOrNull
 import com.adyen.checkout.core.components.paymentmethod.PaymentMethodTypes
 import org.json.JSONObject
 
@@ -25,30 +24,16 @@ abstract class PaymentMethod
 constructor() : PaymentMethodResponse() {
 
     companion object {
-        @Suppress("TooGenericExceptionThrown")
+
         @JvmField
         val SERIALIZER: Serializer<PaymentMethod> = object : Serializer<PaymentMethod> {
             override fun serialize(modelObject: PaymentMethod): JSONObject {
-                val paymentMethodType = with(modelObject.type) {
-                    if (isNullOrEmpty()) {
-                        // TODO - Error Propagation
-                        // throw CheckoutException("PaymentMethod type not found")
-                        throw RuntimeException("PaymentMethod type not found")
-                    } else {
-                        this
-                    }
-                }
-                val serializer = getChildSerializer(paymentMethodType)
+                val serializer = getChildSerializer(modelObject.type)
                 return serializer.serialize(modelObject)
             }
 
             override fun deserialize(jsonObject: JSONObject): PaymentMethod {
-                val type = jsonObject.getStringOrNull(TYPE)
-                if (type.isNullOrEmpty()) {
-                    // TODO - Error Propagation
-                    // throw CheckoutException("PaymentMethod type not found")
-                    throw RuntimeException("PaymentMethod type not found")
-                }
+                val type = jsonObject.getString(TYPE)
                 val serializer = getChildSerializer(type)
                 return serializer.deserialize(jsonObject)
             }

--- a/core/src/main/java/com/adyen/checkout/core/components/data/model/paymentmethod/StoredPaymentMethod.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/data/model/paymentmethod/StoredPaymentMethod.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.core.components.data.model.paymentmethod
 
 import androidx.annotation.RestrictTo
-import com.adyen.checkout.core.common.internal.model.getStringOrNull
 import com.adyen.checkout.core.components.paymentmethod.PaymentMethodTypes
 import org.json.JSONObject
 
@@ -33,26 +32,12 @@ constructor() : PaymentMethodResponse() {
         @JvmField
         val SERIALIZER: Serializer<StoredPaymentMethod> = object : Serializer<StoredPaymentMethod> {
             override fun serialize(modelObject: StoredPaymentMethod): JSONObject {
-                val paymentMethodType = with(modelObject.type) {
-                    if (isNullOrEmpty()) {
-                        // TODO - Error Propagation
-                        // throw CheckoutException("PaymentMethod type not found")
-                        throw RuntimeException("PaymentMethod type not found")
-                    } else {
-                        this
-                    }
-                }
-                val serializer = getChildSerializer(paymentMethodType)
+                val serializer = getChildSerializer(modelObject.type)
                 return serializer.serialize(modelObject)
             }
 
             override fun deserialize(jsonObject: JSONObject): StoredPaymentMethod {
-                val type = jsonObject.getStringOrNull(TYPE)
-                if (type.isNullOrEmpty()) {
-                    // TODO - Error Propagation
-                    // throw CheckoutException("PaymentMethod type not found")
-                    throw RuntimeException("PaymentMethod type not found")
-                }
+                val type = jsonObject.getString(TYPE)
                 val serializer = getChildSerializer(type)
                 return serializer.deserialize(jsonObject)
             }

--- a/core/src/main/java/com/adyen/checkout/core/components/paymentmethod/BlikDetails.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/paymentmethod/BlikDetails.kt
@@ -14,7 +14,7 @@ import org.json.JSONObject
 
 @Parcelize
 data class BlikDetails(
-    override val type: String?,
+    override val type: String,
     override val sdkData: String?,
     val blikCode: String?,
     val storedPaymentMethodId: String?,
@@ -38,7 +38,7 @@ data class BlikDetails(
 
             override fun deserialize(jsonObject: JSONObject): BlikDetails {
                 return BlikDetails(
-                    type = jsonObject.getStringOrNull(TYPE),
+                    type = jsonObject.getString(TYPE),
                     sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     blikCode = jsonObject.getStringOrNull(BLIK_CODE),
                     storedPaymentMethodId = jsonObject.getStringOrNull(STORED_PAYMENT_METHOD_ID),

--- a/core/src/main/java/com/adyen/checkout/core/components/paymentmethod/CardDetails.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/paymentmethod/CardDetails.kt
@@ -13,7 +13,7 @@ import org.json.JSONObject
 
 @Parcelize
 data class CardDetails(
-    override val type: String?,
+    override val type: String,
     override val sdkData: String? = null,
     val encryptedCardNumber: String? = null,
     val encryptedExpiryMonth: String? = null,
@@ -61,7 +61,7 @@ data class CardDetails(
 
             override fun deserialize(jsonObject: JSONObject): CardDetails {
                 return CardDetails(
-                    type = jsonObject.getStringOrNull(TYPE),
+                    type = jsonObject.getString(TYPE),
                     sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     encryptedCardNumber = jsonObject.getStringOrNull(ENCRYPTED_CARD_NUMBER),
                     encryptedExpiryMonth = jsonObject.getStringOrNull(ENCRYPTED_EXPIRY_MONTH),

--- a/core/src/main/java/com/adyen/checkout/core/components/paymentmethod/GenericDetails.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/paymentmethod/GenericDetails.kt
@@ -14,7 +14,7 @@ import org.json.JSONObject
 
 @Parcelize
 data class GenericDetails(
-    override val type: String?,
+    override val type: String,
     override val sdkData: String?,
     val subtype: String?,
 ) : PaymentMethodDetails() {
@@ -35,7 +35,7 @@ data class GenericDetails(
 
             override fun deserialize(jsonObject: JSONObject): GenericDetails {
                 return GenericDetails(
-                    type = jsonObject.getStringOrNull(TYPE),
+                    type = jsonObject.getString(TYPE),
                     sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     subtype = jsonObject.getStringOrNull(SUBTYPE),
                 )

--- a/core/src/main/java/com/adyen/checkout/core/components/paymentmethod/GooglePayDetails.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/paymentmethod/GooglePayDetails.kt
@@ -13,11 +13,11 @@ import org.json.JSONObject
 
 @Parcelize
 data class GooglePayDetails(
-    override val type: String?,
-    override val sdkData: String? = null,
-    val googlePayToken: String? = null,
-    val googlePayCardNetwork: String? = null,
-    val threeDS2SdkVersion: String? = null,
+    override val type: String,
+    override val sdkData: String?,
+    val googlePayToken: String?,
+    val googlePayCardNetwork: String?,
+    val threeDS2SdkVersion: String?,
 ) : PaymentMethodDetails() {
 
     companion object {
@@ -27,7 +27,6 @@ data class GooglePayDetails(
 
         @JvmField
         val SERIALIZER: Serializer<GooglePayDetails> = object : Serializer<GooglePayDetails> {
-            @Suppress("TooGenericExceptionThrown")
             override fun serialize(modelObject: GooglePayDetails): JSONObject {
                 return JSONObject().apply {
                     putOpt(TYPE, modelObject.type)
@@ -40,7 +39,7 @@ data class GooglePayDetails(
 
             override fun deserialize(jsonObject: JSONObject): GooglePayDetails {
                 return GooglePayDetails(
-                    type = jsonObject.getStringOrNull(TYPE),
+                    type = jsonObject.getString(TYPE),
                     sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     googlePayToken = jsonObject.getStringOrNull(GOOGLE_PAY_TOKEN),
                     googlePayCardNetwork = jsonObject.getStringOrNull(GOOGLE_PAY_CARD_NETWORK),

--- a/core/src/main/java/com/adyen/checkout/core/components/paymentmethod/MBWayDetails.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/paymentmethod/MBWayDetails.kt
@@ -14,8 +14,8 @@ import org.json.JSONObject
 
 @Parcelize
 data class MBWayDetails(
-    override val type: String?,
-    override val sdkData: String? = null,
+    override val type: String,
+    override val sdkData: String?,
     val telephoneNumber: String?,
 ) : PaymentMethodDetails() {
 
@@ -35,7 +35,7 @@ data class MBWayDetails(
 
             override fun deserialize(jsonObject: JSONObject): MBWayDetails {
                 return MBWayDetails(
-                    type = jsonObject.getStringOrNull(TYPE),
+                    type = jsonObject.getString(TYPE),
                     sdkData = jsonObject.getStringOrNull(SDK_DATA),
                     telephoneNumber = jsonObject.getStringOrNull(TELEPHONE_NUMBER),
                 )

--- a/core/src/main/java/com/adyen/checkout/core/components/paymentmethod/PaymentMethodDetails.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/paymentmethod/PaymentMethodDetails.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.core.components.paymentmethod
 
 import com.adyen.checkout.core.common.internal.model.ModelObject
-import com.adyen.checkout.core.common.internal.model.getStringOrNull
 import org.json.JSONObject
 
 /**
@@ -21,37 +20,22 @@ import org.json.JSONObject
  */
 abstract class PaymentMethodDetails : ModelObject() {
 
-    abstract val type: String?
+    abstract val type: String
     abstract val sdkData: String?
 
     companion object {
         const val TYPE = "type"
         const val SDK_DATA = "sdkData"
 
-        @Suppress("TooGenericExceptionThrown")
         @JvmField
         val SERIALIZER: Serializer<PaymentMethodDetails> = object : Serializer<PaymentMethodDetails> {
             override fun serialize(modelObject: PaymentMethodDetails): JSONObject {
-                val paymentMethodType = with(modelObject.type) {
-                    if (isNullOrEmpty()) {
-                        // TODO - Error Propagation
-                        // throw CheckoutException("PaymentMethod type not found")
-                        throw RuntimeException("PaymentMethod type not found")
-                    } else {
-                        this
-                    }
-                }
-                val serializer = getChildSerializer(paymentMethodType)
+                val serializer = getChildSerializer(modelObject.type)
                 return serializer.serialize(modelObject)
             }
 
             override fun deserialize(jsonObject: JSONObject): PaymentMethodDetails {
-                val actionType = jsonObject.getStringOrNull(TYPE)
-                if (actionType.isNullOrEmpty()) {
-                    // TODO - Error Propagation
-                    // throw CheckoutException("PaymentMethod type not found")
-                    throw RuntimeException("PaymentMethod type not found")
-                }
+                val actionType = jsonObject.getString(TYPE)
                 val serializer = getChildSerializer(actionType)
                 return serializer.deserialize(jsonObject)
             }

--- a/core/src/main/java/com/adyen/checkout/core/components/paymentmethod/PaymentMethodDetails.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/paymentmethod/PaymentMethodDetails.kt
@@ -35,8 +35,8 @@ abstract class PaymentMethodDetails : ModelObject() {
             }
 
             override fun deserialize(jsonObject: JSONObject): PaymentMethodDetails {
-                val actionType = jsonObject.getString(TYPE)
-                val serializer = getChildSerializer(actionType)
+                val paymentMethodType = jsonObject.getString(TYPE)
+                val serializer = getChildSerializer(paymentMethodType)
                 return serializer.deserialize(jsonObject)
             }
         }

--- a/core/src/test/java/com/adyen/checkout/core/action/data/TestAction.kt
+++ b/core/src/test/java/com/adyen/checkout/core/action/data/TestAction.kt
@@ -12,7 +12,7 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class TestAction(
-    override val type: String? = "test",
+    override val type: String = "test",
     override val paymentData: String? = null,
     override val paymentMethodType: String? = null,
 ) : Action()

--- a/core/src/test/java/com/adyen/checkout/core/action/internal/ActionComponentProviderTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/action/internal/ActionComponentProviderTest.kt
@@ -140,7 +140,7 @@ internal class ActionComponentProviderTest {
     }
 
     private fun generateFactory(actionComponent: ActionComponent) =
-        object : ActionFactory<ActionComponent> {
+        object : ActionFactory<Action, ActionComponent> {
             override fun create(
                 action: Action,
                 coroutineScope: CoroutineScope,

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/ActionHandlerTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/ActionHandlerTest.kt
@@ -205,7 +205,7 @@ internal class ActionHandlerTest(
     private fun registerReturningTestFactory() {
         ActionComponentProvider.register(
             RETURNING_ACTION_TYPE,
-            object : ActionFactory<ActionComponent> {
+            object : ActionFactory<Action, ActionComponent> {
                 override fun create(
                     action: Action,
                     coroutineScope: CoroutineScope,
@@ -220,7 +220,7 @@ internal class ActionHandlerTest(
     private fun registerTestFactory() {
         ActionComponentProvider.register(
             TEST_ACTION_TYPE,
-            object : ActionFactory<ActionComponent> {
+            object : ActionFactory<Action, ActionComponent> {
                 override fun create(
                     action: Action,
                     coroutineScope: CoroutineScope,

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/ActionOnlyCheckoutFlowTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/ActionOnlyCheckoutFlowTest.kt
@@ -8,7 +8,7 @@
 
 package com.adyen.checkout.core.components.internal
 
-import com.adyen.checkout.core.action.data.RedirectAction
+import com.adyen.checkout.core.action.data.TestAction
 import com.adyen.checkout.core.action.internal.ActionComponent
 import com.adyen.checkout.core.common.test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -72,7 +72,7 @@ internal class ActionOnlyCheckoutFlowTest(
         flow.submit()
     }
 
-    private fun createAction() = RedirectAction(
+    private fun createAction() = TestAction(
         type = "redirect",
         paymentData = "test_data",
         paymentMethodType = "scheme",

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/FullCheckoutFlowTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/FullCheckoutFlowTest.kt
@@ -8,7 +8,7 @@
 
 package com.adyen.checkout.core.components.internal
 
-import com.adyen.checkout.core.action.data.RedirectAction
+import com.adyen.checkout.core.action.data.TestAction
 import com.adyen.checkout.core.action.internal.ActionComponent
 import com.adyen.checkout.core.analytics.internal.AnalyticsManager
 import com.adyen.checkout.core.common.CheckoutResultCode
@@ -90,7 +90,7 @@ internal class FullCheckoutFlowTest(
 
         @Test
         fun `when submit results in Action, then navigation emits Action route`() = runTest {
-            val action = RedirectAction(type = "redirect", paymentData = "test_data", paymentMethodType = "scheme")
+            val action = TestAction(type = "redirect", paymentData = "test_data", paymentMethodType = "scheme")
             whenever(componentRequestDispatcher.submit(any())) doReturn SubmitResult.Action(action)
 
             val flow = createFullCheckoutFlow(CoroutineScope(UnconfinedTestDispatcher()))
@@ -275,7 +275,7 @@ internal class FullCheckoutFlowTest(
         @Test
         fun `when submit results in Action and submit is called again, then only one submit request is dispatched`() =
             runTest {
-                val action = RedirectAction(type = "redirect", paymentData = "test_data", paymentMethodType = "scheme")
+                val action = TestAction(type = "redirect", paymentData = "test_data", paymentMethodType = "scheme")
                 whenever(componentRequestDispatcher.submit(any())) doReturn SubmitResult.Action(action)
 
                 val component = TestPaymentComponent(eventFlow)
@@ -301,7 +301,7 @@ internal class FullCheckoutFlowTest(
 
         @Test
         fun `when submit results in Action, then actionHandler handleAction is called`() = runTest {
-            val action = RedirectAction(type = "redirect", paymentData = "test_data", paymentMethodType = "scheme")
+            val action = TestAction(type = "redirect", paymentData = "test_data", paymentMethodType = "scheme")
             whenever(componentRequestDispatcher.submit(any())) doReturn SubmitResult.Action(action)
 
             createFullCheckoutFlow(CoroutineScope(UnconfinedTestDispatcher()))

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentMethodResolverTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentMethodResolverTest.kt
@@ -280,6 +280,9 @@ internal class PaymentMethodResolverTest {
             type = "redirect",
             paymentData = "test_data",
             paymentMethodType = "scheme",
+            method = null,
+            url = null,
+            nativeRedirectData = null,
         ),
         checkoutConfiguration = CheckoutConfiguration(
             environment = Environment.TEST,

--- a/core/src/test/java/com/adyen/checkout/core/components/paymentmethod/TestPaymentDetails.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/paymentmethod/TestPaymentDetails.kt
@@ -12,6 +12,6 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 class TestPaymentDetails(
-    override var type: String? = "test",
+    override var type: String = "test",
     override var sdkData: String? = null,
 ) : PaymentMethodDetails()

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/helper/GooglePayUtils.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/helper/GooglePayUtils.kt
@@ -148,7 +148,7 @@ internal object GooglePayUtils {
      */
     fun createGooglePayDetails(
         paymentData: PaymentData,
-        paymentMethodType: String?,
+        paymentMethodType: String,
         sdkData: String?,
     ): GooglePayDetails {
         val (googlePayToken, googlePayCardNetwork) = try {

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParamsMapper.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParamsMapper.kt
@@ -59,7 +59,6 @@ internal class GooglePayComponentParamsMapper {
     private fun GooglePayConfiguration?.getPreferredGatewayMerchantId(
         paymentMethod: GooglePayPaymentMethod,
     ): String {
-        // TODO - Error propagation - Update the code
         return this?.merchantAccount
             ?: paymentMethod.configuration?.gatewayMerchantId
             ?: throw GenericError(

--- a/redirect/src/main/java/com/adyen/checkout/redirect/internal/ui/RedirectComponent.kt
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/internal/ui/RedirectComponent.kt
@@ -71,7 +71,7 @@ constructor(
     override fun handleAction() {
         val event = GenericEvents.action(
             component = action.paymentMethodType.orEmpty(),
-            subType = action.type.orEmpty(),
+            subType = action.type,
         )
         analyticsManager.trackEvent(event)
 

--- a/redirect/src/main/java/com/adyen/checkout/redirect/internal/ui/RedirectFactory.kt
+++ b/redirect/src/main/java/com/adyen/checkout/redirect/internal/ui/RedirectFactory.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.redirect.internal.ui
 
 import androidx.lifecycle.SavedStateHandle
-import com.adyen.checkout.core.action.data.Action
 import com.adyen.checkout.core.action.data.RedirectAction
 import com.adyen.checkout.core.action.internal.ActionFactory
 import com.adyen.checkout.core.analytics.internal.AnalyticsManager
@@ -20,22 +19,15 @@ import com.adyen.checkout.core.redirect.internal.DefaultRedirectHandler
 import com.adyen.checkout.redirect.internal.data.api.NativeRedirectService
 import kotlinx.coroutines.CoroutineScope
 
-internal class RedirectFactory : ActionFactory<RedirectComponent> {
+internal class RedirectFactory : ActionFactory<RedirectAction, RedirectComponent> {
 
-    @Suppress("TooGenericExceptionThrown")
     override fun create(
-        action: Action,
+        action: RedirectAction,
         coroutineScope: CoroutineScope,
         analyticsManager: AnalyticsManager,
         params: CheckoutParams,
         savedStateHandle: SavedStateHandle,
     ): RedirectComponent {
-        if (action !is RedirectAction) {
-//          TODO - Error Propagation
-//          throw ComponentException("Unsupported action")
-            throw RuntimeException("Unsupported action")
-        }
-
         val redirectHandler = DefaultRedirectHandler()
         val paymentDataRepository = PaymentDataRepository(savedStateHandle)
         val httpClient = HttpClientFactory.getHttpClient(params.environment)

--- a/redirect/src/test/java/com/adyen/checkout/redirect/internal/ui/RedirectComponentTest.kt
+++ b/redirect/src/test/java/com/adyen/checkout/redirect/internal/ui/RedirectComponentTest.kt
@@ -68,7 +68,7 @@ internal class RedirectComponentTest(
         fun `when handleAction is called, then analytics action event is tracked`() {
             // GIVEN
             val component = createComponent(
-                action = RedirectAction(
+                action = redirectAction(
                     paymentMethodType = TEST_PAYMENT_METHOD_TYPE,
                     type = TEST_ACTION_TYPE,
                     paymentData = "paymentData",
@@ -90,7 +90,7 @@ internal class RedirectComponentTest(
         fun `when handleAction is called with regular redirect, then paymentData is stored`() {
             // GIVEN
             val component = createComponent(
-                action = RedirectAction(
+                action = redirectAction(
                     type = ActionTypes.REDIRECT,
                     paymentData = "testPaymentData",
                 ),
@@ -107,7 +107,7 @@ internal class RedirectComponentTest(
         fun `when handleAction is called with native redirect, then nativeRedirectData is stored`() {
             // GIVEN
             val component = createComponent(
-                action = RedirectAction(
+                action = redirectAction(
                     type = ActionTypes.NATIVE_REDIRECT,
                     nativeRedirectData = "testNativeData",
                 ),
@@ -130,7 +130,7 @@ internal class RedirectComponentTest(
             val expectedDetails = JSONObject().apply { put("redirectResult", "testResult") }
             whenever(redirectHandler.parseRedirectResult(anyOrNull())) doReturn expectedDetails
             val component = createComponent(
-                action = RedirectAction(
+                action = redirectAction(
                     type = ActionTypes.REDIRECT,
                     paymentData = "testPaymentData",
                 ),
@@ -156,7 +156,7 @@ internal class RedirectComponentTest(
             val error = GenericError("Failed to parse redirect result.")
             whenever(redirectHandler.parseRedirectResult(anyOrNull())) doAnswer { throw error }
             val component = createComponent(
-                action = RedirectAction(
+                action = redirectAction(
                     type = ActionTypes.REDIRECT,
                     paymentData = "paymentData",
                 ),
@@ -179,7 +179,7 @@ internal class RedirectComponentTest(
             val error = GenericError("Failed to parse redirect result.")
             whenever(redirectHandler.parseRedirectResult(anyOrNull())) doAnswer { throw error }
             val component = createComponent(
-                action = RedirectAction(
+                action = redirectAction(
                     paymentMethodType = TEST_PAYMENT_METHOD_TYPE,
                     type = ActionTypes.REDIRECT,
                 ),
@@ -202,7 +202,7 @@ internal class RedirectComponentTest(
             val error = GenericError("Failed to parse redirect result.")
             whenever(redirectHandler.parseRedirectResult(anyOrNull())) doAnswer { throw error }
             val component = createComponent(
-                action = RedirectAction(
+                action = redirectAction(
                     paymentMethodType = TEST_PAYMENT_METHOD_TYPE,
                     type = ActionTypes.REDIRECT,
                 ),
@@ -234,7 +234,7 @@ internal class RedirectComponentTest(
                 }
                 whenever(redirectHandler.parseRedirectResult(anyOrNull())) doReturn redirectResult
                 val component = createComponent(
-                    action = RedirectAction(
+                    action = redirectAction(
                         type = ActionTypes.NATIVE_REDIRECT,
                         nativeRedirectData = "testNativeData",
                     ),
@@ -263,7 +263,7 @@ internal class RedirectComponentTest(
                 whenever(nativeRedirectService.makeNativeRedirect(any(), any())) doAnswer { throw error }
                 whenever(redirectHandler.parseRedirectResult(anyOrNull())) doReturn JSONObject()
                 val component = createComponent(
-                    action = RedirectAction(
+                    action = redirectAction(
                         paymentMethodType = TEST_PAYMENT_METHOD_TYPE,
                         type = ActionTypes.NATIVE_REDIRECT,
                         nativeRedirectData = "testData",
@@ -290,7 +290,7 @@ internal class RedirectComponentTest(
                 whenever(nativeRedirectService.makeNativeRedirect(any(), any())) doAnswer { throw error }
                 whenever(redirectHandler.parseRedirectResult(anyOrNull())) doReturn JSONObject()
                 val component = createComponent(
-                    action = RedirectAction(
+                    action = redirectAction(
                         paymentMethodType = TEST_PAYMENT_METHOD_TYPE,
                         type = ActionTypes.NATIVE_REDIRECT,
                         nativeRedirectData = "testData",
@@ -317,7 +317,7 @@ internal class RedirectComponentTest(
                 whenever(nativeRedirectService.makeNativeRedirect(any(), any())) doAnswer { throw error }
                 whenever(redirectHandler.parseRedirectResult(anyOrNull())) doReturn JSONObject()
                 val component = createComponent(
-                    action = RedirectAction(
+                    action = redirectAction(
                         paymentMethodType = TEST_PAYMENT_METHOD_TYPE,
                         type = ActionTypes.NATIVE_REDIRECT,
                         nativeRedirectData = "testData",
@@ -343,7 +343,7 @@ internal class RedirectComponentTest(
                 whenever(nativeRedirectService.makeNativeRedirect(any(), any())) doAnswer { throw error }
                 whenever(redirectHandler.parseRedirectResult(anyOrNull())) doReturn JSONObject()
                 val component = createComponent(
-                    action = RedirectAction(
+                    action = redirectAction(
                         paymentMethodType = TEST_PAYMENT_METHOD_TYPE,
                         type = ActionTypes.NATIVE_REDIRECT,
                         nativeRedirectData = "testData",
@@ -364,7 +364,7 @@ internal class RedirectComponentTest(
     }
 
     private fun createComponent(
-        action: RedirectAction = RedirectAction(),
+        action: RedirectAction = redirectAction(),
     ): RedirectComponent {
         return RedirectComponent(
             action = action,
@@ -376,6 +376,20 @@ internal class RedirectComponentTest(
             coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
         )
     }
+
+    private fun redirectAction(
+        type: String = TEST_ACTION_TYPE,
+        paymentMethodType: String? = null,
+        paymentData: String? = null,
+        nativeRedirectData: String? = null,
+    ) = RedirectAction(
+        type = type,
+        paymentMethodType = paymentMethodType,
+        paymentData = paymentData,
+        nativeRedirectData = nativeRedirectData,
+        method = null,
+        url = null,
+    )
 
     companion object {
         private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfgh"


### PR DESCRIPTION
## Description
Cleans up error-handling TODOs across the action and core modules:
- Removes error propagation TODOs and replaces `RuntimeException` with `CheckoutException`.
- Enforces the base URL to be valid in `OkHttpClient`.
- Makes `ActionFactory` generic over the action type (updating `Authentication`, `Await`, and `Redirect` factories/components accordingly).
- Removes the TODO on resolving the Google Pay merchant account.

## Checklist
- [x] Code is unit tested
- [x] Changes are tested manually

## Ticket Number
COSDK-1343