### PR TITLE
v6 - CI - Pass GRADLE_ENCRYPTION_KEY to validate_public_api

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -26,6 +26,8 @@ jobs:
       contents: read
       pull-requests: write
     uses: ./.github/workflows/validate_public_api.yml
+    secrets:
+      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
   verify_dependencies:
     name: Validate dependencies
     permissions:

--- a/.github/workflows/validate_public_api.yml
+++ b/.github/workflows/validate_public_api.yml
@@ -1,7 +1,10 @@
 name: Validate public API
 
 on:
-  workflow_call
+  workflow_call:
+    secrets:
+      GRADLE_ENCRYPTION_KEY:
+        required: true
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description
`validate_public_api.yml` is a reusable workflow (`on: workflow_call`) that uses `${{ secrets.GRADLE_ENCRYPTION_KEY }}` for the Gradle config-cache encryption key. However, its caller `check_pr.yml` invoked it without passing any secrets (and without `secrets: inherit`), so the key silently resolved to empty at runtime — disabling encrypted cache reuse for that job, inconsistent with `build_and_test.yml`.

This wires it up following the existing `publish_docs.yml` pattern:
- `validate_public_api.yml`: declare `GRADLE_ENCRYPTION_KEY` under `on.workflow_call.secrets`.
- `check_pr.yml`: pass `GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}` to the `validate_public_api` job.

Found while auditing all workflow files for correct secret definitions. No "workflow not valid" error was produced by this (that only occurs for explicitly-passed-but-undeclared secrets), but the secret was not properly propagated.