### PR TITLE
v6 - Update branch name for AGP updates

### DIFF
--- a/.github/workflows/update_verification_metadata.yml
+++ b/.github/workflows/update_verification_metadata.yml
@@ -3,7 +3,7 @@ name: Update verification metadata
 on:
   push:
     branches:
-      - 'renovate/android.gradle.plugin'
+      - 'renovate/main-android.gradle.plugin'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Description
The Update verification metadata job was configured to run automatically on renovate branches that update the Android Gradle Plugin. This branch used to be named 'renovate/android.gradle.plugin' but is now named 'renovate/main-android.gradle.plugin' after configuring Renovate to update both main and v5.

## Checklist <!-- Remove any line that's not applicable -->
- [x] Changes are tested manually