### PR TITLE
v6 - Build - Do not make Dokka fail on warnings by default

### DIFF
--- a/build-logic/convention/src/main/kotlin/DokkaConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/DokkaConventionPlugin.kt
@@ -25,13 +25,16 @@ class DokkaConventionPlugin : Plugin<Project> {
 
             val projectName = name
             val mainSourceDir = file("src/main/java")
+            // Warnings are only fatal when explicitly requested, so documentation keeps
+            // publishing while KDoc issues are outstanding. Pass -PdokkaStrict=true to enforce.
+            val dokkaStrict = providers.gradleProperty("dokkaStrict").map { it.toBoolean() }.orElse(false)
 
             extensions.configure<DokkaExtension> {
                 moduleName = projectName
 
                 dokkaPublications.configureEach {
                     suppressInheritedMembers = true
-                    failOnWarning = true
+                    failOnWarning = dokkaStrict
                 }
 
                 dokkaSourceSets.configureEach {


### PR DESCRIPTION
## Description
Dokka is configured with `failOnWarning = true`, but Dokka only runs in `publish_docs.yml`, which is a post-release workflow. There are 24 pre-existing unresolved KDoc links in `:core`, `:checkout-core`, `:components-core` and `:sessions-core`, all reported as warnings with `errorCount=0`.

The gate therefore cannot prevent anything, since the code is already published by the time it runs, and when it fires it withholds the documentation entirely rather than publishing it with a few unresolved links.

This makes strict mode opt-in. `failOnWarning` now defaults to `false` so documentation always publishes, and can be re-enabled on demand with `-PdokkaStrict=true`.

Follow-ups, to be handled separately:
- Fix the 24 unresolved KDoc links.
- Run Dokka with `-PdokkaStrict=true` on a schedule, so warnings surface close to the merge that introduced them rather than at release time.
- `resolveDependencies` resolves project artifacts, which pulls Dokka generation and the unit test suite into the dependency-resolution task graph.

## Checklist
- [x] Changes are tested manually