### PR TITLE
v5 - Agents - Dependency update skill

### DIFF
--- a/.agents/skills/android-update-dependencies-v5/DIFFERENCES.md
+++ b/.agents/skills/android-update-dependencies-v5/DIFFERENCES.md
@@ -1,0 +1,47 @@
+# Deliberate differences between v5 and main
+
+Everything in the build system should be identical to `main` **except** what is listed here. If you find a difference that is not on this list, port it from `main` rather than justifying it. If it should not be ported, add it here with the reason.
+
+Remove an entry as soon as its difference is resolved. A stale entry is worse than a missing one, because it causes the next reader to preserve something that no longer needs preserving.
+
+The *Introduced* column records the PR that added the entry to this file, which is not necessarily when the difference itself first appeared. Commit hashes are omitted because the branch is rebased.
+
+## Versions and build system
+
+| Difference | Why | Introduced |
+| --- | --- | --- |
+| `min-sdk` is lower than main's | v5 is still being released and cannot raise it. Every version ceiling below follows from this; if `min-sdk` changes, re-derive them all | #2886 |
+| Versions capped by that ceiling | See step 3 of the skill. Derive them from the AAR manifests each time; the set changes as AndroidX publishes | #2886 |
+| Versions where `main` is ahead | v5 must not exceed `main`, and does not chase it. Usually the release-age lag below | #2886 |
+| v6-only catalog entries absent — `material3`, `navigation3`, `startup`, `constraintlayout-compose`, `compose-pay-button`, `core-ktx`, `junit`, `junit-version`, their libraries, and the `kotlin-serialization` plugin | Not used on v5 | #2886 |
+| `compose-material` has no explicit version | v5 lets the Compose BOM pin material3; `main` pins it directly | #2886 |
+| `settings.gradle` lacks `authentication`, `core`, `ui` | v6-only modules | #2886 |
+| The root Dokka aggregation lacks the same three modules | Follows from the above | #2886 |
+| `config/detekt/detekt.yml` lacks the Compose relaxations | Compose-motivated configuration is not ported to v5, which has no first-class Compose support | #2886 |
+| `config/module/` absent | **Never port it.** The scaffolding is not compatible with v5 | #2886 |
+| `.agents/` holds only this skill and `DIFFERENCES.md` | General agent guidance is maintained on `main` and read from there. Do not copy `AGENTS.md` or the other skills across; where they state a value that differs on v5, they would mislead | #2886 |
+| `[plugins] kotlin = { id = "kotlin" }` | Left on the legacy id deliberately; `main` uses `org.jetbrains.kotlin.jvm` | #2886 |
+| `DokkaConventionPlugin` points source links at `tree/v5` | `main` points at `tree/main`. Without this every source link in v5's published documentation resolves to v6 code | #2886 |
+| Per-module `build.gradle` and `consumer-rules.pro` files differ throughout | v6 moved packages under `.old`, added the `core`, `authentication` and `ui` modules and adopted Compose across components, so module dependencies, namespaces and keep rules diverge. Expect around twenty files to differ for this reason alone. This covers only differences that follow from the refactor — anything else in those files is still drift, and must be ported or listed here | #2886 |
+
+### Release-age lag
+
+`renovate.json` sets `minimumReleaseAge: 14 days`, so each quarterly PR holds back anything published in the fortnight before it was cut; Renovate lists those under *Pending* in the PR body. `main` updates monthly and picks them up sooner, so v5 will always trail on a handful of dependencies.
+
+This is expected and self-correcting — the next quarterly run takes them. Do not chase them individually, and do not lower `minimumReleaseAge` to avoid it.
+
+## Workflows
+
+| Difference | Why | Introduced |
+| --- | --- | --- |
+| No `merge_group` triggers, no `github.event_name == 'pull_request'` guards, and simpler concurrency groups | v5 does not use merge queues. `main` needs the `pull_request.number \|\| sha` fallback because `head_ref` is empty in a merge group | #2886 |
+| `check_v5.yml` in place of `check_main.yml`, and `v5` branch triggers throughout | Branch identity | #2886 |
+| No prerelease handling — `create_github_release` has no `prerelease` input, `generate_version_name` has no prerelease outputs and uses `version_name.sh` rather than `version_info.sh` and `version_name_from_branch.sh`, `finalize_release` has no `version_info` job or `omitPrereleaseDuringUpdate`, and `update_release_notes` sets `draft: true` | v5 ships stable releases only; prereleases are a v6 concept | #2886 |
+| `release_nightly_app.yml` absent | v5 has no nightly builds | #2886 |
+| `release_acceptance_app.yml` has no `workflow_call` block | That block exists on `main` only so `release_nightly_app.yml` can call it, and v5 does not have that workflow | #2886 |
+| `run_ui_tests.yml` absent | v5 is a maintenance branch and does not run instrumentation tests | #2886 |
+| `stale_issues.yml` absent | Scheduled workflows run only from the default branch, so a copy here would never execute. Issues are repository-wide and managed from `main` | #2886 |
+| `release_snapshot.yml` absent | v5 does not publish snapshots | #2886 |
+| `label_pr_size.yml` absent | v5 PRs are not size-labelled | #2886 |
+| `deprecate_releases.yml`, `.github/scripts/deprecate-releases.js` and `package.json` absent | The script works purely against the GitHub Releases API and does not read the ref it runs from, so v5 releases are deprecated by running that workflow from `main` | #2886 |
+| `ADR/`, `docs/v6/` and `MIGRATION.md` absent | Documentation for v6 | #2886 |

--- a/.agents/skills/android-update-dependencies-v5/SKILL.md
+++ b/.agents/skills/android-update-dependencies-v5/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: android-update-dependencies-v5
+description: Work a Renovate dependency update PR on the v5 branch.
+---
+
+# android-update-dependencies-v5
+
+Bring a Renovate "All v5 dependencies" PR to a mergeable state, keeping v5 as close to `main` as possible while preserving the differences that are deliberate.
+
+## Usage
+
+Invoke this skill when working a Renovate dependency PR whose base is `v5`. Renovate opens one every three months.
+
+**Only applies to `v5` and branches based on it.** Check with `git merge-base --is-ancestor origin/v5 HEAD`. If you are on `main`, ignore this file.
+
+The deliberate differences between the branches are recorded in `DIFFERENCES.md` next to this file. Read it before changing anything, and keep it current — see step 9.
+
+**The two files divide cleanly: this one describes the process, `DIFFERENCES.md` holds the list.** Never name an individual difference here, however convenient it seems mid-step. A specific written into a step then has to be maintained in two places, and this is the copy that gets forgotten — leaving a step that names one difference where several now exist, which reads as an exhaustive list and silently reverts the rest. Point at `DIFFERENCES.md` and verify against it instead.
+
+### General guidance lives on main
+
+Commit, branch, PR and check conventions are maintained on `main` only and are not duplicated here. Read them from git rather than checking `main` out:
+
+```
+git fetch origin main
+git ls-tree -r origin/main --name-only | rg '^\.agents/|^AGENTS.md'
+git show origin/main:<path>
+```
+
+Enumerate them dynamically — a hardcoded list will go stale. Where any of them states a value that differs on v5, such as `minSdk`, take v5's value from the repository rather than the one written there.
+
+### Read the previous update for precedent
+
+```
+gh pr list --base v5 --label Dependencies --state merged --limit 3
+```
+
+Its commits show the shape of the work. Treat them as **precedent, not policy** — `DIFFERENCES.md` is the only authority on what is deliberate.
+
+## The three rules
+
+1. **v5 must never exceed `main`.** `main` owns and validates the toolchain and build system. Anything Renovate raises above `main` comes back down to `main`'s value. Trailing `main` is fine and often expected; see the release-age note in `DIFFERENCES.md`.
+2. **v5 must keep building at its `min-sdk`.** Read the value from `gradle/libs.versions.toml`; never assume it.
+3. **v5 must not diverge on its own.** Every change is either ported from `main` unchanged, or a deliberate divergence that is written down. If something cannot be ported as-is, stop and say so plainly, explain why, and get the user's decision before adapting it. Record the outcome in `DIFFERENCES.md`. Never invent a v5-only solution silently.
+
+Apply rule 1 first, then rule 2. Matching `main` pulls in versions that need a higher `minSdk`, so the ceiling has to be applied afterwards.
+
+## Steps
+
+### 1. Sync build logic and toolchain from main
+
+**Unconditional.** Do this even when v5 builds fine and nothing is failing. A green build is not evidence of alignment, and drift is only ever cheaper to pay down early.
+
+```
+git fetch origin main
+git checkout origin/main -- build-logic/
+```
+
+That copy is wholesale, so it reverts every deliberate difference inside `build-logic/`. Re-apply the ones `DIFFERENCES.md` lists, then check the result against it:
+
+```
+git diff origin/main HEAD -- build-logic/
+```
+
+Every line this prints must match an entry in `DIFFERENCES.md`, and every `build-logic/` entry there must appear in this diff. Treat a mismatch in either direction as a problem: an unlisted change is drift, and a listed one that is missing was just reverted by the copy. Nothing in the build fails either way, so this diff is the only thing that catches it.
+
+Then copy `main`'s toolchain versions into the catalog: AGP, Gradle, Kotlin, KSP, Dokka, detekt, ktlint, kover, sonarqube, binary-compatibility-validator, hilt.
+
+**Scope: everything that configures the build rather than implementing the product.** That is the root and per-module `build.gradle` and `build.gradle.kts`, `settings.gradle`, `gradle.properties`, `gradle/` including the catalog and wrapper, `build-logic/`, `config/`, `scripts/`, `.github/`, `.editorconfig`, and any other `.gradle`, `.kts`, `.properties`, `.toml`, `.sh`, `.py`, `.yml` or dotfile outside `src/`.
+
+**Also look for files that exist on `main` and not on v5 at all.** A new script, workflow or convention plugin will not show up in a diff of shared files:
+
+```
+comm -23 <(git ls-tree -r origin/main --name-only | sort) <(git ls-tree -r HEAD --name-only | sort)
+```
+
+Review every build-related entry: port it, or add it to `DIFFERENCES.md` with the reason. Run the reverse direction too, to catch anything v5 has that `main` does not.
+
+Cross-check the result against `DIFFERENCES.md`, and be careful how: a filename can appear there as part of the *reason* for some other entry while having no entry of its own, so grepping for it gives a false pass. Confirm each path is genuinely listed as a difference in its own right.
+
+Anything not in `DIFFERENCES.md` must match `main`. If you find a difference that is not listed, port it — do not justify it.
+
+**Before porting a workflow, check it can actually run on v5.** Scheduled workflows only run from the default branch, and a reusable workflow with no caller is dead weight.
+
+### 2. Downgrade anything above main
+
+```
+git diff origin/main HEAD -- gradle/libs.versions.toml settings.gradle gradle/wrapper/
+git diff origin/main HEAD -I'^[[:space:]]*uses: ' -- .github/workflows
+```
+
+Use `git diff origin/main HEAD`, not `origin/main...HEAD`. The three-dot form compares against the merge base, which is far behind both branches and will mislead you badly.
+
+**`.github/workflows/` and `settings.gradle` are in scope, not just the catalog.** GitHub Action versions are easy to miss because they do not live in the version catalog. Take `main`'s exact digest and version comment so the pins match what `main` runs.
+
+The `-I` flag hides hunks whose every changed line matches, which is the easiest way to separate real differences from pinned-version churn. It takes a POSIX regex: `\s` silently matches nothing, use `[[:space:]]`.
+
+### 3. Pin anything that breaches min-sdk
+
+Derive the ceilings; never copy a stored table. For every Android artifact the PR bumps, read `minSdkVersion` out of the published AAR and compare it against the project's `min-sdk`:
+
+```
+https://dl.google.com/dl/android/maven2/<group-path>/<name>/<version>/<name>-<version>.aar
+```
+
+Fall back to `https://repo1.maven.org/maven2/...`, then `unzip -p <aar> AndroidManifest.xml | grep minSdkVersion`.
+
+- KMP artifacts have no plain AAR — use the `-android` suffix, for example `ui-android` or `material3-android`.
+- For the Compose BOM, fetch its POM to see what it pins, then check those artifacts.
+- Check first-order transitives too. Gradle resolves the highest version in the graph, so a compliant direct dependency can still drag in a non-compliant one.
+- A ceiling is not reliably "one minor below `main`". Walk versions down until the manifest satisfies `min-sdk`; do not assume.
+
+If `min-sdk` ever changes, every ceiling has to be re-derived.
+
+### 4. Fix toolchain fallout
+
+Compile and configuration failures caused by the new toolchain. This is the step that needs judgement; the rest is mechanical.
+
+Prefer `main`'s solution over inventing one. If `main` has already crossed the same toolchain boundary, it has solved the problem — find out how before debugging from scratch. Inventing a v5-only fix is a rule 3 violation.
+
+### 5. Regenerate the API dump
+
+```
+./gradlew apiDump
+```
+
+Run it every time, whether or not Kotlin moved.
+
+A Kotlin major produces a large dump diff that is **expected and not a real API change**, driven by codegen rather than by source. Known categories: parcelize emitting `CREATOR` as an anonymous object instead of a named `$Creator` class, parcelize marking `describeContents` and `writeToParcel` final, interface methods with default bodies becoming real JVM default methods under `-Xjvm-default=all-compatibility`, and `get$default` bridges appearing for interface methods with default arguments.
+
+Before accepting a large dump diff, confirm nothing actually left the API surface:
+
+- no `public static final field CREATOR` removed
+- every member that became `final` belongs to a `final class`, so nobody could have overridden it
+- `$DefaultImpls` classes retained — that is what keeps already-compiled merchant code linking
+- no change to any method's parameters or return type
+- no class removed other than generated `$Creator` helpers
+
+Account for every removed line. If something does not fit a known codegen category, it is a real API change and needs a decision, not a dump.
+
+### 6. Fix tests and the example app
+
+### 7. Regenerate dependency verification metadata
+
+Do this **last**, once versions are final, as its own commit.
+
+```
+./gradlew --write-verification-metadata sha256 resolveDependencies assembleDebug --refresh-dependencies
+```
+
+`--refresh-dependencies` matters. The writer only records what the build actually resolves, so with a warm cache it silently misses artifacts and the failure surfaces later as a verification error on a cold CI runner.
+
+### 8. Verify
+
+```
+./gradlew apiCheck
+./gradlew check
+./gradlew dokkaGeneratePublicationHtml
+python3 scripts/validate_dependencies_for_release_notes.py
+```
+
+The release-notes validator only checks *added* dependencies, so stale entries for removed ones are harmless.
+
+Then re-run the rule-1 comparison from step 2 and confirm nothing on v5 exceeds `main`.
+
+If you touched secrets or reusable workflows, cross-check them: every secret a reusable workflow references must be declared under `on.workflow_call.secrets`, and every caller must pass exactly what the callee declares. A reference that resolves to an empty string fails silently — an empty `cache-encryption-key`, for instance, simply disables configuration-cache reuse rather than erroring.
+
+### 9. Update this skill and DIFFERENCES.md
+
+Before reporting, fold anything durable back in:
+
+- **A new deliberate difference** — add it to `DIFFERENCES.md` with its reason and the PR it was introduced in. It belongs there and nowhere else: do not also write it into a step above, even if that is the step it will bite.
+- **A difference that is now resolved** — remove the entry. A stale entry is worse than a missing one, because the next reader will preserve something that no longer needs preserving.
+- **The process was wrong or incomplete** — fix this file, so the same gap is not rediscovered next cycle.
+
+Only durable rules and decisions belong in either file. Version numbers, ceilings and accounts of a particular quarter belong in the commits.
+
+### 10. Report and get approval
+
+Present a final report to the user and **wait for explicit approval before the PR is considered ready**:
+
+- the state of the differences before this PR and after it
+- what was **aligned** with `main`, and why it was safe
+- what was **skipped**, and why
+- what was **modified** rather than ported as-is, with the reasoning and the user decision behind each — see rule 3
+- anything that could not be verified
+
+Ask for a final review. Do not treat the work as finished until the user confirms.
+
+## Commits and PR
+
+Follow `main`'s commit and PR skills. Specific to this work:
+
+- One commit per concern, in the order of the steps above. Do not mix the sync, the downgrades, the ceiling pins and the API dump.
+- Explain anything that looks removable. A future maintainer deletes what they cannot explain, so the reasoning belongs in the commit message rather than in a chat log.
+- **Never edit Renovate's PR description, and do not add anything to the PR body.** Renovate regenerates it whenever a rebase is triggered, and it carries a `renovate-debug` block. Its version table describes what was *available*, not what landed.
+- Anything worth keeping belongs in a commit message, or in `DIFFERENCES.md` if it is a decision.


### PR DESCRIPTION
## Description

Renovate opens an "All v5 dependencies" PR against `v5` every three months. The work it needs is repeatable but not obvious, and until now it lived only in the heads of whoever did it last. This adds a skill so the next person, or their agent, starts from the same place.

Two files, split because they change at different rates:

- **`SKILL.md`** — the process. Three rules and their ordering, the ten steps, how to derive the `minSdk` ceilings from AAR manifests rather than trusting a stored table, how to triage the API dump churn a Kotlin major produces, and the verification and reporting expected before the PR is called done.
- **`DIFFERENCES.md`** — the decision record. What is deliberately different from `main`, why, and which PR wrote it down. The process should be near-static; this changes whenever a difference is accepted or resolved.

General commit, branch, PR and check guidance stays on `main` and is read from there rather than duplicated, so only these two files live on v5.

Stacked on #2886 — the differences recorded here are the ones settled while working that PR.

## Checklist
- [x] Changes are tested manually