### PR TITLE
v6 - CI - Declare reusable workflow secrets for release

### DIFF
--- a/.github/workflows/publish_to_maven_central.yml
+++ b/.github/workflows/publish_to_maven_central.yml
@@ -13,6 +13,21 @@ on:
       version-name:
         required: true
         type: string
+    secrets:
+      SONATYPE_CENTRAL_PORTAL_USERNAME:
+        required: true
+      SONATYPE_CENTRAL_PORTAL_PASSWORD:
+        required: true
+      SIGNING_KEY_ID:
+        required: true
+      SIGNING_PASSWORD:
+        required: true
+      SIGNING_SECRET_KEY_RING_FILE:
+        required: true
+      SONATYPE_STAGING_PROFILE_ID:
+        required: true
+      GPG_KEY_CONTENTS:
+        required: true
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description
The `Prepare Release` workflow passes secrets explicitly to the reusable `publish_to_maven_central.yml` workflow, but that workflow only declared its `inputs` under `on.workflow_call` — not the secrets. GitHub validates explicitly-passed secrets against the referenced workflow's `secrets:` declarations, so this failed with:

> Invalid secret, SONATYPE_CENTRAL_PORTAL_USERNAME is not defined in the referenced workflow.

This adds a `secrets:` block under `on.workflow_call` in `publish_to_maven_central.yml` declaring all secrets passed by the caller (SONATYPE credentials, signing keys, GPG key, staging profile). `GITHUB_TOKEN` used by the other reusable workflows needs no declaration since it is always provided automatically.