### PR TITLE
v6 - CI - Increase the Gradle heap for the UI tests job

### DIFF
--- a/.github/workflows/run_ui_tests.yml
+++ b/.github/workflows/run_ui_tests.yml
@@ -26,6 +26,11 @@ jobs:
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
+      # Packaging the test APKs of every module in parallel needs more heap than the shared value provides. The last
+      # occurrence of a key wins, so this overrides org.gradle.jvmargs for this workflow only.
+      - name: Increase the Gradle heap
+        run: echo "org.gradle.jvmargs=-Xmx8g" >> ~/.gradle/gradle.properties
+
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules


### PR DESCRIPTION
## Description
The UI Tests workflow has failed on every run since it moved to the eight core runner: a random module fails `packageDebugAndroidTest` with `OutOfMemoryError: Java heap space` in `zipflinger`/`ApkFlinger`.

That runner packages up to eight test APKs in parallel, each compressing its entries in memory, all inside the 4g daemon heap from the shared `ci-gradle.properties`. It only reproduces on a cold Gradle cache, because that is when enough packaging tasks actually execute instead of being restored: every run with a cache hit rate around 50% passed, every run around 29% failed, and the failing module varied (`:ach`, `:instant`, `:drop-in`).

Diagnostics from a reproducing run ruled out everything else: 223G disk free, 22g of 32g memory available, open file limit 65536, and no kernel OOM kill. So the JVM ceiling was the constraint, not the machine.

The override is applied in this workflow only, because `ci-gradle.properties` is shared with jobs on 16g runners where an 8g ceiling is not safe, the more so since `kotlin.daemon.jvmargs` is unset and the Kotlin daemon would inherit it. `org.gradle.workers.max=4` would be the alternative, but it gives back part of the speed the larger runner was for.

## Checklist
- [x] Changes are tested manually