### PR TITLE
v6 - Core - Centralize text field trailing icon error state handling

### DIFF
--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/BlikCodeField.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/view/BlikCodeField.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.blik.internal.ui.properties.BlikCodeProperties.BLIK_CODE_MAX_LENGTH
 import com.adyen.checkout.blik.internal.ui.properties.BlikCodeProperties.BLIK_CODE_SEPARATOR
 import com.adyen.checkout.blik.internal.ui.properties.BlikCodeProperties.BLIK_CODE_SEPARATORS
+import com.adyen.checkout.core.common.internal.ui.CheckoutTextFieldTrailingIcon
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
@@ -62,6 +63,9 @@ internal fun BlikCodeField(
         inputTransformation = inputTransformation,
         outputTransformation = outputTransformation,
         shouldFocus = blikCodeState.isFocused,
+        trailingIcon = {
+            CheckoutTextFieldTrailingIcon(blikCodeState.trailingIcon)
+        },
     )
 }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/model/CardTrailingIcons.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/model/CardTrailingIcons.kt
@@ -13,23 +13,15 @@ import com.adyen.checkout.core.components.internal.ui.state.model.TrailingIcon
 internal sealed class CardNumberTrailingIcon : TrailingIcon() {
     data object BrandLogos : CardNumberTrailingIcon()
     data object ScanButton : CardNumberTrailingIcon()
-    data object Warning : CardNumberTrailingIcon()
 }
 
 internal sealed class ExpiryDateTrailingIcon : TrailingIcon() {
     data object Placeholder : ExpiryDateTrailingIcon()
     data object Checkmark : ExpiryDateTrailingIcon()
-    data object Warning : ExpiryDateTrailingIcon()
 }
 
 internal sealed class SecurityCodeTrailingIcon : TrailingIcon() {
     data object PlaceholderDefault : SecurityCodeTrailingIcon()
     data object PlaceholderAmex : SecurityCodeTrailingIcon()
     data object Checkmark : SecurityCodeTrailingIcon()
-    data object Warning : SecurityCodeTrailingIcon()
-}
-
-internal sealed class PostalCodeTrailingIcon : TrailingIcon() {
-    data object Placeholder : PostalCodeTrailingIcon()
-    data object Warning : PostalCodeTrailingIcon()
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
@@ -11,7 +11,6 @@ package com.adyen.checkout.card.internal.ui.state
 import com.adyen.checkout.card.internal.helper.isHiddenCardType
 import com.adyen.checkout.card.internal.ui.model.CardNumberTrailingIcon
 import com.adyen.checkout.card.internal.ui.model.ExpiryDateTrailingIcon
-import com.adyen.checkout.card.internal.ui.model.PostalCodeTrailingIcon
 import com.adyen.checkout.card.internal.ui.model.SecurityCodeTrailingIcon
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.components.data.model.Amount
@@ -60,21 +59,19 @@ internal class CardViewStateProducer(
 
         return CardViewState(
             cardNumber = state.cardNumber.copy(description = cardNumberInputDescription).toViewState(
-                trailingIcon = getCardNumberTrailingIcon(state.cardNumber, isCardScanButtonVisible),
+                customTrailingIcon = getCardNumberTrailingIcon(isCardScanButtonVisible),
             ),
             expiryDate = state.expiryDate.toViewState(
-                trailingIcon = getExpiryDateTrailingIcon(state.expiryDate),
+                customTrailingIcon = getExpiryDateTrailingIcon(state.expiryDate),
             ),
             securityCode = state.securityCode.toViewState(
-                trailingIcon = getSecurityCodeTrailingIcon(state.securityCode, cardNumberFormat),
+                customTrailingIcon = getSecurityCodeTrailingIcon(state.securityCode, cardNumberFormat),
             ),
             holderName = state.holderName.toViewState(),
             socialSecurityNumber = state.socialSecurityNumber.toViewState(),
             kcpBirthDateOrTaxNumber = state.kcpBirthDateOrTaxNumber.toViewState(),
             kcpCardPassword = state.kcpCardPassword.toViewState(),
-            postalCode = state.postalCode.toViewState(
-                trailingIcon = getPostalCodeTrailingIcon(state.postalCode),
-            ),
+            postalCode = state.postalCode.toViewState(),
             storePaymentViewState = storePaymentViewState,
             supportedCardBrandsViewState = supportedCardBrandsViewState,
             cardBrandViewState = cardBrandViewState,
@@ -140,28 +137,21 @@ internal class CardViewStateProducer(
         return cardBrandData?.cardBrand.toCardNumberFormat()
     }
 
-    private fun getCardNumberTrailingIcon(
-        cardNumber: TextInputComponentState,
-        isCardScanButtonVisible: Boolean,
-    ): CardNumberTrailingIcon {
-        val isInvalid = cardNumber.showErrorMessage
-        return when {
-            isInvalid -> CardNumberTrailingIcon.Warning
-            isCardScanButtonVisible -> CardNumberTrailingIcon.ScanButton
-            else -> CardNumberTrailingIcon.BrandLogos
+    private fun getCardNumberTrailingIcon(isCardScanButtonVisible: Boolean): CardNumberTrailingIcon {
+        return if (isCardScanButtonVisible) {
+            CardNumberTrailingIcon.ScanButton
+        } else {
+            CardNumberTrailingIcon.BrandLogos
         }
     }
 
     private fun getExpiryDateTrailingIcon(
         expiryDate: TextInputComponentState,
     ): ExpiryDateTrailingIcon {
-        val isValid = expiryDate.errorMessage == null && expiryDate.text.isNotEmpty()
-        val isInvalid = expiryDate.showErrorMessage
-
-        return when {
-            isValid -> ExpiryDateTrailingIcon.Checkmark
-            isInvalid -> ExpiryDateTrailingIcon.Warning
-            else -> ExpiryDateTrailingIcon.Placeholder
+        return if (expiryDate.isValid && expiryDate.text.isNotEmpty()) {
+            ExpiryDateTrailingIcon.Checkmark
+        } else {
+            ExpiryDateTrailingIcon.Placeholder
         }
     }
 
@@ -169,25 +159,10 @@ internal class CardViewStateProducer(
         securityCode: TextInputComponentState,
         cardNumberFormat: CardNumberFormat,
     ): SecurityCodeTrailingIcon {
-        val isValid = securityCode.errorMessage == null && securityCode.text.isNotEmpty()
-        val isInvalid = securityCode.showErrorMessage
-
         return when {
-            isValid -> SecurityCodeTrailingIcon.Checkmark
-            isInvalid -> SecurityCodeTrailingIcon.Warning
+            securityCode.isValid && securityCode.text.isNotEmpty() -> SecurityCodeTrailingIcon.Checkmark
             cardNumberFormat == CardNumberFormat.AMEX -> SecurityCodeTrailingIcon.PlaceholderAmex
             else -> SecurityCodeTrailingIcon.PlaceholderDefault
-        }
-    }
-
-    private fun getPostalCodeTrailingIcon(
-        postalCode: TextInputComponentState
-    ): PostalCodeTrailingIcon {
-        val isInvalid = postalCode.showErrorMessage
-
-        return when {
-            isInvalid -> PostalCodeTrailingIcon.Warning
-            else -> PostalCodeTrailingIcon.Placeholder
         }
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewStateProducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewStateProducer.kt
@@ -25,7 +25,7 @@ internal class StoredCardViewStateProducer(
 
         return StoredCardViewState(
             securityCode = state.securityCode.toViewState(
-                trailingIcon = getSecurityCodeTrailingIcon(state.securityCode, cardNumberFormat),
+                customTrailingIcon = getSecurityCodeTrailingIcon(state.securityCode, cardNumberFormat),
             ),
             brand = state.detectedCardType?.cardBrand,
             cardNumberFormat = cardNumberFormat,
@@ -38,12 +38,8 @@ internal class StoredCardViewStateProducer(
         securityCode: TextInputComponentState,
         cardNumberFormat: CardNumberFormat,
     ): SecurityCodeTrailingIcon {
-        val isValid = securityCode.errorMessage == null && securityCode.text.isNotEmpty()
-        val isInvalid = securityCode.showErrorMessage
-
         return when {
-            isValid -> SecurityCodeTrailingIcon.Checkmark
-            isInvalid -> SecurityCodeTrailingIcon.Warning
+            securityCode.isValid && securityCode.text.isNotEmpty() -> SecurityCodeTrailingIcon.Checkmark
             cardNumberFormat == CardNumberFormat.AMEX -> SecurityCodeTrailingIcon.PlaceholderAmex
             else -> SecurityCodeTrailingIcon.PlaceholderDefault
         }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
@@ -8,7 +8,6 @@
 
 package com.adyen.checkout.card.internal.ui.view
 
-import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -48,9 +47,11 @@ import com.adyen.checkout.core.common.CardType
 import com.adyen.checkout.core.common.internal.properties.CardNumberProperties.CARD_NUMBER_MAXIMUM_LENGTH
 import com.adyen.checkout.core.common.internal.properties.CardNumberProperties.CARD_NUMBER_SEPARATOR
 import com.adyen.checkout.core.common.internal.ui.CheckoutNetworkLogo
+import com.adyen.checkout.core.common.internal.ui.CheckoutTextFieldTrailingIcon
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
+import com.adyen.checkout.core.components.internal.ui.state.model.TrailingIcon
 import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.DigitOnlyInputTransformation
 import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
@@ -130,8 +131,8 @@ private fun CardNumberInputField(
         outputTransformation = outputTransformation,
         shouldFocus = cardNumberState.isFocused,
         trailingIcon = {
-            CardNumberFieldIcon(
-                state = cardNumberState,
+            CardNumberTrailingIcon(
+                trailingIcon = cardNumberState.trailingIcon,
                 cardBrandViewState = cardBrandViewState,
                 onScanButtonClick = onScanButtonClick,
                 onBrandSelect = onBrandSelect,
@@ -141,33 +142,28 @@ private fun CardNumberInputField(
 }
 
 @Composable
-private fun CardNumberFieldIcon(
-    state: TextInputViewState,
+private fun CardNumberTrailingIcon(
+    trailingIcon: TrailingIcon,
     cardBrandViewState: CardBrandViewState,
     onScanButtonClick: () -> Unit,
     onBrandSelect: (CardBrand) -> Unit,
-    modifier: Modifier = Modifier,
 ) {
-    // null is not expected for the trailingIcon
-    val trailingIcon = state.trailingIcon as? CardNumberTrailingIcon ?: return
-    AnimatedContent(targetState = trailingIcon, modifier = modifier) { trailingIcon ->
-        when (trailingIcon) {
-            CardNumberTrailingIcon.Warning -> Icon(
-                modifier = Modifier.size(Dimensions.LogoSize.small),
-                imageVector = ImageVector.vectorResource(com.adyen.checkout.test.R.drawable.ic_warning),
-                contentDescription = null,
-                tint = CheckoutThemeProvider.colors.destructive,
-            )
+    CheckoutTextFieldTrailingIcon(trailingIcon) { state ->
+        // unexpected state - the view state producer should set the correct type
+        if (state !is CardNumberTrailingIcon) return@CheckoutTextFieldTrailingIcon
 
-            CardNumberTrailingIcon.ScanButton -> IconButton(
-                onClick = onScanButtonClick,
-                modifier = Modifier.size(Dimensions.LogoSize.smallSquare),
-            ) {
-                Icon(
-                    imageVector = ImageVector.vectorResource(R.drawable.ic_camera),
-                    contentDescription = null,
-                    tint = CheckoutThemeProvider.colors.primary,
-                )
+        when (state) {
+            CardNumberTrailingIcon.ScanButton -> {
+                IconButton(
+                    onClick = onScanButtonClick,
+                    modifier = Modifier.size(Dimensions.LogoSize.smallSquare),
+                ) {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(R.drawable.ic_camera),
+                        contentDescription = null,
+                        tint = CheckoutThemeProvider.colors.primary,
+                    )
+                }
             }
 
             CardNumberTrailingIcon.BrandLogos -> DetectedBrandsList(cardBrandViewState, onBrandSelect)
@@ -311,7 +307,7 @@ private fun CardNumberFieldPreview(
         CardNumberField(
             cardNumberState = TextInputViewState(
                 text = "",
-                trailingIcon = CardNumberTrailingIcon.ScanButton,
+                customTrailingIcon = CardNumberTrailingIcon.ScanButton,
             ),
             supportedCardBrandsViewState = SupportedCardBrandsViewState(
                 supportedCardBrands = listOf(
@@ -333,7 +329,7 @@ private fun CardNumberFieldPreview(
         CardNumberField(
             cardNumberState = TextInputViewState(
                 text = "5555444433331111",
-                trailingIcon = CardNumberTrailingIcon.BrandLogos,
+                customTrailingIcon = CardNumberTrailingIcon.BrandLogos,
             ),
             supportedCardBrandsViewState = SupportedCardBrandsViewState(
                 supportedCardBrands = emptyList(),
@@ -351,7 +347,7 @@ private fun CardNumberFieldPreview(
         CardNumberField(
             cardNumberState = TextInputViewState(
                 text = "1234123456123451234",
-                trailingIcon = CardNumberTrailingIcon.BrandLogos,
+                customTrailingIcon = CardNumberTrailingIcon.BrandLogos,
             ),
             supportedCardBrandsViewState = SupportedCardBrandsViewState(
                 supportedCardBrands = emptyList(),
@@ -374,7 +370,7 @@ private fun CardNumberFieldPreview(
         CardNumberField(
             cardNumberState = TextInputViewState(
                 text = "5555444433330002",
-                trailingIcon = CardNumberTrailingIcon.BrandLogos,
+                customTrailingIcon = CardNumberTrailingIcon.BrandLogos,
                 supportingText = CheckoutLocalizationKey.CARD_DUAL_BRAND_SELECTOR_DESCRIPTION,
             ),
             supportedCardBrandsViewState = SupportedCardBrandsViewState(
@@ -405,7 +401,6 @@ private fun CardNumberFieldPreview(
             cardNumberState = TextInputViewState(
                 text = "1234",
                 isError = true,
-                trailingIcon = CardNumberTrailingIcon.Warning,
                 supportingText = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
             ),
             supportedCardBrandsViewState = SupportedCardBrandsViewState(

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/ExpiryDateField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/ExpiryDateField.kt
@@ -8,7 +8,6 @@
 
 package com.adyen.checkout.card.internal.ui.view
 
-import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
@@ -24,9 +23,11 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.card.R
 import com.adyen.checkout.card.internal.ui.model.ExpiryDateTrailingIcon
 import com.adyen.checkout.core.common.internal.properties.ExpiryDateProperties
+import com.adyen.checkout.core.common.internal.ui.CheckoutTextFieldTrailingIcon
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
+import com.adyen.checkout.core.components.internal.ui.state.model.TrailingIcon
 import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.SeparatorsOutputTransformation
 import com.adyen.checkout.ui.internal.element.input.TextFieldSeparator
@@ -78,53 +79,48 @@ internal fun ExpiryDateField(
         outputTransformation = outputTransformation,
         shouldFocus = expiryDateState.isFocused,
         trailingIcon = {
-            ExpiryDateIcon(expiryDateState)
+            ExpiryDateTrailingIcon(expiryDateState.trailingIcon)
         },
     )
 }
 
 @Composable
-private fun ExpiryDateIcon(
-    state: TextInputViewState,
-    modifier: Modifier = Modifier,
+private fun ExpiryDateTrailingIcon(
+    trailingIcon: TrailingIcon,
 ) {
-    val trailingIcon = state.trailingIcon as? ExpiryDateTrailingIcon
+    CheckoutTextFieldTrailingIcon(trailingIcon) { state ->
+        // unexpected state - the view state producer should set the correct type
+        if (state !is ExpiryDateTrailingIcon) return@CheckoutTextFieldTrailingIcon
 
-    val resourceId: Int
-    val tint: Color
-    when (trailingIcon) {
-        ExpiryDateTrailingIcon.Checkmark -> {
-            resourceId = com.adyen.checkout.test.R.drawable.ic_checkmark
-            tint = CheckoutThemeProvider.colors.primary
-        }
-
-        ExpiryDateTrailingIcon.Warning -> {
-            resourceId = com.adyen.checkout.test.R.drawable.ic_warning
-            tint = CheckoutThemeProvider.colors.destructive
-        }
-
-        else -> {
-            resourceId = getThemedIcon(
-                backgroundColor = CheckoutThemeProvider.elements.textField.backgroundColor,
-                lightDrawableId = R.drawable.ic_card_expiry_date_light,
-                darkDrawableId = R.drawable.ic_card_expiry_date_dark,
+        when (state) {
+            ExpiryDateTrailingIcon.Checkmark -> ExpiryDateTrailingIcon(
+                resourceId = com.adyen.checkout.test.R.drawable.ic_checkmark,
+                tint = CheckoutThemeProvider.colors.primary,
             )
-            tint = Color.Unspecified
+
+            ExpiryDateTrailingIcon.Placeholder -> ExpiryDateTrailingIcon(
+                resourceId = getThemedIcon(
+                    backgroundColor = CheckoutThemeProvider.elements.textField.backgroundColor,
+                    lightDrawableId = R.drawable.ic_card_expiry_date_light,
+                    darkDrawableId = R.drawable.ic_card_expiry_date_dark,
+                ),
+                tint = Color.Unspecified,
+            )
         }
     }
+}
 
-    AnimatedContent(
-        targetState = resourceId to tint,
-        modifier = modifier,
-        label = "ExpiryDateIcon",
-    ) { (targetResourceId, targetTint) ->
-        Icon(
-            modifier = Modifier.size(Dimensions.LogoSize.small),
-            imageVector = ImageVector.vectorResource(targetResourceId),
-            contentDescription = null,
-            tint = targetTint,
-        )
-    }
+@Composable
+private fun ExpiryDateTrailingIcon(
+    resourceId: Int,
+    tint: Color,
+) {
+    Icon(
+        modifier = Modifier.size(Dimensions.LogoSize.small),
+        imageVector = ImageVector.vectorResource(resourceId),
+        contentDescription = null,
+        tint = tint,
+    )
 }
 
 @Preview
@@ -136,6 +132,7 @@ private fun ExpiryDateFieldPreview(
         ExpiryDateField(
             expiryDateState = TextInputViewState(
                 text = "0330",
+                customTrailingIcon = ExpiryDateTrailingIcon.Checkmark,
             ),
             onValueChange = {},
             onFocusChange = {},
@@ -143,6 +140,7 @@ private fun ExpiryDateFieldPreview(
         ExpiryDateField(
             expiryDateState = TextInputViewState(
                 isOptional = true,
+                customTrailingIcon = ExpiryDateTrailingIcon.Placeholder,
             ),
             onValueChange = {},
             onFocusChange = {},
@@ -150,8 +148,8 @@ private fun ExpiryDateFieldPreview(
 
         ExpiryDateField(
             expiryDateState = TextInputViewState(
+                text = "6415",
                 isError = true,
-                trailingIcon = ExpiryDateTrailingIcon.Warning,
             ),
             onValueChange = {},
             onFocusChange = {},

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/HolderNameField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/HolderNameField.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.adyen.checkout.core.common.internal.ui.CheckoutTextFieldTrailingIcon
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
@@ -51,6 +52,9 @@ internal fun HolderNameField(
             capitalization = KeyboardCapitalization.Words,
         ),
         shouldFocus = holderNameState.isFocused,
+        trailingIcon = {
+            CheckoutTextFieldTrailingIcon(holderNameState.trailingIcon)
+        },
     )
 }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPBirthDateOrTaxNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPBirthDateOrTaxNumberField.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.card.internal.ui.properties.KCPBirthDateOrTaxNumberProperties.KCP_BIRTH_DATE_OR_TAX_NUMBER_MAX_LENGTH
 import com.adyen.checkout.card.internal.ui.properties.KCPBirthDateOrTaxNumberProperties.KCP_BIRTH_DATE_VALID_LENGTH
+import com.adyen.checkout.core.common.internal.ui.CheckoutTextFieldTrailingIcon
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
@@ -63,6 +64,9 @@ internal fun KCPBirthDateOrTaxNumberField(
         onValueChange = onValueChange,
         shouldFocus = kcpBirthDateOrTaxNumberState.isFocused,
         inputTransformation = inputTransformation,
+        trailingIcon = {
+            CheckoutTextFieldTrailingIcon(kcpBirthDateOrTaxNumberState.trailingIcon)
+        },
     )
 }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPCardPasswordField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPCardPasswordField.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.card.internal.ui.properties.KCPCardPasswordProperties.KCP_CARD_PASSWORD_MAX_LENGTH
+import com.adyen.checkout.core.common.internal.ui.CheckoutTextFieldTrailingIcon
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
@@ -55,6 +56,9 @@ internal fun KCPCardPasswordField(
         shouldFocus = kcpCardPasswordState.isFocused,
         inputTransformation = inputTransformation,
         isSecureField = true,
+        trailingIcon = {
+            CheckoutTextFieldTrailingIcon(kcpCardPasswordState.trailingIcon)
+        },
     )
 }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/PostalCodeField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/PostalCodeField.kt
@@ -1,24 +1,18 @@
 package com.adyen.checkout.card.internal.ui.view
 
-import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.InputTransformation
 import androidx.compose.foundation.text.input.maxLength
-import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import com.adyen.checkout.card.internal.ui.model.PostalCodeTrailingIcon
 import com.adyen.checkout.card.internal.ui.properties.PostalCodeProperties
+import com.adyen.checkout.core.common.internal.ui.CheckoutTextFieldTrailingIcon
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
@@ -26,8 +20,6 @@ import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
 import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
 import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
-import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
-import com.adyen.checkout.ui.internal.theme.Dimensions
 import com.adyen.checkout.ui.theme.CheckoutTheme
 
 @Composable
@@ -57,44 +49,9 @@ internal fun PostalCodeField(
         ),
         shouldFocus = postalCodeState.isFocused,
         trailingIcon = {
-            PostalCodeIcon(state = postalCodeState)
+            CheckoutTextFieldTrailingIcon(postalCodeState.trailingIcon)
         },
     )
-}
-
-@Composable
-private fun PostalCodeIcon(
-    state: TextInputViewState,
-    modifier: Modifier = Modifier,
-) {
-    val resourceId: Int?
-    val tint: Color
-    when (state.trailingIcon as? PostalCodeTrailingIcon) {
-        PostalCodeTrailingIcon.Warning -> {
-            resourceId = com.adyen.checkout.test.R.drawable.ic_warning
-            tint = CheckoutThemeProvider.colors.destructive
-        }
-
-        else -> {
-            resourceId = null
-            tint = Color.Unspecified
-        }
-    }
-
-    AnimatedContent(
-        targetState = resourceId to tint,
-        modifier = modifier,
-        label = "PostalCodeIcon",
-    ) { (targetResourceId, targetTint) ->
-        if (targetResourceId != null) {
-            Icon(
-                modifier = Modifier.size(Dimensions.LogoSize.small),
-                imageVector = ImageVector.vectorResource(targetResourceId),
-                contentDescription = null,
-                tint = targetTint,
-            )
-        }
-    }
 }
 
 @Preview
@@ -115,7 +72,6 @@ private fun PostalCodeFieldPreview(
             postalCodeState = TextInputViewState(
                 text = "12",
                 isError = true,
-                trailingIcon = PostalCodeTrailingIcon.Warning,
             ),
             onFocusChange = {},
             onValueChange = {},

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SecurityCodeField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SecurityCodeField.kt
@@ -8,13 +8,15 @@
 
 package com.adyen.checkout.card.internal.ui.view
 
-import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -26,9 +28,11 @@ import com.adyen.checkout.card.internal.ui.model.SecurityCodeTrailingIcon
 import com.adyen.checkout.card.internal.ui.state.CardNumberFormat
 import com.adyen.checkout.core.common.internal.properties.SecurityCodeProperties.SECURITY_CODE_MAX_LENGTH_AMEX
 import com.adyen.checkout.core.common.internal.properties.SecurityCodeProperties.SECURITY_CODE_MAX_LENGTH_DEFAULT
+import com.adyen.checkout.core.common.internal.ui.CheckoutTextFieldTrailingIcon
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
+import com.adyen.checkout.core.components.internal.ui.state.model.TrailingIcon
 import com.adyen.checkout.ui.internal.element.input.CheckoutTextField
 import com.adyen.checkout.ui.internal.element.input.DigitOnlyInputTransformation
 import com.adyen.checkout.ui.internal.element.input.rememberTextFieldStateWithCurrentValue
@@ -85,60 +89,57 @@ internal fun SecurityCodeField(
         inputTransformation = inputTransformation,
         shouldFocus = securityCodeState.isFocused,
         trailingIcon = {
-            SecurityCodeIcon(state = securityCodeState)
+            SecurityCodeTrailingIcon(securityCodeState.trailingIcon)
         },
     )
 }
 
 @Composable
-private fun SecurityCodeIcon(
-    state: TextInputViewState,
-    modifier: Modifier = Modifier,
+private fun SecurityCodeTrailingIcon(
+    trailingIcon: TrailingIcon,
 ) {
-    val resourceId: Int
-    val tint: Color
-    when (state.trailingIcon as? SecurityCodeTrailingIcon) {
-        SecurityCodeTrailingIcon.Warning -> {
-            resourceId = com.adyen.checkout.test.R.drawable.ic_warning
-            tint = CheckoutThemeProvider.colors.destructive
-        }
+    CheckoutTextFieldTrailingIcon(trailingIcon) { state ->
+        // unexpected state - the view state producer should set the correct type
+        if (state !is SecurityCodeTrailingIcon) return@CheckoutTextFieldTrailingIcon
 
-        SecurityCodeTrailingIcon.Checkmark -> {
-            resourceId = com.adyen.checkout.test.R.drawable.ic_checkmark
-            tint = CheckoutThemeProvider.colors.primary
-        }
-
-        SecurityCodeTrailingIcon.PlaceholderAmex -> {
-            resourceId = getThemedIcon(
-                backgroundColor = CheckoutThemeProvider.elements.textField.backgroundColor,
-                lightDrawableId = R.drawable.ic_card_cvc_front_light,
-                darkDrawableId = R.drawable.ic_card_cvc_front_dark,
+        when (state) {
+            SecurityCodeTrailingIcon.Checkmark -> SecurityCodeTrailingIcon(
+                resourceId = com.adyen.checkout.test.R.drawable.ic_checkmark,
+                tint = CheckoutThemeProvider.colors.primary,
             )
-            tint = Color.Unspecified
-        }
 
-        else -> {
-            resourceId = getThemedIcon(
-                backgroundColor = CheckoutThemeProvider.elements.textField.backgroundColor,
-                lightDrawableId = R.drawable.ic_card_cvc_back_light,
-                darkDrawableId = R.drawable.ic_card_cvc_back_dark,
+            SecurityCodeTrailingIcon.PlaceholderAmex -> SecurityCodeTrailingIcon(
+                resourceId = getThemedIcon(
+                    backgroundColor = CheckoutThemeProvider.elements.textField.backgroundColor,
+                    lightDrawableId = R.drawable.ic_card_cvc_front_light,
+                    darkDrawableId = R.drawable.ic_card_cvc_front_dark,
+                ),
+                tint = Color.Unspecified,
             )
-            tint = Color.Unspecified
+
+            SecurityCodeTrailingIcon.PlaceholderDefault -> SecurityCodeTrailingIcon(
+                resourceId = getThemedIcon(
+                    backgroundColor = CheckoutThemeProvider.elements.textField.backgroundColor,
+                    lightDrawableId = R.drawable.ic_card_cvc_back_light,
+                    darkDrawableId = R.drawable.ic_card_cvc_back_dark,
+                ),
+                tint = Color.Unspecified,
+            )
         }
     }
+}
 
-    AnimatedContent(
-        targetState = resourceId to tint,
-        modifier = modifier,
-        label = "SecurityCodeIcon",
-    ) { (targetResourceId, targetTint) ->
-        Icon(
-            modifier = Modifier.size(Dimensions.LogoSize.small),
-            imageVector = ImageVector.vectorResource(targetResourceId),
-            contentDescription = null,
-            tint = targetTint,
-        )
-    }
+@Composable
+private fun SecurityCodeTrailingIcon(
+    resourceId: Int,
+    tint: Color,
+) {
+    Icon(
+        modifier = Modifier.size(Dimensions.LogoSize.small),
+        imageVector = ImageVector.vectorResource(resourceId),
+        contentDescription = null,
+        tint = tint,
+    )
 }
 
 @Preview
@@ -149,7 +150,7 @@ private fun SecurityCodeFieldPreview(
     CheckoutThemePreviewWrapper(theme) {
         SecurityCodeField(
             securityCodeState = TextInputViewState(
-                text = "123",
+                customTrailingIcon = SecurityCodeTrailingIcon.PlaceholderDefault,
             ),
             cardNumberFormat = CardNumberFormat.DEFAULT,
             onValueChange = {},
@@ -159,17 +160,32 @@ private fun SecurityCodeFieldPreview(
         SecurityCodeField(
             securityCodeState = TextInputViewState(
                 isOptional = true,
+                customTrailingIcon = SecurityCodeTrailingIcon.PlaceholderAmex,
             ),
             cardNumberFormat = CardNumberFormat.AMEX,
             onValueChange = {},
             onFocusChange = {},
         )
 
+        val focusRequester = remember { FocusRequester() }
         SecurityCodeField(
             securityCodeState = TextInputViewState(
                 text = "123",
+                customTrailingIcon = SecurityCodeTrailingIcon.Checkmark,
+            ),
+            cardNumberFormat = CardNumberFormat.DEFAULT,
+            modifier = Modifier.focusRequester(focusRequester),
+            onValueChange = {},
+            onFocusChange = {},
+        )
+        LaunchedEffect(Unit) {
+            focusRequester.requestFocus()
+        }
+
+        SecurityCodeField(
+            securityCodeState = TextInputViewState(
+                text = "12",
                 isError = true,
-                trailingIcon = SecurityCodeTrailingIcon.Warning,
             ),
             cardNumberFormat = CardNumberFormat.DEFAULT,
             onValueChange = {},

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SocialSecurityNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SocialSecurityNumberField.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.card.internal.ui.properties.SocialSecurityNumberProperties.SOCIAL_SECURITY_MAX_LENGTH
 import com.adyen.checkout.card.internal.ui.properties.SocialSecurityNumberProperties.SOCIAL_SECURITY_SEPARATORS
+import com.adyen.checkout.core.common.internal.ui.CheckoutTextFieldTrailingIcon
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
@@ -58,6 +59,9 @@ internal fun SocialSecurityNumberField(
         shouldFocus = socialSecurityNumberState.isFocused,
         inputTransformation = inputTransformation,
         outputTransformation = outputTransformation,
+        trailingIcon = {
+            CheckoutTextFieldTrailingIcon(socialSecurityNumberState.trailingIcon)
+        },
     )
 }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardContent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardContent.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.adyen.checkout.card.internal.ui.model.SecurityCodeTrailingIcon
 import com.adyen.checkout.card.internal.ui.state.CardNumberFormat
 import com.adyen.checkout.card.internal.ui.state.StoredCardIntent
 import com.adyen.checkout.card.internal.ui.state.StoredCardViewState
@@ -83,7 +84,9 @@ private fun StoredCardContentPreview(
 ) {
     CheckoutThemePreviewWrapper(theme) {
         val viewState = StoredCardViewState(
-            securityCode = TextInputViewState(),
+            securityCode = TextInputViewState(
+                customTrailingIcon = SecurityCodeTrailingIcon.PlaceholderDefault,
+            ),
             brand = CardBrand(""),
             cardNumberFormat = CardNumberFormat.DEFAULT,
             isLoading = false,

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
@@ -10,13 +10,16 @@ package com.adyen.checkout.card.internal.ui.state
 
 import com.adyen.checkout.card.internal.data.model.Brand
 import com.adyen.checkout.card.internal.ui.model.CardNumberTrailingIcon
+import com.adyen.checkout.card.internal.ui.model.ExpiryDateTrailingIcon
 import com.adyen.checkout.card.internal.ui.model.InstallmentModel
-import com.adyen.checkout.card.internal.ui.model.PostalCodeTrailingIcon
+import com.adyen.checkout.card.internal.ui.model.SecurityCodeTrailingIcon
 import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.components.data.model.Amount
 import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
+import com.adyen.checkout.core.components.internal.ui.state.model.RequirementPolicy
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
+import com.adyen.checkout.core.components.internal.ui.state.model.TrailingIcon
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -306,7 +309,7 @@ internal class CardViewStateProducerTest {
 
     // UC6: Error Hides Brand Logos
     @Test
-    fun `when card number has error with detected brand, then trailing icon is warning and supported brands are hidden`() {
+    fun `when card number has error with detected brand, then trailing icon is error and supported brands are hidden`() {
         // GIVEN
         val componentState = createComponentState(
             cardNumber = TextInputComponentState(
@@ -322,7 +325,7 @@ internal class CardViewStateProducerTest {
 
         // THEN
         assertEquals(
-            CardNumberTrailingIcon.Warning,
+            TrailingIcon.Error,
             viewState.cardNumber?.trailingIcon,
         )
         assertFalse(viewState.supportedCardBrandsViewState.isVisible)
@@ -434,28 +437,6 @@ internal class CardViewStateProducerTest {
     }
 
     @Test
-    fun `when postal code has error, then trailing icon is warning`() {
-        // GIVEN
-        val componentState = createComponentState(
-            postalCode = TextInputComponentState(
-                text = "",
-                errorMessage = CheckoutLocalizationKey.CARD_POSTAL_CODE_INVALID,
-                showError = true,
-            ),
-        )
-
-        // WHEN
-        val viewState = producer.produce(componentState)
-
-        // THEN
-        assertEquals(
-            PostalCodeTrailingIcon.Warning,
-            viewState.postalCode?.trailingIcon,
-        )
-        assertEquals(true, viewState.postalCode?.isError)
-    }
-
-    @Test
     fun `when supported card brands contain hidden brands, then hidden brands are excluded from view state`() {
         // GIVEN
         val componentState = createComponentState(
@@ -477,28 +458,6 @@ internal class CardViewStateProducerTest {
             listOf(CardBrand("visa"), CardBrand("mc")),
             viewState.supportedCardBrandsViewState.supportedCardBrands,
         )
-    }
-
-    @Test
-    fun `when postal code is valid, then trailing icon is placeholder`() {
-        // GIVEN
-        val componentState = createComponentState(
-            postalCode = TextInputComponentState(
-                text = "1234 AB",
-                errorMessage = null,
-                showError = false,
-            ),
-        )
-
-        // WHEN
-        val viewState = producer.produce(componentState)
-
-        // THEN
-        assertEquals(
-            PostalCodeTrailingIcon.Placeholder,
-            viewState.postalCode?.trailingIcon,
-        )
-        assertEquals(false, viewState.postalCode?.isError)
     }
 
     @Test
@@ -563,22 +522,7 @@ internal class CardViewStateProducerTest {
     }
 
     @Test
-    fun `when card scanning is not available and card number is empty, then scan button is not visible`() {
-        // GIVEN
-        val componentState = createComponentState(
-            cardNumber = TextInputComponentState(text = ""),
-            isCardScanningAvailable = false,
-        )
-
-        // WHEN
-        val viewState = producer.produce(componentState)
-
-        // THEN
-        assertFalse(viewState.isCardScanButtonVisible)
-    }
-
-    @Test
-    fun `when card scanning is available and card number has error, then trailing icon is Warning not ScanButton`() {
+    fun `when card scanning is available and card number is showing an error, then trailing icon is Error`() {
         // GIVEN
         val componentState = createComponentState(
             cardNumber = TextInputComponentState(
@@ -594,7 +538,201 @@ internal class CardViewStateProducerTest {
 
         // THEN
         assertTrue(viewState.isCardScanButtonVisible)
-        assertEquals(CardNumberTrailingIcon.Warning, viewState.cardNumber?.trailingIcon)
+        assertEquals(TrailingIcon.Error, viewState.cardNumber?.trailingIcon)
+    }
+
+    @Test
+    fun `when expiry date is valid, then trailing icon is Checkmark`() {
+        // GIVEN
+        val componentState = createComponentState(
+            expiryDate = TextInputComponentState(text = "0330"),
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertEquals(ExpiryDateTrailingIcon.Checkmark, viewState.expiryDate?.trailingIcon)
+    }
+
+    @Test
+    fun `when expiry date is empty, then trailing icon is Placeholder`() {
+        // GIVEN
+        val componentState = createComponentState(
+            expiryDate = TextInputComponentState(text = ""),
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertEquals(ExpiryDateTrailingIcon.Placeholder, viewState.expiryDate?.trailingIcon)
+    }
+
+    @Test
+    fun `when expiry date is partially filled, then trailing icon is Placeholder`() {
+        // GIVEN
+        val componentState = createComponentState(
+            expiryDate = TextInputComponentState(
+                text = "12",
+                errorMessage = CheckoutLocalizationKey.CARD_EXPIRY_DATE_INVALID,
+            ),
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertEquals(ExpiryDateTrailingIcon.Placeholder, viewState.expiryDate?.trailingIcon)
+    }
+
+    @Test
+    fun `when expiry date is optional and empty, then trailing icon is Placeholder`() {
+        // GIVEN
+        val componentState = createComponentState(
+            expiryDate = TextInputComponentState(
+                text = "",
+                requirementPolicy = RequirementPolicy.Optional,
+            ),
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertEquals(ExpiryDateTrailingIcon.Placeholder, viewState.expiryDate?.trailingIcon)
+    }
+
+    @Test
+    fun `when expiry date is showing an error, then trailing icon is Error instead of Placeholder`() {
+        // GIVEN
+        val componentState = createComponentState(
+            expiryDate = TextInputComponentState(
+                text = "6415",
+                errorMessage = CheckoutLocalizationKey.CARD_EXPIRY_DATE_INVALID,
+                showError = true,
+            ),
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertEquals(TrailingIcon.Error, viewState.expiryDate?.trailingIcon)
+    }
+
+    @Test
+    fun `when security code is valid, then trailing icon is Checkmark`() {
+        // GIVEN
+        val componentState = createComponentState(
+            securityCode = TextInputComponentState(text = "123"),
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertEquals(SecurityCodeTrailingIcon.Checkmark, viewState.securityCode?.trailingIcon)
+    }
+
+    @Test
+    fun `when security code is empty and amex is detected, then trailing icon is PlaceholderAmex`() {
+        // GIVEN
+        val componentState = createComponentState(
+            securityCode = TextInputComponentState(text = ""),
+            cardBrandState = CardBrandState.SingleReliableBrand(getCardBrandData(CardBrand("amex"))),
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertEquals(SecurityCodeTrailingIcon.PlaceholderAmex, viewState.securityCode?.trailingIcon)
+    }
+
+    @Test
+    fun `when security code is empty and non-amex is detected, then trailing icon is PlaceholderDefault`() {
+        // GIVEN
+        val componentState = createComponentState(
+            securityCode = TextInputComponentState(text = ""),
+            cardBrandState = CardBrandState.SingleReliableBrand(getCardBrandData(CardBrand("visa"))),
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertEquals(SecurityCodeTrailingIcon.PlaceholderDefault, viewState.securityCode?.trailingIcon)
+    }
+
+    @Test
+    fun `when security code is partially filled and non-amex is detected, then trailing icon is PlaceholderDefault`() {
+        // GIVEN
+        val componentState = createComponentState(
+            securityCode = TextInputComponentState(
+                text = "12",
+                errorMessage = CheckoutLocalizationKey.CARD_SECURITY_CODE_INVALID,
+            ),
+            cardBrandState = CardBrandState.SingleReliableBrand(getCardBrandData(CardBrand("visa"))),
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertEquals(SecurityCodeTrailingIcon.PlaceholderDefault, viewState.securityCode?.trailingIcon)
+    }
+
+    @Test
+    fun `when security code is optional and empty, then trailing icon is PlaceholderDefault`() {
+        // GIVEN
+        val componentState = createComponentState(
+            securityCode = TextInputComponentState(
+                text = "",
+                requirementPolicy = RequirementPolicy.Optional,
+            ),
+            cardBrandState = CardBrandState.SingleReliableBrand(getCardBrandData(CardBrand("visa"))),
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertEquals(SecurityCodeTrailingIcon.PlaceholderDefault, viewState.securityCode?.trailingIcon)
+    }
+
+    @Test
+    fun `when security code is showing an error, then trailing icon is Error instead of PlaceholderDefault`() {
+        // GIVEN
+        val componentState = createComponentState(
+            securityCode = TextInputComponentState(
+                text = "12",
+                errorMessage = CheckoutLocalizationKey.CARD_SECURITY_CODE_INVALID,
+                showError = true,
+            ),
+            cardBrandState = CardBrandState.SingleReliableBrand(getCardBrandData(CardBrand("visa"))),
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertEquals(TrailingIcon.Error, viewState.securityCode?.trailingIcon)
+    }
+
+    @Test
+    fun `when card scanning is not available and card number is empty, then scan button is not visible`() {
+        // GIVEN
+        val componentState = createComponentState(
+            cardNumber = TextInputComponentState(text = ""),
+            isCardScanningAvailable = false,
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertFalse(viewState.isCardScanButtonVisible)
     }
 
     @Test
@@ -620,6 +758,8 @@ internal class CardViewStateProducerTest {
     private fun createComponentState(
         cardNumber: TextInputComponentState = TextInputComponentState(),
         cardBrandState: CardBrandState = CardBrandState.NoBrandsDetected,
+        expiryDate: TextInputComponentState = TextInputComponentState(),
+        securityCode: TextInputComponentState = TextInputComponentState(),
         postalCode: TextInputComponentState = TextInputComponentState(),
         supportedCardBrands: List<CardBrand> = emptyList(),
         showSupportedCardBrandLogos: Boolean = true,
@@ -627,8 +767,8 @@ internal class CardViewStateProducerTest {
         installmentState: InstallmentState = InstallmentState(emptyList(), null),
     ) = CardComponentState(
         cardNumber = cardNumber,
-        expiryDate = TextInputComponentState(),
-        securityCode = TextInputComponentState(),
+        expiryDate = expiryDate,
+        securityCode = securityCode,
         holderName = TextInputComponentState(),
         socialSecurityNumber = TextInputComponentState(),
         kcpBirthDateOrTaxNumber = TextInputComponentState(),
@@ -645,9 +785,9 @@ internal class CardViewStateProducerTest {
         installmentState = installmentState,
     )
 
-    private fun getCardBrandData(): CardBrandData {
+    private fun getCardBrandData(cardBrand: CardBrand = CardBrand("")): CardBrandData {
         return CardBrandData(
-            cardBrand = CardBrand(""),
+            cardBrand = cardBrand,
             enableLuhnCheck = true,
             cvcPolicy = Brand.FieldPolicy.REQUIRED,
             expiryDatePolicy = Brand.FieldPolicy.REQUIRED,

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewStateProducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewStateProducerTest.kt
@@ -16,6 +16,7 @@ import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.components.data.model.Amount
 import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
+import com.adyen.checkout.core.components.internal.ui.state.model.TrailingIcon
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
@@ -131,7 +132,7 @@ internal class StoredCardViewStateProducerTest {
     }
 
     @Test
-    fun `when security code has error, then trailing icon is Warning`() {
+    fun `when security code is showing an error, then trailing icon is Error`() {
         // GIVEN
         val componentState = createComponentState(
             securityCode = TextInputComponentState(
@@ -139,13 +140,14 @@ internal class StoredCardViewStateProducerTest {
                 errorMessage = CheckoutLocalizationKey.CARD_SECURITY_CODE_INVALID,
                 showError = true,
             ),
+            detectedCardType = getDetectedCardType(CardBrand("visa")),
         )
 
         // WHEN
         val viewState = producer.produce(componentState)
 
         // THEN
-        assertEquals(SecurityCodeTrailingIcon.Warning, viewState.securityCode?.trailingIcon)
+        assertEquals(TrailingIcon.Error, viewState.securityCode?.trailingIcon)
     }
 
     @Test
@@ -187,7 +189,7 @@ internal class StoredCardViewStateProducerTest {
     }
 
     @Test
-    fun `when security code has error but showError is false, then trailing icon is placeholder`() {
+    fun `when security code is partially filled, then trailing icon is PlaceholderDefault`() {
         // GIVEN
         val componentState = createComponentState(
             securityCode = TextInputComponentState(
@@ -195,6 +197,7 @@ internal class StoredCardViewStateProducerTest {
                 errorMessage = CheckoutLocalizationKey.CARD_SECURITY_CODE_INVALID,
                 showError = false,
             ),
+            detectedCardType = getDetectedCardType(CardBrand("visa")),
         )
 
         // WHEN

--- a/core/src/main/java/com/adyen/checkout/core/common/internal/ui/CheckoutTextFieldTrailingIcon.kt
+++ b/core/src/main/java/com/adyen/checkout/core/common/internal/ui/CheckoutTextFieldTrailingIcon.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 7/8/2026.
+ */
+
+package com.adyen.checkout.core.common.internal.ui
+
+import androidx.annotation.RestrictTo
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.runtime.Composable
+import com.adyen.checkout.core.components.internal.ui.state.model.TrailingIcon
+import com.adyen.checkout.ui.internal.element.input.CheckoutTextFieldErrorIcon
+
+/**
+ * Renders the trailing icon of a text field, and animates the transitions between icons.
+ *
+ * Pass this as the `trailingIcon` of a `CheckoutTextField` to get the generic
+ * [TrailingIcon.Empty] and [TrailingIcon.Error] states handled for you. Fields that declare their own
+ * [TrailingIcon] states render them through [content].
+ *
+ * @param trailingIcon The icon to render, usually taken from
+ * [com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState.trailingIcon].
+ * @param content Renders the field specific states. It is never invoked for [TrailingIcon.Empty] or
+ * [TrailingIcon.Error], as those are handled internally.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Composable
+fun CheckoutTextFieldTrailingIcon(
+    trailingIcon: TrailingIcon,
+    content: @Composable (TrailingIcon) -> Unit = {},
+) {
+    AnimatedContent(targetState = trailingIcon, label = "TrailingIcon") { state ->
+        when (state) {
+            TrailingIcon.Empty -> Unit
+            TrailingIcon.Error -> CheckoutTextFieldErrorIcon()
+            else -> content(state)
+        }
+    }
+}

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputViewState.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputViewState.kt
@@ -19,16 +19,26 @@ data class TextInputViewState(
     val supportingText: CheckoutLocalizationKey? = null,
     val isFocused: Boolean = false,
     val isError: Boolean = false,
-    val trailingIcon: TrailingIcon? = null,
+    // The field specific icon, shown while the field is not in an error state. Do not render this directly, use
+    // [trailingIcon] instead.
+    val customTrailingIcon: TrailingIcon? = null,
     val isOptional: Boolean = false,
-)
+) {
+
+    /**
+     * The trailing icon to render. The generic [TrailingIcon.Error] icon always takes precedence over
+     * [customTrailingIcon], so that every field shows the error state consistently.
+     */
+    val trailingIcon: TrailingIcon
+        get() = if (isError) TrailingIcon.Error else customTrailingIcon ?: TrailingIcon.Empty
+}
 
 /**
  * Maps a TextInputComponentState to a TextInputViewState or returns null if the view should not be displayed on the UI.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun TextInputComponentState.toViewState(
-    trailingIcon: TrailingIcon? = null,
+    customTrailingIcon: TrailingIcon? = null,
 ): TextInputViewState? {
     if (requirementPolicy == RequirementPolicy.Hidden) return null
     return TextInputViewState(
@@ -36,7 +46,7 @@ fun TextInputComponentState.toViewState(
         supportingText = if (showErrorMessage) errorMessage else description,
         isFocused = isFocused,
         isError = showErrorMessage,
-        trailingIcon = trailingIcon,
+        customTrailingIcon = customTrailingIcon,
         isOptional = requirementPolicy is RequirementPolicy.Optional,
     )
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/model/TrailingIcon.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/model/TrailingIcon.kt
@@ -9,6 +9,29 @@
 package com.adyen.checkout.core.components.internal.ui.state.model
 
 import androidx.annotation.RestrictTo
+import com.adyen.checkout.core.common.internal.ui.CheckoutTextFieldTrailingIcon
 
+/**
+ * The trailing icon to be displayed at the end of a text field.
+ *
+ * [Empty] and [Error] are generic states handled by [CheckoutTextFieldTrailingIcon] for every field. Fields that need
+ * their own icons declare additional states by extending this class.
+ *
+ * Implementations must be comparable by equality, as they are used as the target state of an animation. Prefer
+ * `data object` or `data class`.
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-abstract class TrailingIcon
+abstract class TrailingIcon {
+
+    /**
+     * No icon is displayed.
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data object Empty : TrailingIcon()
+
+    /**
+     * The generic error icon, displayed whenever the field is showing an error.
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data object Error : TrailingIcon()
+}

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputComponentStateExtTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputComponentStateExtTest.kt
@@ -12,9 +12,12 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertNull
 
+/**
+ * Tests the extensions in `TextInputComponentStateExt.kt`: how the requirement policy of a field affects its payment
+ * data value and whether it needs validation.
+ */
 internal class TextInputComponentStateExtTest {
     @Test
     fun `when field is hidden and empty, then value should be null`() {
@@ -101,34 +104,6 @@ internal class TextInputComponentStateExtTest {
 
         // THEN
         assertEquals("text", paymentDataValue)
-    }
-
-    @Test
-    fun `when field is hidden, then view state should be null so it doesn't get displayed`() {
-        // GIVEN
-        val state = TextInputComponentState(
-            requirementPolicy = RequirementPolicy.Hidden,
-        )
-
-        // WHEN
-        val viewState = state.toViewState()
-
-        // THEN
-        assertNull(viewState)
-    }
-
-    @Test
-    fun `when field is optional, then view state should exist`() {
-        // GIVEN
-        val state = TextInputComponentState(
-            requirementPolicy = RequirementPolicy.Optional,
-        )
-
-        // WHEN
-        val viewState = state.toViewState()
-
-        // THEN
-        assertNotNull(viewState)
     }
 
     @Test

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputComponentStateTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputComponentStateTest.kt
@@ -14,6 +14,13 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
+/**
+ * Tests `TextInputComponentState.kt`: how the state of a field evolves as the shopper types, focuses and blurs, and
+ * when that results in an error being displayed. Some tests observe the outcome through `toViewState`, as that is what
+ * the UI ends up rendering.
+ *
+ * Tests for the mapping itself live in `TextInputViewStateTest`.
+ */
 internal class TextInputComponentStateTest {
 
     // UC1: Error on Explicit Validation

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputViewStateTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputViewStateTest.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 7/8/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui.state.model
+
+import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
+import org.junit.jupiter.api.assertNull
+
+/**
+ * Tests `TextInputViewState.kt`: the icon [TextInputViewState.trailingIcon] resolves to, and the `toViewState` mapping.
+ *
+ * Tests for the behaviour of the component state itself live in `TextInputComponentStateTest`.
+ */
+internal class TextInputViewStateTest {
+
+    @Test
+    fun `when there is no error and no custom icon, then trailing icon is Empty`() {
+        // GIVEN
+        val viewState = TextInputViewState(isError = false, customTrailingIcon = null)
+
+        // WHEN
+        val trailingIcon = viewState.trailingIcon
+
+        // THEN
+        assertEquals(TrailingIcon.Empty, trailingIcon)
+    }
+
+    @Test
+    fun `when there is no error and a custom icon, then trailing icon is the custom icon`() {
+        // GIVEN
+        val viewState = TextInputViewState(isError = false, customTrailingIcon = TestTrailingIcon)
+
+        // WHEN
+        val trailingIcon = viewState.trailingIcon
+
+        // THEN
+        assertEquals(TestTrailingIcon, trailingIcon)
+    }
+
+    @Test
+    fun `when there is an error and no custom icon, then trailing icon is Error`() {
+        // GIVEN
+        val viewState = TextInputViewState(isError = true, customTrailingIcon = null)
+
+        // WHEN
+        val trailingIcon = viewState.trailingIcon
+
+        // THEN
+        assertEquals(TrailingIcon.Error, trailingIcon)
+    }
+
+    @Test
+    fun `when there is an error and a custom icon, then the error icon takes precedence`() {
+        // GIVEN
+        val viewState = TextInputViewState(isError = true, customTrailingIcon = TestTrailingIcon)
+
+        // WHEN
+        val trailingIcon = viewState.trailingIcon
+
+        // THEN
+        assertEquals(TrailingIcon.Error, trailingIcon)
+    }
+
+    @Test
+    fun `when component state is showing an error, then trailing icon is Error`() {
+        // GIVEN
+        val componentState = TextInputComponentState(
+            text = "invalid",
+            errorMessage = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
+            showError = true,
+        )
+
+        // WHEN
+        val viewState = componentState.toViewState(customTrailingIcon = TestTrailingIcon)
+
+        // THEN
+        assertEquals(TrailingIcon.Error, viewState?.trailingIcon)
+    }
+
+    @Test
+    fun `when component state has an error that is not shown yet, then trailing icon is the custom icon`() {
+        // GIVEN
+        val componentState = TextInputComponentState(
+            text = "invalid",
+            errorMessage = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
+            showError = false,
+        )
+
+        // WHEN
+        val viewState = componentState.toViewState(customTrailingIcon = TestTrailingIcon)
+
+        // THEN
+        assertEquals(TestTrailingIcon, viewState?.trailingIcon)
+    }
+
+    @Test
+    fun `when component state has no custom icon, then trailing icon is Empty`() {
+        // GIVEN
+        val componentState = TextInputComponentState(text = "1234")
+
+        // WHEN
+        val viewState = componentState.toViewState()
+
+        // THEN
+        assertEquals(TrailingIcon.Empty, viewState?.trailingIcon)
+    }
+
+    @Test
+    fun `when field is hidden, then view state should be null so it doesn't get displayed`() {
+        // GIVEN
+        val state = TextInputComponentState(
+            requirementPolicy = RequirementPolicy.Hidden,
+        )
+
+        // WHEN
+        val viewState = state.toViewState()
+
+        // THEN
+        assertNull(viewState)
+    }
+
+    @Test
+    fun `when field is optional, then view state should exist`() {
+        // GIVEN
+        val state = TextInputComponentState(
+            requirementPolicy = RequirementPolicy.Optional,
+        )
+
+        // WHEN
+        val viewState = state.toViewState()
+
+        // THEN
+        assertNotNull(viewState)
+    }
+
+    private data object TestTrailingIcon : TrailingIcon()
+}

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MBWayPhoneNumberField.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/view/MBWayPhoneNumberField.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.adyen.checkout.core.common.internal.ui.CheckoutTextFieldTrailingIcon
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
@@ -49,6 +50,9 @@ internal fun MBWayPhoneNumberField(
         onValueChange = onValueChange,
         inputTransformation = inputTransformation,
         shouldFocus = mbWayPhoneNumberFieldState.isFocused,
+        trailingIcon = {
+            CheckoutTextFieldTrailingIcon(mbWayPhoneNumberFieldState.trailingIcon)
+        },
     )
 }
 

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/input/CheckoutTextField.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/input/CheckoutTextField.kt
@@ -69,9 +69,10 @@ import kotlinx.coroutines.flow.collectLatest
  * [CheckoutTextFieldDecorationBox].
  * @param prefix An optional string to be displayed at the beginning of the input area,
  * before the user's input.
- * @param trailingIcon An optional composable function that provides a trailing icon to be
- * displayed at the end of the text field. Payment method fields should render this through
+ * @param trailingIcon A composable function that provides a trailing icon to be displayed at the end
+ * of the text field, or null for no icon at all. Payment method fields should render this through
  * `CheckoutTextFieldTrailingIcon`, which handles the generic empty and error icons for every field.
+ * This parameter is required so that every new field has to make a deliberate choice about it.
  */
 @Suppress("LongMethod")
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -93,7 +94,7 @@ fun CheckoutTextField(
     prefix: String? = null,
     hint: String? = null,
     isSecureField: Boolean = false,
-    trailingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)?,
 ) {
     val style = CheckoutThemeProvider.elements.textField
     val innerTextStyle = CheckoutThemeProvider.textStyles.body
@@ -190,6 +191,7 @@ private fun CheckoutTextFieldPreview(
             label = "Label",
             state = rememberTextFieldStateWithCurrentValue(""),
             supportingText = "Description",
+            trailingIcon = null,
         )
 
         CheckoutTextField(
@@ -197,6 +199,7 @@ private fun CheckoutTextFieldPreview(
             label = "Label",
             state = rememberTextFieldStateWithCurrentValue(""),
             prefix = "Prefix",
+            trailingIcon = null,
         )
 
         val focusRequester = remember { FocusRequester() }
@@ -234,6 +237,7 @@ private fun CheckoutTextFieldPreview(
             label = "Password",
             isSecureField = true,
             modifier = Modifier.focusRequester(focusRequester),
+            trailingIcon = null,
         )
     }
 }

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/input/CheckoutTextField.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/input/CheckoutTextField.kt
@@ -70,7 +70,8 @@ import kotlinx.coroutines.flow.collectLatest
  * @param prefix An optional string to be displayed at the beginning of the input area,
  * before the user's input.
  * @param trailingIcon An optional composable function that provides a trailing icon to be
- * displayed at the end of the text field.
+ * displayed at the end of the text field. Payment method fields should render this through
+ * `CheckoutTextFieldTrailingIcon`, which handles the generic empty and error icons for every field.
  */
 @Suppress("LongMethod")
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -222,6 +223,9 @@ private fun CheckoutTextFieldPreview(
             label = "Label",
             supportingText = "Invalid input",
             isError = true,
+            // Components get this icon from CheckoutTextFieldTrailingIcon, it is passed manually here so that the
+            // preview matches what an errored field actually looks like.
+            trailingIcon = { CheckoutTextFieldErrorIcon() },
         )
 
         CheckoutTextField(

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/input/CheckoutTextFieldErrorIcon.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/input/CheckoutTextFieldErrorIcon.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 7/8/2026.
+ */
+
+package com.adyen.checkout.ui.internal.element.input
+
+import androidx.annotation.RestrictTo
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import com.adyen.checkout.test.R
+import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
+import com.adyen.checkout.ui.internal.theme.Dimensions
+
+/**
+ * The generic trailing icon of a [CheckoutTextField] that is showing an error.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Composable
+fun CheckoutTextFieldErrorIcon() {
+    Icon(
+        modifier = Modifier.size(Dimensions.LogoSize.small),
+        imageVector = ImageVector.vectorResource(R.drawable.ic_warning),
+        contentDescription = null,
+        tint = CheckoutThemeProvider.colors.destructive,
+    )
+}


### PR DESCRIPTION
## Description
Fixes a bug where only 4 text fields showed the generic error icon on validation errors and the rest did not.

- `TextInputViewState.trailingIcon` now resolves to `TrailingIcon.Error` whenever the field is showing an error, so the icon is decided in one place instead of each field opting in.
- `CheckoutTextFieldTrailingIcon` renders it and animates the transitions between icons.
- Field specific icons (brand logos, scan button, security code and expiry date placeholders) are now produced independently of the error state.
- `trailingIcon` is now required on `CheckoutTextField`, so a new field cannot silently omit it. Fields that render their own icon, like the search field, are unaffected.

**Trade-off:** a field whose icon resolves to `TrailingIcon.Empty` still emits an empty `AnimatedContent`, which takes up 8dp of trailing space. Not emitting it would drop the animation between the empty and error states.

## Checklist
- [x] Code is unit tested
- [x] Changes are tested manually