### PR TITLE
[WIP - TO BE DISCUSSED] v6 - Drop-in - Extract PaymentFlowCoordinator

### DIFF
--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInControllerProvider.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInControllerProvider.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 13/8/2026.
+ */
+
+package com.adyen.checkout.dropin.internal.ui
+
+import com.adyen.checkout.core.action.data.ActionComponentData
+import com.adyen.checkout.core.common.CheckoutContext
+import com.adyen.checkout.core.components.AdditionalDetailsResult
+import com.adyen.checkout.core.components.AdvancedCheckoutCallbacks
+import com.adyen.checkout.core.components.BeforeSubmitResult
+import com.adyen.checkout.core.components.CheckoutController
+import com.adyen.checkout.core.components.CheckoutTarget
+import com.adyen.checkout.core.components.SessionCheckoutCallbacks
+import com.adyen.checkout.core.components.SessionCheckoutResult
+import com.adyen.checkout.core.components.SubmitResult
+import com.adyen.checkout.core.components.data.BeforeSubmitData
+import com.adyen.checkout.core.components.data.PaymentComponentData
+import com.adyen.checkout.core.error.CheckoutError
+import com.adyen.checkout.dropin.internal.service.DropInServiceManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * Creates the [CheckoutController] that drives a single Drop-in checkout flow.
+ */
+internal fun interface DropInControllerProvider {
+
+    /**
+     * @param paymentFlowType The payment method the flow is started for.
+     * @param coroutineScope The scope tied to the lifetime of the flow. Cancelling it tears the flow down.
+     */
+    fun provide(
+        paymentFlowType: DropInPaymentFlowType,
+        coroutineScope: CoroutineScope,
+    ): CheckoutController
+}
+
+internal class DefaultDropInControllerProvider(
+    private val checkoutContext: CheckoutContext,
+    private val dropInServiceManager: DropInServiceManager,
+) : DropInControllerProvider {
+
+    override fun provide(
+        paymentFlowType: DropInPaymentFlowType,
+        coroutineScope: CoroutineScope,
+    ): CheckoutController {
+        val target = createTarget(paymentFlowType)
+
+        return when (checkoutContext) {
+            is CheckoutContext.Advanced -> {
+                CheckoutController(
+                    target = target,
+                    context = checkoutContext,
+                    callbacks = AdvancedCheckoutCallbacks(
+                        onSubmit = ::onSubmit,
+                        onAdditionalDetails = ::onAdditionalDetails,
+                        onFailure = { error -> onFailure(coroutineScope, error) },
+                    ),
+                    coroutineScope = coroutineScope,
+                )
+            }
+
+            is CheckoutContext.Sessions -> {
+                CheckoutController(
+                    target = target,
+                    context = checkoutContext,
+                    callbacks = SessionCheckoutCallbacks(
+                        onBeforeSubmit = ::onBeforeSubmit,
+                        onFailure = { error -> onFailure(coroutineScope, error) },
+                        onComplete = { result -> onComplete(coroutineScope, result) },
+                    ),
+                    coroutineScope = coroutineScope,
+                )
+            }
+
+            is CheckoutContext.ActionOnly -> error("Unsupported context: $checkoutContext")
+        }
+    }
+
+    private fun createTarget(paymentFlowType: DropInPaymentFlowType): CheckoutTarget {
+        return when (paymentFlowType) {
+            is DropInPaymentFlowType.RegularPaymentMethod -> {
+                CheckoutTarget.PaymentMethod(type = paymentFlowType.txVariant)
+            }
+
+            is DropInPaymentFlowType.StoredPaymentMethod -> {
+                CheckoutTarget.StoredPaymentMethod(id = paymentFlowType.id)
+            }
+        }
+    }
+
+    private suspend fun onBeforeSubmit(data: BeforeSubmitData): BeforeSubmitResult {
+        // TODO - Implement after beforeSubmit is added to DropInService
+        return BeforeSubmitResult.Proceed(data)
+    }
+
+    private suspend fun onSubmit(paymentComponentData: PaymentComponentData<*>): SubmitResult {
+        return dropInServiceManager.requestOnSubmit(paymentComponentData)
+    }
+
+    private suspend fun onAdditionalDetails(data: ActionComponentData): AdditionalDetailsResult {
+        return dropInServiceManager.requestOnAdditionalDetails(data)
+    }
+
+    private fun onFailure(coroutineScope: CoroutineScope, error: CheckoutError) {
+        coroutineScope.launch {
+            dropInServiceManager.onFailure(error)
+        }
+    }
+
+    private fun onComplete(coroutineScope: CoroutineScope, result: SessionCheckoutResult) {
+        // TODO - Implement after signature of onFinished is updated
+        coroutineScope.launch {
+            dropInServiceManager.onPaymentCompleted(result.resultCode)
+        }
+    }
+}

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInNavKeys.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInNavKeys.kt
@@ -11,6 +11,12 @@ package com.adyen.checkout.dropin.internal.ui
 import androidx.navigation3.runtime.NavKey
 import kotlinx.serialization.Serializable
 
+/**
+ * Marks the keys that are part of an active payment flow. The flow, and therefore its controller, is kept alive as
+ * long as at least one key of this type is on the back stack.
+ */
+internal sealed interface PaymentFlowNavKey : NavKey
+
 @Serializable
 internal data object EmptyNavKey : NavKey
 
@@ -28,4 +34,4 @@ internal data object StoredPaymentMethodsNavKey : NavKey
 @Serializable
 internal data class PaymentMethodNavKey(
     val paymentFlowType: DropInPaymentFlowType,
-) : NavKey
+) : PaymentFlowNavKey

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInNavigator.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInNavigator.kt
@@ -13,15 +13,22 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.navigation3.runtime.NavKey
 import com.adyen.checkout.dropin.internal.helper.BackStackPersister
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 internal class DropInNavigator(
     private val backStackPersister: BackStackPersister,
 ) {
 
+    // The back stack is exposed in two shapes: [backStack] is observed by Compose, [backStackFlow] by everything
+    // outside of composition. Both are kept in sync by onBackStackChanged().
+
     // Initialized with an empty key to make the preselected bottom sheet possible
     private val _backStack: SnapshotStateList<NavKey> = mutableStateListOf(EmptyNavKey)
     val backStack: List<NavKey> get() = _backStack
+
+    private val _backStackFlow: MutableStateFlow<List<NavKey>> = MutableStateFlow(_backStack.toList())
+    val backStackFlow: StateFlow<List<NavKey>> = _backStackFlow.asStateFlow()
 
     private val _finishFlow = MutableStateFlow(false)
     val finishFlow = _finishFlow.asStateFlow()
@@ -34,19 +41,20 @@ internal class DropInNavigator(
         if (didRestoreState) {
             _backStack.clear()
             _backStack.addAll(restored)
+            _backStackFlow.value = _backStack.toList()
         }
     }
 
     fun navigateTo(key: NavKey) {
         _backStack.add(key)
-        persist()
+        onBackStackChanged()
     }
 
     fun clearAndNavigateTo(key: NavKey) {
         _backStack.clear()
         _backStack.add(EmptyNavKey)
         _backStack.add(key)
-        persist()
+        onBackStackChanged()
     }
 
     fun back() {
@@ -55,14 +63,15 @@ internal class DropInNavigator(
         if (_backStack.singleOrNull() == EmptyNavKey) {
             _finishFlow.tryEmit(true)
         }
-        persist()
+        onBackStackChanged()
     }
 
     fun isEmptyAfterCurrent(): Boolean {
         return _backStack.filterNot { it is EmptyNavKey }.size <= 1
     }
 
-    private fun persist() {
+    private fun onBackStackChanged() {
+        _backStackFlow.value = _backStack.toList()
         backStackPersister.store(_backStack)
     }
 }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModel.kt
@@ -12,6 +12,7 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.adyen.checkout.core.common.AdyenLogLevel
 import com.adyen.checkout.core.common.CheckoutContext
@@ -38,9 +39,18 @@ internal class DropInViewModel(
 
     lateinit var paymentMethodRepository: PaymentMethodRepository
 
-    val checkoutContext = input.checkoutContext
+    private val checkoutContext = input.checkoutContext
 
-    val dropInServiceManager = DropInServiceManager(input.serviceClass)
+    private val dropInServiceManager = DropInServiceManager(input.serviceClass)
+
+    val paymentFlowCoordinator = PaymentFlowCoordinator(
+        navigator = navigator,
+        controllerProvider = DefaultDropInControllerProvider(
+            checkoutContext = checkoutContext,
+            dropInServiceManager = dropInServiceManager,
+        ),
+        coroutineScope = viewModelScope,
+    )
 
     val resultFlow: Flow<DropInResult> = merge(
         dropInServiceManager.paymentResultFlow.map { DropInResult.Completed(it) },
@@ -52,6 +62,7 @@ internal class DropInViewModel(
         initializePaymentMethods()
         initializeDropInParams()
         initializeBackStack()
+        paymentFlowCoordinator.restoreFlow()
     }
 
     private fun initializePaymentMethods() {

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/NavigationStack.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/NavigationStack.kt
@@ -15,11 +15,17 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.ui.NavDisplay
+import com.adyen.checkout.core.common.AdyenLogLevel
+import com.adyen.checkout.core.common.internal.helper.adyenLog
 
 @Composable
 internal fun NavigationStack(
     viewModel: DropInViewModel,
 ) {
+    // TODO - Investigate scoping view models to their nav entry with rememberViewModelStoreNavEntryDecorator. It
+    //  requires the lifecycle-viewmodel-navigation3 dependency and clears a view model once its entry left the
+    //  composition, which makes the key below obsolete and would allow screens to get the controller from their own
+    //  view model.
     NavDisplay(
         backStack = viewModel.navigator.backStack,
         sceneStrategies = remember { listOf(BottomSheetSceneStrategy()) },
@@ -55,6 +61,7 @@ private fun preselectedPaymentMethodNavEntry(
                 storedPaymentMethodId = key.storedPaymentMethodId,
                 paymentMethodRepository = viewModel.paymentMethodRepository,
                 navigator = viewModel.navigator,
+                paymentFlowCoordinator = viewModel.paymentFlowCoordinator,
             ),
         ),
     )
@@ -68,8 +75,9 @@ private fun paymentMethodListNavEntry(
     metadata = DropInTransitions.slideInAndOutVertically(),
 ) {
     PaymentMethodListScreen(
-        viewModel.navigator,
-        viewModel(
+        navigator = viewModel.navigator,
+        paymentFlowCoordinator = viewModel.paymentFlowCoordinator,
+        viewModel = viewModel(
             factory = PaymentMethodListViewModel.Factory(
                 dropInParams = viewModel.dropInParams,
                 paymentMethodRepository = viewModel.paymentMethodRepository,
@@ -109,16 +117,26 @@ private fun paymentMethodNavEntry(
         key = key,
         metadata = transitions,
     ) {
+        // The controller is intentionally only read once, so this screen keeps rendering while it is navigated away
+        // from and its flow is being torn down.
+        val controller = remember(key) { viewModel.paymentFlowCoordinator.activeController } ?: run {
+            adyenLog(AdyenLogLevel.ERROR, "paymentMethodNavEntry") {
+                "No active payment flow, the PaymentMethodScreen cannot be displayed."
+            }
+            return@NavEntry
+        }
+
         PaymentMethodScreen(
             navigator = viewModel.navigator,
+            controller = controller,
             viewModel = viewModel(
                 factory = PaymentMethodViewModel.Factory(
                     paymentFlowType = key.paymentFlowType,
                     paymentMethodRepository = viewModel.paymentMethodRepository,
-                    checkoutContext = viewModel.checkoutContext,
-                    dropInServiceManager = viewModel.dropInServiceManager,
                 ),
-                key = key.paymentFlowType.hashCode().toString(),
+                // View models are scoped to the activity, so each payment method needs a unique key of its own.
+                // TODO - Remove this key when view models are scoped to their nav entry instead.
+                key = key.toString(),
             ),
         )
     }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentFlowCoordinator.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentFlowCoordinator.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 13/8/2026.
+ */
+
+package com.adyen.checkout.dropin.internal.ui
+
+import com.adyen.checkout.core.components.CheckoutController
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+
+/**
+ * Owns the lifecycle of the [CheckoutController] that drives the payment flow of a single payment method.
+ *
+ * Only one flow can be active at a time. Starting a new flow tears the previous one down. A flow stays alive as long
+ * as at least one [PaymentFlowNavKey] is on the back stack, and is torn down as soon as none is left.
+ */
+internal class PaymentFlowCoordinator(
+    private val navigator: DropInNavigator,
+    private val controllerProvider: DropInControllerProvider,
+    private val coroutineScope: CoroutineScope,
+) {
+
+    private var activeFlow: ActiveFlow? = null
+
+    /**
+     * The controller of the active flow, or `null` if no flow is active.
+     */
+    val activeController: CheckoutController? get() = activeFlow?.controller
+
+    init {
+        observeBackStack()
+    }
+
+    /**
+     * Starts a new flow for [paymentFlowType] and navigates to its payment method screen.
+     *
+     * @param replaceBackStack Whether the current back stack should be replaced instead of being added to.
+     */
+    fun startFlow(paymentFlowType: DropInPaymentFlowType, replaceBackStack: Boolean = false) {
+        createFlow(paymentFlowType)
+
+        val key = PaymentMethodNavKey(paymentFlowType)
+        if (replaceBackStack) {
+            navigator.clearAndNavigateTo(key)
+        } else {
+            navigator.navigateTo(key)
+        }
+    }
+
+    /**
+     * Starts a new flow for a [paymentFlowType] that is already on the back stack, without navigating.
+     *
+     * A controller cannot be restored, therefore the flow is started from scratch.
+     */
+    // TODO - Revisit when action and result screens are added: when they are pushed on top of the payment method
+    //  screen, its key is no longer last and the flow is not restored.
+    // TODO - Only the navigation is restored. Restoring the contents of the flow (entered input, an in-flight submit or
+    //  an in-progress redirect) requires component state saving in the core module.
+    fun restoreFlow() {
+        when (val key = navigator.backStack.lastOrNull()) {
+            is PaymentMethodNavKey -> createFlow(key.paymentFlowType)
+            else -> Unit
+        }
+    }
+
+    private fun createFlow(paymentFlowType: DropInPaymentFlowType) {
+        cancelActiveFlow()
+
+        val flowScope = createFlowScope()
+        activeFlow = ActiveFlow(
+            controller = controllerProvider.provide(paymentFlowType, flowScope),
+            coroutineScope = flowScope,
+        )
+    }
+
+    private fun observeBackStack() {
+        coroutineScope.launch {
+            navigator.backStackFlow.collect { backStack ->
+                if (backStack.none { it is PaymentFlowNavKey }) {
+                    cancelActiveFlow()
+                }
+            }
+        }
+    }
+
+    private fun cancelActiveFlow() {
+        activeFlow?.coroutineScope?.cancel()
+        activeFlow = null
+    }
+
+    /**
+     * Creates a child scope of [coroutineScope]: cancelling the parent cancels the flow, but cancelling the flow
+     * leaves the parent untouched. [SupervisorJob] makes sure a failure inside the flow does not cancel Drop-in.
+     */
+    private fun createFlowScope(): CoroutineScope {
+        val parentContext = coroutineScope.coroutineContext
+        return CoroutineScope(parentContext + SupervisorJob(parentContext[Job]))
+    }
+
+    private class ActiveFlow(
+        val controller: CheckoutController,
+        val coroutineScope: CoroutineScope,
+    )
+}

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodListScreen.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodListScreen.kt
@@ -59,17 +59,22 @@ private const val AMOUNT_VISIBLE_BRANDS = 3
 @Composable
 internal fun PaymentMethodListScreen(
     navigator: DropInNavigator,
+    paymentFlowCoordinator: PaymentFlowCoordinator,
     viewModel: PaymentMethodListViewModel,
 ) {
     val viewState by viewModel.viewState.collectAsStateWithLifecycle()
-    PaymentMethodListContent(navigator, viewState, navigator::navigateTo)
+    PaymentMethodListContent(
+        navigator = navigator,
+        viewState = viewState,
+        onPaymentMethodClick = { paymentFlowCoordinator.startFlow(it) },
+    )
 }
 
 @Composable
 private fun PaymentMethodListContent(
     navigator: DropInNavigator,
     viewState: PaymentMethodListViewState,
-    onPaymentMethodClick: (PaymentMethodNavKey) -> Unit,
+    onPaymentMethodClick: (DropInPaymentFlowType) -> Unit,
 ) {
     DropInScaffold(
         navigationIcon = {
@@ -106,7 +111,7 @@ private fun PaymentMethodListContent(
                     items = it.options,
                     onActionClick = { navigator.navigateTo(StoredPaymentMethodsNavKey) },
                     onPaymentMethodClick = { pm ->
-                        onPaymentMethodClick(PaymentMethodNavKey(DropInPaymentFlowType.StoredPaymentMethod(pm.id)))
+                        onPaymentMethodClick(DropInPaymentFlowType.StoredPaymentMethod(pm.id))
                     },
                 )
 
@@ -119,7 +124,7 @@ private fun PaymentMethodListContent(
                     actionText = it.action,
                     items = it.options,
                     onPaymentMethodClick = { pm ->
-                        onPaymentMethodClick(PaymentMethodNavKey(DropInPaymentFlowType.RegularPaymentMethod(pm.id)))
+                        onPaymentMethodClick(DropInPaymentFlowType.RegularPaymentMethod(pm.id))
                     },
                 )
             }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodScreen.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodScreen.kt
@@ -33,10 +33,11 @@ import com.adyen.checkout.ui.internal.theme.Dimensions
 @Composable
 internal fun PaymentMethodScreen(
     navigator: DropInNavigator,
+    controller: CheckoutController,
     viewModel: PaymentMethodViewModel,
 ) {
     val viewState by viewModel.viewState.collectAsStateWithLifecycle()
-    PaymentMethodScreenContent(navigator, viewState, viewModel.controller)
+    PaymentMethodScreenContent(navigator, viewState, controller)
 }
 
 @Composable

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodViewModel.kt
@@ -10,42 +10,25 @@ package com.adyen.checkout.dropin.internal.ui
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
-import com.adyen.checkout.core.action.data.ActionComponentData
-import com.adyen.checkout.core.common.CheckoutContext
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
-import com.adyen.checkout.core.components.AdditionalDetailsResult
-import com.adyen.checkout.core.components.AdvancedCheckoutCallbacks
-import com.adyen.checkout.core.components.BeforeSubmitResult
-import com.adyen.checkout.core.components.CheckoutController
-import com.adyen.checkout.core.components.CheckoutTarget
-import com.adyen.checkout.core.components.SessionCheckoutCallbacks
-import com.adyen.checkout.core.components.SessionCheckoutResult
-import com.adyen.checkout.core.components.SubmitResult
-import com.adyen.checkout.core.components.data.BeforeSubmitData
-import com.adyen.checkout.core.components.data.PaymentComponentData
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethodResponse
 import com.adyen.checkout.core.components.paymentmethod.PaymentMethodTypes
-import com.adyen.checkout.core.error.CheckoutError
 import com.adyen.checkout.dropin.internal.data.PaymentMethodRepository
-import com.adyen.checkout.dropin.internal.service.DropInServiceManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 
+// TODO - Verify whether this still needs to be a view model now that it no longer owns the checkout controller. Its
+//  view state never changes, so it could be a plain value instead of a state flow. Its factory also still uses the
+//  deprecated create() overload, unlike the other view models in this module.
 internal class PaymentMethodViewModel(
     private val paymentFlowType: DropInPaymentFlowType,
     private val paymentMethodRepository: PaymentMethodRepository,
-    private val checkoutContext: CheckoutContext,
-    private val dropInServiceManager: DropInServiceManager,
 ) : ViewModel() {
 
     private val _viewState = MutableStateFlow(createViewState())
     val viewState: StateFlow<PaymentMethodViewState> = _viewState.asStateFlow()
-
-    val controller = createCheckoutController()
 
     private fun createViewState(): PaymentMethodViewState {
         val paymentMethod = when (paymentFlowType) {
@@ -73,87 +56,15 @@ internal class PaymentMethodViewModel(
         }
     }
 
-    private fun createCheckoutController(): CheckoutController {
-        val target = when (paymentFlowType) {
-            is DropInPaymentFlowType.RegularPaymentMethod -> {
-                CheckoutTarget.PaymentMethod(type = paymentFlowType.txVariant)
-            }
-
-            is DropInPaymentFlowType.StoredPaymentMethod -> {
-                CheckoutTarget.StoredPaymentMethod(id = paymentFlowType.id)
-            }
-        }
-
-        return when (checkoutContext) {
-            is CheckoutContext.Advanced -> {
-                CheckoutController(
-                    target = target,
-                    context = checkoutContext,
-                    callbacks = AdvancedCheckoutCallbacks(
-                        onSubmit = ::onSubmit,
-                        onAdditionalDetails = ::onAdditionalDetails,
-                        onFailure = ::onFailure,
-                    ),
-                    coroutineScope = viewModelScope,
-                )
-            }
-
-            is CheckoutContext.Sessions -> {
-                CheckoutController(
-                    target = target,
-                    context = checkoutContext,
-                    callbacks = SessionCheckoutCallbacks(
-                        onBeforeSubmit = ::onBeforeSubmit,
-                        onFailure = ::onFailure,
-                        onComplete = ::onComplete,
-                    ),
-                    coroutineScope = viewModelScope,
-                )
-            }
-
-            is CheckoutContext.ActionOnly -> error("Unsupported context: $checkoutContext")
-        }
-    }
-
-    private suspend fun onBeforeSubmit(data: BeforeSubmitData): BeforeSubmitResult {
-        // TODO - Implement after beforeSubmit is added to DropInService
-        return BeforeSubmitResult.Proceed(data)
-    }
-
-    private suspend fun onSubmit(paymentComponentData: PaymentComponentData<*>): SubmitResult {
-        return dropInServiceManager.requestOnSubmit(paymentComponentData)
-    }
-
-    private suspend fun onAdditionalDetails(data: ActionComponentData): AdditionalDetailsResult {
-        return dropInServiceManager.requestOnAdditionalDetails(data)
-    }
-
-    private fun onFailure(error: CheckoutError) {
-        viewModelScope.launch {
-            dropInServiceManager.onFailure(error)
-        }
-    }
-
-    private fun onComplete(result: SessionCheckoutResult) {
-        // TODO - Implement after signature of onFinished is updated
-        viewModelScope.launch {
-            dropInServiceManager.onPaymentCompleted(result.resultCode)
-        }
-    }
-
     class Factory(
         private val paymentFlowType: DropInPaymentFlowType,
         private val paymentMethodRepository: PaymentMethodRepository,
-        private val checkoutContext: CheckoutContext,
-        private val dropInServiceManager: DropInServiceManager,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
             return PaymentMethodViewModel(
                 paymentFlowType = paymentFlowType,
                 paymentMethodRepository = paymentMethodRepository,
-                checkoutContext = checkoutContext,
-                dropInServiceManager = dropInServiceManager,
             ) as T
         }
     }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PreselectedPaymentMethodViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PreselectedPaymentMethodViewModel.kt
@@ -25,6 +25,7 @@ internal class PreselectedPaymentMethodViewModel(
     private val paymentMethodRepository: PaymentMethodRepository,
     private val storedPaymentMethodId: String,
     private val navigator: DropInNavigator,
+    private val paymentFlowCoordinator: PaymentFlowCoordinator,
 ) : ViewModel() {
 
     private val _viewState = MutableStateFlow<PreselectedPaymentMethodViewState?>(null)
@@ -59,7 +60,7 @@ internal class PreselectedPaymentMethodViewModel(
 
     fun onPayClicked() {
         val type = DropInPaymentFlowType.StoredPaymentMethod(storedPaymentMethodId)
-        navigator.clearAndNavigateTo(PaymentMethodNavKey(type))
+        paymentFlowCoordinator.startFlow(paymentFlowType = type, replaceBackStack = true)
     }
 
     fun onOtherPaymentMethodClicked() {
@@ -75,6 +76,7 @@ internal class PreselectedPaymentMethodViewModel(
         private val storedPaymentMethodId: String,
         private val paymentMethodRepository: PaymentMethodRepository,
         private val navigator: DropInNavigator,
+        private val paymentFlowCoordinator: PaymentFlowCoordinator,
     ) : ViewModelProvider.Factory {
 
         @Suppress("UNCHECKED_CAST")
@@ -84,6 +86,7 @@ internal class PreselectedPaymentMethodViewModel(
                 paymentMethodRepository = paymentMethodRepository,
                 storedPaymentMethodId = storedPaymentMethodId,
                 navigator = navigator,
+                paymentFlowCoordinator = paymentFlowCoordinator,
             ) as T
         }
     }

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/DropInNavigatorTest.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/DropInNavigatorTest.kt
@@ -45,6 +45,22 @@ internal class DropInNavigatorTest {
     }
 
     @Test
+    fun `when initialized then back stack flow contains only empty key`() {
+        assertEquals(listOf(EmptyNavKey), navigator.backStackFlow.value)
+    }
+
+    @Test
+    fun `when the back stack changes then back stack flow is updated`() {
+        val key = TestNavKey("test")
+
+        navigator.navigateTo(key)
+        assertEquals(listOf(EmptyNavKey, key), navigator.backStackFlow.value)
+
+        navigator.back()
+        assertEquals(listOf(EmptyNavKey), navigator.backStackFlow.value)
+    }
+
+    @Test
     fun `when clearing and navigating to a key then back stack is cleared and key is added`() {
         val initialKey = TestNavKey("initial")
         navigator.navigateTo(initialKey)
@@ -99,6 +115,16 @@ internal class DropInNavigatorTest {
         val restoredNavigator = DropInNavigator(persister)
 
         assertEquals(listOf(EmptyNavKey, key), restoredNavigator.backStack)
+    }
+
+    @Test
+    fun `when restoring from saved state then back stack flow is restored`() {
+        val key = TestNavKey("test")
+        navigator.navigateTo(key)
+
+        val restoredNavigator = DropInNavigator(persister)
+
+        assertEquals(listOf(EmptyNavKey, key), restoredNavigator.backStackFlow.value)
     }
 
     @Serializable

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/PaymentFlowCoordinatorTest.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/PaymentFlowCoordinatorTest.kt
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 13/8/2026.
+ */
+
+package com.adyen.checkout.dropin.internal.ui
+
+import com.adyen.checkout.core.components.CheckoutController
+import com.adyen.checkout.dropin.internal.helper.InMemoryBackStackPersister
+import com.adyen.checkout.test.LoggingExtension
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.kotlin.mock
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(LoggingExtension::class)
+internal class PaymentFlowCoordinatorTest {
+
+    private val requestedPaymentFlowTypes = mutableListOf<DropInPaymentFlowType>()
+    private val createdFlowScopes = mutableListOf<CoroutineScope>()
+
+    private val controllerProvider = DropInControllerProvider { paymentFlowType, flowScope ->
+        requestedPaymentFlowTypes += paymentFlowType
+        createdFlowScopes += flowScope
+        mock<CheckoutController>()
+    }
+
+    private lateinit var persister: InMemoryBackStackPersister
+    private lateinit var navigator: DropInNavigator
+    private lateinit var coroutineScope: CoroutineScope
+
+    @BeforeEach
+    fun setUp() {
+        persister = InMemoryBackStackPersister()
+        navigator = DropInNavigator(persister)
+        coroutineScope = CoroutineScope(UnconfinedTestDispatcher())
+    }
+
+    @AfterEach
+    fun tearDown() {
+        coroutineScope.cancel()
+    }
+
+    @Test
+    fun `when starting a flow, then a controller is created for the payment flow type`() {
+        val coordinator = createCoordinator()
+
+        coordinator.startFlow(REGULAR_TYPE)
+
+        assertEquals(listOf(REGULAR_TYPE), requestedPaymentFlowTypes)
+        assertNotNull(coordinator.activeController)
+    }
+
+    @Test
+    fun `when starting a flow, then it navigates to the payment method`() {
+        navigator.navigateTo(PaymentMethodListNavKey)
+        val coordinator = createCoordinator()
+
+        coordinator.startFlow(REGULAR_TYPE)
+
+        val expected = listOf(EmptyNavKey, PaymentMethodListNavKey, PaymentMethodNavKey(REGULAR_TYPE))
+        assertEquals(expected, navigator.backStack)
+    }
+
+    @Test
+    fun `when starting a flow while replacing the back stack, then only the payment method is left`() {
+        navigator.navigateTo(PreselectedPaymentMethodNavKey(STORED_ID))
+        val coordinator = createCoordinator()
+
+        coordinator.startFlow(STORED_TYPE, replaceBackStack = true)
+
+        assertEquals(listOf(EmptyNavKey, PaymentMethodNavKey(STORED_TYPE)), navigator.backStack)
+    }
+
+    @Test
+    fun `when starting a second flow, then the first flow is torn down and a new controller is created`() {
+        val coordinator = createCoordinator()
+        coordinator.startFlow(REGULAR_TYPE)
+        val firstController = coordinator.activeController
+
+        coordinator.startFlow(STORED_TYPE, replaceBackStack = true)
+
+        assertFalse(createdFlowScopes[0].isActive)
+        assertTrue(createdFlowScopes[1].isActive)
+        assertNotSame(firstController, coordinator.activeController)
+    }
+
+    @Test
+    fun `when re-entering the same payment method, then a new controller is created`() {
+        navigator.navigateTo(PaymentMethodListNavKey)
+        val coordinator = createCoordinator()
+        coordinator.startFlow(REGULAR_TYPE)
+        val firstController = coordinator.activeController
+        navigator.back()
+
+        coordinator.startFlow(REGULAR_TYPE)
+
+        assertEquals(listOf(REGULAR_TYPE, REGULAR_TYPE), requestedPaymentFlowTypes)
+        assertNotSame(firstController, coordinator.activeController)
+    }
+
+    @Test
+    fun `when no payment flow key is left on the back stack, then the flow is torn down`() {
+        navigator.navigateTo(PaymentMethodListNavKey)
+        val coordinator = createCoordinator()
+        coordinator.startFlow(REGULAR_TYPE)
+
+        navigator.back()
+
+        assertNull(coordinator.activeController)
+        assertFalse(createdFlowScopes[0].isActive)
+    }
+
+    @Test
+    fun `when a payment flow key is still on the back stack, then the flow is kept alive`() {
+        val coordinator = createCoordinator()
+        coordinator.startFlow(REGULAR_TYPE)
+
+        navigator.navigateTo(StoredPaymentMethodsNavKey)
+
+        assertNotNull(coordinator.activeController)
+        assertTrue(createdFlowScopes[0].isActive)
+    }
+
+    @Test
+    fun `when the parent scope is cancelled, then the flow is torn down`() {
+        val coordinator = createCoordinator()
+        coordinator.startFlow(REGULAR_TYPE)
+
+        coroutineScope.cancel()
+
+        assertFalse(createdFlowScopes[0].isActive)
+    }
+
+    @Test
+    fun `when restoring a flow, then a controller is created without navigating`() {
+        navigator.navigateTo(PaymentMethodNavKey(REGULAR_TYPE))
+        val restoredNavigator = DropInNavigator(persister)
+        val coordinator = createCoordinator(restoredNavigator)
+
+        coordinator.restoreFlow()
+
+        assertEquals(listOf(REGULAR_TYPE), requestedPaymentFlowTypes)
+        assertNotNull(coordinator.activeController)
+        assertEquals(listOf(EmptyNavKey, PaymentMethodNavKey(REGULAR_TYPE)), restoredNavigator.backStack)
+    }
+
+    @Test
+    fun `when restoring a flow without a payment method on the back stack, then no controller is created`() {
+        navigator.navigateTo(PaymentMethodListNavKey)
+        val restoredNavigator = DropInNavigator(persister)
+        val coordinator = createCoordinator(restoredNavigator)
+
+        coordinator.restoreFlow()
+
+        assertEquals(emptyList<DropInPaymentFlowType>(), requestedPaymentFlowTypes)
+        assertNull(coordinator.activeController)
+    }
+
+    private fun createCoordinator(navigator: DropInNavigator = this.navigator) = PaymentFlowCoordinator(
+        navigator = navigator,
+        controllerProvider = controllerProvider,
+        coroutineScope = coroutineScope,
+    )
+
+    private companion object {
+        private const val STORED_ID = "stored-id-1"
+        private val REGULAR_TYPE = DropInPaymentFlowType.RegularPaymentMethod("scheme")
+        private val STORED_TYPE = DropInPaymentFlowType.StoredPaymentMethod(STORED_ID)
+    }
+}

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/PreselectedPaymentMethodViewModelTest.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/PreselectedPaymentMethodViewModelTest.kt
@@ -15,18 +15,27 @@ import com.adyen.checkout.core.components.paymentmethod.PaymentMethodTypes
 import com.adyen.checkout.dropin.internal.data.TestPaymentMethodRepository
 import com.adyen.checkout.dropin.internal.helper.InMemoryBackStackPersister
 import com.adyen.checkout.test.LoggingExtension
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.kotlin.mock
 import java.util.Locale
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(LoggingExtension::class)
 internal class PreselectedPaymentMethodViewModelTest {
 
     private lateinit var navigator: DropInNavigator
+    private lateinit var coordinatorScope: CoroutineScope
+    private lateinit var paymentFlowCoordinator: PaymentFlowCoordinator
 
     private val dropInParams = DropInParams(
         shopperLocale = Locale.US,
@@ -50,6 +59,17 @@ internal class PreselectedPaymentMethodViewModelTest {
     @BeforeEach
     fun setUp() {
         navigator = DropInNavigator(InMemoryBackStackPersister())
+        coordinatorScope = CoroutineScope(UnconfinedTestDispatcher())
+        paymentFlowCoordinator = PaymentFlowCoordinator(
+            navigator = navigator,
+            controllerProvider = DropInControllerProvider { _, _ -> mock() },
+            coroutineScope = coordinatorScope,
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        coordinatorScope.cancel()
     }
 
     @Test
@@ -137,5 +157,6 @@ internal class PreselectedPaymentMethodViewModelTest {
         paymentMethodRepository = repository,
         storedPaymentMethodId = storedPaymentMethodId,
         navigator = navigator,
+        paymentFlowCoordinator = paymentFlowCoordinator,
     )
 }


### PR DESCRIPTION
## Description

Drop-in delegates all of its in-payment-method navigation to core's `CheckoutPaymentFlow`. Before that
can be replaced with the granular `CheckoutPaymentMethod` / `CheckoutAction` / `CheckoutSecondary`
composables, controller ownership has to move out of `PaymentMethodViewModel`. This PR does only that
part — `PaymentMethodScreen` still renders `CheckoutPaymentFlow`, so there is no visible change yet.

- Adds `PaymentFlowCoordinator`, owning the single active `CheckoutController` and giving each flow its
  own child scope of `viewModelScope`.
- Adds the `DropInControllerProvider` interface and its default implementation, so controller creation
  is injectable and the coordinator is unit-testable without Compose or Robolectric.
- Moves `createCheckoutController` and the `onSubmit` / `onAdditionalDetails` / `onFailure` /
  `onComplete` / `onBeforeSubmit` wiring out of `PaymentMethodViewModel`, which is now view state only.
- Creates the controller on the navigation event instead of lazily during composition, and cancels a
  flow once no `PaymentFlowNavKey` is left on the back stack.
- `DropInNavigator` also exposes the back stack as a `StateFlow`, so the coordinator can observe it
  outside composition.
- On restore, a back stack ending in `PaymentMethodNavKey` re-starts that flow once, outside composition.

### Fixed

navigation3 has no ViewModelStore decorator, so a `PaymentMethodViewModel` created inside a `NavEntry`
was scoped to the activity and outlived its entry. Re-entering a payment method reused the previous
controller along with its already-consumed `canSubmit` flag, giving a stuck pay button and a silently
dropped second `submit()`. Controllers are now created per entry into the flow and cancelled when the
flow leaves the back stack.

Intentional behaviour change: re-entering a payment method now starts fresh rather than restoring the
previous form state. This matches v5 and Web.

### Progress

➡️ **Phase 1 — Extract the coordinator (this PR)**
Phase 2 — Swap to the granular composables
Phase 3 — Direct submit for no-UI payment methods
Phase 4 — Redirect return handling

## Checklist
- [x] Code is unit tested
- [ ] Changes are tested manually

## Ticket Number
COSDK-1420
