### PR TITLE
v6 - Errors - Add InvalidConfigurationError and use it for a missing Google Pay merchant account

### DIFF
--- a/core/src/main/java/com/adyen/checkout/core/error/CheckoutErrorMapper.kt
+++ b/core/src/main/java/com/adyen/checkout/core/error/CheckoutErrorMapper.kt
@@ -11,6 +11,7 @@ package com.adyen.checkout.core.error
 import com.adyen.checkout.core.error.internal.GenericError
 import com.adyen.checkout.core.error.internal.HttpError
 import com.adyen.checkout.core.error.internal.InternalCheckoutError
+import com.adyen.checkout.core.error.internal.InvalidConfigurationError
 import com.adyen.checkout.core.error.internal.PaymentMethodUnavailableError
 
 /**
@@ -20,6 +21,7 @@ internal fun InternalCheckoutError.toCheckoutError(): CheckoutError {
     val errorCode = when (this) {
         is HttpError -> CheckoutError.ErrorCode.HTTP
         is GenericError -> CheckoutError.ErrorCode.GENERIC
+        is InvalidConfigurationError -> CheckoutError.ErrorCode.INVALID_CONFIGURATION
         is PaymentMethodUnavailableError -> CheckoutError.ErrorCode.PAYMENT_METHOD_FAILURE
     }
 

--- a/core/src/main/java/com/adyen/checkout/core/error/internal/InvalidConfigurationError.kt
+++ b/core/src/main/java/com/adyen/checkout/core/error/internal/InvalidConfigurationError.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 3/8/2026.
+ */
+
+package com.adyen.checkout.core.error.internal
+
+import androidx.annotation.RestrictTo
+
+/**
+ * Indicates that the configuration required to complete the checkout is missing or invalid.
+ *
+ * Use this for merchant facing configuration problems that can only be detected once the payment
+ * method data is known, such as a missing merchant account. Configuration that can be validated up
+ * front is instead reported through `CheckoutConfiguration.validate()`.
+ *
+ * @param message A human-readable description of the error.
+ * @param cause The underlying cause of this error, if any.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class InvalidConfigurationError(
+    message: String,
+    cause: Throwable? = null,
+) : InternalCheckoutError(message, cause)

--- a/core/src/test/java/com/adyen/checkout/core/error/CheckoutErrorMapperTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/error/CheckoutErrorMapperTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 3/8/2026.
+ */
+
+package com.adyen.checkout.core.error
+
+import com.adyen.checkout.core.error.internal.GenericError
+import com.adyen.checkout.core.error.internal.HttpError
+import com.adyen.checkout.core.error.internal.InvalidConfigurationError
+import com.adyen.checkout.core.error.internal.PaymentMethodUnavailableError
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+internal class CheckoutErrorMapperTest {
+
+    @Test
+    fun `when error is GenericError, then code is GENERIC`() {
+        val error = GenericError("generic message")
+
+        val result = error.toCheckoutError()
+
+        assertEquals(CheckoutError.ErrorCode.GENERIC, result.code)
+        assertEquals("generic message", result.message)
+        assertSame(error, result.cause)
+    }
+
+    @Test
+    fun `when error is InvalidConfigurationError, then code is INVALID_CONFIGURATION`() {
+        val error = InvalidConfigurationError("configuration message")
+
+        val result = error.toCheckoutError()
+
+        assertEquals(CheckoutError.ErrorCode.INVALID_CONFIGURATION, result.code)
+        assertEquals("configuration message", result.message)
+        assertSame(error, result.cause)
+    }
+
+    @Test
+    fun `when error is PaymentMethodUnavailableError, then code is PAYMENT_METHOD_FAILURE`() {
+        val error = PaymentMethodUnavailableError("unavailable message")
+
+        val result = error.toCheckoutError()
+
+        assertEquals(CheckoutError.ErrorCode.PAYMENT_METHOD_FAILURE, result.code)
+        assertEquals("unavailable message", result.message)
+        assertSame(error, result.cause)
+    }
+
+    @Test
+    fun `when error is HttpError, then code is HTTP`() {
+        val error = HttpError(code = 422, message = "http message", errorBody = null)
+
+        val result = error.toCheckoutError()
+
+        assertEquals(CheckoutError.ErrorCode.HTTP, result.code)
+        assertEquals("http message", result.message)
+        assertSame(error, result.cause)
+    }
+
+    @Test
+    fun `when throwable is an InternalCheckoutError, then it delegates to the internal mapping`() {
+        // The Throwable type is required, without it the call resolves to the InternalCheckoutError
+        // overload and the delegation branch under test is never executed.
+        val throwable: Throwable = InvalidConfigurationError("configuration message")
+
+        val result = throwable.toCheckoutError()
+
+        assertEquals(CheckoutError.ErrorCode.INVALID_CONFIGURATION, result.code)
+    }
+
+    @Test
+    fun `when throwable is not an InternalCheckoutError, then code is GENERIC`() {
+        val throwable = IllegalStateException("boom")
+
+        val result = throwable.toCheckoutError()
+
+        assertEquals(CheckoutError.ErrorCode.GENERIC, result.code)
+        assertEquals("boom", result.message)
+        assertSame(throwable, result.cause)
+    }
+}

--- a/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParamsMapper.kt
+++ b/googlepay/src/main/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParamsMapper.kt
@@ -15,7 +15,7 @@ import com.adyen.checkout.core.common.internal.CheckoutParams
 import com.adyen.checkout.core.common.internal.helper.adyenLog
 import com.adyen.checkout.core.components.data.model.Amount
 import com.adyen.checkout.core.components.data.model.paymentmethod.GooglePayPaymentMethod
-import com.adyen.checkout.core.error.internal.GenericError
+import com.adyen.checkout.core.error.internal.InvalidConfigurationError
 import com.adyen.checkout.googlepay.AllowedAuthMethods
 import com.adyen.checkout.googlepay.AllowedCardNetworks
 import com.adyen.checkout.googlepay.GooglePayAllowedPaymentMethods
@@ -61,7 +61,7 @@ internal class GooglePayComponentParamsMapper {
     ): String {
         return this?.merchantAccount
             ?: paymentMethod.configuration?.gatewayMerchantId
-            ?: throw GenericError(
+            ?: throw InvalidConfigurationError(
                 message = "GooglePay merchantAccount not found. Update your API version or pass it " +
                     "manually inside your GooglePayConfiguration",
             )

--- a/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParamsMapperTest.kt
+++ b/googlepay/src/test/java/com/adyen/checkout/googlepay/internal/ui/model/GooglePayComponentParamsMapperTest.kt
@@ -17,7 +17,7 @@ import com.adyen.checkout.core.components.data.model.paymentmethod.GooglePayPaym
 import com.adyen.checkout.core.components.internal.AnalyticsParams
 import com.adyen.checkout.core.components.internal.AnalyticsParamsLevel
 import com.adyen.checkout.core.components.paymentmethod.PaymentMethodTypes
-import com.adyen.checkout.core.error.internal.InternalCheckoutError
+import com.adyen.checkout.core.error.internal.InvalidConfigurationError
 import com.adyen.checkout.googlepay.AllowedAuthMethods
 import com.adyen.checkout.googlepay.AllowedCardNetworks
 import com.adyen.checkout.googlepay.BillingAddressParameters
@@ -202,7 +202,7 @@ internal class GooglePayComponentParamsMapperTest {
             ),
         )
 
-        assertThrows<InternalCheckoutError> {
+        assertThrows<InvalidConfigurationError> {
             googlePayComponentParamsMapper.mapToParams(
                 params = checkoutParams,
                 paymentMethod = createPaymentMethod(),


### PR DESCRIPTION
## Description
Introduces `InvalidConfigurationError`, a new internal error type that maps to the existing but previously unused `CheckoutError.ErrorCode.INVALID_CONFIGURATION` code, and uses it for the missing Google Pay merchant account case.

Previously this was reported as a `GenericError`, so merchants received the catch-all `Generic` code with no indication that the cause was a configuration mistake on their side.

This aligns with iOS, where `ApplePayComponent.Error` already has dedicated configuration cases (`emptyMerchantIdentifier`, `missingConfiguration`).

- Add `InvalidConfigurationError`, a new subclass of the sealed `InternalCheckoutError`.
- Map it to `CheckoutError.ErrorCode.INVALID_CONFIGURATION` in `CheckoutErrorMapper`.
- `GooglePayComponentParamsMapper` now throws it instead of `GenericError` when neither `GooglePayConfiguration.merchantAccount` nor `paymentMethod.configuration.gatewayMerchantId` is set.

## Checklist
- [x] Code is unit tested
- [x] Changes are tested manually
- [x] Aligned public API changes with other platforms (if applicable)

## Ticket Number
COSDK-1002

## Release notes
### Changed
- A missing Google Pay `merchantAccount` is now reported with the `InvalidConfiguration` error code instead of `Generic`.
