### PR TITLE
v6 - Core - Several compose improvements

### DIFF
--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/BlikCodeField.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/BlikCodeField.kt
@@ -24,9 +24,9 @@ import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewS
 import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.DigitOnlyInputTransformation
 import com.adyen.checkout.ui.internal.element.input.SeparatorsOutputTransformation
-import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
 import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
 import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @Composable
@@ -68,7 +68,7 @@ internal fun BlikCodeField(
 @Preview
 @Composable
 private fun BlikCodeFieldPreview(
-    @PreviewParameter(TextFieldStylePreviewParameterProvider::class) theme: CheckoutTheme,
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
     CheckoutThemePreviewWrapper(theme) {
         BlikCodeField(

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/BlikCodeField.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/BlikCodeField.kt
@@ -26,7 +26,7 @@ import com.adyen.checkout.ui.internal.element.input.DigitOnlyInputTransformation
 import com.adyen.checkout.ui.internal.element.input.SeparatorsOutputTransformation
 import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
 import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
-import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @Composable
@@ -70,7 +70,7 @@ internal fun BlikCodeField(
 private fun BlikCodeFieldPreview(
     @PreviewParameter(TextFieldStylePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
-    CheckoutThemeWrapper(theme) {
+    CheckoutThemePreviewWrapper(theme) {
         BlikCodeField(
             blikCodeState = TextInputViewState(
                 text = "123456",

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
@@ -55,7 +55,7 @@ import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.DigitOnlyInputTransformation
 import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
 import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
-import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
 import com.adyen.checkout.ui.internal.helper.getThemedIcon
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
 import com.adyen.checkout.ui.internal.theme.Dimensions
@@ -306,7 +306,7 @@ private fun BrandLogo(
 private fun CardNumberFieldPreview(
     @PreviewParameter(TextFieldStylePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
-    CheckoutThemeWrapper(theme) {
+    CheckoutThemePreviewWrapper(theme) {
         // empty input
         CardNumberField(
             cardNumberState = TextInputViewState(

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
@@ -53,9 +53,9 @@ import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.DigitOnlyInputTransformation
-import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
 import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
 import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.helper.getThemedIcon
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
 import com.adyen.checkout.ui.internal.theme.Dimensions
@@ -304,7 +304,7 @@ private fun BrandLogo(
 @Preview
 @Composable
 private fun CardNumberFieldPreview(
-    @PreviewParameter(TextFieldStylePreviewParameterProvider::class) theme: CheckoutTheme,
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
     CheckoutThemePreviewWrapper(theme) {
         // empty input

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/ExpiryDateField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/ExpiryDateField.kt
@@ -30,9 +30,9 @@ import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewS
 import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.SeparatorsOutputTransformation
 import com.adyen.checkout.ui.internal.element.input.TextFieldSeparator
-import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
 import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
 import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.helper.getThemedIcon
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
 import com.adyen.checkout.ui.internal.theme.Dimensions
@@ -130,7 +130,7 @@ private fun ExpiryDateIcon(
 @Preview
 @Composable
 private fun ExpiryDateFieldPreview(
-    @PreviewParameter(TextFieldStylePreviewParameterProvider::class) theme: CheckoutTheme,
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
     CheckoutThemePreviewWrapper(theme) {
         ExpiryDateField(

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/ExpiryDateField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/ExpiryDateField.kt
@@ -32,7 +32,7 @@ import com.adyen.checkout.ui.internal.element.input.SeparatorsOutputTransformati
 import com.adyen.checkout.ui.internal.element.input.TextFieldSeparator
 import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
 import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
-import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
 import com.adyen.checkout.ui.internal.helper.getThemedIcon
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
 import com.adyen.checkout.ui.internal.theme.Dimensions
@@ -132,7 +132,7 @@ private fun ExpiryDateIcon(
 private fun ExpiryDateFieldPreview(
     @PreviewParameter(TextFieldStylePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
-    CheckoutThemeWrapper(theme) {
+    CheckoutThemePreviewWrapper(theme) {
         ExpiryDateField(
             expiryDateState = TextInputViewState(
                 text = "0330",

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/HolderNameField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/HolderNameField.kt
@@ -21,9 +21,9 @@ import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
-import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
 import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
 import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @Composable
@@ -57,7 +57,7 @@ internal fun HolderNameField(
 @Preview
 @Composable
 private fun HolderNameFieldPreview(
-    @PreviewParameter(TextFieldStylePreviewParameterProvider::class) theme: CheckoutTheme,
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
     CheckoutThemePreviewWrapper(theme) {
         HolderNameField(

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/HolderNameField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/HolderNameField.kt
@@ -23,7 +23,7 @@ import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewS
 import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
 import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
-import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @Composable
@@ -59,7 +59,7 @@ internal fun HolderNameField(
 private fun HolderNameFieldPreview(
     @PreviewParameter(TextFieldStylePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
-    CheckoutThemeWrapper(theme) {
+    CheckoutThemePreviewWrapper(theme) {
         HolderNameField(
             holderNameState = TextInputViewState(
                 text = "John Smith",

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPBirthDateOrTaxNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPBirthDateOrTaxNumberField.kt
@@ -24,7 +24,7 @@ import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.DigitOnlyInputTransformation
 import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
 import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
-import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @Composable
@@ -71,7 +71,7 @@ internal fun KCPBirthDateOrTaxNumberField(
 private fun KCPBirthDateOrTaxNumberFieldPreview(
     @PreviewParameter(TextFieldStylePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
-    CheckoutThemeWrapper(theme) {
+    CheckoutThemePreviewWrapper(theme) {
         KCPBirthDateOrTaxNumberField(
             kcpBirthDateOrTaxNumberState = TextInputViewState(
                 text = "230704",

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPBirthDateOrTaxNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPBirthDateOrTaxNumberField.kt
@@ -22,9 +22,9 @@ import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.DigitOnlyInputTransformation
-import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
 import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
 import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @Composable
@@ -69,7 +69,7 @@ internal fun KCPBirthDateOrTaxNumberField(
 @Preview
 @Composable
 private fun KCPBirthDateOrTaxNumberFieldPreview(
-    @PreviewParameter(TextFieldStylePreviewParameterProvider::class) theme: CheckoutTheme,
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
     CheckoutThemePreviewWrapper(theme) {
         KCPBirthDateOrTaxNumberField(

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPCardPasswordField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPCardPasswordField.kt
@@ -23,7 +23,7 @@ import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.DigitOnlyInputTransformation
 import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
 import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
-import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @Composable
@@ -63,7 +63,7 @@ internal fun KCPCardPasswordField(
 private fun KCPCardPasswordFieldPreview(
     @PreviewParameter(TextFieldStylePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
-    CheckoutThemeWrapper(theme) {
+    CheckoutThemePreviewWrapper(theme) {
         KCPCardPasswordField(
             kcpCardPasswordState = TextInputViewState(
                 text = "12",

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPCardPasswordField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPCardPasswordField.kt
@@ -21,9 +21,9 @@ import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.DigitOnlyInputTransformation
-import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
 import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
 import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @Composable
@@ -61,7 +61,7 @@ internal fun KCPCardPasswordField(
 @Preview
 @Composable
 private fun KCPCardPasswordFieldPreview(
-    @PreviewParameter(TextFieldStylePreviewParameterProvider::class) theme: CheckoutTheme,
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
     CheckoutThemePreviewWrapper(theme) {
         KCPCardPasswordField(

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/PostalCodeField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/PostalCodeField.kt
@@ -23,9 +23,9 @@ import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
-import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
 import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
 import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
 import com.adyen.checkout.ui.internal.theme.Dimensions
 import com.adyen.checkout.ui.theme.CheckoutTheme
@@ -100,7 +100,7 @@ private fun PostalCodeIcon(
 @Preview
 @Composable
 private fun PostalCodeFieldPreview(
-    @PreviewParameter(TextFieldStylePreviewParameterProvider::class) theme: CheckoutTheme,
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
     CheckoutThemePreviewWrapper(theme) {
         PostalCodeField(

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/PostalCodeField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/PostalCodeField.kt
@@ -25,7 +25,7 @@ import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewS
 import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
 import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
-import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
 import com.adyen.checkout.ui.internal.theme.Dimensions
 import com.adyen.checkout.ui.theme.CheckoutTheme
@@ -102,7 +102,7 @@ private fun PostalCodeIcon(
 private fun PostalCodeFieldPreview(
     @PreviewParameter(TextFieldStylePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
-    CheckoutThemeWrapper(theme) {
+    CheckoutThemePreviewWrapper(theme) {
         PostalCodeField(
             postalCodeState = TextInputViewState(
                 text = "1234 AB",

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SecurityCodeField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SecurityCodeField.kt
@@ -31,9 +31,9 @@ import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.DigitOnlyInputTransformation
-import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
 import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
 import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.helper.getThemedIcon
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
 import com.adyen.checkout.ui.internal.theme.Dimensions
@@ -144,7 +144,7 @@ private fun SecurityCodeIcon(
 @Preview
 @Composable
 private fun SecurityCodeFieldPreview(
-    @PreviewParameter(TextFieldStylePreviewParameterProvider::class) theme: CheckoutTheme,
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
     CheckoutThemePreviewWrapper(theme) {
         SecurityCodeField(

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SecurityCodeField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SecurityCodeField.kt
@@ -33,7 +33,7 @@ import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.DigitOnlyInputTransformation
 import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
 import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
-import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
 import com.adyen.checkout.ui.internal.helper.getThemedIcon
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
 import com.adyen.checkout.ui.internal.theme.Dimensions
@@ -146,7 +146,7 @@ private fun SecurityCodeIcon(
 private fun SecurityCodeFieldPreview(
     @PreviewParameter(TextFieldStylePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
-    CheckoutThemeWrapper(theme) {
+    CheckoutThemePreviewWrapper(theme) {
         SecurityCodeField(
             securityCodeState = TextInputViewState(
                 text = "123",

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SocialSecurityNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SocialSecurityNumberField.kt
@@ -24,7 +24,7 @@ import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.DigitOnlyInputTransformation
 import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
 import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
-import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @Composable
@@ -66,7 +66,7 @@ internal fun SocialSecurityNumberField(
 private fun SocialSecurityNumberFieldPreview(
     @PreviewParameter(TextFieldStylePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
-    CheckoutThemeWrapper(theme) {
+    CheckoutThemePreviewWrapper(theme) {
         SocialSecurityNumberField(
             socialSecurityNumberState = TextInputViewState(
                 text = "12312312312",

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SocialSecurityNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SocialSecurityNumberField.kt
@@ -22,9 +22,9 @@ import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.DigitOnlyInputTransformation
-import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
 import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
 import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @Composable
@@ -64,7 +64,7 @@ internal fun SocialSecurityNumberField(
 @Preview
 @Composable
 private fun SocialSecurityNumberFieldPreview(
-    @PreviewParameter(TextFieldStylePreviewParameterProvider::class) theme: CheckoutTheme,
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
     CheckoutThemePreviewWrapper(theme) {
         SocialSecurityNumberField(

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardContent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardContent.kt
@@ -24,7 +24,7 @@ import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.components.internal.ui.PayButton
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 import com.adyen.checkout.ui.internal.element.ComponentScaffold
-import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
 import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.theme.Dimensions
 import com.adyen.checkout.ui.theme.CheckoutTheme
@@ -81,7 +81,7 @@ private fun StoredCardContent(
 private fun StoredCardContentPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
-    CheckoutThemeWrapper(theme) {
+    CheckoutThemePreviewWrapper(theme) {
         val viewState = StoredCardViewState(
             securityCode = TextInputViewState(),
             brand = CardBrand(""),

--- a/core/src/main/java/com/adyen/checkout/core/common/internal/helper/CheckoutCompositionLocalProvider.kt
+++ b/core/src/main/java/com/adyen/checkout/core/common/internal/helper/CheckoutCompositionLocalProvider.kt
@@ -18,27 +18,37 @@ import androidx.compose.ui.platform.LocalContext
 import com.adyen.checkout.core.common.Environment
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationProvider
 import com.adyen.checkout.core.common.localization.internal.LocalizationResolver
+import com.adyen.checkout.ui.internal.theme.InternalCheckoutTheme
+import com.adyen.checkout.ui.theme.CheckoutTheme
 import java.util.Locale
 
+/**
+ * Initializer wrapper for all Checkout components.
+ *
+ * Every public Compose component in the SDK should be wrapped in this function.
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Composable
 fun CheckoutCompositionLocalProvider(
+    theme: CheckoutTheme,
     locale: Locale,
     localizationProvider: CheckoutLocalizationProvider?,
     environment: Environment,
     content: @Composable () -> Unit,
 ) {
-    val context = LocalContext.current
-    val localizedContext = remember(context, locale) {
-        context.createLocalizedContext(locale)
-    }
-    CompositionLocalProvider(
-        LocalLocalizationResolver provides LocalizationResolver(localizationProvider),
-        LocalLocalizedContext provides localizedContext,
-        LocalLocale provides locale,
-        LocalEnvironment provides environment,
-    ) {
-        content()
+    InternalCheckoutTheme(theme) {
+        val context = LocalContext.current
+        val localizedContext = remember(context, locale) {
+            context.createLocalizedContext(locale)
+        }
+        CompositionLocalProvider(
+            LocalLocalizationResolver provides LocalizationResolver(localizationProvider),
+            LocalLocalizedContext provides localizedContext,
+            LocalLocale provides locale,
+            LocalEnvironment provides environment,
+        ) {
+            content()
+        }
     }
 }
 

--- a/core/src/main/java/com/adyen/checkout/core/components/CheckoutAction.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/CheckoutAction.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.adyen.checkout.core.common.internal.helper.CheckoutCompositionLocalProvider
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationProvider
-import com.adyen.checkout.ui.internal.theme.InternalCheckoutTheme
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
 /**
@@ -33,14 +32,13 @@ fun CheckoutAction(
     theme: CheckoutTheme = CheckoutTheme(),
     localizationProvider: CheckoutLocalizationProvider? = null,
 ) {
-    InternalCheckoutTheme(theme) {
-        CheckoutCompositionLocalProvider(
-            locale = controller.shopperLocale,
-            localizationProvider = localizationProvider,
-            environment = controller.environment,
-        ) {
-            CheckoutActionInternal(controller, modifier)
-        }
+    CheckoutCompositionLocalProvider(
+        theme = theme,
+        locale = controller.shopperLocale,
+        localizationProvider = localizationProvider,
+        environment = controller.environment,
+    ) {
+        CheckoutActionInternal(controller, modifier)
     }
 }
 

--- a/core/src/main/java/com/adyen/checkout/core/components/CheckoutPaymentFlow.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/CheckoutPaymentFlow.kt
@@ -23,7 +23,6 @@ import com.adyen.checkout.core.common.internal.helper.CheckoutCompositionLocalPr
 import com.adyen.checkout.core.common.internal.helper.adyenLog
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationProvider
 import com.adyen.checkout.core.components.internal.CheckoutFullScreenDialog
-import com.adyen.checkout.ui.internal.theme.InternalCheckoutTheme
 import com.adyen.checkout.ui.theme.CheckoutTheme
 import kotlinx.parcelize.Parcelize
 
@@ -69,21 +68,20 @@ fun CheckoutPaymentFlow(
         }
     }
 
-    InternalCheckoutTheme(theme) {
-        CheckoutCompositionLocalProvider(
-            locale = controller.shopperLocale,
-            localizationProvider = localizationProvider,
-            environment = controller.environment,
-        ) {
-            CheckoutContent(
-                controller = controller,
-                modifier = modifier,
-                state = state,
-                onSecondaryDismissed = {
-                    state = CheckoutPaymentFlowState.PaymentMethod
-                },
-            )
-        }
+    CheckoutCompositionLocalProvider(
+        theme = theme,
+        locale = controller.shopperLocale,
+        localizationProvider = localizationProvider,
+        environment = controller.environment,
+    ) {
+        CheckoutContent(
+            controller = controller,
+            modifier = modifier,
+            state = state,
+            onSecondaryDismissed = {
+                state = CheckoutPaymentFlowState.PaymentMethod
+            },
+        )
     }
 }
 

--- a/core/src/main/java/com/adyen/checkout/core/components/CheckoutPaymentMethod.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/CheckoutPaymentMethod.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.adyen.checkout.core.common.internal.helper.CheckoutCompositionLocalProvider
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationProvider
-import com.adyen.checkout.ui.internal.theme.InternalCheckoutTheme
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
 /**
@@ -33,14 +32,13 @@ fun CheckoutPaymentMethod(
     theme: CheckoutTheme = CheckoutTheme(),
     localizationProvider: CheckoutLocalizationProvider? = null,
 ) {
-    InternalCheckoutTheme(theme) {
-        CheckoutCompositionLocalProvider(
-            locale = controller.shopperLocale,
-            localizationProvider = localizationProvider,
-            environment = controller.environment,
-        ) {
-            CheckoutPaymentMethodInternal(controller, modifier)
-        }
+    CheckoutCompositionLocalProvider(
+        theme = theme,
+        locale = controller.shopperLocale,
+        localizationProvider = localizationProvider,
+        environment = controller.environment,
+    ) {
+        CheckoutPaymentMethodInternal(controller, modifier)
     }
 }
 

--- a/core/src/main/java/com/adyen/checkout/core/components/CheckoutSecondary.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/CheckoutSecondary.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.Modifier
 import com.adyen.checkout.core.common.internal.helper.CheckoutCompositionLocalProvider
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationProvider
 import com.adyen.checkout.core.components.internal.ui.SecondaryScreenComponent
-import com.adyen.checkout.ui.internal.theme.InternalCheckoutTheme
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
 /**
@@ -36,14 +35,13 @@ fun CheckoutSecondary(
     theme: CheckoutTheme = CheckoutTheme(),
     localizationProvider: CheckoutLocalizationProvider? = null,
 ) {
-    InternalCheckoutTheme(theme) {
-        CheckoutCompositionLocalProvider(
-            locale = controller.shopperLocale,
-            localizationProvider = localizationProvider,
-            environment = controller.environment,
-        ) {
-            CheckoutSecondaryInternal(identifier, controller, modifier)
-        }
+    CheckoutCompositionLocalProvider(
+        theme = theme,
+        locale = controller.shopperLocale,
+        localizationProvider = localizationProvider,
+        environment = controller.environment,
+    ) {
+        CheckoutSecondaryInternal(identifier, controller, modifier)
     }
 }
 

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/ConfirmationDialog.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/ConfirmationDialog.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.adyen.checkout.ui.internal.element.button.DestructiveButton
 import com.adyen.checkout.ui.internal.element.button.SecondaryButton
-import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
 import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.theme.Dimensions
 import com.adyen.checkout.ui.theme.CheckoutTheme
@@ -76,7 +76,7 @@ internal fun ConfirmationDialog(
 private fun ConfirmationDialogPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
-    CheckoutThemeWrapper(theme) {
+    CheckoutThemePreviewWrapper(theme) {
         ConfirmationDialog(
             confirmationText = "Confirm",
             onConfirmationClick = {},

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInActivity.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInActivity.kt
@@ -22,7 +22,7 @@ import com.adyen.checkout.core.common.internal.helper.CheckoutCompositionLocalPr
 import com.adyen.checkout.core.common.internal.helper.adyenLog
 import com.adyen.checkout.dropin.DropInResult
 import com.adyen.checkout.dropin.internal.DropInResultContract
-import com.adyen.checkout.ui.internal.theme.InternalCheckoutTheme
+import com.adyen.checkout.ui.theme.CheckoutTheme
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
@@ -54,15 +54,15 @@ class DropInActivity : ComponentActivity() {
             .launchIn(lifecycleScope)
 
         setContent {
-            InternalCheckoutTheme {
-                CheckoutCompositionLocalProvider(
-                    locale = viewModel.dropInParams.shopperLocale,
-                    // TODO - support custom localization for drop-in
-                    localizationProvider = null,
-                    environment = viewModel.dropInParams.environment,
-                ) {
-                    NavigationStack(viewModel)
-                }
+            CheckoutCompositionLocalProvider(
+                // TODO - support custom theme for drop-in
+                theme = CheckoutTheme(),
+                locale = viewModel.dropInParams.shopperLocale,
+                // TODO - support custom localization for drop-in
+                localizationProvider = null,
+                environment = viewModel.dropInParams.environment,
+            ) {
+                NavigationStack(viewModel)
             }
         }
     }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInScaffold.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInScaffold.kt
@@ -22,9 +22,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
 import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
-import com.adyen.checkout.ui.internal.theme.InternalCheckoutTheme
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -55,7 +55,7 @@ internal fun DropInScaffold(
 private fun DropInScaffoldPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
-    InternalCheckoutTheme(theme) {
+    CheckoutThemePreviewWrapper(theme) {
         DropInScaffold(
             navigationIcon = {
                 IconButton(

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInTopAppBar.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInTopAppBar.kt
@@ -20,10 +20,10 @@ import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
 import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.text.Title
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
-import com.adyen.checkout.ui.internal.theme.InternalCheckoutTheme
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class)
@@ -53,7 +53,7 @@ internal fun DropInTopAppBar(
 private fun DropInTopAppBarPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
-    InternalCheckoutTheme(theme) {
+    CheckoutThemePreviewWrapper(theme) {
         DropInTopAppBar(
             title = "Title",
             navigationIcon = {

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodListScreen.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodListScreen.kt
@@ -31,14 +31,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalLocale
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.adyen.checkout.core.common.Environment
-import com.adyen.checkout.core.common.internal.helper.CheckoutCompositionLocalProvider
 import com.adyen.checkout.core.common.internal.ui.CheckoutNetworkLogo
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
@@ -46,12 +44,15 @@ import com.adyen.checkout.dropin.R
 import com.adyen.checkout.dropin.internal.helper.SavedStateBackStackPersister
 import com.adyen.checkout.dropin.internal.ui.PaymentMethodListViewState.PaymentMethodItem
 import com.adyen.checkout.ui.internal.element.ListItem
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.text.Body
 import com.adyen.checkout.ui.internal.text.BodyEmphasized
 import com.adyen.checkout.ui.internal.text.SubHeadline
 import com.adyen.checkout.ui.internal.text.SubHeadlineEmphasized
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
 import com.adyen.checkout.ui.internal.theme.Dimensions
+import com.adyen.checkout.ui.theme.CheckoutTheme
 
 private const val AMOUNT_VISIBLE_BRANDS = 3
 
@@ -255,12 +256,10 @@ private fun PaymentMethodItemTrailingContent(item: PaymentMethodItem) {
 @Suppress("LongMethod")
 @Preview(showBackground = true)
 @Composable
-private fun PaymentMethodListContentPreview() {
-    CheckoutCompositionLocalProvider(
-        locale = LocalLocale.current.platformLocale,
-        localizationProvider = null,
-        environment = Environment.TEST,
-    ) {
+private fun PaymentMethodListContentPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
         val storedPaymentMethods = listOf(
             PaymentMethodItem(
                 id = "advantage",

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/StoredPaymentMethodsScreen.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/StoredPaymentMethodsScreen.kt
@@ -24,22 +24,23 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalLocale
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.adyen.checkout.core.common.Environment
-import com.adyen.checkout.core.common.internal.helper.CheckoutCompositionLocalProvider
 import com.adyen.checkout.core.common.internal.ui.CheckoutNetworkLogo
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.dropin.internal.helper.SavedStateBackStackPersister
 import com.adyen.checkout.dropin.internal.ui.StoredPaymentMethodsViewState.StoredPaymentMethodsListItem
 import com.adyen.checkout.ui.internal.element.ListItem
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.text.Body
 import com.adyen.checkout.ui.internal.text.SubHeadlineEmphasized
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
 import com.adyen.checkout.ui.internal.theme.Dimensions
+import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @Composable
 internal fun StoredPaymentMethodsScreen(
@@ -165,12 +166,10 @@ private fun StoredPaymentMethodListItem(
 
 @Preview(showBackground = true)
 @Composable
-private fun StoredPaymentMethodsContentPreview() {
-    CheckoutCompositionLocalProvider(
-        locale = LocalLocale.current.platformLocale,
-        localizationProvider = null,
-        environment = Environment.TEST,
-    ) {
+private fun StoredPaymentMethodsContentPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
         val viewState = StoredPaymentMethodsViewState(
             cards = listOf(
                 StoredPaymentMethodsListItem(

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/view/GooglePayButton.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/view/GooglePayButton.kt
@@ -19,7 +19,7 @@ import com.adyen.checkout.googlepay.GooglePayButtonStyling
 import com.adyen.checkout.googlepay.GooglePayButtonTheme
 import com.adyen.checkout.googlepay.GooglePayButtonType
 import com.adyen.checkout.googlepay.internal.ui.state.GooglePayButtonViewState
-import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
 import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.helper.isDark
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
@@ -58,7 +58,7 @@ private val DEFAULT_CORNER_RADIUS = 100.dp
 private fun GooglePayButtonPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
-    CheckoutThemeWrapper(theme) {
+    CheckoutThemePreviewWrapper(theme) {
         GooglePayButton(
             buttonViewState = GooglePayButtonViewState(
                 allowedPaymentMethods = "[]",

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MBWayPhoneNumberField.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MBWayPhoneNumberField.kt
@@ -20,9 +20,9 @@ import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.DigitOnlyInputTransformation
-import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
 import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
 import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @Composable
@@ -55,7 +55,7 @@ internal fun MBWayPhoneNumberField(
 @Preview
 @Composable
 private fun MBWayPhoneNumberFieldPreview(
-    @PreviewParameter(TextFieldStylePreviewParameterProvider::class) theme: CheckoutTheme,
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
     CheckoutThemePreviewWrapper(theme) {
         MBWayPhoneNumberField(

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MBWayPhoneNumberField.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MBWayPhoneNumberField.kt
@@ -22,7 +22,7 @@ import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.DigitOnlyInputTransformation
 import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
 import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
-import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @Composable
@@ -57,7 +57,7 @@ internal fun MBWayPhoneNumberField(
 private fun MBWayPhoneNumberFieldPreview(
     @PreviewParameter(TextFieldStylePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
-    CheckoutThemeWrapper(theme) {
+    CheckoutThemePreviewWrapper(theme) {
         MBWayPhoneNumberField(
             mbWayPhoneNumberFieldState = TextInputViewState(
                 text = "12345612",

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/ProgressBar.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/ProgressBar.kt
@@ -14,7 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
 import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
 import com.adyen.checkout.ui.theme.CheckoutTheme
@@ -38,7 +38,7 @@ fun ProgressBar(
 private fun ProgressBarPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
-    CheckoutThemeWrapper(theme) {
+    CheckoutThemePreviewWrapper(theme) {
         ProgressBar()
     }
 }

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/SearchField.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/SearchField.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.test.R
 import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
-import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
 import com.adyen.checkout.ui.internal.theme.Dimensions
 import com.adyen.checkout.ui.theme.CheckoutTheme
@@ -102,7 +102,7 @@ private fun TrailingSearchIcon(
 private fun SearchFieldPreview(
     @PreviewParameter(TextFieldStylePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
-    CheckoutThemeWrapper(theme) {
+    CheckoutThemePreviewWrapper(theme) {
         SearchField(
             hint = "Search..",
         )

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/SearchField.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/SearchField.kt
@@ -28,8 +28,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.test.R
 import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
-import com.adyen.checkout.ui.internal.element.input.TextFieldStylePreviewParameterProvider
 import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
 import com.adyen.checkout.ui.internal.theme.Dimensions
 import com.adyen.checkout.ui.theme.CheckoutTheme
@@ -100,7 +100,7 @@ private fun TrailingSearchIcon(
 @Preview
 @Composable
 private fun SearchFieldPreview(
-    @PreviewParameter(TextFieldStylePreviewParameterProvider::class) theme: CheckoutTheme,
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
     CheckoutThemePreviewWrapper(theme) {
         SearchField(

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/Stepper.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/Stepper.kt
@@ -29,7 +29,7 @@ import androidx.constraintlayout.compose.ConstraintLayoutBaseScope
 import androidx.constraintlayout.compose.ConstraintLayoutScope
 import androidx.constraintlayout.compose.Dimension
 import com.adyen.checkout.test.R
-import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
 import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.text.Body
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
@@ -145,7 +145,7 @@ private fun ConstraintLayoutScope.StepConnector(
 private fun StepperPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
-    CheckoutThemeWrapper(theme) {
+    CheckoutThemePreviewWrapper(theme) {
         val steps = listOf(
             "Step 1: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin et lectus in leo varius " +
                 "facilisis sit amet ut ipsum.",

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/Switch.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/Switch.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
-import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
 import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.text.Body
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
@@ -87,7 +87,7 @@ private fun Switch(
 private fun SwitchContainerPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
-    CheckoutThemeWrapper(theme) {
+    CheckoutThemePreviewWrapper(theme) {
         val description = "A very long and detailed description that covers multiple lines"
         SwitchContainer(
             checked = false,

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/button/Buttons.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/button/Buttons.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import com.adyen.checkout.test.R
-import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
 import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.text.BodyEmphasized
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
@@ -57,7 +57,7 @@ fun PrimaryButton(
 private fun PrimaryButtonPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
-    CheckoutThemeWrapper(theme) {
+    CheckoutThemePreviewWrapper(theme) {
         PrimaryButton(
             onClick = {},
             text = "Primary",
@@ -106,7 +106,7 @@ fun SecondaryButton(
 private fun SecondaryButtonPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
-    CheckoutThemeWrapper(theme) {
+    CheckoutThemePreviewWrapper(theme) {
         SecondaryButton(
             onClick = {},
             text = "Secondary",
@@ -155,7 +155,7 @@ fun TertiaryButton(
 private fun TertiaryButtonPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
-    CheckoutThemeWrapper(theme) {
+    CheckoutThemePreviewWrapper(theme) {
         TertiaryButton(
             onClick = {},
             text = "Tertiary",
@@ -204,7 +204,7 @@ fun DestructiveButton(
 private fun DestructiveButtonPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
-    CheckoutThemeWrapper(theme) {
+    CheckoutThemePreviewWrapper(theme) {
         DestructiveButton(
             onClick = {},
             text = "Destructive",

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/button/CheckoutButtonGroup.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/button/CheckoutButtonGroup.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
 import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.text.Body
 import com.adyen.checkout.ui.internal.text.BodyEmphasized
@@ -108,7 +108,7 @@ private fun CheckoutToggleButton(
 private fun CheckoutButtonGroupPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
-    CheckoutThemeWrapper(theme) {
+    CheckoutThemePreviewWrapper(theme) {
         CheckoutButtonGroup(
             items = listOf("Item 1", "Item 2", "Item 3"),
             onItemSelected = {},

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/input/CheckoutTextField.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/input/CheckoutTextField.kt
@@ -38,7 +38,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.sp
 import com.adyen.checkout.test.R
 import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
@@ -180,7 +179,7 @@ fun rememberTextFieldStateWithCurrentValue(currentText: String): TextFieldState 
 @Preview
 @Composable
 private fun CheckoutTextFieldPreview(
-    @PreviewParameter(TextFieldStylePreviewParameterProvider::class) theme: CheckoutTheme,
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
     CheckoutThemePreviewWrapper(theme) {
         CheckoutTextField(
@@ -229,21 +228,6 @@ private fun CheckoutTextFieldPreview(
             label = "Password",
             isSecureField = true,
             modifier = Modifier.focusRequester(focusRequester),
-        )
-    }
-}
-
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class TextFieldStylePreviewParameterProvider : PreviewParameterProvider<CheckoutTheme> {
-
-    private val themeProvider = ThemePreviewParameterProvider()
-
-    override val values = themeProvider.values + themeProvider.values.map { theme ->
-        theme.copy(
-            colors = theme.colors.copy(
-                container = theme.colors.background,
-                containerOutline = theme.colors.separator,
-            ),
         )
     }
 }

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/input/CheckoutTextField.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/input/CheckoutTextField.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.sp
 import com.adyen.checkout.test.R
-import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
 import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
 import com.adyen.checkout.ui.theme.CheckoutTheme
@@ -182,7 +182,7 @@ fun rememberTextFieldStateWithCurrentValue(currentText: String): TextFieldState 
 private fun CheckoutTextFieldPreview(
     @PreviewParameter(TextFieldStylePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
-    CheckoutThemeWrapper(theme) {
+    CheckoutThemePreviewWrapper(theme) {
         CheckoutTextField(
             onValueChange = {},
             label = "Label",

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/input/ValuePickerField.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/input/ValuePickerField.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.test.R
 import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.text.Body
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
 import com.adyen.checkout.ui.theme.CheckoutTheme
@@ -81,7 +82,7 @@ fun ValuePickerField(
 @Preview
 @Composable
 private fun ValuePickerFieldPreview(
-    @PreviewParameter(TextFieldStylePreviewParameterProvider::class) theme: CheckoutTheme,
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
     CheckoutThemePreviewWrapper(theme) {
         ValuePickerField(

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/input/ValuePickerField.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/input/ValuePickerField.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.test.R
-import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
 import com.adyen.checkout.ui.internal.text.Body
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
 import com.adyen.checkout.ui.theme.CheckoutTheme
@@ -83,7 +83,7 @@ fun ValuePickerField(
 private fun ValuePickerFieldPreview(
     @PreviewParameter(TextFieldStylePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
-    CheckoutThemeWrapper(theme) {
+    CheckoutThemePreviewWrapper(theme) {
         ValuePickerField(
             value = "Value",
             label = "Label",

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/helper/CheckoutThemePreviewWrapper.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/helper/CheckoutThemePreviewWrapper.kt
@@ -20,9 +20,13 @@ import com.adyen.checkout.ui.internal.theme.InternalCheckoutTheme
 import com.adyen.checkout.ui.internal.theme.toCompose
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
+/**
+ * A wrapper that provides a preview environment for a [CheckoutTheme].
+ * This should only be used in compose previews.
+ */
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-fun CheckoutThemeWrapper(
+fun CheckoutThemePreviewWrapper(
     theme: CheckoutTheme,
     content: @Composable () -> Unit
 ) {

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/helper/ThemePreviewParameterProvider.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/helper/ThemePreviewParameterProvider.kt
@@ -13,6 +13,10 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.adyen.checkout.ui.theme.CheckoutColors
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
+/**
+ * Preview parameter provider for [CheckoutTheme].
+ * Should be used in combination with [CheckoutThemePreviewWrapper] for all composables.
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class ThemePreviewParameterProvider : PreviewParameterProvider<CheckoutTheme> {
 

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/text/Text.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/text/Text.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.sp
-import com.adyen.checkout.ui.internal.helper.CheckoutThemeWrapper
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
 import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
 import com.adyen.checkout.ui.theme.CheckoutTheme
@@ -147,7 +147,7 @@ private fun CheckoutText(
 private fun TextPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
-    CheckoutThemeWrapper(theme) {
+    CheckoutThemePreviewWrapper(theme) {
         Title("Title")
         Subtitle("Subtitle")
         Body("Body")

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/theme/InternalCheckoutTheme.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/theme/InternalCheckoutTheme.kt
@@ -22,7 +22,7 @@ import com.adyen.checkout.ui.theme.CheckoutTheme
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Composable
 fun InternalCheckoutTheme(
-    theme: CheckoutTheme = CheckoutTheme(),
+    theme: CheckoutTheme,
     content: @Composable () -> Unit,
 ) {
     val colors = remember(theme.colors) { InternalColors.from(theme.colors) }


### PR DESCRIPTION
## Description
- Make `CheckoutCompositionLocalProvider` the single entry point for all public composables.
- Rename `CheckoutThemeWrapper` to `CheckoutThemePreviewWrapper` to bring more clarity.
- Remove `TextFieldStylePreviewParameterProvider` in favor of `ThemePreviewParameterProvider`.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually