### PR TITLE
v6 - Agents - Dependency change guidance

### DIFF
--- a/.agents/skills/android-add-dependency/SKILL.md
+++ b/.agents/skills/android-add-dependency/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: android-add-dependency
+description: Decide on and apply a dependency change — impact assessment, libs.versions.toml, release notes dependency list, and verification metadata.
+---
+
+# android-add-dependency
+
+Decide whether to add, change, or remove a dependency in the Adyen Android SDK, then apply it without breaking release notes generation or dependency verification.
+
+## Usage
+
+Invoke this skill **before** touching `gradle/libs.versions.toml` — as soon as it looks like work will need a new library or plugin, a different version or artifact, or the removal of an existing one. This applies even when the dependency change is a side effect of a larger task, and even when the developer named the dependency themselves.
+
+Renovate handles routine version bumps. This skill is for dependency changes made by hand.
+
+## Steps
+
+### 1. Stop and get approval for the dependency itself
+
+**Do not edit any file yet.** This is a decision, not a mechanical step. We are an SDK: every dependency we take is imposed on every merchant that integrates us, and every one we drop or re-point can break them. The default answer to a new dependency is no.
+
+**First, try to avoid it:**
+
+- Does the Android platform, AndroidX, or something already in `gradle/libs.versions.toml` cover this?
+- Is the part we actually need small enough to implement ourselves? For published modules, prefer a small internal implementation over a new dependency.
+- Does it already reach us transitively? Declaring an existing transitive dependency explicitly is a much smaller step than taking a genuinely new artifact.
+
+**Then present the impact.** Answer every line — "none" is a valid answer, guessing is not:
+
+> **Impact of `<group:name:version>`**
+> - **Scope** — which modules, and which configuration (`api`, `implementation`, `compileOnly`, `testImplementation`, `androidTestImplementation`)
+> - **Merchants** — does it end up in merchant builds? Cover version conflicts with libraries merchants commonly use, `minSdk` (ours is 23), download size and method count, and the transitive artifacts it drags in
+> - **Public API** — do its types appear in our public API? If so its version becomes part of our contract and later upgrades turn into breaking changes. Prefer keeping it out of signatures and off `api`
+> - **R8 / ProGuard** — consumer rules or `dontwarn` needed? If it is an optional external SDK, does it need the `compileOnly` + `runCompileOnly` treatment from the "Adding New Modules" section of `AGENTS.md`?
+> - **Release notes** — `[included]` or `[excluded]`, and why (step 4 works out the exact entry)
+> - **Build and CI** — verification metadata churn, build and CI time, added Renovate surface
+> - **Tests** — impact on the test suite, if any
+> - **Maintenance and supply chain** — license, release cadence, last release, maintainer, and whether the version is at least 14 days old (matching the `minimumReleaseAge` Renovate uses in `renovate.json`)
+> - **Alternatives considered** — what you rejected, and why this is the better option
+
+For a **change**, also state what moves: the size of the version jump, breaking changes in the new version, and any coordinate or artifact swap.
+
+For a **removal**, also state whether anything still uses it, whether its types were exposed in our public API, and whether merchants may be resolving it through us. Removing a dependency merchants rely on transitively is a breaking change — follow the breaking change rules in `AGENTS.md`.
+
+**Ask for explicit approval and wait for an answer.** This holds even when the developer already asked for this exact dependency; they should see the impact before it lands. If they have clearly already decided, keep the summary short, but still show it.
+
+### 2. Choose the version and declaration
+
+- Never use a dynamic version (`+`, `latest.release`).
+- If the artifact is covered by a BoM that is already declared (e.g. `compose-bom`), declare it without a version — see `compose-ui-main` in `gradle/libs.versions.toml`.
+- Use the narrowest configuration that works. `implementation` over `api`, and test configurations over production ones.
+
+### 3. Update `gradle/libs.versions.toml`
+
+- Add the version to `[versions]` under the matching comment group, and the entry to `[libraries]` or `[plugins]`.
+- Follow the ordering of the group you are adding to.
+- Omit `version.ref` when the version comes from a BoM.
+
+### 4. Update `.github/release_notes_dependency_list.toml`
+
+Every dependency must appear in `[included]` or `[excluded]`. This is enforced: `scripts/validate_dependencies_for_release_notes.py` runs on every PR through `.github/workflows/validate_dependencies.yml` and fails the build for unlisted dependencies.
+
+**Derive the id.** The key is not the alias. It is derived from the entry:
+
+| Entry has | Id to use |
+|-----------|-----------|
+| `group` and `name` | `<group>:<name>` |
+| `module` | the `module` value |
+| neither (plugins) | the `id` value |
+
+**Choose the section.** Use `[included]` only when both are true:
+
+1. The dependency is merchant-relevant, meaning either:
+   - It ships to merchants — declared in a published SDK module as `api`, `implementation`, or `compileOnly`, so it resolves in a merchant's build. Compare `com.squareup.okhttp3:okhttp` (in `core` and `checkout-core`, included) against `com.squareup.okhttp3:logging-interceptor` (example app only, excluded).
+   - Or it is part of the toolchain merchants have to be compatible with. This applies to the Android Gradle Plugin and Kotlin only — every other build, CI, and code quality tool is excluded.
+2. No existing `[included]` entry already represents it. A BoM covers its artifacts, or a sibling from the same release train is already listed. The Kotlin artifacts and plugins are all represented by the single `kotlin` entry, and `com.android.application`/`com.android.library` by `com.android.tools.build:gradle`.
+
+Everything else goes in `[excluded]`: test-only, example-app-only, lint, `build-logic`, CI, and code quality tooling.
+
+> Do not use the comment groups in `libs.versions.toml` to decide. `# Production libraries` also holds example-app and tooling dependencies such as `leak-canary`, `retrofit-main`, and `ktlint-cli`. Find where the alias is actually used, and in which configuration.
+
+**Write the entry.**
+
+`[excluded]` values are an empty string. Add a comment when the reason is not obvious — in particular when a production dependency is excluded because another entry covers it:
+
+```toml
+# This dependency is already defined by another
+"androidx.navigation3:navigation3-ui" = ""
+```
+
+`[included]` values are a markdown link. `{}` is replaced with the new version when release notes are generated:
+
+```toml
+"androidx.startup:startup-runtime" = "[AndroidX Startup](https://developer.android.com/jetpack/androidx/releases/startup#{})"
+```
+
+- Use a version-anchored URL so the entry deep-links to the notes for that release. Follow a neighbouring entry from the same vendor:
+  - AndroidX: `https://developer.android.com/jetpack/androidx/releases/<artifact>#{}`
+  - GitHub releases: `https://github.com/<org>/<repo>/releases/tag/{}` — check whether the project prefixes its tags with `v`.
+- If the project publishes no per-version anchor, use a stable changelog or docs URL and leave out `{}`. See the OkHttp and TWINT entries.
+- Verify the formatted URL resolves for the version you are adding. A misplaced `{}` produces a dead link in published release notes.
+- Use a human-readable display name in the style of the surrounding entries.
+- Keep the list alphabetically ordered by id.
+
+### 5. Confirm the entry with the developer
+
+This is the second confirmation, and it is about the entry rather than the dependency. Always ask, even when the choice looks obvious. Show:
+
+- The id, and the section you propose
+- Why that section applies
+- For `[included]`, the link template and the URL it produces for the version being added
+
+Do not write the entry before you get an answer. If you cannot work out a good link, ask instead of guessing.
+
+### 6. Update verification metadata
+
+Dependency verification is enabled in `gradle/verification-metadata.xml`, so a new artifact fails the build until its checksum is recorded:
+
+```bash
+./gradlew --write-verification-metadata sha256 resolveDependencies assembleDebug
+```
+
+`assembleDebug` is included so dynamic dependencies such as `aapt2` resolve. Review the diff — it should only add entries for the new dependency and its transitives — and include the file in the commit.
+
+### 7. Verify
+
+- Run the same validation CI runs: `python3 scripts/validate_dependencies_for_release_notes.py`. It compares against the merge base with `origin/main`, so run it on your branch.
+- Use the `android-check` skill (`.agents/skills/android-check/SKILL.md`) to run compile, lint, and unit tests.
+
+## Modifying and removing dependencies
+
+- **Changed coordinates** on an existing alias (`group`, `name`, or `module`): update the id in `.github/release_notes_dependency_list.toml` too. PR validation only inspects newly added *aliases*, so a coordinate change passes CI and instead breaks release notes generation later with `Dependency not recognized`.
+- **Removed dependency**: remove its entry from `[included]` or `[excluded]` in the same change, unless the same id is still declared by another alias.
+- **Version-only bumps**: no change to the dependency list is needed. Step 1 still applies for a major version jump, since that is a merchant-visible change.
+
+## Important
+
+- Never add, change, or remove a dependency without approval from the developer first. Present the impact before making any change, including when they named the dependency themselves.
+- Taking a new dependency in a published module is a decision about our SDK's contract with merchants, not an implementation detail.
+- Never change `gradle/libs.versions.toml` without updating `.github/release_notes_dependency_list.toml` in the same change.
+- Always have the developer confirm the `[included]`/`[excluded]` choice and the link before writing it.
+- Never guess a release notes URL, a license, or a maintenance status. Look it up, or say you could not determine it.
+- `[included]` entries are published to merchants in the release notes. Treat them as merchant-facing content.

--- a/.agents/skills/android-add-dependency/SKILL.md
+++ b/.agents/skills/android-add-dependency/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: android-add-dependency
-description: Decide on and apply a dependency change — impact assessment, libs.versions.toml, release notes dependency list, and verification metadata.
+description: Add, remove or update an external dependency in the SDK.
 ---
 
 # android-add-dependency

--- a/.agents/skills/android-commit/SKILL.md
+++ b/.agents/skills/android-commit/SKILL.md
@@ -39,7 +39,7 @@ Stage only the specific files that were modified and are necessary for the commi
 
 Include any `.api` files if they were updated (e.g., after running `apiDump` for intentional public API changes).
 
-**If `gradle/libs.versions.toml` is among the changes:** confirm the developer approved the dependency change itself, that `.github/release_notes_dependency_list.toml` covers every added or re-pointed dependency, and that `gradle/verification-metadata.xml` was regenerated. Stage all three files. If the approval or either of the other two is missing, stop and use the `android-add-dependency` skill (`.agents/skills/android-add-dependency/SKILL.md`) before committing.
+**If `gradle/libs.versions.toml` is among the changes:** confirm the developer approved the dependency change itself, that `.github/release_notes_dependency_list.toml` covers every added or re-pointed dependency, and that `gradle/verification-metadata.xml` was regenerated. Stage these files. If the approval or any of these files is missing, stop and use the `android-add-dependency` skill (`.agents/skills/android-add-dependency/SKILL.md`) before committing.
 
 ### 6. Security scan
 

--- a/.agents/skills/android-commit/SKILL.md
+++ b/.agents/skills/android-commit/SKILL.md
@@ -21,7 +21,7 @@ Also ensure the branch is up to date with its upstream branch. If behind, pull t
 
 ### 2. Run pre-commit checks
 
-Use the `android-check` skill (`.agents/skills/android-check.md`) to run verification checks. Scope the checks to the modules that have changes.
+Use the `android-check` skill (`.agents/skills/android-check/SKILL.md`) to run verification checks. Scope the checks to the modules that have changes.
 
 **If checks fail:** Do not proceed to committing.
 
@@ -38,6 +38,8 @@ Ask the user for the ticket number (format: `COSDK-XXXX`). If the user has alrea
 Stage only the specific files that were modified and are necessary for the commit. **Never use `git add -A` or `git add .`**. Use `git add <file1> <file2> ...` for individual files.
 
 Include any `.api` files if they were updated (e.g., after running `apiDump` for intentional public API changes).
+
+**If `gradle/libs.versions.toml` is among the changes:** confirm the developer approved the dependency change itself, that `.github/release_notes_dependency_list.toml` covers every added or re-pointed dependency, and that `gradle/verification-metadata.xml` was regenerated. Stage all three files. If the approval or either of the other two is missing, stop and use the `android-add-dependency` skill (`.agents/skills/android-add-dependency/SKILL.md`) before committing.
 
 ### 6. Security scan
 
@@ -79,6 +81,7 @@ Confirm the commit was created successfully by running `git log --oneline -1`.
 
 - Never skip pre-commit checks.
 - Never use `git add -A` or `git add .`.
+- If `gradle/libs.versions.toml` changed, the dependency change must have been approved by the developer, and the release notes dependency list must be updated in the same commit.
 - Always ask for ticket number if not already known.
 - Always confirm the commit message with the user before executing.
 - Stop immediately if secrets are detected in the diff.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,30 +287,7 @@ if (checkCompileOnly("com.external.sdk.SomeClass")) {
 
 ### Adding or Modifying Dependencies
 
-**Get explicit approval before adding, changing, or removing a dependency — before making any code change.**
-
-We are an SDK. Every dependency we take is imposed on every merchant that integrates us, and every one we drop or re-point can break them. The default answer to a new dependency is no. Check first whether the platform, AndroidX, or an existing dependency already covers the need, or whether the part we need is small enough to implement ourselves.
-
-**Explain the impact before asking**, even when the developer named the dependency themselves:
-- Which modules and configuration (`api`, `implementation`, `compileOnly`, test-only)
-- Whether it reaches merchant builds, and the version conflict, `minSdk`, and size consequences
-- Whether it touches our public API — if its types are exposed, its version becomes part of our contract
-- R8/ProGuard needs, build and CI impact, test impact
-- License, maintenance status, and the alternatives you rejected
-
-Removing a dependency merchants resolve through us is a breaking change.
-
-**Every dependency in `gradle/libs.versions.toml` must also be listed in `.github/release_notes_dependency_list.toml`:**
-- `[included]` — merchant-relevant dependencies: shipped in a published module, or part of the toolchain merchants must be compatible with (AGP and Kotlin). The value is a markdown link to the vendor's release notes, with `{}` where the version goes. These entries are published in our release notes.
-- `[excluded]` — everything else (tests, example app, build logic, CI, code quality tooling), plus merchant-relevant dependencies already covered by another entry such as a BoM. The value is an empty string.
-
-**Always ask the developer to confirm the section and the link before writing the entry.** Never guess a release notes URL.
-
-CI enforces this: a newly added dependency that appears in neither list fails the `validate_dependencies` check on every PR.
-
-Dependency verification is enabled, so a new dependency also requires regenerating `gradle/verification-metadata.xml` or the build fails on a missing checksum.
-
-Use the `android-add-dependency` skill (`.agents/skills/android-add-dependency/SKILL.md`) for the full procedure, including the impact assessment template, how the id is derived, and how to choose the link pattern.
+If a new dependency needs to be added, or an existing dependency needs to be updated or removed, use the `android-add-dependency` skill (`.agents/skills/android-add-dependency/SKILL.md`). It covers the full procedure, including getting approval, the impact assessment template, updating `gradle/libs.versions.toml` and `.github/release_notes_dependency_list.toml`, and regenerating `gradle/verification-metadata.xml`.
 
 ## Verification Checklist
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ This document outlines important patterns, practices, and rules to follow when w
 
 **Commit workflow - CRITICAL:**
 - **Complete one phase fully before moving to the next**
-- After completing a phase, use the `android-commit` skill (`.agents/skills/android-commit.md`) to commit
+- After completing a phase, use the `android-commit` skill (`.agents/skills/android-commit/SKILL.md`) to commit
 - Never accumulate multiple phases in a single commit
 - Each commit should represent a logical, complete unit of work
 - This ensures work can be reviewed incrementally and rolled back if needed
@@ -285,6 +285,33 @@ if (checkCompileOnly("com.external.sdk.SomeClass")) {
 }
 ```
 
+### Adding or Modifying Dependencies
+
+**Get explicit approval before adding, changing, or removing a dependency — before making any code change.**
+
+We are an SDK. Every dependency we take is imposed on every merchant that integrates us, and every one we drop or re-point can break them. The default answer to a new dependency is no. Check first whether the platform, AndroidX, or an existing dependency already covers the need, or whether the part we need is small enough to implement ourselves.
+
+**Explain the impact before asking**, even when the developer named the dependency themselves:
+- Which modules and configuration (`api`, `implementation`, `compileOnly`, test-only)
+- Whether it reaches merchant builds, and the version conflict, `minSdk`, and size consequences
+- Whether it touches our public API — if its types are exposed, its version becomes part of our contract
+- R8/ProGuard needs, build and CI impact, test impact
+- License, maintenance status, and the alternatives you rejected
+
+Removing a dependency merchants resolve through us is a breaking change.
+
+**Every dependency in `gradle/libs.versions.toml` must also be listed in `.github/release_notes_dependency_list.toml`:**
+- `[included]` — merchant-relevant dependencies: shipped in a published module, or part of the toolchain merchants must be compatible with (AGP and Kotlin). The value is a markdown link to the vendor's release notes, with `{}` where the version goes. These entries are published in our release notes.
+- `[excluded]` — everything else (tests, example app, build logic, CI, code quality tooling), plus merchant-relevant dependencies already covered by another entry such as a BoM. The value is an empty string.
+
+**Always ask the developer to confirm the section and the link before writing the entry.** Never guess a release notes URL.
+
+CI enforces this: a newly added dependency that appears in neither list fails the `validate_dependencies` check on every PR.
+
+Dependency verification is enabled, so a new dependency also requires regenerating `gradle/verification-metadata.xml` or the build fails on a missing checksum.
+
+Use the `android-add-dependency` skill (`.agents/skills/android-add-dependency/SKILL.md`) for the full procedure, including the impact assessment template, how the id is derived, and how to choose the link pattern.
+
 ## Verification Checklist
 
 Before considering work complete:
@@ -296,8 +323,9 @@ Before considering work complete:
 6. If layout/styles changed: Styles added, proper attributes used, hierarchy maintained
 7. If strings changed: All translations present, localized context applied
 8. If new module added: Gradle configuration reviewed, external SDKs handled properly
-9. If refactoring: Test coverage exists for affected code
-10. Added classes and functions have unit tests following given-when-then structure
+9. If dependencies changed: Dependency approved by the developer with its impact explained, release notes dependency list updated and confirmed, verification metadata regenerated
+10. If refactoring: Test coverage exists for affected code
+11. Added classes and functions have unit tests following given-when-then structure
 
 ## When in Doubt
 


### PR DESCRIPTION
## Description
Nothing in our agent guidance asked an agent to justify taking a dependency, or to update `.github/release_notes_dependency_list.toml` when adding one — which CI rejects on every PR. Neither file was mentioned in any markdown in the repo.

Guidance is added in three layers so it applies regardless of how a task is framed:

- **`AGENTS.md` — new "Adding or Modifying Dependencies" section.** Always-on context, so it also applies when a dependency change is a side effect of unrelated work. Leads with the approval gate, then the release notes list rules. Adds a verification checklist item.
- **New `android-add-dependency` skill.** Step 1 blocks on an impact assessment (scope, merchant impact, public API exposure, R8/ProGuard, build/CI, tests, licensing, rejected alternatives) before any edit. Then the mechanics: deriving the dependency id, choosing `[included]` vs `[excluded]`, writing the release notes link, and regenerating verification metadata.
- **`android-commit` gate.** If `gradle/libs.versions.toml` is staged, verify the change was approved and that both the dependency list and verification metadata are updated.

Also fixes two stale skill paths left over from the pre-`SKILL.md` layout.

Markdown only — no code, Gradle, or resource changes.

## Checklist
- [x] Changes are tested manually