### PR TITLE
v6 - UI - Add ThemePreviewParameterProvider to remaining Compose previews

### DIFF
--- a/await/src/main/java/com/adyen/checkout/await/internal/ui/view/AwaitContent.kt
+++ b/await/src/main/java/com/adyen/checkout/await/internal/ui/view/AwaitContent.kt
@@ -16,11 +16,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.ui.internal.element.ProgressBar
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.text.Body
 import com.adyen.checkout.ui.internal.theme.Dimensions
+import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @Composable
 internal fun AwaitContent(
@@ -38,6 +42,10 @@ internal fun AwaitContent(
 
 @Preview(showBackground = true)
 @Composable
-private fun AwaitContentPreview() {
-    AwaitContent()
+private fun AwaitContentPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        AwaitContent()
+    }
 }

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/BlikContent.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/BlikContent.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.adyen.checkout.blik.internal.ui.state.BlikIntent
 import com.adyen.checkout.blik.internal.ui.state.BlikViewState
@@ -22,8 +23,11 @@ import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.PayButton
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 import com.adyen.checkout.ui.internal.element.ComponentScaffold
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.text.Body
 import com.adyen.checkout.ui.internal.theme.Dimensions
+import com.adyen.checkout.ui.theme.CheckoutTheme
 import kotlinx.coroutines.flow.StateFlow
 
 @Composable
@@ -75,15 +79,19 @@ private fun BlikContent(
 
 @Preview(showBackground = true)
 @Composable
-private fun BlikContentPreview() {
-    BlikContent(
-        viewState = BlikViewState(
-            blikCode = TextInputViewState(),
-            isLoading = false,
-            amount = null,
-        ),
-        onIntent = {},
-        onSubmitClick = {},
-        modifier = Modifier,
-    )
+private fun BlikContentPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        BlikContent(
+            viewState = BlikViewState(
+                blikCode = TextInputViewState(),
+                isLoading = false,
+                amount = null,
+            ),
+            onIntent = {},
+            onSubmitClick = {},
+            modifier = Modifier,
+        )
+    }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardContent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardContent.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.adyen.checkout.card.internal.ui.model.InstallmentModel
 import com.adyen.checkout.card.internal.ui.model.toDisplayText
@@ -43,9 +44,12 @@ import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewS
 import com.adyen.checkout.ui.internal.element.ComponentScaffold
 import com.adyen.checkout.ui.internal.element.SwitchContainer
 import com.adyen.checkout.ui.internal.element.input.ValuePickerField
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.text.Body
 import com.adyen.checkout.ui.internal.text.Subtitle
 import com.adyen.checkout.ui.internal.theme.Dimensions
+import com.adyen.checkout.ui.theme.CheckoutTheme
 import kotlinx.coroutines.flow.StateFlow
 
 @Composable
@@ -209,52 +213,99 @@ private fun CardDetailsSection(
 
 @Preview(showBackground = true)
 @Composable
-private fun CardContentPreview() {
-    CardContent(
-        viewState = CardViewState(
-            cardNumber = TextInputViewState(
-                text = "5555444433331111",
-            ),
-            expiryDate = TextInputViewState(
-                text = "1234",
-            ),
-            securityCode = TextInputViewState(
-                text = "737",
-            ),
-            holderName = TextInputViewState(
-                text = "J. Smith",
-            ),
-            socialSecurityNumber = TextInputViewState(
-                text = "12123123123412",
-            ),
-            kcpBirthDateOrTaxNumber = TextInputViewState(
-                text = "1234567890",
-            ),
-            kcpCardPassword = TextInputViewState(
-                text = "12",
-            ),
-            postalCode = TextInputViewState(
-                text = "1234 AB",
-            ),
-            storePaymentViewState = StorePaymentViewState(isSelected = true),
+private fun CardContentPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        CardContent(
+            viewState = CardViewState(
+                cardNumber = TextInputViewState(
+                    text = "5555444433331111",
+                ),
+                expiryDate = TextInputViewState(
+                    text = "1234",
+                ),
+                securityCode = TextInputViewState(
+                    text = "737",
+                ),
+                holderName = null,
+                socialSecurityNumber = null,
+                kcpBirthDateOrTaxNumber = null,
+                kcpCardPassword = null,
+                postalCode = null,
+                storePaymentViewState = StorePaymentViewState(isSelected = true),
 
-            supportedCardBrandsViewState = SupportedCardBrandsViewState(
-                supportedCardBrands = emptyList(),
-                isVisible = false,
+                supportedCardBrandsViewState = SupportedCardBrandsViewState(
+                    supportedCardBrands = emptyList(),
+                    isVisible = false,
+                ),
+                isLoading = false,
+                isCardScanButtonVisible = false,
+                cardBrandViewState = CardBrandViewState.SingleBrand(CardBrand(CardType.MASTERCARD.txVariant)),
+                cardNumberFormat = CardNumberFormat.DEFAULT,
+                installmentViewState = null,
+                amount = null,
             ),
-            isLoading = false,
-            isCardScanButtonVisible = false,
-            cardBrandViewState = CardBrandViewState.SingleBrand(CardBrand(CardType.MASTERCARD.txVariant)),
-            cardNumberFormat = CardNumberFormat.DEFAULT,
-            installmentViewState = InstallmentViewState(
-                installmentOptions = listOf(InstallmentModel.OneTime),
-                selectedInstallment = InstallmentModel.OneTime,
+            onIntent = {},
+            onSubmitClick = {},
+            onScanButtonClick = {},
+            onInstallmentPickerClick = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, heightDp = 1100)
+@Composable
+private fun CardContentPreviewAllFields(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        CardContent(
+            viewState = CardViewState(
+                cardNumber = TextInputViewState(
+                    text = "5555444433331111",
+                ),
+                expiryDate = TextInputViewState(
+                    text = "1234",
+                ),
+                securityCode = TextInputViewState(
+                    text = "737",
+                ),
+                holderName = TextInputViewState(
+                    text = "J. Smith",
+                ),
+                socialSecurityNumber = TextInputViewState(
+                    text = "12123123123412",
+                ),
+                kcpBirthDateOrTaxNumber = TextInputViewState(
+                    text = "1234567890",
+                ),
+                kcpCardPassword = TextInputViewState(
+                    text = "12",
+                ),
+                postalCode = TextInputViewState(
+                    text = "1234 AB",
+                ),
+                storePaymentViewState = StorePaymentViewState(isSelected = true),
+
+                supportedCardBrandsViewState = SupportedCardBrandsViewState(
+                    supportedCardBrands = emptyList(),
+                    isVisible = false,
+                ),
+                isLoading = false,
+                isCardScanButtonVisible = false,
+                cardBrandViewState = CardBrandViewState.SingleBrand(CardBrand(CardType.MASTERCARD.txVariant)),
+                cardNumberFormat = CardNumberFormat.DEFAULT,
+                installmentViewState = InstallmentViewState(
+                    installmentOptions = listOf(InstallmentModel.OneTime),
+                    selectedInstallment = InstallmentModel.OneTime,
+                ),
+                amount = null,
             ),
-            amount = null,
-        ),
-        onIntent = {},
-        onSubmitClick = {},
-        onScanButtonClick = {},
-        onInstallmentPickerClick = {},
-    )
+            onIntent = {},
+            onSubmitClick = {},
+            onScanButtonClick = {},
+            onInstallmentPickerClick = {},
+        )
+    }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/InstallmentPicker.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/InstallmentPicker.kt
@@ -16,14 +16,18 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.card.internal.ui.model.InstallmentModel
 import com.adyen.checkout.card.internal.ui.model.toDisplayText
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.data.model.Amount
 import com.adyen.checkout.ui.internal.element.SelectableListItem
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.text.Body
 import com.adyen.checkout.ui.internal.theme.Dimensions
+import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @Composable
 internal fun InstallmentPicker(
@@ -53,24 +57,28 @@ internal fun InstallmentPicker(
 @Suppress("MagicNumber")
 @Preview(showBackground = true)
 @Composable
-private fun InstallmentPickerPreview() {
-    val options = listOf(
-        InstallmentModel.OneTime,
-        InstallmentModel.Revolving,
-        InstallmentModel.Regular(
-            numberOfInstallments = 2,
-            amountPerInstallment = null,
-            showAmount = false,
-        ),
-        InstallmentModel.Regular(
-            numberOfInstallments = 3,
-            amountPerInstallment = Amount("EUR", 100),
-            showAmount = true,
-        ),
-    )
-    InstallmentPicker(
-        installmentOptions = options,
-        selectedInstallment = options.first(),
-        onItemClick = {},
-    )
+private fun InstallmentPickerPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        val options = listOf(
+            InstallmentModel.OneTime,
+            InstallmentModel.Revolving,
+            InstallmentModel.Regular(
+                numberOfInstallments = 2,
+                amountPerInstallment = null,
+                showAmount = false,
+            ),
+            InstallmentModel.Regular(
+                numberOfInstallments = 3,
+                amountPerInstallment = Amount("EUR", 100),
+                showAmount = true,
+            ),
+        )
+        InstallmentPicker(
+            installmentOptions = options,
+            selectedInstallment = options.first(),
+            onItemClick = {},
+        )
+    }
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PreselectedPaymentMethodScreen.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PreselectedPaymentMethodScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.adyen.checkout.core.common.internal.ui.CheckoutNetworkLogo
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
@@ -31,10 +32,13 @@ import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.dropin.R
 import com.adyen.checkout.ui.internal.element.button.PrimaryButton
 import com.adyen.checkout.ui.internal.element.button.SecondaryButton
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.text.Body
 import com.adyen.checkout.ui.internal.text.Title
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
 import com.adyen.checkout.ui.internal.theme.Dimensions
+import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @Composable
 internal fun PreselectedPaymentMethodScreen(
@@ -124,17 +128,21 @@ private fun PreselectedPaymentMethodContent(
 
 @Preview(showBackground = true)
 @Composable
-private fun PreselectedPaymentMethodScreenPreview() {
-    val viewState = PreselectedPaymentMethodViewState(
-        logoTxVariant = "visa",
-        title = "•••• 1234",
-        subtitle = "Use Visa to pay $9.99",
-        payButtonText = "Pay $9.99",
-    )
-    PreselectedPaymentMethodContent(
-        viewState = viewState,
-        onBackClicked = {},
-        onPayClicked = {},
-        onOtherPaymentMethodClicked = {},
-    )
+private fun PreselectedPaymentMethodScreenPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        val viewState = PreselectedPaymentMethodViewState(
+            logoTxVariant = "visa",
+            title = "•••• 1234",
+            subtitle = "Use Visa to pay $9.99",
+            payButtonText = "Pay $9.99",
+        )
+        PreselectedPaymentMethodContent(
+            viewState = viewState,
+            onBackClicked = {},
+            onPayClicked = {},
+            onOtherPaymentMethodClicked = {},
+        )
+    }
 }

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/CountryCodePicker.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/CountryCodePicker.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.model.CountryModel
@@ -19,6 +20,9 @@ import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewS
 import com.adyen.checkout.mbway.internal.ui.state.MBWayViewState
 import com.adyen.checkout.ui.internal.element.SearchableValuePicker
 import com.adyen.checkout.ui.internal.element.ValuePickerItem
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
+import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @Composable
 internal fun CountryCodePicker(
@@ -49,19 +53,23 @@ internal fun CountryCodePicker(
 
 @Preview(showBackground = true)
 @Composable
-private fun CountryCodePickerPreview() {
-    val countries = listOf(
-        CountryModel(isoCode = "PT", countryName = "Portugal", callingCode = "+351"),
-        CountryModel(isoCode = "ES", countryName = "Spain", callingCode = "+34"),
-    )
-    CountryCodePicker(
-        viewState = MBWayViewState(
-            countries = countries,
-            isLoading = false,
-            selectedCountryCode = countries.first(),
-            phoneNumber = TextInputViewState(),
-            amount = null,
-        ),
-        onItemClick = {},
-    )
+private fun CountryCodePickerPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        val countries = listOf(
+            CountryModel(isoCode = "PT", countryName = "Portugal", callingCode = "+351"),
+            CountryModel(isoCode = "ES", countryName = "Spain", callingCode = "+34"),
+        )
+        CountryCodePicker(
+            viewState = MBWayViewState(
+                countries = countries,
+                isLoading = false,
+                selectedCountryCode = countries.first(),
+                phoneNumber = TextInputViewState(),
+                amount = null,
+            ),
+            onItemClick = {},
+        )
+    }
 }

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MBWayContent.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MBWayContent.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
@@ -25,7 +26,10 @@ import com.adyen.checkout.mbway.internal.ui.state.MBWayIntent
 import com.adyen.checkout.mbway.internal.ui.state.MBWayViewState
 import com.adyen.checkout.ui.internal.element.ComponentScaffold
 import com.adyen.checkout.ui.internal.element.input.ValuePickerField
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.theme.Dimensions
+import com.adyen.checkout.ui.theme.CheckoutTheme
 import kotlinx.coroutines.flow.StateFlow
 
 @Composable
@@ -90,21 +94,25 @@ private fun MBWayContent(
 
 @Preview(showBackground = true)
 @Composable
-private fun MBWayContentPreview() {
-    val countries = listOf(
-        CountryModel(isoCode = "PT", countryName = "Portugal", callingCode = "+351"),
-        CountryModel(isoCode = "ES", countryName = "Spain", callingCode = "+34"),
-    )
-    MBWayContent(
-        viewState = MBWayViewState(
-            countries = countries,
-            isLoading = false,
-            selectedCountryCode = countries.first(),
-            phoneNumber = TextInputViewState(),
-            amount = null,
-        ),
-        onIntent = {},
-        onSubmitClick = {},
-        onCountryCodePickerClick = {},
-    )
+private fun MBWayContentPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        val countries = listOf(
+            CountryModel(isoCode = "PT", countryName = "Portugal", callingCode = "+351"),
+            CountryModel(isoCode = "ES", countryName = "Spain", callingCode = "+34"),
+        )
+        MBWayContent(
+            viewState = MBWayViewState(
+                countries = countries,
+                isLoading = false,
+                selectedCountryCode = countries.first(),
+                phoneNumber = TextInputViewState(),
+                amount = null,
+            ),
+            onIntent = {},
+            onSubmitClick = {},
+            onCountryCodePickerClick = {},
+        )
+    }
 }

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/ListItem.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/ListItem.kt
@@ -27,13 +27,17 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import com.adyen.checkout.test.R
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.text.Body
 import com.adyen.checkout.ui.internal.text.BodyEmphasized
 import com.adyen.checkout.ui.internal.text.SubHeadline
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
 import com.adyen.checkout.ui.internal.theme.Dimensions
+import com.adyen.checkout.ui.theme.CheckoutTheme
 
 /**
  * A list item component that displays a title, an optional subtitle, an optional leading icon and optional trailing
@@ -95,120 +99,152 @@ fun ListItem(
 
 @Preview(showBackground = true)
 @Composable
-private fun ListItemPreview() {
-    ListItem(title = "Title", onClick = {}, subtitle = "Subtitle")
+private fun ListItemPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        ListItem(title = "Title", onClick = {}, subtitle = "Subtitle")
+    }
 }
 
 @Preview(showBackground = true)
 @Composable
-private fun ListItemNoSubtitlePreview() {
-    ListItem(title = "Title", onClick = {})
+private fun ListItemNoSubtitlePreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        ListItem(title = "Title", onClick = {})
+    }
 }
 
 @Preview(showBackground = true)
 @Composable
-private fun ListItemWithLeadingIconNoSubtitlePreview() {
-    ListItem(
-        title = "Title",
-        onClick = {},
-        leadingIcon = {
-            Icon(
-                imageVector = ImageVector.vectorResource(
-                    R.drawable.ic_placeholder_image,
-                ),
-                contentDescription = null,
-                tint = CheckoutThemeProvider.colors.text,
-            )
-        },
-    )
+private fun ListItemWithLeadingIconNoSubtitlePreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        ListItem(
+            title = "Title",
+            onClick = {},
+            leadingIcon = {
+                Icon(
+                    imageVector = ImageVector.vectorResource(
+                        R.drawable.ic_placeholder_image,
+                    ),
+                    contentDescription = null,
+                    tint = CheckoutThemeProvider.colors.text,
+                )
+            },
+        )
+    }
 }
 
 @Preview(showBackground = true)
 @Composable
-private fun ListItemWithLeadingIconPreview() {
-    ListItem(
-        title = "Title",
-        onClick = {},
-        subtitle = "Subtitle",
-        leadingIcon = {
-            Icon(
-                imageVector = ImageVector.vectorResource(
-                    R.drawable.ic_placeholder_image,
-                ),
-                contentDescription = null,
-                tint = CheckoutThemeProvider.colors.text,
-            )
-        },
-    )
+private fun ListItemWithLeadingIconPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        ListItem(
+            title = "Title",
+            onClick = {},
+            subtitle = "Subtitle",
+            leadingIcon = {
+                Icon(
+                    imageVector = ImageVector.vectorResource(
+                        R.drawable.ic_placeholder_image,
+                    ),
+                    contentDescription = null,
+                    tint = CheckoutThemeProvider.colors.text,
+                )
+            },
+        )
+    }
 }
 
 @Preview(showBackground = true)
 @Composable
-private fun ListItemWithTrailingIconPreview() {
-    ListItem(
-        title = "Title",
-        onClick = {},
-        subtitle = "Subtitle",
-        trailingContent = {
-            Icon(
-                imageVector = ImageVector.vectorResource(
-                    R.drawable.ic_placeholder_image,
-                ),
-                contentDescription = null,
-                tint = CheckoutThemeProvider.colors.text,
-            )
-        },
-    )
+private fun ListItemWithTrailingIconPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        ListItem(
+            title = "Title",
+            onClick = {},
+            subtitle = "Subtitle",
+            trailingContent = {
+                Icon(
+                    imageVector = ImageVector.vectorResource(
+                        R.drawable.ic_placeholder_image,
+                    ),
+                    contentDescription = null,
+                    tint = CheckoutThemeProvider.colors.text,
+                )
+            },
+        )
+    }
 }
 
 @Preview(showBackground = true)
 @Composable
-private fun ListItemWithTrailingActionPreview() {
-    ListItem(
-        title = "Title",
-        onClick = {},
-        subtitle = "Subtitle",
-        trailingContent = {
-            Body("Action")
-        },
-    )
+private fun ListItemWithTrailingActionPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        ListItem(
+            title = "Title",
+            onClick = {},
+            subtitle = "Subtitle",
+            trailingContent = {
+                Body("Action")
+            },
+        )
+    }
 }
 
 @Preview(showBackground = true)
 @Composable
-private fun ListItemWithIconsPreview() {
-    ListItem(
-        title = "Title",
-        onClick = {},
-        subtitle = "Subtitle",
-        leadingIcon = {
-            Icon(
-                imageVector = ImageVector.vectorResource(
-                    R.drawable.ic_placeholder_image,
-                ),
-                contentDescription = null,
-                tint = CheckoutThemeProvider.colors.text,
-            )
-        },
-        trailingContent = {
-            Icon(
-                imageVector = ImageVector.vectorResource(
-                    R.drawable.ic_placeholder_image,
-                ),
-                contentDescription = null,
-                tint = CheckoutThemeProvider.colors.text,
-            )
-        },
-    )
+private fun ListItemWithIconsPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        ListItem(
+            title = "Title",
+            onClick = {},
+            subtitle = "Subtitle",
+            leadingIcon = {
+                Icon(
+                    imageVector = ImageVector.vectorResource(
+                        R.drawable.ic_placeholder_image,
+                    ),
+                    contentDescription = null,
+                    tint = CheckoutThemeProvider.colors.text,
+                )
+            },
+            trailingContent = {
+                Icon(
+                    imageVector = ImageVector.vectorResource(
+                        R.drawable.ic_placeholder_image,
+                    ),
+                    contentDescription = null,
+                    tint = CheckoutThemeProvider.colors.text,
+                )
+            },
+        )
+    }
 }
 
 @Suppress("MagicNumber")
 @Preview(showBackground = true)
 @Composable
-private fun ListItemListPreview() {
-    Column {
-        repeat(5) {
-            ListItem(title = "Title", onClick = {}, subtitle = "Subtitle")
+private fun ListItemListPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        Column {
+            repeat(5) {
+                ListItem(title = "Title", onClick = {}, subtitle = "Subtitle")
+            }
         }
     }
 }

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/SearchableValuePicker.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/SearchableValuePicker.kt
@@ -20,7 +20,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.theme.Dimensions
+import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Composable
@@ -55,14 +59,18 @@ fun SearchableValuePicker(
 @Suppress("MagicNumber")
 @Preview(showBackground = true)
 @Composable
-private fun SearchableValuePickerPreview() {
-    val items = List(5) {
-        ValuePickerItem(id = "$it", title = "$it - Title", subtitle = "Subtitle", isSelected = it == 0)
-    }
+private fun SearchableValuePickerPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        val items = List(5) {
+            ValuePickerItem(id = "$it", title = "$it - Title", subtitle = "Subtitle", isSelected = it == 0)
+        }
 
-    SearchableValuePicker(
-        searchHint = "Search..",
-        items = items,
-        onItemClick = {},
-    )
+        SearchableValuePicker(
+            searchHint = "Search..",
+            items = items,
+            onItemClick = {},
+        )
+    }
 }

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/SelectableListItem.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/SelectableListItem.kt
@@ -20,9 +20,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import com.adyen.checkout.test.R
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
+import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Composable
@@ -62,80 +66,108 @@ fun SelectableListItem(
 
 @Preview(showBackground = true)
 @Composable
-private fun SelectableListItemNoSubtitlePreview() {
-    SelectableListItem(title = "Title", onClick = {}, isSelected = true)
+private fun SelectableListItemNoSubtitlePreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        SelectableListItem(title = "Title", onClick = {}, isSelected = true)
+    }
 }
 
 @Preview(showBackground = true)
 @Composable
-private fun SelectableListItemWithLeadingIconNoSubtitlePreview() {
-    SelectableListItem(
-        title = "Title",
-        onClick = {},
-        isSelected = true,
-        leadingIcon = {
-            Icon(
-                imageVector = ImageVector.vectorResource(
-                    R.drawable.ic_placeholder_image,
-                ),
-                contentDescription = null,
-                tint = CheckoutThemeProvider.colors.text,
-            )
-        },
-    )
+private fun SelectableListItemWithLeadingIconNoSubtitlePreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        SelectableListItem(
+            title = "Title",
+            onClick = {},
+            isSelected = true,
+            leadingIcon = {
+                Icon(
+                    imageVector = ImageVector.vectorResource(
+                        R.drawable.ic_placeholder_image,
+                    ),
+                    contentDescription = null,
+                    tint = CheckoutThemeProvider.colors.text,
+                )
+            },
+        )
+    }
 }
 
 @Preview(showBackground = true)
 @Composable
-private fun SelectableListItemUnselectedPreview() {
-    SelectableListItem(title = "Title", onClick = {}, subtitle = "Subtitle", isSelected = false)
+private fun SelectableListItemUnselectedPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        SelectableListItem(title = "Title", onClick = {}, subtitle = "Subtitle", isSelected = false)
+    }
 }
 
 @Preview(showBackground = true)
 @Composable
-private fun SelectableListItemPreview() {
-    SelectableListItem(title = "Title", onClick = {}, subtitle = "Subtitle", isSelected = true)
+private fun SelectableListItemPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        SelectableListItem(title = "Title", onClick = {}, subtitle = "Subtitle", isSelected = true)
+    }
 }
 
 @Preview(showBackground = true)
 @Composable
-private fun SelectableListItemWithLeadingIconPreview() {
-    SelectableListItem(
-        title = "Title",
-        onClick = {},
-        subtitle = "Subtitle",
-        isSelected = true,
-        leadingIcon = {
-            Icon(
-                imageVector = ImageVector.vectorResource(
-                    R.drawable.ic_placeholder_image,
-                ),
-                contentDescription = null,
-                tint = CheckoutThemeProvider.colors.text,
-            )
-        },
-    )
+private fun SelectableListItemWithLeadingIconPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        SelectableListItem(
+            title = "Title",
+            onClick = {},
+            subtitle = "Subtitle",
+            isSelected = true,
+            leadingIcon = {
+                Icon(
+                    imageVector = ImageVector.vectorResource(
+                        R.drawable.ic_placeholder_image,
+                    ),
+                    contentDescription = null,
+                    tint = CheckoutThemeProvider.colors.text,
+                )
+            },
+        )
+    }
 }
 
 @Preview(showBackground = true)
 @Composable
-private fun SelectableListItemLongTitlePreview() {
-    SelectableListItem(
-        title = "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the " +
-            "industry's standard dummy text ever since the 1500s.",
-        onClick = {},
-        subtitle = "Subtitle",
-        isSelected = true,
-    )
+private fun SelectableListItemLongTitlePreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        SelectableListItem(
+            title = "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been " +
+                "the industry's standard dummy text ever since the 1500s.",
+            onClick = {},
+            subtitle = "Subtitle",
+            isSelected = true,
+        )
+    }
 }
 
 @Suppress("MagicNumber")
 @Preview(showBackground = true)
 @Composable
-private fun SelectableListItemListPreview() {
-    Column {
-        repeat(5) {
-            SelectableListItem(title = "Title", onClick = {}, subtitle = "Subtitle", isSelected = it == 1)
+private fun SelectableListItemListPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        Column {
+            repeat(5) {
+                SelectableListItem(title = "Title", onClick = {}, subtitle = "Subtitle", isSelected = it == 1)
+            }
         }
     }
 }

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/Switch.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/Switch.kt
@@ -88,19 +88,18 @@ private fun SwitchContainerPreview(
     @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
 ) {
     CheckoutThemePreviewWrapper(theme) {
-        val description = "A very long and detailed description that covers multiple lines"
         SwitchContainer(
             checked = false,
             onCheckedChange = null,
         ) {
-            Body(description)
+            Body("A short description")
         }
 
         SwitchContainer(
             checked = true,
             onCheckedChange = null,
         ) {
-            Body(description)
+            Body("A very long and detailed description that covers multiple lines")
         }
     }
 }

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/ValuePicker.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/ValuePicker.kt
@@ -17,7 +17,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.theme.Dimensions
+import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @Composable
 internal fun ValuePicker(
@@ -55,13 +59,17 @@ data class ValuePickerItem(
 @Suppress("MagicNumber")
 @Preview(showBackground = true)
 @Composable
-private fun ValuePickerPreview() {
-    val items = List(5) {
-        ValuePickerItem(id = "$it", title = "Title", subtitle = "Subtitle", isSelected = it == 0)
-    }
+private fun ValuePickerPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        val items = List(5) {
+            ValuePickerItem(id = "$it", title = "Title", subtitle = "Subtitle", isSelected = it == 0)
+        }
 
-    ValuePicker(
-        items = items,
-        onItemClick = {},
-    )
+        ValuePicker(
+            items = items,
+            onItemClick = {},
+        )
+    }
 }


### PR DESCRIPTION
## Description
Updates all non-example-app Compose `@Preview` functions that were missing theme coverage to use `ThemePreviewParameterProvider` and `CheckoutThemePreviewWrapper`, matching the existing pattern (e.g. `BlikCodeFieldPreview`). This gives light/dark theme coverage to previews in `ui`, `drop-in`, `await`, `mbway`, `blik`, and `card` modules.

Also splits `CardContentPreview` into a compact preview and a taller `CardContentPreviewAllFields` preview (`heightDp = 1100`) so all fields, including the installments picker and pay button, are visible without needing interactive scrolling in the preview panel.

Example app previews were intentionally left unchanged.

## Checklist
- [x] Changes are tested manually