### PR TITLE
v6 - Errors - Convert creation errors to CheckoutException and report unsupported actions

### DIFF
--- a/core/src/main/java/com/adyen/checkout/core/action/internal/ActionComponentProvider.kt
+++ b/core/src/main/java/com/adyen/checkout/core/action/internal/ActionComponentProvider.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.adyen.checkout.core.action.data.Action
 import com.adyen.checkout.core.analytics.internal.AnalyticsManager
 import com.adyen.checkout.core.common.internal.CheckoutParams
+import com.adyen.checkout.core.error.internal.GenericError
 import kotlinx.coroutines.CoroutineScope
 import java.util.concurrent.ConcurrentHashMap
 
@@ -44,9 +45,10 @@ object ActionComponentProvider {
             analyticsManager = analyticsManager,
             params = params,
             savedStateHandle = savedStateHandle,
-        ) ?: run {
-            error("Factory for action type: ${action.type} is not registered.")
-        }
+        ) ?: throw GenericError(
+            "Action type '${action.type}' is not supported. " +
+                "Ensure the corresponding module is included in your build dependencies.",
+        )
     }
 
     /**

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ActionHandler.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ActionHandler.kt
@@ -22,6 +22,7 @@ import com.adyen.checkout.core.common.CheckoutResultCode
 import com.adyen.checkout.core.common.internal.CheckoutParams
 import com.adyen.checkout.core.common.internal.helper.adyenLog
 import com.adyen.checkout.core.components.AdditionalDetailsResult
+import com.adyen.checkout.core.error.internal.InternalCheckoutError
 import com.adyen.checkout.core.error.toCheckoutError
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -42,15 +43,22 @@ internal class ActionHandler(
 
     fun handleAction(action: Action) {
         job?.cancel()
+        this.actionComponent = null
 
-        val actionComponent = ActionComponentProvider.get(
-            action = action,
-            coroutineScope = coroutineScope,
-            analyticsManager = analyticsManager,
-            params = params,
-            // TODO - Check if we really need saved state handle
-            savedStateHandle = @SuppressLint("VisibleForTests") SavedStateHandle(),
-        )
+        val actionComponent = try {
+            ActionComponentProvider.get(
+                action = action,
+                coroutineScope = coroutineScope,
+                analyticsManager = analyticsManager,
+                params = params,
+                // TODO - Check if we really need saved state handle
+                savedStateHandle = @SuppressLint("VisibleForTests") SavedStateHandle(),
+            )
+        } catch (e: InternalCheckoutError) {
+            adyenLog(AdyenLogLevel.ERROR, e) { "Could not create an action component for action '${action.type}'" }
+            componentRequestDispatcher.failure(e.toCheckoutError())
+            return
+        }
         this.actionComponent = actionComponent
 
         job = actionComponent.eventFlow

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutControllerFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutControllerFactory.kt
@@ -24,6 +24,9 @@ import com.adyen.checkout.core.components.CheckoutController
 import com.adyen.checkout.core.components.CheckoutTarget
 import com.adyen.checkout.core.components.SessionCheckoutCallbacks
 import com.adyen.checkout.core.components.internal.data.provider.DefaultSdkDataProvider
+import com.adyen.checkout.core.error.CheckoutException
+import com.adyen.checkout.core.error.internal.InternalCheckoutError
+import com.adyen.checkout.core.error.toCheckoutError
 import com.adyen.checkout.core.sessions.internal.data.api.SessionRepository
 import com.adyen.checkout.core.sessions.internal.data.api.SessionService
 import kotlinx.coroutines.CoroutineScope
@@ -35,9 +38,9 @@ internal class CheckoutControllerFactory {
         context: CheckoutContext.Advanced,
         callbacks: AdvancedCheckoutCallbacks,
         coroutineScope: CoroutineScope,
-    ): CheckoutController {
+    ): CheckoutController = runCatchingCreation {
         val componentRequestDispatcher = AdvancedComponentRequestDispatcher(callbacks)
-        return createFullCheckoutController(
+        createFullCheckoutController(
             target = target,
             context = context,
             callbacks = callbacks,
@@ -51,12 +54,12 @@ internal class CheckoutControllerFactory {
         context: CheckoutContext.Sessions,
         callbacks: SessionCheckoutCallbacks,
         coroutineScope: CoroutineScope,
-    ): CheckoutController {
+    ): CheckoutController = runCatchingCreation {
         val componentRequestDispatcher = createSessionComponentRequestDispatcher(
             context = context,
             callbacks = callbacks,
         )
-        return createFullCheckoutController(
+        createFullCheckoutController(
             target = target,
             context = context,
             callbacks = callbacks,
@@ -69,7 +72,7 @@ internal class CheckoutControllerFactory {
         context: CheckoutContext.ActionOnly,
         callbacks: ActionOnlyCheckoutCallbacks,
         coroutineScope: CoroutineScope,
-    ): CheckoutController {
+    ): CheckoutController = runCatchingCreation {
         val checkoutParams = createCheckoutParams(context)
         // TODO - what should be the payment method type for action only?
         val analyticsManager = createAnalyticsManager(
@@ -89,11 +92,27 @@ internal class CheckoutControllerFactory {
             action = context.action,
             actionHandler = actionHandler,
         )
-        return CheckoutController(
+        CheckoutController(
             flow = flow,
             environment = checkoutParams.environment,
             shopperLocale = checkoutParams.shopperLocale,
         )
+    }
+
+    /**
+     * Runs the controller creation, converting any [InternalCheckoutError] that escapes into the
+     * public [CheckoutException].
+     *
+     * Only [InternalCheckoutError] is caught on purpose. Programming errors and broken invariants
+     * are expected to fail fast so that they surface as bugs instead of being reported as checkout
+     * errors.
+     */
+    // The caught error is not swallowed, toCheckoutError() keeps it as the cause of the thrown exception.
+    @Suppress("SwallowedException")
+    private inline fun <T> runCatchingCreation(block: () -> T): T = try {
+        block()
+    } catch (e: InternalCheckoutError) {
+        throw CheckoutException(e.toCheckoutError())
     }
 
     private fun createFullCheckoutController(

--- a/core/src/main/java/com/adyen/checkout/core/error/internal/InternalCheckoutError.kt
+++ b/core/src/main/java/com/adyen/checkout/core/error/internal/InternalCheckoutError.kt
@@ -16,6 +16,23 @@ import androidx.annotation.RestrictTo
  * All internal error types extend this class directly. Being sealed ensures exhaustive handling
  * in `when` expressions, so adding a new error type forces a compiler error at all handling sites.
  *
+ * The SDK reports failures through three distinct mechanisms. Pick the matching one when adding
+ * new failure handling:
+ *
+ * 1. Configuration that can be checked up front returns a `CheckoutError` instead of throwing. See
+ * `CheckoutConfiguration.validate()`, which surfaces the error as `Checkout.Result.Error` before a
+ * controller exists.
+ *
+ * 2. Failures a correctly integrated app can hit at runtime are represented by an
+ * [InternalCheckoutError]. They are mapped with `toCheckoutError()` and delivered to the merchant,
+ * either through `onFailure` while the flow is running, or as a `CheckoutException` when they occur
+ * while the controller is being created.
+ *
+ * 3. Broken invariants that can only happen when something is wired incorrectly use plain runtime
+ * exceptions such as `IllegalStateException` and `IllegalArgumentException`. These are deliberately
+ * not converted, so that they fail fast and surface as bugs rather than being reported as checkout
+ * errors.
+ *
  * @param message A human-readable description of the error.
  * @param cause The underlying cause of this error, if any.
  */

--- a/core/src/test/java/com/adyen/checkout/core/action/internal/ActionComponentProviderTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/action/internal/ActionComponentProviderTest.kt
@@ -17,6 +17,7 @@ import com.adyen.checkout.core.common.Environment
 import com.adyen.checkout.core.common.internal.CheckoutParams
 import com.adyen.checkout.core.components.internal.AnalyticsParams
 import com.adyen.checkout.core.components.internal.AnalyticsParamsLevel
+import com.adyen.checkout.core.error.internal.GenericError
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -117,7 +118,7 @@ internal class ActionComponentProviderTest {
 
     @Test
     fun `when get is called for an unregistered factory, then an error is thrown`() = runTest {
-        assertThrows<IllegalStateException> {
+        assertThrows<GenericError> {
             ActionComponentProvider.get(
                 action = TestAction(type = "unregistered_actionType"),
                 coroutineScope = this,

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/ActionHandlerTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/ActionHandlerTest.kt
@@ -46,6 +46,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -122,6 +123,43 @@ internal class ActionHandlerTest(
 
             val component = actionHandler.actionComponent as? ControllableActionComponent
             assertEquals(1, component?.handleActionCallCount)
+        }
+
+        @Test
+        fun `when the action type is not registered, then failure is called on the dispatcher`() {
+            val actionHandler = createActionHandler()
+
+            actionHandler.handleAction(TestAction(type = "unregistered_actionType"))
+
+            val captor = argumentCaptor<CheckoutError>()
+            verify(componentRequestDispatcher).failure(captor.capture())
+
+            val error = captor.firstValue
+            assertEquals(CheckoutError.ErrorCode.GENERIC, error.code)
+            assertEquals(
+                "Action type 'unregistered_actionType' is not supported. " +
+                    "Ensure the corresponding module is included in your build dependencies.",
+                error.message,
+            )
+        }
+
+        @Test
+        fun `when the action type is not registered, then actionComponent stays null`() {
+            val actionHandler = createActionHandler()
+
+            actionHandler.handleAction(TestAction(type = "unregistered_actionType"))
+
+            assertNull(actionHandler.actionComponent)
+        }
+
+        @Test
+        fun `when the action type is not registered after a successful action, then actionComponent is cleared`() {
+            val actionHandler = createActionHandler()
+            actionHandler.handleAction(TestAction(type = TEST_ACTION_TYPE))
+
+            actionHandler.handleAction(TestAction(type = "unregistered_actionType"))
+
+            assertNull(actionHandler.actionComponent)
         }
     }
 

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/CheckoutControllerFactoryTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/CheckoutControllerFactoryTest.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 3/8/2026.
+ */
+
+package com.adyen.checkout.core.components.internal
+
+import com.adyen.checkout.core.analytics.internal.AnalyticsManager
+import com.adyen.checkout.core.common.CheckoutContext
+import com.adyen.checkout.core.common.Environment
+import com.adyen.checkout.core.common.internal.CheckoutParams
+import com.adyen.checkout.core.components.AdditionalDetailsResult
+import com.adyen.checkout.core.components.AdvancedCheckoutCallbacks
+import com.adyen.checkout.core.components.CheckoutAdditionalCallback
+import com.adyen.checkout.core.components.CheckoutConfiguration
+import com.adyen.checkout.core.components.CheckoutTarget
+import com.adyen.checkout.core.components.SubmitResult
+import com.adyen.checkout.core.components.data.model.paymentmethod.GenericPaymentMethod
+import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
+import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethods
+import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
+import com.adyen.checkout.core.components.internal.ui.PaymentComponent
+import com.adyen.checkout.core.error.CheckoutError
+import com.adyen.checkout.core.error.CheckoutException
+import com.adyen.checkout.core.error.internal.GenericError
+import com.adyen.checkout.core.error.internal.InvalidConfigurationError
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import java.util.Locale
+
+@RunWith(RobolectricTestRunner::class)
+internal class CheckoutControllerFactoryTest {
+
+    private val coroutineScope = CoroutineScope(Dispatchers.Unconfined)
+
+    @Before
+    fun setUp() {
+        ApplicationContextHolder.set(RuntimeEnvironment.getApplication())
+        PaymentMethodProvider.clear()
+    }
+
+    @After
+    fun tearDown() {
+        PaymentMethodProvider.clear()
+        ApplicationContextHolder.reset()
+    }
+
+    @Test
+    fun `when creation throws InvalidConfigurationError, then CheckoutException with INVALID_CONFIGURATION is thrown`() {
+        registerThrowingFactory(InvalidConfigurationError("missing merchant account"))
+
+        val exception = assertThrows(CheckoutException::class.java) {
+            createAdvancedController()
+        }
+
+        assertEquals(CheckoutError.ErrorCode.INVALID_CONFIGURATION, exception.error.code)
+        assertEquals("missing merchant account", exception.error.message)
+    }
+
+    @Test
+    fun `when creation throws GenericError, then CheckoutException with GENERIC is thrown`() {
+        registerThrowingFactory(GenericError("something went wrong"))
+
+        val exception = assertThrows(CheckoutException::class.java) {
+            createAdvancedController()
+        }
+
+        assertEquals(CheckoutError.ErrorCode.GENERIC, exception.error.code)
+        assertEquals("something went wrong", exception.error.message)
+    }
+
+    @Test
+    fun `when creation throws a non internal error, then it is not converted`() {
+        registerThrowingFactory(IllegalArgumentException("Incorrect paymentMethod"))
+
+        assertThrows(IllegalArgumentException::class.java) {
+            createAdvancedController()
+        }
+    }
+
+    private fun createAdvancedController() = CheckoutControllerFactory().create(
+        target = CheckoutTarget.PaymentMethod(TEST_PAYMENT_METHOD_TYPE),
+        context = CheckoutContext.Advanced(
+            paymentMethods = PaymentMethods(
+                paymentMethods = listOf(
+                    GenericPaymentMethod(type = TEST_PAYMENT_METHOD_TYPE, name = "Test"),
+                ),
+            ),
+            checkoutConfiguration = CheckoutConfiguration(
+                environment = Environment.TEST,
+                clientKey = TEST_CLIENT_KEY,
+                shopperLocale = Locale.US,
+            ),
+            checkoutAttemptId = "",
+            publicKey = null,
+        ),
+        callbacks = AdvancedCheckoutCallbacks(
+            onSubmit = { SubmitResult.Completion("Authorised") },
+            onAdditionalDetails = { AdditionalDetailsResult.Completion("Authorised") },
+            onFailure = {},
+        ),
+        coroutineScope = coroutineScope,
+    )
+
+    private fun registerThrowingFactory(throwable: Throwable) {
+        PaymentMethodProvider.register(
+            TEST_PAYMENT_METHOD_TYPE,
+            object : PaymentComponentFactory<PaymentComponent> {
+                override fun create(
+                    paymentMethod: PaymentMethod,
+                    coroutineScope: CoroutineScope,
+                    analyticsManager: AnalyticsManager,
+                    sdkDataProvider: SdkDataProvider,
+                    params: CheckoutParams,
+                    additionalCallbacks: Set<CheckoutAdditionalCallback>,
+                ): PaymentComponent = throw throwable
+            },
+        )
+    }
+
+    companion object {
+        private const val TEST_PAYMENT_METHOD_TYPE = "test_payment_method"
+        private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
+    }
+}


### PR DESCRIPTION
## Description
Internal errors could escape to merchants unconverted, and a missing action module crashed the payment flow. This PR closes both gaps.

**Convert internal errors escaping controller creation.** `CheckoutControllerFactory` now wraps all three `create` overloads in `runCatchingCreation`, which catches `InternalCheckoutError` and rethrows it as the public `CheckoutException`. Only `InternalCheckoutError` is caught on purpose — broken invariants and programming errors still fail fast, so they surface as bugs instead of being reported as checkout errors. This is what makes the Google Pay `InvalidConfigurationError` from the previous PR reach merchants as a `CheckoutException` rather than an internal type.

**Report an unsupported action type instead of crashing.** `ActionComponentProvider.get` threw `IllegalStateException` when no factory was registered for an action type. That crashed the flow mid-payment: it happens after `/payments` has already returned an action, inside an SDK-owned coroutine where no merchant stack frame exists to catch it, so the merchant received no callback at all while a payment was in flight. It now throws `GenericError`, and `ActionHandler.handleAction` catches it and dispatches `onFailure`. This aligns actions with payment methods, which already degrade gracefully through `PaymentComponentResult.Failure`. The usual cause is a merchant not including the module for that action type, so the message points at build dependencies.

**Document the error handling model.** Added KDoc on `InternalCheckoutError` describing the three tiers: configuration validation returning a `CheckoutError`, internal runtime errors converted through `toCheckoutError()`, and plain runtime exceptions reserved for invariants and integration bugs.

## Checklist
- [x] Code is unit tested

## Ticket Number
COSDK-1002

## Release notes
### Fixed
- An unsupported action type no longer crashes the payment flow. The error is now delivered through `onFailure`, with a message indicating that the corresponding module is missing from the build dependencies.

### Changed
- Internal errors that occur while creating a checkout controller are now surfaced as a `CheckoutException` instead of an internal error type.
