### PR TITLE
v6 - Core - Fix shopper input loss on backgrounding in ComponentStateFlow

### DIFF
--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/BlikComponent.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/BlikComponent.kt
@@ -49,7 +49,6 @@ constructor(
         initialState = componentStateFactory.createInitialState(),
         reducer = componentStateReducer,
         validator = componentStateValidator,
-        coroutineScope = coroutineScope,
     )
 
     private val viewState = componentState.viewState(viewStateProducer, coroutineScope)

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/CardComponent.kt
@@ -96,7 +96,6 @@ constructor(
         initialState = componentStateFactory.createInitialState(),
         reducer = componentStateReducer,
         validator = componentStateValidator,
-        coroutineScope = coroutineScope,
     )
 
     private val viewState = componentState.viewState(viewStateProducer, coroutineScope)

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/StoredCardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/StoredCardComponent.kt
@@ -72,7 +72,6 @@ constructor(
         initialState = componentStateFactory.createInitialState(),
         reducer = componentStateReducer,
         validator = componentStateValidator,
-        coroutineScope = coroutineScope,
     )
 
     private val viewState = componentState.viewState(viewStateProducer, coroutineScope)

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/ComponentStateFlow.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/ComponentStateFlow.kt
@@ -11,14 +11,13 @@ package com.adyen.checkout.core.components.internal.ui.state
 import androidx.annotation.RestrictTo
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalForInheritanceCoroutinesApi
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.receiveAsFlow
-import kotlinx.coroutines.flow.runningFold
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 
 @Suppress("UnnecessaryOptInAnnotation")
 @OptIn(ExperimentalForInheritanceCoroutinesApi::class)
@@ -32,47 +31,42 @@ fun <C : ComponentState, I : ComponentStateIntent> ComponentStateFlow(
     initialState: C,
     reducer: ComponentStateReducer<C, I>,
     validator: ComponentStateValidator<C>,
-    coroutineScope: CoroutineScope,
 ): ComponentStateFlow<C, I> = ComponentStateFlowImplementation(
     initialState = initialState,
     reducer = reducer,
     validator = validator,
-    coroutineScope = coroutineScope,
 )
 
+// Owns its state directly in a MutableStateFlow rather than folding intents over a cold flow. A cold flow's
+// accumulator is torn down by WhileSubscribed once the last collector goes away (e.g. the app is backgrounded for
+// longer than the sharing timeout), and nothing replays the intents handled while nobody was collecting - so
+// shopper input would silently be discarded. Owning the state directly means there is no subscription whose
+// cancellation could lose anything.
+//
+// This requires reducer.reduce and validator.validate to be pure (no side effects), because MutableStateFlow.update
+// can re-invoke its lambda under contention.
 private class ComponentStateFlowImplementation<C : ComponentState, I : ComponentStateIntent>(
     initialState: C,
-    reducer: ComponentStateReducer<C, I>,
-    validator: ComponentStateValidator<C>,
-    coroutineScope: CoroutineScope,
+    private val reducer: ComponentStateReducer<C, I>,
+    private val validator: ComponentStateValidator<C>,
 ) : ComponentStateFlow<C, I> {
-
-    private val intents = Channel<I>(Channel.BUFFERED)
 
     // Validated up front: isValid reads the errorMessage that validate() writes, so an unvalidated state reports
     // itself valid no matter what it contains.
-    private val validatedInitialState = validator.validate(initialState)
-
-    private val stateFlow: StateFlow<C> = intents
-        .receiveAsFlow()
-        .runningFold(validatedInitialState) { state, intent ->
-            val reduced = reducer.reduce(state, intent)
-            validator.validate(reduced)
-        }
-        .stateIn(coroutineScope, SharingStarted.WhileSubscribed(SUBSCRIBE_TIMEOUT_MS), validatedInitialState)
+    private val state = MutableStateFlow(validator.validate(initialState))
 
     override val value: C
-        get() = stateFlow.value
+        get() = state.value
 
     override val replayCache: List<C>
-        get() = stateFlow.replayCache
+        get() = state.replayCache
 
     override suspend fun collect(collector: FlowCollector<C>): Nothing {
-        stateFlow.collect(collector)
+        state.collect(collector)
     }
 
     override fun handleIntent(intent: I) {
-        intents.trySend(intent)
+        state.update { validator.validate(reducer.reduce(it, intent)) }
     }
 }
 

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/ui/state/ComponentStateFlowTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/ui/state/ComponentStateFlowTest.kt
@@ -11,7 +11,6 @@ package com.adyen.checkout.core.components.internal.ui.state
 import com.adyen.checkout.core.common.test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -84,7 +83,7 @@ internal class ComponentStateFlowTest {
         }
 
     @Test
-    fun `when nothing is collecting, then a handled intent is not applied`() = runTest {
+    fun `when nothing is collecting, then a handled intent is still applied`() = runTest {
         // GIVEN
         val stateFlow = createStateFlow()
 
@@ -93,7 +92,7 @@ internal class ComponentStateFlowTest {
         testScheduler.runCurrent()
 
         // THEN
-        assertEquals(VALIDATED_INITIAL_STATE, stateFlow.value)
+        assertEquals(TestState(value = "a", validationCount = 2), stateFlow.value)
     }
 
     @Test
@@ -111,7 +110,7 @@ internal class ComponentStateFlowTest {
     }
 
     @Test
-    fun `when collection stops for longer than the sharing timeout, then the state resets to the initial state`() =
+    fun `when collection stops for longer than the sharing timeout, then the state survives`() =
         runTest {
             // GIVEN
             val stateFlow = createStateFlow()
@@ -127,7 +126,7 @@ internal class ComponentStateFlowTest {
             testScheduler.runCurrent()
 
             // THEN
-            assertEquals(VALIDATED_INITIAL_STATE, stateFlow.value)
+            assertEquals(TestState(value = "a", validationCount = 2), stateFlow.value)
         }
 
     @Test
@@ -156,11 +155,10 @@ internal class ComponentStateFlowTest {
         assertEquals(TestViewState(value = "a"), viewStates.latestValue)
     }
 
-    private fun TestScope.createStateFlow() = ComponentStateFlow(
+    private fun createStateFlow() = ComponentStateFlow(
         initialState = INITIAL_STATE,
         reducer = reducer,
         validator = TestValidator,
-        coroutineScope = backgroundScope,
     )
 
     private data class TestState(
@@ -198,7 +196,7 @@ internal class ComponentStateFlowTest {
 
         private val INITIAL_STATE = TestState()
 
-        // ComponentStateFlow validates the initial state before seeding the fold, so this is what it actually emits.
+        // ComponentStateFlow validates the initial state before it is stored, so this is what it actually emits.
         private val VALIDATED_INITIAL_STATE = TestState(validationCount = 1)
 
         // Mirrors the private SUBSCRIBE_TIMEOUT_MS in ComponentStateFlow.

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/GooglePayComponent.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/GooglePayComponent.kt
@@ -78,7 +78,6 @@ internal class GooglePayComponent(
         initialState = componentStateFactory.createInitialState(),
         reducer = componentStateReducer,
         validator = componentStateValidator,
-        coroutineScope = coroutineScope,
     )
 
     internal val viewState = componentState.viewState(viewStateProducer, coroutineScope)

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/MBWayComponent.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/MBWayComponent.kt
@@ -53,7 +53,6 @@ constructor(
         initialState = componentStateFactory.createInitialState(),
         reducer = componentStateReducer,
         validator = componentStateValidator,
-        coroutineScope = coroutineScope,
     )
 
     private val viewState = componentState.viewState(viewStateProducer, coroutineScope)


### PR DESCRIPTION
## Description

`ComponentStateFlow` backed the accumulated form state with `runningFold` over a `Channel`, shared via `stateIn(WhileSubscribed(5s))`. Backgrounding the app (`collectAsStateWithLifecycle` unsubscribes below `STARTED`) tears that subscription down after 5s per layer (~10s total once `viewState()`'s own `WhileSubscribed` is stacked on top). The next collection restarts the fold from `initialState` with no replay, silently discarding everything the shopper typed.

#### How to reproduce
Example app → MB Way → type a phone number → background the app for 15s → return to the app. The phone number field is empty. Returning within 9s preserves it.
`CardComponent` was accidentally immune because a permanent analytics subscriber kept the sharing coroutine alive.

#### Fix
Own the state directly in a `MutableStateFlow`. `handleIntent()` updates it synchronously, so there is no subscription to tear down and nothing to discard. This also drops the now-unused `coroutineScope` parameter from `ComponentStateFlow(...)` — safe to remove because it was only ever used to launch the `stateIn` sharing coroutine for the internal fold, not as a lifecycle guard; every place that legitimately ties its lifetime to the merchant-owned scope (`viewState()`'s own `stateIn`, and `CardComponent`'s `.launchIn(coroutineScope)` analytics/bin-callback collectors) still receives and uses it unchanged.

#### Why `viewState()` still uses `WhileSubscribed` safely
`WhileSubscribed(5s)` is the Android-team-recommended default for `stateIn`, and it was originally applied to both `stateIn` calls in this file without noticing that using it on the state *accumulator* itself was unsafe. `viewState()` doesn't have that problem: its `stateIn` wraps a pure re-derivation (`producer.produce(state)`) of `componentState`, which is now a hot, conflated `MutableStateFlow` that retains its value with no subscribers needed. If `viewState()`'s sharing coroutine is torn down and restarts, it just re-subscribes to `componentState` and recomputes — cheap, pure, no I/O, and nothing to lose because `viewState()` was never the one holding the data. Concretely: while the sharing coroutine is stopped, `viewState.value` simply holds its last emitted value frozen in place; `WhileSubscribed`'s `replayExpirationMillis` defaults to infinite, and we don't override it, so it only ever emits `STOP` (keep the replay cache) and never `STOP_AND_RESET_REPLAY_CACHE` (reset to the initial seed). `componentState` keeps accepting `handleIntent()` calls the entire time regardless, so when a new collector appears there's nothing stale to reconcile — the map just recomputes from the current truth.

#### Discarded alternative
`SharingStarted.Eagerly` instead of `WhileSubscribed` — a one-line fix that keeps the fold alive forever. Rejected because the state would still live inside a flow operator chain "by promise" rather than by construction, and the `Channel` round-trip would leave `componentState.value` briefly stale right after `handleIntent()` returns.

#### Precondition
`MutableStateFlow.update {}` can re-invoke its lambda under contention, so `reducer.reduce`/`validator.validate` must stay pure — true today for all reducers.

## Checklist
- [x] Code is unit tested
- [x] Changes are tested manually
