### PR TITLE
v6 - Components - Hide submit button when configured

### DIFF
--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/BlikFactory.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/BlikFactory.kt
@@ -40,7 +40,7 @@ internal class BlikFactory :
             componentStateFactory = BlikComponentStateFactory(),
             componentStateReducer = BlikComponentStateReducer(),
             componentStateValidator = BlikComponentStateValidator(),
-            viewStateProducer = BlikViewStateProducer(params.amount),
+            viewStateProducer = BlikViewStateProducer(params.amount, params.showSubmitButton),
             coroutineScope = coroutineScope,
         )
     }

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/state/BlikViewState.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/state/BlikViewState.kt
@@ -8,12 +8,12 @@
 
 package com.adyen.checkout.blik.internal.ui.state
 
-import com.adyen.checkout.core.components.data.model.Amount
 import com.adyen.checkout.core.components.internal.ui.state.ViewState
+import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 
 internal data class BlikViewState(
     val blikCode: TextInputViewState?,
     val isLoading: Boolean,
-    val amount: Amount?,
+    val payButtonViewState: PayButtonViewState,
 ) : ViewState

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/state/BlikViewState.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/state/BlikViewState.kt
@@ -15,5 +15,5 @@ import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewS
 internal data class BlikViewState(
     val blikCode: TextInputViewState?,
     val isLoading: Boolean,
-    val payButtonViewState: PayButtonViewState,
+    val payButtonViewState: PayButtonViewState?,
 ) : ViewState

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/state/BlikViewStateProducer.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/state/BlikViewStateProducer.kt
@@ -15,13 +15,14 @@ import com.adyen.checkout.core.components.internal.ui.state.model.toViewState
 
 internal class BlikViewStateProducer(
     private val amount: Amount?,
+    private val showSubmitButton: Boolean,
 ) : ViewStateProducer<BlikComponentState, BlikViewState> {
 
     override fun produce(state: BlikComponentState): BlikViewState {
         return BlikViewState(
             blikCode = state.blikCode.toViewState(),
             isLoading = state.isLoading,
-            payButtonViewState = PayButtonViewState(amount, state.isLoading),
+            payButtonViewState = if (showSubmitButton) PayButtonViewState(amount, state.isLoading) else null,
         )
     }
 }

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/state/BlikViewStateProducer.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/state/BlikViewStateProducer.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.blik.internal.ui.state
 
 import com.adyen.checkout.core.components.data.model.Amount
 import com.adyen.checkout.core.components.internal.ui.state.ViewStateProducer
+import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
 import com.adyen.checkout.core.components.internal.ui.state.model.toViewState
 
 internal class BlikViewStateProducer(
@@ -20,7 +21,7 @@ internal class BlikViewStateProducer(
         return BlikViewState(
             blikCode = state.blikCode.toViewState(),
             isLoading = state.isLoading,
-            amount = amount,
+            payButtonViewState = PayButtonViewState(amount, state.isLoading),
         )
     }
 }

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/BlikContent.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/BlikContent.kt
@@ -21,6 +21,7 @@ import com.adyen.checkout.blik.internal.ui.state.BlikViewState
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.PayButton
+import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 import com.adyen.checkout.ui.internal.element.ComponentScaffold
 import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
@@ -57,7 +58,7 @@ private fun BlikContent(
         modifier = modifier,
         disableInteraction = viewState.isLoading,
         footer = {
-            PayButton(amount = viewState.amount, onClick = onSubmitClick, isLoading = viewState.isLoading)
+            PayButton(payButtonViewState = viewState.payButtonViewState, onClick = onSubmitClick)
         },
     ) {
         Column(
@@ -87,7 +88,7 @@ private fun BlikContentPreview(
             viewState = BlikViewState(
                 blikCode = TextInputViewState(),
                 isLoading = false,
-                amount = null,
+                payButtonViewState = PayButtonViewState(null, false),
             ),
             onIntent = {},
             onSubmitClick = {},

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/BlikContent.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/BlikContent.kt
@@ -20,7 +20,7 @@ import com.adyen.checkout.blik.internal.ui.state.BlikIntent
 import com.adyen.checkout.blik.internal.ui.state.BlikViewState
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
-import com.adyen.checkout.core.components.internal.ui.PayButton
+import com.adyen.checkout.core.components.internal.ui.payButtonAsComponentScaffoldFooter
 import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 import com.adyen.checkout.ui.internal.element.ComponentScaffold
@@ -57,9 +57,7 @@ private fun BlikContent(
     ComponentScaffold(
         modifier = modifier,
         disableInteraction = viewState.isLoading,
-        footer = {
-            PayButton(payButtonViewState = viewState.payButtonViewState, onClick = onSubmitClick)
-        },
+        footer = payButtonAsComponentScaffoldFooter(viewState.payButtonViewState, onSubmitClick),
     ) {
         Column(
             verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.Large),

--- a/blik/src/test/java/com/adyen/checkout/blik/internal/ui/BlikComponentTest.kt
+++ b/blik/src/test/java/com/adyen/checkout/blik/internal/ui/BlikComponentTest.kt
@@ -117,7 +117,7 @@ internal class BlikComponentTest(
             componentStateValidator = componentStateValidator,
             componentStateFactory = BlikComponentStateFactory(),
             componentStateReducer = BlikComponentStateReducer(),
-            viewStateProducer = BlikViewStateProducer(null),
+            viewStateProducer = BlikViewStateProducer(amount = null, showSubmitButton = true),
             coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
         )
     }

--- a/blik/src/test/java/com/adyen/checkout/blik/internal/ui/state/BlikViewStateProducerTest.kt
+++ b/blik/src/test/java/com/adyen/checkout/blik/internal/ui/state/BlikViewStateProducerTest.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.blik.internal.ui.state
 
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.components.data.model.Amount
+import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -47,7 +48,7 @@ internal class BlikViewStateProducerTest {
                 isError = true,
             ),
             isLoading = true,
-            amount = TEST_AMOUNT,
+            payButtonViewState = PayButtonViewState(TEST_AMOUNT, true),
         )
 
         assertEquals(expected, actual)

--- a/blik/src/test/java/com/adyen/checkout/blik/internal/ui/state/BlikViewStateProducerTest.kt
+++ b/blik/src/test/java/com/adyen/checkout/blik/internal/ui/state/BlikViewStateProducerTest.kt
@@ -14,6 +14,7 @@ import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewS
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -23,7 +24,7 @@ internal class BlikViewStateProducerTest {
 
     @BeforeEach
     fun beforeEach() {
-        producer = BlikViewStateProducer(amount = TEST_AMOUNT)
+        producer = BlikViewStateProducer(amount = TEST_AMOUNT, showSubmitButton = true)
     }
 
     @Test
@@ -52,6 +53,15 @@ internal class BlikViewStateProducerTest {
         )
 
         assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `when show submit button is false then pay button view state is null`() {
+        val producer = BlikViewStateProducer(amount = TEST_AMOUNT, showSubmitButton = false)
+
+        val actual = producer.produce(BlikComponentState(blikCode = TextInputComponentState(), isLoading = false))
+
+        assertNull(actual.payButtonViewState)
     }
 
     companion object {

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardFactory.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardFactory.kt
@@ -69,7 +69,7 @@ internal class CardFactory :
         val cardBrandIntentsHandler = CardBrandIntentsHandler(cardComponentParams, detectCardTypeBinHelper)
         val componentStateReducer = CardComponentStateReducer(cardBrandIntentsHandler)
         val componentStateValidator = CardComponentStateValidator(cardValidationMapper)
-        val viewStateProducer = CardViewStateProducer(params.amount)
+        val viewStateProducer = CardViewStateProducer(params.amount, params.showSubmitButton)
 
         val cardEncryptor = CardEncryptorFactory.provide()
         val genericEncryptor = GenericEncryptorFactory.provide()
@@ -136,7 +136,7 @@ internal class CardFactory :
         )
         val componentStateReducer = StoredCardComponentStateReducer()
         val componentStateValidator = StoredCardComponentStateValidator(cardValidationMapper)
-        val viewStateProducer = StoredCardViewStateProducer(params.amount)
+        val viewStateProducer = StoredCardViewStateProducer(params.amount, params.showSubmitButton)
 
         val cardEncryptor = CardEncryptorFactory.provide()
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewState.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewState.kt
@@ -28,5 +28,5 @@ internal data class CardViewState(
     val isLoading: Boolean,
     val isCardScanButtonVisible: Boolean,
     val installmentViewState: InstallmentViewState?,
-    val payButtonViewState: PayButtonViewState,
+    val payButtonViewState: PayButtonViewState?,
 ) : ViewState

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewState.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewState.kt
@@ -8,8 +8,8 @@
 
 package com.adyen.checkout.card.internal.ui.state
 
-import com.adyen.checkout.core.components.data.model.Amount
 import com.adyen.checkout.core.components.internal.ui.state.ViewState
+import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 
 internal data class CardViewState(
@@ -28,5 +28,5 @@ internal data class CardViewState(
     val isLoading: Boolean,
     val isCardScanButtonVisible: Boolean,
     val installmentViewState: InstallmentViewState?,
-    val amount: Amount?,
+    val payButtonViewState: PayButtonViewState,
 ) : ViewState

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
@@ -16,6 +16,7 @@ import com.adyen.checkout.card.internal.ui.model.SecurityCodeTrailingIcon
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.components.data.model.Amount
 import com.adyen.checkout.core.components.internal.ui.state.ViewStateProducer
+import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
 import com.adyen.checkout.core.components.internal.ui.state.model.toViewState
 
@@ -80,7 +81,10 @@ internal class CardViewStateProducer(
             isLoading = state.isLoading,
             isCardScanButtonVisible = isCardScanButtonVisible,
             installmentViewState = state.installmentState.toViewState(),
-            amount = amount,
+            payButtonViewState = PayButtonViewState(
+                amount = amount,
+                isLoading = state.isLoading,
+            ),
         )
     }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
@@ -22,6 +22,7 @@ import com.adyen.checkout.core.components.internal.ui.state.model.toViewState
 
 internal class CardViewStateProducer(
     private val amount: Amount?,
+    private val showSubmitButton: Boolean,
 ) : ViewStateProducer<CardComponentState, CardViewState> {
 
     override fun produce(state: CardComponentState): CardViewState {
@@ -81,10 +82,7 @@ internal class CardViewStateProducer(
             isLoading = state.isLoading,
             isCardScanButtonVisible = isCardScanButtonVisible,
             installmentViewState = state.installmentState.toViewState(),
-            payButtonViewState = PayButtonViewState(
-                amount = amount,
-                isLoading = state.isLoading,
-            ),
+            payButtonViewState = if (showSubmitButton) PayButtonViewState(amount, state.isLoading) else null,
         )
     }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewState.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewState.kt
@@ -18,5 +18,5 @@ internal data class StoredCardViewState(
     val brand: CardBrand?,
     val cardNumberFormat: CardNumberFormat,
     val isLoading: Boolean,
-    val payButtonViewState: PayButtonViewState,
+    val payButtonViewState: PayButtonViewState?,
 ) : ViewState

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewState.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewState.kt
@@ -9,8 +9,8 @@
 package com.adyen.checkout.card.internal.ui.state
 
 import com.adyen.checkout.core.common.CardBrand
-import com.adyen.checkout.core.components.data.model.Amount
 import com.adyen.checkout.core.components.internal.ui.state.ViewState
+import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 
 internal data class StoredCardViewState(
@@ -18,5 +18,5 @@ internal data class StoredCardViewState(
     val brand: CardBrand?,
     val cardNumberFormat: CardNumberFormat,
     val isLoading: Boolean,
-    val amount: Amount?,
+    val payButtonViewState: PayButtonViewState,
 ) : ViewState

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewStateProducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewStateProducer.kt
@@ -17,6 +17,7 @@ import com.adyen.checkout.core.components.internal.ui.state.model.toViewState
 
 internal class StoredCardViewStateProducer(
     private val amount: Amount?,
+    private val showSubmitButton: Boolean,
 ) : ViewStateProducer<StoredCardComponentState, StoredCardViewState> {
 
     override fun produce(state: StoredCardComponentState): StoredCardViewState {
@@ -29,7 +30,7 @@ internal class StoredCardViewStateProducer(
             brand = state.detectedCardType?.cardBrand,
             cardNumberFormat = cardNumberFormat,
             isLoading = state.isLoading,
-            payButtonViewState = PayButtonViewState(amount, state.isLoading),
+            payButtonViewState = if (showSubmitButton) PayButtonViewState(amount, state.isLoading) else null,
         )
     }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewStateProducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewStateProducer.kt
@@ -11,6 +11,7 @@ package com.adyen.checkout.card.internal.ui.state
 import com.adyen.checkout.card.internal.ui.model.SecurityCodeTrailingIcon
 import com.adyen.checkout.core.components.data.model.Amount
 import com.adyen.checkout.core.components.internal.ui.state.ViewStateProducer
+import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
 import com.adyen.checkout.core.components.internal.ui.state.model.toViewState
 
@@ -28,7 +29,7 @@ internal class StoredCardViewStateProducer(
             brand = state.detectedCardType?.cardBrand,
             cardNumberFormat = cardNumberFormat,
             isLoading = state.isLoading,
-            amount = amount,
+            payButtonViewState = PayButtonViewState(amount, state.isLoading),
         )
     }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardContent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardContent.kt
@@ -39,7 +39,7 @@ import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.common.CardType
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
-import com.adyen.checkout.core.components.internal.ui.PayButton
+import com.adyen.checkout.core.components.internal.ui.payButtonAsComponentScaffoldFooter
 import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 import com.adyen.checkout.ui.internal.element.ComponentScaffold
@@ -102,9 +102,7 @@ private fun CardContent(
     ComponentScaffold(
         modifier = modifier,
         disableInteraction = viewState.isLoading,
-        footer = {
-            PayButton(payButtonViewState = viewState.payButtonViewState, onClick = onSubmitClick)
-        },
+        footer = payButtonAsComponentScaffoldFooter(viewState.payButtonViewState, onSubmitClick),
     ) {
         CardDetailsSection(
             viewState = viewState,
@@ -246,7 +244,7 @@ private fun CardContentPreview(
                 cardBrandViewState = CardBrandViewState.SingleBrand(CardBrand(CardType.MASTERCARD.txVariant)),
                 cardNumberFormat = CardNumberFormat.DEFAULT,
                 installmentViewState = null,
-                amount = null,
+                payButtonViewState = PayButtonViewState(null, false),
             ),
             onIntent = {},
             onSubmitClick = {},

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardContent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardContent.kt
@@ -40,6 +40,7 @@ import com.adyen.checkout.core.common.CardType
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.PayButton
+import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 import com.adyen.checkout.ui.internal.element.ComponentScaffold
 import com.adyen.checkout.ui.internal.element.SwitchContainer
@@ -101,7 +102,7 @@ private fun CardContent(
     ComponentScaffold(
         modifier = modifier,
         footer = {
-            PayButton(amount = viewState.amount, onClick = onSubmitClick, isLoading = viewState.isLoading)
+            PayButton(payButtonViewState = viewState.payButtonViewState, onClick = onSubmitClick)
         },
     ) {
         CardDetailsSection(
@@ -300,7 +301,7 @@ private fun CardContentPreviewAllFields(
                     installmentOptions = listOf(InstallmentModel.OneTime),
                     selectedInstallment = InstallmentModel.OneTime,
                 ),
-                amount = null,
+                payButtonViewState = PayButtonViewState(null, false),
             ),
             onIntent = {},
             onSubmitClick = {},

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardContent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardContent.kt
@@ -101,6 +101,7 @@ private fun CardContent(
 ) {
     ComponentScaffold(
         modifier = modifier,
+        disableInteraction = viewState.isLoading,
         footer = {
             PayButton(payButtonViewState = viewState.payButtonViewState, onClick = onSubmitClick)
         },

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardContent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardContent.kt
@@ -22,6 +22,7 @@ import com.adyen.checkout.card.internal.ui.state.StoredCardIntent
 import com.adyen.checkout.card.internal.ui.state.StoredCardViewState
 import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.components.internal.ui.PayButton
+import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 import com.adyen.checkout.ui.internal.element.ComponentScaffold
 import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
@@ -58,7 +59,7 @@ private fun StoredCardContent(
         ComponentScaffold(
             modifier = modifier,
             footer = {
-                PayButton(amount = viewState.amount, onClick = onSubmitClick, isLoading = viewState.isLoading)
+                PayButton(payButtonViewState = viewState.payButtonViewState, onClick = onSubmitClick)
             },
         ) {
             Column(
@@ -87,7 +88,7 @@ private fun StoredCardContentPreview(
             brand = CardBrand(""),
             cardNumberFormat = CardNumberFormat.DEFAULT,
             isLoading = false,
-            amount = null,
+            payButtonViewState = PayButtonViewState(null, false),
         )
 
         StoredCardContent(

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardContent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardContent.kt
@@ -21,7 +21,7 @@ import com.adyen.checkout.card.internal.ui.state.CardNumberFormat
 import com.adyen.checkout.card.internal.ui.state.StoredCardIntent
 import com.adyen.checkout.card.internal.ui.state.StoredCardViewState
 import com.adyen.checkout.core.common.CardBrand
-import com.adyen.checkout.core.components.internal.ui.PayButton
+import com.adyen.checkout.core.components.internal.ui.payButtonAsComponentScaffoldFooter
 import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 import com.adyen.checkout.ui.internal.element.ComponentScaffold
@@ -59,9 +59,7 @@ private fun StoredCardContent(
         ComponentScaffold(
             modifier = modifier,
             disableInteraction = viewState.isLoading,
-            footer = {
-                PayButton(payButtonViewState = viewState.payButtonViewState, onClick = onSubmitClick)
-            },
+            footer = payButtonAsComponentScaffoldFooter(viewState.payButtonViewState, onSubmitClick),
         ) {
             Column(
                 modifier = Modifier.fillMaxWidth(),

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardContent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardContent.kt
@@ -58,6 +58,7 @@ private fun StoredCardContent(
     if (viewState.securityCode != null) {
         ComponentScaffold(
             modifier = modifier,
+            disableInteraction = viewState.isLoading,
             footer = {
                 PayButton(payButtonViewState = viewState.payButtonViewState, onClick = onSubmitClick)
             },

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/CardComponentTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/CardComponentTest.kt
@@ -298,7 +298,7 @@ internal class CardComponentTest(
             componentStateValidator = CardComponentStateValidator(CardValidationMapper()),
             componentStateFactory = CardComponentStateFactory(cardComponentParams),
             componentStateReducer = CardComponentStateReducer(cardBrandIntentsHandler),
-            viewStateProducer = CardViewStateProducer(amount = null),
+            viewStateProducer = CardViewStateProducer(amount = null, showSubmitButton = true),
             coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
             sdkDataProvider = sdkDataProvider,
             paymentMethodType = PAYMENT_METHOD_TYPE,

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/StoredCardComponentTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/StoredCardComponentTest.kt
@@ -238,7 +238,7 @@ internal class StoredCardComponentTest(
             componentStateValidator = StoredCardComponentStateValidator(CardValidationMapper()),
             componentStateFactory = StoredCardComponentStateFactory(storedPaymentMethod, componentParams),
             componentStateReducer = StoredCardComponentStateReducer(),
-            viewStateProducer = StoredCardViewStateProducer(null),
+            viewStateProducer = StoredCardViewStateProducer(amount = null, showSubmitButton = true),
             coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
             sdkDataProvider = sdkDataProvider,
             publicKey = publicKey,

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
@@ -15,6 +15,7 @@ import com.adyen.checkout.card.internal.ui.model.PostalCodeTrailingIcon
 import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.components.data.model.Amount
+import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -33,7 +34,7 @@ internal class CardViewStateProducerTest {
     }
 
     @Test
-    fun `when produce is called, then amount is propagated to the view state`() {
+    fun `when produce is called, then pay button state is propagated to the view state`() {
         // GIVEN
         val componentState = createComponentState()
 
@@ -41,7 +42,7 @@ internal class CardViewStateProducerTest {
         val viewState = producer.produce(componentState)
 
         // THEN
-        assertEquals(TEST_AMOUNT, viewState.amount)
+        assertEquals(PayButtonViewState(TEST_AMOUNT, false), viewState.payButtonViewState)
     }
 
     // UC5: Brand Detection Hides Placeholder (No Error)

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
@@ -30,7 +30,7 @@ internal class CardViewStateProducerTest {
 
     @BeforeEach
     fun beforeEach() {
-        producer = CardViewStateProducer(amount = TEST_AMOUNT)
+        producer = CardViewStateProducer(amount = TEST_AMOUNT, showSubmitButton = true)
     }
 
     @Test
@@ -43,6 +43,19 @@ internal class CardViewStateProducerTest {
 
         // THEN
         assertEquals(PayButtonViewState(TEST_AMOUNT, false), viewState.payButtonViewState)
+    }
+
+    @Test
+    fun `when show submit button is false then pay button view state is null`() {
+        // GIVEN
+        val producer = CardViewStateProducer(amount = TEST_AMOUNT, showSubmitButton = false)
+        val componentState = createComponentState()
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertNull(viewState.payButtonViewState)
     }
 
     // UC5: Brand Detection Hides Placeholder (No Error)

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewStateProducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewStateProducerTest.kt
@@ -27,7 +27,7 @@ internal class StoredCardViewStateProducerTest {
 
     @BeforeEach
     fun beforeEach() {
-        producer = StoredCardViewStateProducer(amount = TEST_AMOUNT)
+        producer = StoredCardViewStateProducer(amount = TEST_AMOUNT, showSubmitButton = true)
     }
 
     @Test
@@ -40,6 +40,19 @@ internal class StoredCardViewStateProducerTest {
 
         // THEN
         assertEquals(PayButtonViewState(TEST_AMOUNT, false), viewState.payButtonViewState)
+    }
+
+    @Test
+    fun `when show submit button is false then pay button view state is null`() {
+        // GIVEN
+        val producer = StoredCardViewStateProducer(amount = TEST_AMOUNT, showSubmitButton = false)
+        val componentState = createComponentState()
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertNull(viewState.payButtonViewState)
     }
 
     @Test

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewStateProducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewStateProducerTest.kt
@@ -14,6 +14,7 @@ import com.adyen.checkout.card.internal.ui.model.SecurityCodeTrailingIcon
 import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.components.data.model.Amount
+import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -30,7 +31,7 @@ internal class StoredCardViewStateProducerTest {
     }
 
     @Test
-    fun `when produce is called, then amount is propagated to the view state`() {
+    fun `when produce is called, then pay button state is propagated to the view state`() {
         // GIVEN
         val componentState = createComponentState()
 
@@ -38,7 +39,7 @@ internal class StoredCardViewStateProducerTest {
         val viewState = producer.produce(componentState)
 
         // THEN
-        assertEquals(TEST_AMOUNT, viewState.amount)
+        assertEquals(PayButtonViewState(TEST_AMOUNT, false), viewState.payButtonViewState)
     }
 
     @Test

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/PayButton.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/PayButton.kt
@@ -82,3 +82,19 @@ private fun PayButtonPreview(
         )
     }
 }
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Composable
+fun payButtonAsComponentScaffoldFooter(
+    payButtonViewState: PayButtonViewState?,
+    onSubmitClick: () -> Unit
+): (@Composable () -> Unit)? {
+    return payButtonViewState?.let {
+        @Composable {
+            PayButton(
+                payButtonViewState = it,
+                onClick = onSubmitClick,
+            )
+        }
+    }
+}

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/PayButton.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/PayButton.kt
@@ -12,29 +12,73 @@ import androidx.annotation.RestrictTo
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.core.common.internal.helper.LocalLocale
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.data.model.Amount
 import com.adyen.checkout.core.components.data.model.format
+import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
 import com.adyen.checkout.ui.internal.element.button.PrimaryButton
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
+import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Composable
 fun PayButton(
-    amount: Amount?,
+    payButtonViewState: PayButtonViewState,
     onClick: () -> Unit,
-    isLoading: Boolean = false,
 ) {
+    val amount = payButtonViewState.amount
     val text = when {
         amount == null -> resolveString(CheckoutLocalizationKey.PAY_BUTTON_NO_AMOUNT)
         amount.value == 0L -> resolveString(CheckoutLocalizationKey.PAY_BUTTON_ZERO_AMOUNT)
         else -> resolveString(CheckoutLocalizationKey.PAY_BUTTON_WITH_AMOUNT, amount.format(LocalLocale.current))
     }
+
     PrimaryButton(
         onClick = onClick,
         text = text,
-        isLoading = isLoading,
+        isLoading = payButtonViewState.isLoading,
         modifier = Modifier.fillMaxWidth(),
     )
+}
+
+@Preview
+@Composable
+private fun PayButtonPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        PayButton(
+            payButtonViewState = PayButtonViewState(
+                amount = Amount(currency = "EUR", value = 1337),
+                isLoading = false,
+            ),
+            onClick = {},
+        )
+        PayButton(
+            payButtonViewState = PayButtonViewState(
+                amount = Amount(currency = "EUR", value = 0),
+                isLoading = false,
+            ),
+            onClick = {},
+        )
+        PayButton(
+            payButtonViewState = PayButtonViewState(
+                amount = null,
+                isLoading = false,
+            ),
+            onClick = {},
+        )
+        PayButton(
+            payButtonViewState = PayButtonViewState(
+                amount = Amount(currency = "EUR", value = 1337),
+                isLoading = true,
+            ),
+            onClick = {},
+        )
+    }
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/model/PayButtonViewState.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/model/PayButtonViewState.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 27/7/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui.state.model
+
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.core.components.data.model.Amount
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class PayButtonViewState(
+    val amount: Amount?,
+    val isLoading: Boolean,
+)

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6Screen.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6Screen.kt
@@ -137,10 +137,17 @@ private fun Component(
             )
         }
 
-        var showButton by remember { mutableStateOf(true) }
-        if (!uiState.checkoutController.requiresUserInteraction() && showButton) {
+        CheckoutPaymentFlow(
+            controller = uiState.checkoutController,
+            theme = theme,
+            modifier = Modifier.padding(ExampleTheme.dimensions.grid_2),
+        )
+
+        var showButton by remember(uiState.checkoutController) { mutableStateOf(true) }
+        if (uiState.showCustomButton && showButton) {
             Button(
                 onClick = {
+                    // TODO do not hide button if component is not valid on click
                     showButton = false
                     uiState.checkoutController.submit()
                 },
@@ -151,12 +158,6 @@ private fun Component(
                 Text("Submit")
             }
         }
-
-        CheckoutPaymentFlow(
-            controller = uiState.checkoutController,
-            theme = theme,
-            modifier = Modifier.padding(ExampleTheme.dimensions.grid_2),
-        )
     }
 }
 

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6SessionsViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6SessionsViewModel.kt
@@ -49,8 +49,10 @@ internal class V6SessionsViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
     private val paymentsRepository: PaymentsRepository,
     private val keyValueStorage: KeyValueStorage,
-    private val checkoutConfigurationProvider: CheckoutConfigurationProvider,
+    checkoutConfigurationProvider: CheckoutConfigurationProvider,
 ) : ViewModel() {
+
+    private val checkoutConfiguration = checkoutConfigurationProvider.checkoutConfig
 
     private lateinit var checkoutContext: CheckoutContext.Sessions
 
@@ -86,7 +88,7 @@ internal class V6SessionsViewModel @Inject constructor(
 
         val result = Checkout.setup(
             sessionResponse = sessionResponse,
-            configuration = checkoutConfigurationProvider.checkoutConfig,
+            configuration = checkoutConfiguration,
         )
 
         uiState = when (result) {
@@ -94,14 +96,16 @@ internal class V6SessionsViewModel @Inject constructor(
             is Checkout.Result.Success -> {
                 checkoutContext = result.checkoutContext
                 val paymentMethods = checkoutContext.getPaymentMethods()
+                val checkoutController = createAndSetCheckoutController(
+                    paymentMethod = paymentMethods.first(),
+                    checkoutContext = checkoutContext,
+                )
                 V6UiState.Component(
                     paymentMethods = paymentMethods,
                     storedPaymentMethods = checkoutContext.getStoredPaymentMethods(),
                     selectedPaymentMethod = paymentMethods.first(),
-                    checkoutController = createCheckoutController(
-                        paymentMethod = paymentMethods.first(),
-                        checkoutContext = checkoutContext,
-                    ),
+                    checkoutController = checkoutController,
+                    showCustomButton = showCustomButton(checkoutController),
                 )
             }
         }
@@ -126,12 +130,14 @@ internal class V6SessionsViewModel @Inject constructor(
     }
 
     fun onPaymentMethodSelected(paymentMethod: PaymentMethodResponse) {
+        val checkoutController = createAndSetCheckoutController(
+            paymentMethod = paymentMethod,
+            checkoutContext = checkoutContext,
+        )
         val newState = (uiState as? V6UiState.Component)?.copy(
             selectedPaymentMethod = paymentMethod,
-            checkoutController = createCheckoutController(
-                paymentMethod = paymentMethod,
-                checkoutContext = checkoutContext,
-            ),
+            checkoutController = checkoutController,
+            showCustomButton = showCustomButton(checkoutController),
         )
 
         if (newState != null) {
@@ -139,7 +145,7 @@ internal class V6SessionsViewModel @Inject constructor(
         }
     }
 
-    private fun createCheckoutController(
+    private fun createAndSetCheckoutController(
         paymentMethod: PaymentMethodResponse,
         checkoutContext: CheckoutContext.Sessions,
     ): CheckoutController {
@@ -166,6 +172,10 @@ internal class V6SessionsViewModel @Inject constructor(
         ).also {
             checkoutController = it
         }
+    }
+
+    private fun showCustomButton(checkoutController: CheckoutController): Boolean {
+        return checkoutConfiguration.showSubmitButton == false || !checkoutController.requiresUserInteraction()
     }
 
     fun onNewIntent(intent: Intent) {

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6UiState.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6UiState.kt
@@ -22,6 +22,7 @@ sealed interface V6UiState {
         val storedPaymentMethods: List<StoredPaymentMethod>,
         val selectedPaymentMethod: PaymentMethodResponse,
         val checkoutController: CheckoutController,
+        val showCustomButton: Boolean,
     ) : V6UiState
 
     data object Loading : V6UiState

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6ViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6ViewModel.kt
@@ -51,8 +51,10 @@ internal class V6ViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
     private val paymentsRepository: PaymentsRepository,
     private val keyValueStorage: KeyValueStorage,
-    private val checkoutConfigurationProvider: CheckoutConfigurationProvider,
+    checkoutConfigurationProvider: CheckoutConfigurationProvider,
 ) : ViewModel() {
+
+    private val checkoutConfiguration = checkoutConfigurationProvider.checkoutConfig
 
     private lateinit var checkoutContext: CheckoutContext.Advanced
 
@@ -87,7 +89,7 @@ internal class V6ViewModel @Inject constructor(
 
         val result = Checkout.setup(
             paymentMethods = paymentMethods,
-            configuration = checkoutConfigurationProvider.checkoutConfig,
+            configuration = checkoutConfiguration,
         )
 
         uiState = when (result) {
@@ -95,14 +97,16 @@ internal class V6ViewModel @Inject constructor(
             is Checkout.Result.Success -> {
                 checkoutContext = result.checkoutContext
                 val paymentMethods = checkoutContext.getPaymentMethods()
+                val checkoutController = createAndSetCheckoutController(
+                    paymentMethod = paymentMethods.first(),
+                    checkoutContext = result.checkoutContext,
+                )
                 V6UiState.Component(
                     paymentMethods = paymentMethods,
                     storedPaymentMethods = checkoutContext.getStoredPaymentMethods(),
                     selectedPaymentMethod = paymentMethods.first(),
-                    checkoutController = createCheckoutController(
-                        paymentMethod = paymentMethods.first(),
-                        checkoutContext = result.checkoutContext,
-                    ),
+                    checkoutController = checkoutController,
+                    showCustomButton = showCustomButton(checkoutController),
                 )
             }
         }
@@ -178,12 +182,14 @@ internal class V6ViewModel @Inject constructor(
     }
 
     fun onPaymentMethodSelected(paymentMethod: PaymentMethodResponse) {
+        val checkoutController = createAndSetCheckoutController(
+            paymentMethod = paymentMethod,
+            checkoutContext = checkoutContext,
+        )
         val newState = (uiState as? V6UiState.Component)?.copy(
             selectedPaymentMethod = paymentMethod,
-            checkoutController = createCheckoutController(
-                paymentMethod = paymentMethod,
-                checkoutContext = checkoutContext,
-            ),
+            checkoutController = checkoutController,
+            showCustomButton = showCustomButton(checkoutController),
         )
 
         if (newState != null) {
@@ -191,7 +197,7 @@ internal class V6ViewModel @Inject constructor(
         }
     }
 
-    private fun createCheckoutController(
+    private fun createAndSetCheckoutController(
         paymentMethod: PaymentMethodResponse,
         checkoutContext: CheckoutContext.Advanced,
     ): CheckoutController {
@@ -219,6 +225,10 @@ internal class V6ViewModel @Inject constructor(
         ).also {
             checkoutController = it
         }
+    }
+
+    private fun showCustomButton(checkoutController: CheckoutController): Boolean {
+        return checkoutConfiguration.showSubmitButton == false || !checkoutController.requiresUserInteraction()
     }
 
     fun onNewIntent(intent: Intent) {

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/GooglePayFactory.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/GooglePayFactory.kt
@@ -54,7 +54,7 @@ internal class GooglePayFactory : PaymentComponentFactory<GooglePayComponent> {
             componentStateValidator = GooglePayComponentStateValidator(),
             componentStateFactory = GooglePayComponentStateFactory(componentParams),
             componentStateReducer = GooglePayComponentStateReducer(),
-            viewStateProducer = GooglePayViewStateProducer(),
+            viewStateProducer = GooglePayViewStateProducer(showSubmitButton = params.showSubmitButton),
             coroutineScope = coroutineScope,
         )
     }

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/state/GooglePayViewState.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/state/GooglePayViewState.kt
@@ -11,5 +11,6 @@ package com.adyen.checkout.googlepay.internal.ui.state
 import com.adyen.checkout.core.components.internal.ui.state.ViewState
 
 internal data class GooglePayViewState(
-    val buttonViewState: GooglePayButtonViewState?,
+    val isLoading: Boolean,
+    val payButtonViewState: GooglePayButtonViewState?,
 ) : ViewState

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/state/GooglePayViewStateProducer.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/state/GooglePayViewStateProducer.kt
@@ -10,14 +10,17 @@ package com.adyen.checkout.googlepay.internal.ui.state
 
 import com.adyen.checkout.core.components.internal.ui.state.ViewStateProducer
 
-internal class GooglePayViewStateProducer : ViewStateProducer<GooglePayComponentState, GooglePayViewState> {
+internal class GooglePayViewStateProducer(
+    private val showSubmitButton: Boolean,
+) : ViewStateProducer<GooglePayComponentState, GooglePayViewState> {
 
     override fun produce(state: GooglePayComponentState) = GooglePayViewState(
-        buttonViewState = createButtonViewState(state),
+        isLoading = state.isLoading,
+        payButtonViewState = createButtonViewState(state),
     )
 
     private fun createButtonViewState(state: GooglePayComponentState): GooglePayButtonViewState? {
-        if (!state.isAvailable || !state.isButtonVisible) return null
+        if (!showSubmitButton || !state.isAvailable || !state.isButtonVisible) return null
         return GooglePayButtonViewState(
             allowedPaymentMethods = state.allowedPaymentMethods,
             buttonStyling = state.buttonStyling,

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/view/GooglePayContent.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/view/GooglePayContent.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.adyen.checkout.googlepay.internal.ui.GooglePayViewEvent
 import com.adyen.checkout.googlepay.internal.ui.state.GooglePayViewState
+import com.adyen.checkout.ui.internal.element.ComponentScaffold
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.wallet.PaymentData
 import com.google.android.gms.wallet.contract.ApiTaskResult
@@ -49,24 +50,17 @@ internal fun GooglePayContent(
     }
 
     val viewState by viewStateFlow.collectAsStateWithLifecycle()
-    GooglePayContent(
-        viewState = viewState,
-        onSubmit = onSubmit,
+    ComponentScaffold(
         modifier = modifier,
+        disableInteraction = viewState.isLoading,
+        footer = viewState.payButtonViewState?.let {
+            @Composable {
+                GooglePayButton(
+                    buttonViewState = it,
+                    onClick = onSubmit,
+                )
+            }
+        },
+        content = null,
     )
-}
-
-@Composable
-private fun GooglePayContent(
-    viewState: GooglePayViewState,
-    onSubmit: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    viewState.buttonViewState?.let { buttonViewState ->
-        GooglePayButton(
-            buttonViewState = buttonViewState,
-            onClick = onSubmit,
-            modifier = modifier,
-        )
-    }
 }

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/GooglePayComponentTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/GooglePayComponentTest.kt
@@ -78,7 +78,7 @@ internal class GooglePayComponentTest {
 
         component.setLoading(true)
 
-        val buttonViewState = requireNotNull(viewState.latestValue.buttonViewState)
+        val buttonViewState = requireNotNull(viewState.latestValue.payButtonViewState)
         assertTrue(buttonViewState.isLoading)
     }
 
@@ -89,7 +89,7 @@ internal class GooglePayComponentTest {
 
         component.submit()
 
-        val buttonViewState = requireNotNull(viewState.latestValue.buttonViewState)
+        val buttonViewState = requireNotNull(viewState.latestValue.payButtonViewState)
         assertTrue(buttonViewState.isLoading)
     }
 
@@ -192,7 +192,7 @@ internal class GooglePayComponentTest {
         component.onPaymentResult(createResult(CommonStatusCodes.CANCELED))
 
         assertTrue(events.values.isEmpty())
-        val buttonViewState = requireNotNull(viewState.latestValue.buttonViewState)
+        val buttonViewState = requireNotNull(viewState.latestValue.payButtonViewState)
         assertFalse(buttonViewState.isLoading)
     }
 
@@ -227,7 +227,7 @@ internal class GooglePayComponentTest {
         )
         val viewState = component.viewState.test(testScheduler)
 
-        assertNotNull(viewState.latestValue.buttonViewState)
+        assertNotNull(viewState.latestValue.payButtonViewState)
     }
 
     @Test
@@ -238,7 +238,7 @@ internal class GooglePayComponentTest {
         )
         val viewState = component.viewState.test(testScheduler)
 
-        assertNull(viewState.latestValue.buttonViewState)
+        assertNull(viewState.latestValue.payButtonViewState)
     }
 
     @Test
@@ -265,7 +265,7 @@ internal class GooglePayComponentTest {
             )
             val viewState = component.viewState.test(testScheduler)
 
-            val buttonViewState = requireNotNull(viewState.latestValue.buttonViewState)
+            val buttonViewState = requireNotNull(viewState.latestValue.payButtonViewState)
             assertTrue(buttonViewState.allowedPaymentMethods.isNotEmpty())
             assertEquals(buttonStyling, buttonViewState.buttonStyling)
         }
@@ -313,7 +313,7 @@ internal class GooglePayComponentTest {
             componentStateValidator = GooglePayComponentStateValidator(),
             componentStateFactory = GooglePayComponentStateFactory(componentParams),
             componentStateReducer = GooglePayComponentStateReducer(),
-            viewStateProducer = GooglePayViewStateProducer(),
+            viewStateProducer = GooglePayViewStateProducer(showSubmitButton = true),
             coroutineScope = coroutineScope,
         )
     }

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/state/GooglePayViewStateProducerTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/state/GooglePayViewStateProducerTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 27/7/2026.
+ */
+
+package com.adyen.checkout.googlepay.internal.ui.state
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+internal class GooglePayViewStateProducerTest {
+
+    @Test
+    fun `when google pay is available and button is visible then button view state is created`() {
+        val producer = GooglePayViewStateProducer(showSubmitButton = true)
+        val state = createState(
+            isAvailable = true,
+            isButtonVisible = true,
+            isLoading = true,
+        )
+
+        val actual = producer.produce(state)
+
+        val expected = GooglePayButtonViewState(
+            allowedPaymentMethods = ALLOWED_PAYMENT_METHODS,
+            buttonStyling = null,
+            isLoading = true,
+        )
+        assertEquals(expected, actual.payButtonViewState)
+    }
+
+    @Test
+    fun `when show submit button is false then button view state is null`() {
+        val producer = GooglePayViewStateProducer(showSubmitButton = false)
+        val state = createState(
+            isAvailable = true,
+            isButtonVisible = true,
+        )
+
+        val actual = producer.produce(state)
+
+        assertNull(actual.payButtonViewState)
+    }
+
+    @Test
+    fun `when google pay is unavailable then button view state is null`() {
+        val producer = GooglePayViewStateProducer(showSubmitButton = true)
+        val state = createState(
+            isAvailable = false,
+            isButtonVisible = true,
+        )
+
+        val actual = producer.produce(state)
+
+        assertNull(actual.payButtonViewState)
+    }
+
+    @Test
+    fun `when button is not visible then button view state is null`() {
+        val producer = GooglePayViewStateProducer(showSubmitButton = true)
+        val state = createState(
+            isAvailable = true,
+            isButtonVisible = false,
+        )
+
+        val actual = producer.produce(state)
+
+        assertNull(actual.payButtonViewState)
+    }
+
+    private fun createState(
+        isAvailable: Boolean = true,
+        isButtonVisible: Boolean = true,
+        isLoading: Boolean = false,
+    ) = GooglePayComponentState(
+        allowedPaymentMethods = ALLOWED_PAYMENT_METHODS,
+        buttonStyling = null,
+        isButtonVisible = isButtonVisible,
+        isLoading = isLoading,
+        isAvailable = isAvailable,
+    )
+
+    companion object {
+        private const val ALLOWED_PAYMENT_METHODS = "[]"
+    }
+}

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/MBWayFactory.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/MBWayFactory.kt
@@ -36,7 +36,7 @@ internal class MBWayFactory : PaymentComponentFactory<MBWayComponent> {
             componentStateFactory = MBWayComponentStateFactory(params.shopperLocale),
             componentStateReducer = MBWayComponentStateReducer(),
             componentStateValidator = MBWayComponentStateValidator(),
-            viewStateProducer = MBWayViewStateProducer(params.amount),
+            viewStateProducer = MBWayViewStateProducer(params.amount, params.showSubmitButton),
             coroutineScope = coroutineScope,
         )
     }

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/state/MBWayViewState.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/state/MBWayViewState.kt
@@ -9,9 +9,9 @@
 package com.adyen.checkout.mbway.internal.ui.state
 
 import androidx.compose.runtime.Immutable
-import com.adyen.checkout.core.components.data.model.Amount
 import com.adyen.checkout.core.components.internal.ui.model.CountryModel
 import com.adyen.checkout.core.components.internal.ui.state.ViewState
+import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 
 @Immutable
@@ -20,5 +20,5 @@ internal data class MBWayViewState(
     val selectedCountryCode: CountryModel,
     val phoneNumber: TextInputViewState?,
     val isLoading: Boolean,
-    val amount: Amount?,
+    val payButtonViewState: PayButtonViewState,
 ) : ViewState

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/state/MBWayViewState.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/state/MBWayViewState.kt
@@ -20,5 +20,5 @@ internal data class MBWayViewState(
     val selectedCountryCode: CountryModel,
     val phoneNumber: TextInputViewState?,
     val isLoading: Boolean,
-    val payButtonViewState: PayButtonViewState,
+    val payButtonViewState: PayButtonViewState?,
 ) : ViewState

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/state/MBWayViewStateProducer.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/state/MBWayViewStateProducer.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.mbway.internal.ui.state
 
 import com.adyen.checkout.core.components.data.model.Amount
 import com.adyen.checkout.core.components.internal.ui.state.ViewStateProducer
+import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
 import com.adyen.checkout.core.components.internal.ui.state.model.toViewState
 
 internal class MBWayViewStateProducer(
@@ -22,7 +23,7 @@ internal class MBWayViewStateProducer(
             selectedCountryCode = state.selectedCountryCode,
             phoneNumber = state.phoneNumber.toViewState(),
             isLoading = state.isLoading,
-            amount = amount,
+            payButtonViewState = PayButtonViewState(amount, state.isLoading),
         )
     }
 }

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/state/MBWayViewStateProducer.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/state/MBWayViewStateProducer.kt
@@ -15,6 +15,7 @@ import com.adyen.checkout.core.components.internal.ui.state.model.toViewState
 
 internal class MBWayViewStateProducer(
     private val amount: Amount?,
+    private val showSubmitButton: Boolean,
 ) : ViewStateProducer<MBWayComponentState, MBWayViewState> {
 
     override fun produce(state: MBWayComponentState): MBWayViewState {
@@ -23,7 +24,7 @@ internal class MBWayViewStateProducer(
             selectedCountryCode = state.selectedCountryCode,
             phoneNumber = state.phoneNumber.toViewState(),
             isLoading = state.isLoading,
-            payButtonViewState = PayButtonViewState(amount, state.isLoading),
+            payButtonViewState = if (showSubmitButton) PayButtonViewState(amount, state.isLoading) else null,
         )
     }
 }

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/CountryCodePicker.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/CountryCodePicker.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.model.CountryModel
+import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 import com.adyen.checkout.mbway.internal.ui.state.MBWayViewState
 import com.adyen.checkout.ui.internal.element.SearchableValuePicker
@@ -67,7 +68,7 @@ private fun CountryCodePickerPreview(
                 isLoading = false,
                 selectedCountryCode = countries.first(),
                 phoneNumber = TextInputViewState(),
-                amount = null,
+                payButtonViewState = PayButtonViewState(null, false),
             ),
             onItemClick = {},
         )

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MBWayContent.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MBWayContent.kt
@@ -21,6 +21,7 @@ import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.PayButton
 import com.adyen.checkout.core.components.internal.ui.model.CountryModel
+import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 import com.adyen.checkout.mbway.internal.ui.state.MBWayIntent
 import com.adyen.checkout.mbway.internal.ui.state.MBWayViewState
@@ -63,7 +64,7 @@ private fun MBWayContent(
         modifier = modifier,
         disableInteraction = viewState.isLoading,
         footer = {
-            PayButton(amount = viewState.amount, onClick = onSubmitClick, isLoading = viewState.isLoading)
+            PayButton(payButtonViewState = viewState.payButtonViewState, onClick = onSubmitClick)
         },
     ) {
         Column(
@@ -108,7 +109,7 @@ private fun MBWayContentPreview(
                 isLoading = false,
                 selectedCountryCode = countries.first(),
                 phoneNumber = TextInputViewState(),
-                amount = null,
+                payButtonViewState = PayButtonViewState(null, false),
             ),
             onIntent = {},
             onSubmitClick = {},

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MBWayContent.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MBWayContent.kt
@@ -19,8 +19,8 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
-import com.adyen.checkout.core.components.internal.ui.PayButton
 import com.adyen.checkout.core.components.internal.ui.model.CountryModel
+import com.adyen.checkout.core.components.internal.ui.payButtonAsComponentScaffoldFooter
 import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 import com.adyen.checkout.mbway.internal.ui.state.MBWayIntent
@@ -63,9 +63,7 @@ private fun MBWayContent(
     ComponentScaffold(
         modifier = modifier,
         disableInteraction = viewState.isLoading,
-        footer = {
-            PayButton(payButtonViewState = viewState.payButtonViewState, onClick = onSubmitClick)
-        },
+        footer = payButtonAsComponentScaffoldFooter(viewState.payButtonViewState, onSubmitClick),
     ) {
         Column(
             verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.Large),

--- a/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/MBWayComponentTest.kt
+++ b/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/MBWayComponentTest.kt
@@ -118,7 +118,7 @@ internal class MBWayComponentTest(
             componentStateValidator = componentStateValidator,
             componentStateFactory = MBWayComponentStateFactory(Locale("pt", "PT")),
             componentStateReducer = MBWayComponentStateReducer(),
-            viewStateProducer = MBWayViewStateProducer(null),
+            viewStateProducer = MBWayViewStateProducer(amount = null, showSubmitButton = true),
             coroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
         )
     }

--- a/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/state/MBWayViewStateProducerTest.kt
+++ b/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/state/MBWayViewStateProducerTest.kt
@@ -3,6 +3,7 @@ package com.adyen.checkout.mbway.internal.ui.state
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.components.data.model.Amount
 import com.adyen.checkout.core.components.internal.ui.model.CountryModel
+import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -47,7 +48,7 @@ internal class MBWayViewStateProducerTest {
                 isError = true,
             ),
             isLoading = true,
-            amount = TEST_AMOUNT,
+            payButtonViewState = PayButtonViewState(TEST_AMOUNT, true),
         )
 
         assertEquals(expected, actual)

--- a/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/state/MBWayViewStateProducerTest.kt
+++ b/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/state/MBWayViewStateProducerTest.kt
@@ -7,6 +7,7 @@ import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewS
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -16,7 +17,7 @@ internal class MBWayViewStateProducerTest {
 
     @BeforeEach
     fun beforeEach() {
-        producer = MBWayViewStateProducer(amount = TEST_AMOUNT)
+        producer = MBWayViewStateProducer(amount = TEST_AMOUNT, showSubmitButton = true)
     }
 
     @Test
@@ -48,10 +49,26 @@ internal class MBWayViewStateProducerTest {
                 isError = true,
             ),
             isLoading = true,
-            payButtonViewState = PayButtonViewState(TEST_AMOUNT, true),
+            payButtonViewState = PayButtonViewState(amount = TEST_AMOUNT, isLoading = true),
         )
 
         assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `when show submit button is false then pay button view state is null`() {
+        val producer = MBWayViewStateProducer(amount = TEST_AMOUNT, showSubmitButton = false)
+        val country = CountryModel("PT", "Portugal", "351")
+        val componentState = MBWayComponentState(
+            countries = listOf(country),
+            selectedCountryCode = country,
+            phoneNumber = TextInputComponentState(),
+            isLoading = false,
+        )
+
+        val actual = producer.produce(componentState)
+
+        assertNull(actual.payButtonViewState)
     }
 
     companion object {

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/ComponentScaffold.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/ComponentScaffold.kt
@@ -28,7 +28,7 @@ fun ComponentScaffold(
     modifier: Modifier = Modifier,
     footer: (@Composable () -> Unit)?,
     disableInteraction: Boolean,
-    content: @Composable () -> Unit,
+    content: (@Composable () -> Unit)?,
 ) {
     val focusManager = LocalFocusManager.current
     LaunchedEffect(disableInteraction) {
@@ -42,11 +42,13 @@ fun ComponentScaffold(
             modifier = modifier.fillMaxWidth(),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            content()
-            if (footer != null) {
+            content?.invoke()
+
+            if (content != null && footer != null) {
                 Spacer(Modifier.size(16.dp))
-                footer()
             }
+
+            footer?.invoke()
         }
 
         if (disableInteraction) {

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/ComponentScaffold.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/ComponentScaffold.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun ComponentScaffold(
     modifier: Modifier = Modifier,
-    footer: @Composable () -> Unit = {},
+    footer: (@Composable () -> Unit)?,
     disableInteraction: Boolean,
     content: @Composable () -> Unit,
 ) {
@@ -43,8 +43,10 @@ fun ComponentScaffold(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             content()
-            Spacer(Modifier.size(16.dp))
-            footer()
+            if (footer != null) {
+                Spacer(Modifier.size(16.dp))
+                footer()
+            }
         }
 
         if (disableInteraction) {

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/ComponentScaffold.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/ComponentScaffold.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.unit.dp
 fun ComponentScaffold(
     modifier: Modifier = Modifier,
     footer: @Composable () -> Unit = {},
-    disableInteraction: Boolean = false,
+    disableInteraction: Boolean,
     content: @Composable () -> Unit,
 ) {
     val focusManager = LocalFocusManager.current


### PR DESCRIPTION
## Description
Updates v6 components to honor `configuration.showSubmitButton = false` by hiding the default submit button and letting integrations provide their own submit UI.

This change:
- Adds shared PayButton view state handling so components can omit the footer when submit buttons are disabled.
- Applies `showSubmitButton` handling to Card, Stored Card, BLIK, MB WAY, and Google Pay.
- Blocks interaction while Card and Stored Card components are submitting.
- Updates the example app to show a custom Pay button when the built-in submit button is hidden.
- Adds unit coverage for hidden submit button states.

## Checklist
- [x] Code is unit tested
- [x] Changes are tested manually
- [x] Related issues are linked

## Ticket Number
COSDK-1405