### PR TITLE
v6 - CI - Pass github-token to release reusable workflows

### DIFF
--- a/.github/workflows/create_github_release.yml
+++ b/.github/workflows/create_github_release.yml
@@ -9,6 +9,9 @@ on:
       prerelease:
         required: true
         type: boolean
+    secrets:
+      github-token:
+        required: true
 
 permissions:
   contents: write
@@ -24,7 +27,7 @@ jobs:
       - name: Create Github release
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.github-token }}
           VERSION_NAME: ${{ inputs.version-name }}
         with:
           token: ${{ env.GITHUB_TOKEN }}

--- a/.github/workflows/create_release_notes_pr.yml
+++ b/.github/workflows/create_release_notes_pr.yml
@@ -6,6 +6,9 @@ on:
       version-name:
         required: true
         type: string
+    secrets:
+      github-token:
+        required: true
 
 permissions:
   contents: write
@@ -29,7 +32,7 @@ jobs:
         env:
           BASE_BRANCH: "release-notes"
           VERSION_NAME: ${{ inputs.version-name }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.github-token }}
           GITHUB_REPO: ${{ github.repository }}
         run: |
           chmod +x scripts/create_release_notes_pr.sh

--- a/.github/workflows/generate_release_notes.yml
+++ b/.github/workflows/generate_release_notes.yml
@@ -6,6 +6,9 @@ on:
       version-name:
         required: true
         type: string
+    secrets:
+      github-token:
+        required: true
 
 jobs:
   get_allowed_labels:
@@ -56,7 +59,7 @@ jobs:
         env:
           ALLOWED_LABELS: ${{ needs.get_allowed_labels.outputs.allowed-labels }}
           VERSION_NAME: ${{ inputs.version-name }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.github-token }}
           GITHUB_REPO: ${{ github.repository }}
         run: |
           chmod +x scripts/generate_release_notes.py

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -39,7 +39,7 @@ jobs:
       contents: write
     uses: ./.github/workflows/create_github_release.yml
     secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}
     needs: [generate_version_name, publish_to_maven_central]
     with:
       version-name: ${{ needs.generate_version_name.outputs.version-name }}
@@ -50,7 +50,7 @@ jobs:
       contents: write
     uses: ./.github/workflows/generate_release_notes.yml
     secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}
     needs: [generate_version_name, create_github_release]
     with:
       version-name: ${{ needs.generate_version_name.outputs.version-name }}
@@ -60,6 +60,8 @@ jobs:
       contents: write
       pull-requests: write
     uses: ./.github/workflows/create_release_notes_pr.yml
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
     needs: [generate_version_name, generate_release_notes]
     with:
       version-name: ${{ needs.generate_version_name.outputs.version-name }}


### PR DESCRIPTION
## Description
Follow-up to the reusable-workflow secrets fix. The `Prepare Release` workflow was passing `GITHUB_TOKEN` explicitly to reusable workflows, which failed validation:

> Invalid secret, GITHUB_TOKEN is not defined in the referenced workflow.

`GITHUB_TOKEN` is a reserved secret — it cannot be declared in `on.workflow_call.secrets` (the `GITHUB_` prefix is reserved) nor passed under that literal name. This aligns the release workflows with the pattern already used in `build_and_test.yml` and `update_release_notes.yml`: the token is passed as a `github-token` named secret.

Changes:
- `prepare_release.yml`: pass `github-token: ${{ secrets.GITHUB_TOKEN }}` to `create_github_release`, `generate_release_notes`, and `create_release_notes_pr`.
- `create_github_release.yml`, `generate_release_notes.yml`, `create_release_notes_pr.yml`: declare `github-token` under `on.workflow_call.secrets` and reference `${{ secrets.github-token }}` internally.
