### PR TITLE
v6 - Skills - Add release notes guidance for merchant-observable changes

### DIFF
--- a/.agents/skills/android-branch-create/SKILL.md
+++ b/.agents/skills/android-branch-create/SKILL.md
@@ -23,7 +23,13 @@ Ask the user what type of work this is:
 | `fix/` | Bug fixes |
 | `chore/` | Internal changes, refactoring, tooling, maintenance |
 
-> **Note:** Until v6 is released, use `chore/` for all branches based on `main` (where v6 development happens). The `feature/` and `fix/` prefixes require release notes, which are not applicable during v6 development.
+> **Note:** The prefix determines whether release notes are required — `feature/` and `fix/` require them, `chore/` and `renovate/` do not. Because the first alpha has been released, merchants can already observe changes made on `main`, so choose the prefix based on whether the change is merchant-observable:
+>
+> - **Public API change** (any `.api` file is updated) → `feature/` or `fix/`
+> - **Behavioral change** without an API change — a different error code, a callback where there used to be a crash, changed defaults or validation → `feature/` or `fix/`
+> - **Neither** — internal refactoring, tests, tooling, documentation → `chore/`
+>
+> If it is unclear whether a change is merchant-observable, ask the user before choosing the prefix.
 
 ### 2. Determine base branch
 

--- a/.agents/skills/android-pr-create/SKILL.md
+++ b/.agents/skills/android-pr-create/SKILL.md
@@ -27,6 +27,8 @@ Determine from the branch name:
 - **Branch type**: `feature/`, `fix/`, `chore/`, or `renovate/`
 - **Whether release notes are required**: Yes for `feature/` and `fix/`, No for `chore/` and `renovate/`
 
+Then verify the prefix actually matches the change. Inspect the diff for public API changes (updated `.api` files) and for behavioral changes a merchant could observe — a different error code, a callback where there used to be a crash, changed defaults or validation. If the branch is `chore/` or `renovate/` but the diff contains either, the prefix is probably wrong and release notes are likely required. Tell the user and ask whether to rename the branch or proceed anyway. Never omit release notes silently.
+
 ### 2. Determine base branch
 
 - Default base: `main`


### PR DESCRIPTION
## Description
Since we released `6.0.0-alpha.1`, PRs with public or behavioural changes should have release notes. This updates the skills to reflect that.
