### PR TITLE
v6 - Fix full screen dialog close button color

### DIFF
--- a/core/src/main/java/com/adyen/checkout/core/components/CheckoutPaymentFlow.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/CheckoutPaymentFlow.kt
@@ -78,7 +78,6 @@ fun CheckoutPaymentFlow(
             CheckoutContent(
                 controller = controller,
                 modifier = modifier,
-                theme = theme,
                 state = state,
                 onSecondaryDismissed = {
                     state = CheckoutPaymentFlowState.PaymentMethod
@@ -92,7 +91,6 @@ fun CheckoutPaymentFlow(
 private fun CheckoutContent(
     controller: CheckoutController,
     modifier: Modifier,
-    theme: CheckoutTheme,
     state: CheckoutPaymentFlowState,
     onSecondaryDismissed: () -> Unit,
 ) {
@@ -124,7 +122,6 @@ private fun CheckoutContent(
 
     if (state is CheckoutPaymentFlowState.Secondary) {
         CheckoutFullScreenDialog(
-            theme = theme,
             onDismissRequest = onSecondaryDismissed,
         ) {
             CheckoutSecondaryInternal(

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutFullScreenDialog.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutFullScreenDialog.kt
@@ -22,17 +22,17 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
+import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
 import com.adyen.checkout.ui.internal.theme.Dimensions
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @Composable
 internal fun CheckoutFullScreenDialog(
-    theme: CheckoutTheme,
+    @Suppress("unused") theme: CheckoutTheme,
     onDismissRequest: () -> Unit,
     content: @Composable () -> Unit,
 ) {
@@ -49,12 +49,16 @@ internal fun CheckoutFullScreenDialog(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(color = Color(theme.colors.background.value))
+                .background(color = CheckoutThemeProvider.colors.background)
                 // keep content out from under the bars, while the surface stays edge-to-edge
                 .safeDrawingPadding(),
         ) {
             IconButton(onClick = onDismissRequest) {
-                Icon(Icons.Default.Close, resolveString(CheckoutLocalizationKey.GENERAL_CLOSE))
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = resolveString(CheckoutLocalizationKey.GENERAL_CLOSE),
+                    tint = CheckoutThemeProvider.colors.primary,
+                )
             }
 
             Box(

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutFullScreenDialog.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutFullScreenDialog.kt
@@ -28,11 +28,9 @@ import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
 import com.adyen.checkout.ui.internal.theme.Dimensions
-import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @Composable
 internal fun CheckoutFullScreenDialog(
-    @Suppress("unused") theme: CheckoutTheme,
     onDismissRequest: () -> Unit,
     content: @Composable () -> Unit,
 ) {


### PR DESCRIPTION
## Description
This PR sets the tint color of the close button of the full screen dialog. This fixes an issue where the button would not change color in for example dark mode.

<img width="1280" height="2856" alt="image" src="https://github.com/user-attachments/assets/4b281796-84a8-4877-8870-482df1dc9695" />

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually
