### PR TITLE
v6 - Fix Sonatype POM validation: inline resolved versions and stop publishing test fixtures

### DIFF
--- a/build-logic/convention/src/main/kotlin/PublishConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/PublishConventionPlugin.kt
@@ -8,6 +8,7 @@
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.component.AdhocComponentWithVariants
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.publish.PublishingExtension
@@ -79,8 +80,24 @@ class PublishConventionPlugin : Plugin<Project> {
         extensions.configure<PublishingExtension> {
             publications {
                 create<MavenPublication>("release") {
+                    versionMapping {
+                        allVariants {
+                            fromResolutionOf("releaseRuntimeClasspath")
+                        }
+                    }
+
                     afterEvaluate {
-                        from(components.getByName("release"))
+                        val releaseComponent = components.getByName("release") as AdhocComponentWithVariants
+                        configurations
+                            .matching {
+                                it.name.startsWith("releaseTestFixturesVariant") &&
+                                    (it.name.endsWith("ApiPublication") || it.name.endsWith("RuntimePublication"))
+                            }
+                            .forEach { testFixturesConfiguration ->
+                                releaseComponent.withVariantsFromConfiguration(testFixturesConfiguration) { skip() }
+                            }
+
+                        from(releaseComponent)
 
                         groupId = checkoutGroupId
                         artifactId = extension.id.get()


### PR DESCRIPTION
## Description
Sonatype Central Portal component validation rejected 4 of our 110 modules during the `6.0.0-alpha` release with:

```
Dependency version information is missing for dependency: <dep>
```

- `cse` → `org.junit.platform:junit-platform-launcher`
- `components-core` → `org.junit.platform:junit-platform-launcher`
- `drop-in` → `androidx.compose.material:material-icons-core`
- `core` → `androidx.compose.ui:ui`, `ui-graphics`, `ui-tooling-preview`, `material-icons-core`, `junit-platform-launcher`

### Root cause
The generated POMs contained dependencies **without a `<version>`**. Gradle's default POM generation writes each dependency's *declared* version, which is empty for two kinds of deps, and Central requires every dependency to have a version:

1. **Compose BOM-managed deps** (`core`, `drop-in`): declared version-less on purpose (the Compose BOM supplies the version). Central does a static per-dependency version check and does **not** resolve the `compose-bom` `<dependencyManagement>` import (the BOM isn't on Maven Central anyway), so these fail.
2. **`junit-platform-launcher`** (`core`, `components-core`, `cse`): declared version-less in the version catalog and pulled in via `testFixturesImplementation libs.bundles.junit`. Because these modules enable `testFixtures` and we publish `from(components["release"])`, AGP folds the **test-fixtures variant into the release component**, leaking all its deps (junit/mockito) into the main POM — version-less for the launcher.

Only 4 modules failed because only those were (re)published in this batch (note the mixed alpha versions). The defect is latent across all BOM/test-fixtures modules and would resurface as others are bumped — so the fix lives in the shared publish convention plugin.

### Fix
Both changes in `build-logic/convention/src/main/kotlin/PublishConventionPlugin.kt`:

1. **Inline resolved versions** via `versionMapping { allVariants { fromResolutionOf("releaseRuntimeClasspath") } }` — writes concrete resolved versions into the POM/GMM (fixes the Compose-BOM deps). Note: `fromResolutionResult()` does **not** inline them here; `fromResolutionOf("releaseRuntimeClasspath")` does.
2. **Stop publishing test fixtures** — skip the test-fixtures `Api`/`Runtime` publication variants from the `release` component. Test fixtures stay enabled and are still consumed internally via `testImplementation testFixtures(project(...))`; only their *publication* is removed. This drops the junit/mockito leak (incl. version-less `junit-platform-launcher`) from the main POMs.

### Verification (local)
Generated POMs + Gradle Module Metadata for **all 55 published modules** and scanned programmatically:

- **All 55 POMs** → zero version-less dependencies.
- **All 55 `.module` files** → zero version-less deps, **no test-fixtures variants/artifacts**, all 4 main variants (`api`/`runtime`/`source`/`javaDoc`) intact.
- 4 failing modules confirmed fixed: compose deps inlined (`ui`=`1.11.2`, `material-icons-core`=`1.7.8`), junit/mockito gone.
- All 5 test-fixtures modules cleaned (incl. latent `action-core`, `ui-core`).
- Normal modules (`mbway`, `googlepay`) unaffected — no deps dropped.
- Release artifacts (aar/sources/javadoc) assemble correctly; the test-fixtures aar is still built for internal use but excluded from publication.

### Notes
- The `<dependencyManagement>` compose-bom import remains in the POM but is harmless: it carries a version, and the dependencies now have explicit versions, so Central's "missing version" check is satisfied.
