### PR TITLE
v6 - Release - Fix prerelease boolean coercion in prepare release

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -43,7 +43,7 @@ jobs:
     needs: [generate_version_name, publish_to_maven_central]
     with:
       version-name: ${{ needs.generate_version_name.outputs.version-name }}
-      prerelease: ${{ needs.generate_version_name.outputs.prerelease }}
+      prerelease: ${{ fromJSON(needs.generate_version_name.outputs.prerelease) }}
   generate_release_notes:
     name: Generate release notes
     permissions:


### PR DESCRIPTION
## Description
Fixes the `prepare_release` workflow failing at the `create_github_release` step with *"Unexpected value 'true'"*.

Reusable-workflow (`workflow_call`) outputs are always strings, but `create_github_release.yml` declares its `prerelease` input as `type: boolean`. Passing the string output directly caused the job to fail during input evaluation — which happens only after the ~1h `publish_to_maven_central` step, making the failure expensive.

Wrapping the value in `fromJSON()` coerces the `true`/`false` string to a real boolean. Since `version_info.sh` always emits exactly `true` or `false` on success (and aborts early on invalid input), the coercion cannot fail at the expensive stage.

## Checklist
- [x] Changes are tested manually