### PR TITLE
v6 - Skills - Support GitHub stacked pull requests

### DIFF
--- a/.agents/PR_REVIEWS.md
+++ b/.agents/PR_REVIEWS.md
@@ -2,10 +2,6 @@
 
 This document outlines how to handle review comments on Pull Requests in the Adyen Android SDK repository.
 
-**Related guides:**
-- [Pull Request Guide](PULL_REQUEST_GUIDE.md) - PR creation and templates
-- [GitHub CLI Commands](GH_CLI_COMMANDS.md) - `gh` command reference
-
 ## Workflow Overview
 
 1. Fetch review comments
@@ -54,6 +50,14 @@ git push
 ```
 
 The PR will automatically update with the new commit.
+
+For a PR that is part of a stack, pushing a single branch is not enough — see below.
+
+## Addressing Reviews in a Stack
+
+**Fix each comment in the layer that owns it.** Never work around a lower-layer problem from a higher branch — the fix ends up in the wrong PR and confuses every review above it. After committing the fix, rebase and push the whole stack, not just the branch you edited, or the layers above are left stale.
+
+A change in a lower layer can break a higher one even when the rebase is clean, so re-run the `android-check` skill on the layers above, not just the branch you edited.
 
 ## Resolving Conversations
 
@@ -127,6 +131,8 @@ PRs may go through multiple review rounds:
 3. Mark resolved conversations
 4. Wait for the next review round
 5. Repeat until approved
+
+For stacks, reviewers can work on layers in parallel, so rounds may not arrive in order. Collect the feedback for each layer, fix each one on its own branch, and rebase the stack once rather than after every individual comment.
 
 ## Quick Reference
 

--- a/.agents/skills/android-branch-create/SKILL.md
+++ b/.agents/skills/android-branch-create/SKILL.md
@@ -35,7 +35,7 @@ Ask the user what type of work this is:
 
 - Default: `main` (current development branch, v6)
 - Use `v5` only for essential fixes or features required for v5 maintenance
-- If this is part of a branch chain (phased work), the base should be the parent branch from the previous phase
+- If this is part of a branch chain (phased work), the base is the branch from the previous phase, and `main`/`v5` becomes the **trunk** of the stack
 - If unsure, ask the user
 
 ### 3. Compose branch name
@@ -65,6 +65,8 @@ Present the proposed branch name and base branch. Ask for approval before creati
 
 ### 5. Create and checkout
 
+**Single branch** (not part of a chain):
+
 ```bash
 git checkout <base-branch>
 git pull
@@ -72,9 +74,12 @@ git checkout -b <branch-name>
 git push --set-upstream origin <branch-name>
 ```
 
-Confirm the branch was created by running `git rev-parse --abbrev-ref HEAD`.
+**Chained branches** — build a stack so each layer targets the one below it, with `main`/`v5` as the trunk. If stacking is unavailable, base each branch on the previous phase and set each PR's base manually.
+
+Confirm the branch was created.
 
 ## Important
 
 - Never create a branch without confirming the name and base with the user.
 - Always pull the latest base branch before creating the new branch.
+- Open the PRs for a stack with the `android-pr-create` skill.

--- a/.agents/skills/android-migrate-payment-method-v6/SKILL.md
+++ b/.agents/skills/android-migrate-payment-method-v6/SKILL.md
@@ -54,7 +54,7 @@ Follow this loop for each phase below:
 
 ### 1. Branch (and chain)
 
-Use the `android-branch-create` skill to create a `chore/` branch (base `main` during v6). For a multi-phase migration, **chain branches** and open a **stacked draft PR** per branch so reviewers can review incrementally, at the cadence agreed with the developer (see *Before you start* — default is one branch/PR per cohesive group of phases, not per commit). Keep the same prefix and extend the name (e.g. `chore/v6-ideal-state`, `chore/v6-ideal-view`).
+Use the `android-branch-create` skill to create a `chore/` branch (base `main` during v6). For a multi-phase migration, build a **stack** with one draft PR per layer so reviewers can review incrementally, at the cadence agreed with the developer (see *Before you start* — default is one branch/PR per cohesive group of phases, not per commit). Keep the same prefix and extend the name (e.g. `chore/v6-ideal-state`, `chore/v6-ideal-view`). The phase order below is already a valid dependency order, so it maps directly onto stack layers.
 
 ### 2. Preserve the v5 implementation (`old/` package)
 
@@ -135,7 +135,7 @@ Use the `android-branch-create` skill to create a `chore/` branch (base `main` d
 
 - **Plan first, code after approval.** No implementation before the plan document is approved.
 - **Tests are part of every step** — created for new layers, moved with relocated v5 code. Never weaken or delete tests to make a phase pass.
-- **Small commits; PRs at an agreed cadence.** One logical change per commit via `android-commit`. PRs do **not** have to be per commit — group cohesive phases into stacked draft PRs (`android-branch-create` + `android-pr-create`), and agree the per-phase vs per-group cadence with the developer during planning.
+- **Small commits; PRs at an agreed cadence.** One logical change per commit via `android-commit`. PRs do **not** have to be per commit — group cohesive phases into stacked draft PRs (`android-branch-create` + `android-pr-create`), and agree the per-phase vs per-group cadence with the developer during planning. When review feedback lands on a lower layer, fix it on that branch and rebase the layers above — see `.agents/PR_REVIEWS.md`.
 - **Don't skip serializer registration** in `PaymentMethodDetails.getChildSerializer`.
 - **Default to `internal`.** Only the configuration/DSL is public. Discuss any breaking change before proceeding.
 - **Adapt per method.** No single reference is complete: Google Pay (external SDK, no fields), MBWay (input + secondary screen, no params/mapper), Card (input + stored). Confirm which collaborators and optional capabilities — params/mapper, input/validation, stored variant, secondary screen — your method actually needs rather than copying all of them.

--- a/.agents/skills/android-pr-create/SKILL.md
+++ b/.agents/skills/android-pr-create/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: android-pr-create
-description: Create a draft PR with title, body, and checklist.
+description: Create a PR with title, body, and checklist.
 ---
 
 # android-pr-create
 
-Create a draft Pull Request for the Adyen Android SDK following project conventions.
+Create a Pull Request for the Adyen Android SDK following project conventions.
 
 ## Usage
 
-Invoke this skill when you are ready to open a PR for the current branch. The skill generates the full PR body, shows it for user approval, and creates the PR as a draft.
+Invoke this skill when you are ready to open a PR for the current branch. The skill generates the full PR body, shows it for user approval, and creates the PR.
 
 ## Steps
 
@@ -33,7 +33,7 @@ Then verify the prefix actually matches the change. Inspect the diff for public 
 
 - Default base: `main`
 - If the branch name contains `v5` or the user specifies, use `v5`
-- If this is part of a PR chain, ask the user for the parent branch name and use that as base
+- If this branch is a layer in a stack, the base is the branch **directly below it**, not the trunk. For a chain built with plain git, ask the user for the parent branch name.
 
 ### 3. Compose PR title
 
@@ -80,6 +80,8 @@ Rules:
   ```
 - If there is an implementation plan file (`*_IMPLEMENTATION_PLAN.md`), use it to identify the phases
 - If the work is not phased, omit this section entirely
+
+Keep this section for stacked PRs too — the stack shows branch order, but not the plan behind it.
 
 #### Checklist section
 
@@ -133,17 +135,18 @@ Ask for approval. If the user wants changes, adjust and re-present.
 
 ### 6. Create the PR
 
-After approval, create as a **draft**:
+After approval, open the PR against the base branch determined above, as a draft unless the user wants it ready for review.
 
-```bash
-gh pr create --draft --base <base-branch> --title "<title>" --body "<body>"
-```
+For a stack, PRs are opened and linked per layer in one go, covering **every** branch that does not have a PR yet. The generated titles and bodies do not follow the conventions above, so correct them afterwards.
 
-Show the PR URL to the user after creation.
+Show the PR URL(s) to the user after creation.
+
+### Merging a stack
+
+Worth telling the user when a stack is opened: stacks merge **bottom-up**, so merging a PR also merges every unmerged PR below it.
 
 ## Important
 
-- Always create PRs as draft. Never create a non-draft PR.
 - PRs should be opened in the name of the developer, not the AI agent.
 - Never assign reviewers — GitHub CODEOWNERS handles this automatically.
 - Remove all template comments from the final PR body.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ This document outlines important patterns, practices, and rules to follow when w
 
 **Commit workflow - CRITICAL:**
 - **Complete one phase fully before moving to the next**
-- After completing a phase, use the `android-commit` skill (`.agents/skills/android-commit.md`) to commit
+- After completing a phase, use the `android-commit` skill (`.agents/skills/android-commit/SKILL.md`) to commit
 - Never accumulate multiple phases in a single commit
 - Each commit should represent a logical, complete unit of work
 - This ensures work can be reviewed incrementally and rolled back if needed


### PR DESCRIPTION
## Description
GitHub now supports stacked pull requests natively. This updates the agent
skills so multi-phase work is described as a stack, without spelling out the
CLI commands — the agent can pick its own tooling.

- `android-branch-create` — a chained branch is a layer in a stack, with
  `main`/`v5` as the trunk.
- `android-pr-create` — a layer's base is the branch below it, not the trunk.
  Stack PRs are opened per layer and their generated titles and bodies need
  correcting to match our template. Creating PRs as a draft is no longer a
  hard rule.
- `PR_REVIEWS` — review feedback is fixed in the layer that owns it, and the
  whole stack is rebased and pushed, not just the edited branch.
- `android-migrate-payment-method-v6` — existing stacking wording updated.

Single-branch work is unchanged. Using stacks requires the GitHub CLI
extension: `gh extension install github/gh-stack`.

Also fixes the `android-commit` skill path in `AGENTS.md`.

## Checklist
- [x] Changes are tested manually

## Ticket Number
N/A
