### PR TITLE
v6 - Example app - Take keyboard into account while scrolling

### DIFF
--- a/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6Screen.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6Screen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -111,6 +112,7 @@ private fun Component(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier
             .fillMaxSize()
+            .imePadding()
             .verticalScroll(rememberScrollState()),
     ) {
         var shouldShowDialog by remember { mutableStateOf(false) }


### PR DESCRIPTION
## Description
Fix an issue where the component screen in the example app does not take the keyboard into account while scrolling.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually