### PR TITLE
v6 - Core - Show secondary contents in full screen dialog

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation libs.compose.activity
     implementation libs.okhttp
     implementation libs.androidx.startup
+    implementation libs.compose.material.icons
 
     testImplementation libs.json
     testImplementation libs.bundles.junit

--- a/core/src/main/java/com/adyen/checkout/core/components/CheckoutAction.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/CheckoutAction.kt
@@ -39,7 +39,15 @@ fun CheckoutAction(
             localizationProvider = localizationProvider,
             environment = controller.environment,
         ) {
-            controller.actionComponent?.Content(modifier)
+            CheckoutActionInternal(controller, modifier)
         }
     }
+}
+
+@Composable
+internal fun CheckoutActionInternal(
+    controller: CheckoutController,
+    modifier: Modifier,
+) {
+    controller.actionComponent?.Content(modifier)
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/CheckoutPaymentFlow.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/CheckoutPaymentFlow.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Modifier
 import com.adyen.checkout.core.common.AdyenLogLevel
 import com.adyen.checkout.core.common.internal.helper.adyenLog
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationProvider
+import com.adyen.checkout.core.components.internal.CheckoutFullScreenDialog
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
 /**
@@ -64,9 +65,30 @@ fun CheckoutPaymentFlow(
         }
     }
 
+    CheckoutContent(
+        controller = controller,
+        modifier = modifier,
+        theme = theme,
+        localizationProvider = localizationProvider,
+        state = state,
+        onSecondaryDismissed = {
+            state = CheckoutPaymentFlowState.PaymentMethod
+        },
+    )
+}
+
+@Composable
+private fun CheckoutContent(
+    controller: CheckoutController,
+    modifier: Modifier,
+    theme: CheckoutTheme = CheckoutTheme(),
+    localizationProvider: CheckoutLocalizationProvider?,
+    state: CheckoutPaymentFlowState,
+    onSecondaryDismissed: () -> Unit,
+) {
     AnimatedContent(state) { localState ->
         when (localState) {
-            CheckoutPaymentFlowState.PaymentMethod -> {
+            CheckoutPaymentFlowState.PaymentMethod, is CheckoutPaymentFlowState.Secondary -> {
                 CheckoutPaymentMethod(
                     controller = controller,
                     modifier = modifier,
@@ -83,16 +105,21 @@ fun CheckoutPaymentFlow(
                     localizationProvider = localizationProvider,
                 )
             }
+        }
+    }
 
-            is CheckoutPaymentFlowState.Secondary -> {
-                CheckoutSecondary(
-                    identifier = localState.identifier,
-                    controller = controller,
-                    modifier = modifier,
-                    theme = theme,
-                    localizationProvider = localizationProvider,
-                )
-            }
+    if (state is CheckoutPaymentFlowState.Secondary) {
+        CheckoutFullScreenDialog(
+            theme = theme,
+            onDismissRequest = onSecondaryDismissed,
+        ) {
+            CheckoutSecondary(
+                identifier = state.identifier,
+                controller = controller,
+                modifier = modifier,
+                theme = theme,
+                localizationProvider = localizationProvider,
+            )
         }
     }
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/CheckoutPaymentFlow.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/CheckoutPaymentFlow.kt
@@ -18,9 +18,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.adyen.checkout.core.common.AdyenLogLevel
+import com.adyen.checkout.core.common.internal.helper.CheckoutCompositionLocalProvider
 import com.adyen.checkout.core.common.internal.helper.adyenLog
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationProvider
 import com.adyen.checkout.core.components.internal.CheckoutFullScreenDialog
+import com.adyen.checkout.ui.internal.theme.InternalCheckoutTheme
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
 /**
@@ -65,24 +67,30 @@ fun CheckoutPaymentFlow(
         }
     }
 
-    CheckoutContent(
-        controller = controller,
-        modifier = modifier,
-        theme = theme,
-        localizationProvider = localizationProvider,
-        state = state,
-        onSecondaryDismissed = {
-            state = CheckoutPaymentFlowState.PaymentMethod
-        },
-    )
+    InternalCheckoutTheme(theme) {
+        CheckoutCompositionLocalProvider(
+            locale = controller.shopperLocale,
+            localizationProvider = localizationProvider,
+            environment = controller.environment,
+        ) {
+            CheckoutContent(
+                controller = controller,
+                modifier = modifier,
+                theme = theme,
+                state = state,
+                onSecondaryDismissed = {
+                    state = CheckoutPaymentFlowState.PaymentMethod
+                },
+            )
+        }
+    }
 }
 
 @Composable
 private fun CheckoutContent(
     controller: CheckoutController,
     modifier: Modifier,
-    theme: CheckoutTheme = CheckoutTheme(),
-    localizationProvider: CheckoutLocalizationProvider?,
+    theme: CheckoutTheme,
     state: CheckoutPaymentFlowState,
     onSecondaryDismissed: () -> Unit,
 ) {
@@ -97,20 +105,16 @@ private fun CheckoutContent(
     AnimatedContent(checkoutContentState) { localState ->
         when (localState) {
             CheckoutContentState.PAYMENT_METHOD -> {
-                CheckoutPaymentMethod(
+                CheckoutPaymentMethodInternal(
                     controller = controller,
                     modifier = modifier,
-                    theme = theme,
-                    localizationProvider = localizationProvider,
                 )
             }
 
             CheckoutContentState.ACTION -> {
-                CheckoutAction(
+                CheckoutActionInternal(
                     controller = controller,
                     modifier = modifier,
-                    theme = theme,
-                    localizationProvider = localizationProvider,
                 )
             }
         }
@@ -121,11 +125,10 @@ private fun CheckoutContent(
             theme = theme,
             onDismissRequest = onSecondaryDismissed,
         ) {
-            CheckoutSecondary(
+            CheckoutSecondaryInternal(
                 identifier = state.identifier,
                 controller = controller,
-                theme = theme,
-                localizationProvider = localizationProvider,
+                modifier = Modifier,
             )
         }
     }

--- a/core/src/main/java/com/adyen/checkout/core/components/CheckoutPaymentFlow.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/CheckoutPaymentFlow.kt
@@ -86,9 +86,17 @@ private fun CheckoutContent(
     state: CheckoutPaymentFlowState,
     onSecondaryDismissed: () -> Unit,
 ) {
-    AnimatedContent(state) { localState ->
+    // AnimatedContent redraws/animates every time its target state changes
+    // when moving from Secondary to PaymentMethod, the state does change but the displayed content is the same
+    // this mapping ensures the target state does not change and prevents the AnimatedContent from flickering
+    val checkoutContentState = when (state) {
+        CheckoutPaymentFlowState.Action -> CheckoutContentState.ACTION
+        CheckoutPaymentFlowState.PaymentMethod,
+        is CheckoutPaymentFlowState.Secondary -> CheckoutContentState.PAYMENT_METHOD
+    }
+    AnimatedContent(checkoutContentState) { localState ->
         when (localState) {
-            CheckoutPaymentFlowState.PaymentMethod, is CheckoutPaymentFlowState.Secondary -> {
+            CheckoutContentState.PAYMENT_METHOD -> {
                 CheckoutPaymentMethod(
                     controller = controller,
                     modifier = modifier,
@@ -97,7 +105,7 @@ private fun CheckoutContent(
                 )
             }
 
-            CheckoutPaymentFlowState.Action -> {
+            CheckoutContentState.ACTION -> {
                 CheckoutAction(
                     controller = controller,
                     modifier = modifier,
@@ -128,4 +136,9 @@ private sealed class CheckoutPaymentFlowState {
     data object PaymentMethod : CheckoutPaymentFlowState()
     data object Action : CheckoutPaymentFlowState()
     data class Secondary(val identifier: String) : CheckoutPaymentFlowState()
+}
+
+private enum class CheckoutContentState {
+    PAYMENT_METHOD,
+    ACTION,
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/CheckoutPaymentFlow.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/CheckoutPaymentFlow.kt
@@ -124,7 +124,6 @@ private fun CheckoutContent(
             CheckoutSecondary(
                 identifier = state.identifier,
                 controller = controller,
-                modifier = modifier,
                 theme = theme,
                 localizationProvider = localizationProvider,
             )

--- a/core/src/main/java/com/adyen/checkout/core/components/CheckoutPaymentFlow.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/CheckoutPaymentFlow.kt
@@ -8,13 +8,14 @@
 
 package com.adyen.checkout.core.components
 
+import android.os.Parcelable
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.adyen.checkout.core.common.AdyenLogLevel
@@ -24,6 +25,7 @@ import com.adyen.checkout.core.common.localization.CheckoutLocalizationProvider
 import com.adyen.checkout.core.components.internal.CheckoutFullScreenDialog
 import com.adyen.checkout.ui.internal.theme.InternalCheckoutTheme
 import com.adyen.checkout.ui.theme.CheckoutTheme
+import kotlinx.parcelize.Parcelize
 
 /**
  * A [Composable] that renders the full checkout flow for the given [controller], automatically switching
@@ -41,7 +43,7 @@ fun CheckoutPaymentFlow(
     theme: CheckoutTheme = CheckoutTheme(),
     localizationProvider: CheckoutLocalizationProvider? = null,
 ) {
-    var state by remember(controller) {
+    var state by rememberSaveable(controller) {
         val initialState = when {
             controller.actionComponent != null -> CheckoutPaymentFlowState.Action
             else -> CheckoutPaymentFlowState.PaymentMethod
@@ -134,9 +136,15 @@ private fun CheckoutContent(
     }
 }
 
-private sealed class CheckoutPaymentFlowState {
+private sealed class CheckoutPaymentFlowState : Parcelable {
+
+    @Parcelize
     data object PaymentMethod : CheckoutPaymentFlowState()
+
+    @Parcelize
     data object Action : CheckoutPaymentFlowState()
+
+    @Parcelize
     data class Secondary(val identifier: String) : CheckoutPaymentFlowState()
 }
 

--- a/core/src/main/java/com/adyen/checkout/core/components/CheckoutPaymentMethod.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/CheckoutPaymentMethod.kt
@@ -39,7 +39,15 @@ fun CheckoutPaymentMethod(
             localizationProvider = localizationProvider,
             environment = controller.environment,
         ) {
-            controller.paymentComponent?.Content(modifier)
+            CheckoutPaymentMethodInternal(controller, modifier)
         }
     }
+}
+
+@Composable
+internal fun CheckoutPaymentMethodInternal(
+    controller: CheckoutController,
+    modifier: Modifier,
+) {
+    controller.paymentComponent?.Content(modifier)
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/CheckoutSecondary.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/CheckoutSecondary.kt
@@ -42,7 +42,16 @@ fun CheckoutSecondary(
             localizationProvider = localizationProvider,
             environment = controller.environment,
         ) {
-            (controller.paymentComponent as? SecondaryScreenComponent?)?.SecondaryContent(identifier, modifier)
+            CheckoutSecondaryInternal(identifier, controller, modifier)
         }
     }
+}
+
+@Composable
+internal fun CheckoutSecondaryInternal(
+    identifier: String,
+    controller: CheckoutController,
+    modifier: Modifier,
+) {
+    (controller.paymentComponent as? SecondaryScreenComponent?)?.SecondaryContent(identifier, modifier)
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutFullScreenDialog.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutFullScreenDialog.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 22/7/2026.
+ */
+
+package com.adyen.checkout.core.components.internal
+
+import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.window.DialogWindowProvider
+import androidx.core.view.WindowCompat
+import com.adyen.checkout.ui.theme.CheckoutTheme
+
+@Composable
+internal fun CheckoutFullScreenDialog(
+    theme: CheckoutTheme,
+    onDismissRequest: () -> Unit,
+    content: @Composable () -> Unit,
+) {
+    Dialog(
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+        onDismissRequest = onDismissRequest,
+    ) {
+        val dialogWindow = (LocalView.current.parent as? DialogWindowProvider)?.window
+        SideEffect {
+            dialogWindow?.let { window ->
+                // remove dark scrim
+                window.setDimAmount(0f)
+                // truly full window
+                window.setLayout(MATCH_PARENT, MATCH_PARENT)
+                // draw edge-to-edge
+                WindowCompat.setDecorFitsSystemWindows(window, false)
+            }
+        }
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = Color(theme.colors.background.value),
+        ) {
+            // keep content out from under the bars, while the surface stays edge-to-edge
+            Box(modifier = Modifier.safeDrawingPadding()) {
+                content()
+            }
+        }
+    }
+}

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutFullScreenDialog.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutFullScreenDialog.kt
@@ -8,11 +8,10 @@
 
 package com.adyen.checkout.core.components.internal
 
-import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.rememberScrollState
@@ -21,16 +20,11 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import androidx.compose.ui.window.DialogWindowProvider
-import androidx.core.view.WindowCompat
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.ui.internal.theme.Dimensions
@@ -43,41 +37,31 @@ internal fun CheckoutFullScreenDialog(
     content: @Composable () -> Unit,
 ) {
     Dialog(
-        properties = DialogProperties(usePlatformDefaultWidth = false),
         onDismissRequest = onDismissRequest,
+        properties = DialogProperties(
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true,
+            usePlatformDefaultWidth = false,
+            decorFitsSystemWindows = false,
+        ),
     ) {
-        val dialogWindow = (LocalView.current.parent as? DialogWindowProvider)?.window
-        SideEffect {
-            dialogWindow?.let { window ->
-                // remove dark scrim
-                window.setDimAmount(0f)
-                // truly full window
-                window.setLayout(MATCH_PARENT, MATCH_PARENT)
-                // draw edge-to-edge
-                WindowCompat.setDecorFitsSystemWindows(window, false)
-            }
-        }
-        Surface(
-            modifier = Modifier.fillMaxSize(),
-            color = Color(theme.colors.background.value),
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(color = Color(theme.colors.background.value))
+                // keep content out from under the bars, while the surface stays edge-to-edge
+                .safeDrawingPadding(),
         ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    // keep content out from under the bars, while the surface stays edge-to-edge
-                    .safeDrawingPadding(),
-            ) {
-                IconButton(onClick = onDismissRequest) {
-                    Icon(Icons.Default.Close, resolveString(CheckoutLocalizationKey.GENERAL_CLOSE))
-                }
+            IconButton(onClick = onDismissRequest) {
+                Icon(Icons.Default.Close, resolveString(CheckoutLocalizationKey.GENERAL_CLOSE))
+            }
 
-                Box(
-                    modifier = Modifier
-                        .padding(horizontal = Dimensions.Spacing.Large, vertical = Dimensions.Spacing.Small)
-                        .verticalScroll(rememberScrollState()),
-                ) {
-                    content()
-                }
+            Box(
+                modifier = Modifier
+                    .padding(horizontal = Dimensions.Spacing.Large, vertical = Dimensions.Spacing.Small)
+                    .verticalScroll(rememberScrollState()),
+            ) {
+                content()
             }
         }
     }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutFullScreenDialog.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutFullScreenDialog.kt
@@ -9,9 +9,16 @@
 package com.adyen.checkout.core.components.internal
 
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
@@ -22,6 +29,9 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.DialogWindowProvider
 import androidx.core.view.WindowCompat
+import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
+import com.adyen.checkout.core.common.localization.internal.helper.resolveString
+import com.adyen.checkout.ui.internal.theme.Dimensions
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @Composable
@@ -49,8 +59,18 @@ internal fun CheckoutFullScreenDialog(
             modifier = Modifier.fillMaxSize(),
             color = Color(theme.colors.background.value),
         ) {
-            // keep content out from under the bars, while the surface stays edge-to-edge
-            Box(modifier = Modifier.safeDrawingPadding()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    // keep content out from under the bars, while the surface stays edge-to-edge
+                    .safeDrawingPadding(),
+            ) {
+                IconButton(onClick = onDismissRequest) {
+                    Icon(Icons.Default.Close, resolveString(CheckoutLocalizationKey.GENERAL_CLOSE))
+                }
+
+                Spacer(Modifier.size(Dimensions.Spacing.Small))
+
                 content()
             }
         }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutFullScreenDialog.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutFullScreenDialog.kt
@@ -9,12 +9,14 @@
 package com.adyen.checkout.core.components.internal
 
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
@@ -69,9 +71,13 @@ internal fun CheckoutFullScreenDialog(
                     Icon(Icons.Default.Close, resolveString(CheckoutLocalizationKey.GENERAL_CLOSE))
                 }
 
-                Spacer(Modifier.size(Dimensions.Spacing.Small))
-
-                content()
+                Box(
+                    modifier = Modifier
+                        .padding(horizontal = Dimensions.Spacing.Large, vertical = Dimensions.Spacing.Small)
+                        .verticalScroll(rememberScrollState()),
+                ) {
+                    content()
+                }
             }
         }
     }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutFullScreenDialog.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutFullScreenDialog.kt
@@ -36,6 +36,7 @@ internal fun CheckoutFullScreenDialog(
     onDismissRequest: () -> Unit,
     content: @Composable () -> Unit,
 ) {
+    // TODO investigate switching to a full height ModalBottomSheet later - currently the animation looks janky
     Dialog(
         onDismissRequest = onDismissRequest,
         properties = DialogProperties(


### PR DESCRIPTION
## Description
By default we should show secondary content (e.g country selection, installments) in a full screen dialog instead of replacing the main payment method content.

This provides an easier integration for merchants who want to add UI elements around the component but not worrying about the content resizing when a secondary screen is shown or having to hide certain UI elements.
It also produces a similar experience to iOS.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually

[Screen_recording_20260722_172835.webm](https://github.com/user-attachments/assets/1934796b-742f-48f1-ae13-76f3bb147f82)
[Screen_recording_20260722_173032.webm](https://github.com/user-attachments/assets/1bc3fc1a-7cb6-482a-b6d6-8be7ab11861a)