### PR TITLE
Remove version name regex in release notes branch

### DIFF
--- a/.github/workflows/fetch_version_name_from_release_notes.yml
+++ b/.github/workflows/fetch_version_name_from_release_notes.yml
@@ -15,7 +15,7 @@ jobs:
       version-name: ${{ steps.fetch_version_name.outputs.version-name }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Fetch version name from latest release notes
         id: fetch_version_name
         run: |

--- a/scripts/fetch_release_notes_version_name.sh
+++ b/scripts/fetch_release_notes_version_name.sh
@@ -13,24 +13,14 @@ function fetch_release_notes_version_name() {
     fi
     commit_message=$1
 
-    # Extract the branch name
-    release_notes_branch_name=$(echo "$commit_message" | grep -oE 'release-notes.*')
-
-    # Check if "release-notes" was found
-    if [[ -z "$release_notes_branch_name" ]]; then
-        echo "No part starting with 'release-notes' found in the string." >&2
-        exit 1
-    fi
-
-    # Regex for version (starts with a version number like 1.2.3.md)
-    version_name_regex="[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}(-(alpha|beta|rc)[0-9]{2})?"
-
-    # Extract the version name from the "release-notes" part
-    version_name=$(echo "$release_notes_branch_name" | grep -oE "$version_name_regex")
-
-    # Check if version name was found
-    if [[ -z "$version_name" ]]; then
-        echo "Version cannot be extracted." >&2
+    # The release notes branch is named "release-notes-<version>", e.g.
+    # "Merge pull request #2782 from Adyen/release-notes-5.19.0".
+    # Capture the version token right after "release-notes-" so trailing text
+    # (multi-line commit bodies, descriptions) is not included.
+    if [[ "$commit_message" =~ release-notes-([0-9a-zA-Z.-]+) ]]; then
+        version_name="${BASH_REMATCH[1]}"
+    else
+        echo "No part starting with 'release-notes-' found in the string." >&2
         exit 1
     fi
 


### PR DESCRIPTION
## Description
- Remove version name regex in release notes and simplify release notes version extraction using parameter expansion.
- Update Checkout Github action version

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually