### PR TITLE
v6 - Release - Skip docs publishing for prereleases

### DIFF
--- a/.github/workflows/finalize_release.yml
+++ b/.github/workflows/finalize_release.yml
@@ -10,6 +10,27 @@ on:
         type: string
 
 jobs:
+  version_info:
+    name: Resolve version info
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      prerelease: ${{ steps.version_info.outputs.prerelease }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Resolve version info
+        id: version_info
+        env:
+          VERSION_NAME: ${{ inputs.version-name }}
+        run: |
+          chmod +x scripts/version_info.sh
+          VERSION_INFO=$(./scripts/version_info.sh "$VERSION_NAME")
+          echo "$VERSION_INFO"
+
+          PRERELEASE=$(echo "$VERSION_INFO" | grep '^prerelease=' | cut -d= -f2-)
+          echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
+
   update_release_notes:
     name: Update release notes
     permissions:
@@ -17,6 +38,7 @@ jobs:
     uses: ./.github/workflows/update_release_notes.yml
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
+    needs: version_info
     with:
       version-name: ${{ inputs.version-name }}
 
@@ -78,4 +100,5 @@ jobs:
     uses: ./.github/workflows/publish_docs.yml
     secrets:
       GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-    needs: publish_draft_release
+    needs: [publish_draft_release, version_info]
+    if: needs.version_info.outputs.prerelease == 'false'

--- a/.github/workflows/generate_version_name.yml
+++ b/.github/workflows/generate_version_name.yml
@@ -25,8 +25,9 @@ jobs:
       - name: Generate version name
         id: generate_version_name
         run: |
-          chmod +x scripts/version_info.sh
-          VERSION_INFO=$(./scripts/version_info.sh)
+          chmod +x scripts/version_name_from_branch.sh scripts/version_info.sh
+          VERSION_NAME=$(./scripts/version_name_from_branch.sh)
+          VERSION_INFO=$(./scripts/version_info.sh "$VERSION_NAME")
           echo "$VERSION_INFO"
 
           VERSION_NAME=$(echo "$VERSION_INFO" | grep '^version_name=' | cut -d= -f2-)

--- a/scripts/version_info.sh
+++ b/scripts/version_info.sh
@@ -1,20 +1,21 @@
 #!/bin/bash
 
-# Derives release version information from the current release branch.
+# Validates a version name and derives release information from it.
+#
+# Usage: version_info.sh <version_name>
 #
 # Output: one `key=value` line per value on stdout, so callers can parse each value by key.
 # The keys are:
 #   version_name  The validated version name (e.g. `6.1.0` or `6.1.0-alpha.1`).
 #   prerelease    `true` if the version name is a pre-release, `false` otherwise.
 function version_info() {
-    local branch_name=$(git branch --show-current)
+    local version_name="$1"
 
-    if [[ $branch_name != release/* ]]; then
-      echo "Error: invalid branch name. Branch name should start with \"release/\"." >&2
-      exit 1
+    if [[ -z "$version_name" ]]; then
+        echo "Error: no version name provided. Usage: version_info.sh <version_name>." >&2
+        exit 1
     fi
 
-    local version_name="${branch_name#*release/}"
     local version_name_regex="^[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}(-(alpha|beta|rc)\.[0-9]{1,2})?$"
 
     if [[ ! ${version_name} =~ ${version_name_regex} ]]; then
@@ -32,4 +33,4 @@ function version_info() {
     echo "prerelease=$prerelease"
 }
 
-version_info
+version_info "$1"

--- a/scripts/version_name_from_branch.sh
+++ b/scripts/version_name_from_branch.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Extracts the release version name from the current release branch.
+#
+# The release branch convention is `release/<version_name>` (e.g. `release/6.1.0`).
+#
+# Output: the extracted version name on stdout.
+function version_name_from_branch() {
+    local branch_name="${GITHUB_REF_NAME:-$(git branch --show-current)}"
+
+    if [[ $branch_name != release/* ]]; then
+        echo "Error: invalid branch name. Branch name should start with \"release/\"." >&2
+        exit 1
+    fi
+
+    echo "${branch_name#*release/}"
+}
+
+version_name_from_branch


### PR DESCRIPTION
## Description
Prevents documentation from being published for prereleases, and refactors the release version handling that supports it.

- `finalize_release.yml` adds a `version_info` job that validates the input version name and resolves the `prerelease` flag by reusing `version_info.sh`. All mutating jobs are gated behind successful validation, and `publish_docs_to_github_pages` is skipped when the release is a prerelease.
- Splits release version parsing into two single-responsibility scripts:
  - `version_name_from_branch.sh` — resolves the version name from the `release/**` branch.
  - `version_info.sh` — now a pure function of a given version name; validates it and derives the `prerelease` flag (no branch knowledge).
- `generate_version_name.yml` composes both scripts (unchanged behavior).

## Checklist
- [x] Changes are tested manually