### PR TITLE
v6 - CI - Fix OSSRH Staging API Cloudflare 1010 by setting User-Agent

### DIFF
--- a/scripts/drop_all_open_ossrh_repositories.py
+++ b/scripts/drop_all_open_ossrh_repositories.py
@@ -12,6 +12,9 @@ SONATYPE_API_BASE_URL = "https://ossrh-staging-api.central.sonatype.com/manual"
 SEARCH_REPOSITORIES_URL = f"{SONATYPE_API_BASE_URL}/search/repositories"
 DROP_REPOSITORY_BASE_URL = f"{SONATYPE_API_BASE_URL}/drop/repository" # Key will be appended
 TIMEOUT_SECONDS = 60
+# Explicit User-Agent: the default urllib UA (Python-urllib/x) is blocked by
+# Cloudflare (error 1010) on the OSSRH Staging API, so we send a custom one.
+USER_AGENT = "adyen-android-release-bot/1.0 (+https://github.com/Adyen/adyen-android)"
 
 class _SimpleResponse:
     def __init__(self, status_code, text):
@@ -38,6 +41,7 @@ def _make_api_request(method, url, auth, params=None, headers=None, expected_suc
     if headers is None:
         headers = {}
     headers.setdefault("Accept", "application/json") # Default Accept header
+    headers.setdefault("User-Agent", USER_AGENT)
 
     if expected_success_codes is None:
         expected_success_codes = [200]

--- a/scripts/move_ossrh_repository_to_central_portal.py
+++ b/scripts/move_ossrh_repository_to_central_portal.py
@@ -12,6 +12,9 @@ SONATYPE_API_BASE_URL = "https://ossrh-staging-api.central.sonatype.com/manual"
 SEARCH_REPOSITORIES_URL = f"{SONATYPE_API_BASE_URL}/search/repositories"
 UPLOAD_REPO_BASE_URL = f"{SONATYPE_API_BASE_URL}/upload/repository" # Key will be appended
 TIMEOUT_SECONDS = 180 # Setting a timeout a bit higher, in case the Sonatype API takes longer to respond
+# Explicit User-Agent: the default urllib UA (Python-urllib/x) is blocked by
+# Cloudflare (error 1010) on the OSSRH Staging API, so we send a custom one.
+USER_AGENT = "adyen-android-release-bot/1.0 (+https://github.com/Adyen/adyen-android)"
 
 class _SimpleResponse:
     def __init__(self, status_code, text):
@@ -47,6 +50,7 @@ def _make_api_request(method, url, auth, params=None, headers=None, expected_suc
     if headers is None:
         headers = {}
     headers.setdefault("Accept", "application/json") # Default Accept header
+    headers.setdefault("User-Agent", USER_AGENT)
 
     if expected_success_codes is None:
         if method.upper() == "POST":


### PR DESCRIPTION
## Description
Release automation calls the OSSRH Staging API (`ossrh-staging-api.central.sonatype.com`) from CI to search/drop/move staging repositories. These calls started failing with:

```
403 — Cloudflare Error 1010: "The site owner has blocked access based on your browser's signature." (browser_signature_banned)
```

### Root cause
The scripts were migrated from the `requests` library to `urllib`, which changed the outgoing `User-Agent` to `Python-urllib/<version>`. Cloudflare's bot ruleset on the Sonatype endpoint bans that specific signature (the previous `python-requests/<version>` UA, still used on the `v5` branch, is not banned — which is why v5 keeps working). The request never reaches the API; it's blocked at Cloudflare's edge, so it is not an authentication problem.

### Fix
Set an explicit, self-descriptive `User-Agent` header on all requests in:
- `scripts/drop_all_open_ossrh_repositories.py`
- `scripts/move_ossrh_repository_to_central_portal.py`

`User-Agent: adyen-android-release-bot/1.0 (+https://github.com/Adyen/adyen-android)`

A custom descriptive UA (rather than a browser or library string) was chosen because it needs no maintenance (no version/browser string to keep current) and is not part of the banned "known automation library" class.

### Verification (tested in CI)
Added a temporary probe workflow and ran it on a GitHub-hosted runner (same datacenter-IP environment as releases), hitting the real `GET /manual/search/repositories` endpoint with multiple User-Agents via `urllib`:

- `Python-urllib/3.14` (old) → **403 / Cloudflare 1010** (banned)
- `python-requests/2.32.3`, `curl/8.7.1`, browser, and the custom UA → **passed Cloudflare**
- **Authenticated** search (real credentials, GET only — never drop) with the custom UA → **HTTP 200**, valid JSON response

Workflow run: https://github.com/Adyen/adyen-android/actions/runs/30089562089

The probe only performed read-only `GET /search` calls (never `DELETE /drop`), and printed only status codes/counts — no secrets or response bodies. The temporary probe workflow/branch has been removed.

### Notes / follow-up
- Any UA-based approach is a stopgap against Cloudflare bot-management. The durable fix is to migrate off these manual OSSRH endpoints to the Central Portal Publisher API once an official Gradle plugin is available (tracked separately; a support request has also been raised with Sonatype).
