### PR TITLE
v6 - POC - Form field architecture

### DIFF
--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentState.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentState.kt
@@ -12,6 +12,7 @@ import com.adyen.checkout.card.internal.data.model.Brand
 import com.adyen.checkout.card.internal.ui.model.InstallmentModel
 import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.components.internal.ui.state.ComponentState
+import com.adyen.checkout.core.components.internal.ui.state.form.FormState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
 
 internal data class CardComponentState(
@@ -37,7 +38,21 @@ internal data class CardComponentState(
     val cardBrandState: CardBrandState,
     val networkBinLookupState: NetworkBinLookupState?,
     val installmentState: InstallmentState,
-) : ComponentState
+) : ComponentState {
+
+    /**
+     * Which fields are on screen and in which order. Derived from the fields above rather than stored, so that it
+     * cannot disagree with them, and computed once per state because both the reducer and the view state producer read
+     * it several times.
+     *
+     * [LazyThreadSafetyMode.PUBLICATION] because the merchant owns the coroutine scope this component runs in, so the
+     * same state can be read from more than one thread. Deriving the same value twice is harmless; publishing it
+     * unsafely would not be.
+     */
+    val form: FormState<CardFieldId> by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        FormState(order = visibleCardFields(this))
+    }
+}
 
 internal sealed class CardBrandState {
     // No brands

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentState.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentState.kt
@@ -12,6 +12,7 @@ import com.adyen.checkout.card.internal.data.model.Brand
 import com.adyen.checkout.card.internal.ui.model.InstallmentModel
 import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.components.internal.ui.state.ComponentState
+import com.adyen.checkout.core.components.internal.ui.state.form.FocusRequest
 import com.adyen.checkout.core.components.internal.ui.state.form.FormState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
 
@@ -38,19 +39,23 @@ internal data class CardComponentState(
     val cardBrandState: CardBrandState,
     val networkBinLookupState: NetworkBinLookupState?,
     val installmentState: InstallmentState,
+
+    // A focus move the state layer is asking the UI to make. Unlike the field order this is not derivable, since it
+    // records something that happened rather than something that is.
+    val focusRequest: FocusRequest<CardFieldId>? = null,
 ) : ComponentState {
 
     /**
-     * Which fields are on screen and in which order. Derived from the fields above rather than stored, so that it
-     * cannot disagree with them, and computed once per state because both the reducer and the view state producer read
-     * it several times.
+     * Which fields are on screen and in which order, plus any pending focus move. The order is derived from the fields
+     * above rather than stored, so that it cannot disagree with them, and computed once per state because both the
+     * reducer and the view state producer read it several times.
      *
      * [LazyThreadSafetyMode.PUBLICATION] because the merchant owns the coroutine scope this component runs in, so the
      * same state can be read from more than one thread. Deriving the same value twice is harmless; publishing it
      * unsafely would not be.
      */
     val form: FormState<CardFieldId> by lazy(LazyThreadSafetyMode.PUBLICATION) {
-        FormState(order = visibleCardFields(this))
+        FormState(order = visibleCardFields(this), focusRequest = focusRequest)
     }
 }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateFactory.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateFactory.kt
@@ -14,6 +14,7 @@ import com.adyen.checkout.card.internal.ui.model.CardComponentParams
 import com.adyen.checkout.card.internal.ui.model.InstallmentModel
 import com.adyen.checkout.card.internal.ui.model.mapToInstallmentModels
 import com.adyen.checkout.core.components.internal.ui.state.ComponentStateFactory
+import com.adyen.checkout.core.components.internal.ui.state.form.FocusRequest
 import com.adyen.checkout.core.components.internal.ui.state.model.RequirementPolicy
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
 
@@ -27,6 +28,8 @@ internal class CardComponentStateFactory(
             ?: emptyList()
 
         return CardComponentState(
+            // TODO - Form fields cleanup: will be removed. The focusRequest below is what focuses the card number
+            // now. The flag is still read by the components that have not moved over yet.
             cardNumber = TextInputComponentState(isFocused = true),
             expiryDate = TextInputComponentState(),
             securityCode = TextInputComponentState(
@@ -59,6 +62,8 @@ internal class CardComponentStateFactory(
                 installmentOptions = installmentOptions,
                 selectedInstallment = getPreselectedInstallment(installmentOptions),
             ),
+            // The shopper starts at the first field, with the keyboard already open.
+            focusRequest = FocusRequest(id = CardFieldId.CARD_NUMBER),
         )
     }
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateReducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateReducer.kt
@@ -56,6 +56,12 @@ internal class CardComponentStateReducer(
 
             is CardIntent.UpdateFieldFocus -> state.updateFieldFocus(intent.id, intent.hasFocus)
 
+            is CardIntent.FocusRequestConsumed -> if (state.focusRequest?.id == intent.id) {
+                state.copy(focusRequest = null)
+            } else {
+                state
+            }
+
             is CardIntent.UpdateStorePaymentMethod -> state.copy(
                 storePaymentMethod = intent.isChecked,
             )

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateReducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateReducer.kt
@@ -10,77 +10,51 @@ package com.adyen.checkout.card.internal.ui.state
 
 import com.adyen.checkout.card.internal.helper.ExpiryDateParser
 import com.adyen.checkout.core.components.internal.ui.state.ComponentStateReducer
+import com.adyen.checkout.core.components.internal.ui.state.form.FocusRequest
+import com.adyen.checkout.core.components.internal.ui.state.form.firstInvalid
+import com.adyen.checkout.core.components.internal.ui.state.form.nextTextInputAfter
+import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
 
 internal class CardComponentStateReducer(
     private val cardBrandIntentsHandler: CardBrandIntentsHandler,
 ) : ComponentStateReducer<CardComponentState, CardIntent> {
 
-    @Suppress("CyclomaticComplexMethod", "LongMethod")
+    @Suppress("CyclomaticComplexMethod")
     override fun reduce(state: CardComponentState, intent: CardIntent): CardComponentState {
         return when (intent) {
             is CardIntent.UpdateCardNumber -> state.copy(
                 cardNumber = state.cardNumber.updateText(intent.number),
             )
 
-            is CardIntent.UpdateCardNumberFocus -> state.copy(
-                cardNumber = state.cardNumber.updateFocus(intent.hasFocus),
-            )
-
             is CardIntent.UpdateExpiryDate -> state.copy(
                 expiryDate = state.expiryDate.updateText(intent.expiryDate),
-            )
-
-            is CardIntent.UpdateExpiryDateFocus -> state.copy(
-                expiryDate = state.expiryDate.updateFocus(intent.hasFocus),
             )
 
             is CardIntent.UpdateSecurityCode -> state.copy(
                 securityCode = state.securityCode.updateText(intent.securityCode),
             )
 
-            is CardIntent.UpdateSecurityCodeFocus -> state.copy(
-                securityCode = state.securityCode.updateFocus(intent.hasFocus),
-            )
-
             is CardIntent.UpdateHolderName -> state.copy(
                 holderName = state.holderName.updateText(intent.holderName),
-            )
-
-            is CardIntent.UpdateHolderNameFocus -> state.copy(
-                holderName = state.holderName.updateFocus(intent.hasFocus),
             )
 
             is CardIntent.UpdateSocialSecurityNumber -> state.copy(
                 socialSecurityNumber = state.socialSecurityNumber.updateText(intent.socialSecurityNumber),
             )
 
-            is CardIntent.UpdateSocialSecurityNumberFocus -> state.copy(
-                socialSecurityNumber = state.socialSecurityNumber.updateFocus(intent.hasFocus),
-            )
-
             is CardIntent.UpdateKcpBirthDateOrTaxNumber -> state.copy(
                 kcpBirthDateOrTaxNumber = state.kcpBirthDateOrTaxNumber.updateText(intent.kcpBirthDateOrTaxNumber),
-            )
-
-            is CardIntent.UpdateKcpBirthDateOrTaxNumberFocus -> state.copy(
-                kcpBirthDateOrTaxNumber = state.kcpBirthDateOrTaxNumber.updateFocus(intent.hasFocus),
             )
 
             is CardIntent.UpdateKcpCardPassword -> state.copy(
                 kcpCardPassword = state.kcpCardPassword.updateText(intent.kcpCardPassword),
             )
 
-            is CardIntent.UpdateKcpCardPasswordFocus -> state.copy(
-                kcpCardPassword = state.kcpCardPassword.updateFocus(intent.hasFocus),
-            )
-
             is CardIntent.UpdatePostalCode -> state.copy(
                 postalCode = state.postalCode.updateText(intent.postalCode)
             )
 
-            is CardIntent.UpdatePostalCodeFocus -> state.copy(
-                postalCode = state.postalCode.updateFocus(intent.hasFocus)
-            )
+            is CardIntent.UpdateFieldFocus -> state.updateFieldFocus(intent.id, intent.hasFocus)
 
             is CardIntent.UpdateStorePaymentMethod -> state.copy(
                 storePaymentMethod = intent.isChecked,
@@ -111,47 +85,115 @@ internal class CardComponentStateReducer(
                 expiryDate = state.expiryDate.updateText(
                     ExpiryDateParser.formatToMMyy(intent.expiryMonth, intent.expiryYear),
                 ),
-            )
+            ).requestFocusAfterScan(intent)
 
             is CardIntent.HighlightValidationErrors -> highlightValidationErrors(state)
         }
     }
 
-    private fun highlightValidationErrors(state: CardComponentState): CardComponentState {
-        var isFocusConsumed = false
+    /**
+     * Moves the shopper to the first field the scan did not fill. A scan can come back with only part of a card, or
+     * with nothing usable at all, and a scan that returns no card number also clears the one that was there, so the
+     * shopper has to go back rather than forward.
+     *
+     * This goes by what the scanner returned rather than by what is still invalid, because the reducer runs before the
+     * validator: at this point every error still describes the text from before the scan.
+     */
+    private fun CardComponentState.requestFocusAfterScan(
+        intent: CardIntent.UpdateCardScanResult,
+    ): CardComponentState {
+        val focusTarget = when {
+            intent.pan.isNullOrBlank() -> CardFieldId.CARD_NUMBER
+            intent.expiryMonth == null || intent.expiryYear == null -> form.nextTextInputAfter(CardFieldId.CARD_NUMBER)
+            else -> form.nextTextInputAfter(CardFieldId.EXPIRY_DATE)
+        }
+        return copy(focusRequest = focusTarget?.let { FocusRequest(id = it) })
+    }
 
-        fun shouldFocus(hasError: Boolean): Boolean {
-            return (hasError && !isFocusConsumed).also { shouldFocus ->
-                if (shouldFocus) isFocusConsumed = true
+    /**
+     * A focus gain normally means the shopper tapped the field, and a field the shopper is working on should not be
+     * showing an error. The exception is focus we asked for after the shopper pressed pay, which exists precisely to
+     * point at an error and so must not clear it.
+     *
+     * Losing focus is the same event whatever caused it, and always shows an error the field is holding back.
+     */
+    // TODO - Form fields rollout: will move to core, so that every component shares these rules instead of copying
+    // them. Nothing here is about cards. Only updateTextField stays behind, because just the card state knows which
+    // property each id points at.
+    private fun CardComponentState.updateFieldFocus(id: CardFieldId, hasFocus: Boolean): CardComponentState {
+        val request = focusRequest?.takeIf { it.id == id }
+        val updated = updateTextField(id) { field ->
+            // TODO - Form fields cleanup: will be removed. FormState.focusRequest does this job instead, but the UI
+            // does not read it yet, so this flag is still what moves focus on screen and has to be kept up to date.
+            val focused = field.copy(isFocused = hasFocus)
+            when {
+                !hasFocus -> focused.showErrorIfPresent()
+                request?.keepErrorHighlight == true -> focused
+                else -> focused.hideErrorIfPresent()
             }
         }
 
-        val hasCardNumberError = !state.cardNumber.isValid
-        val hasExpiryDateError = !state.expiryDate.isValid
-        val hasSecurityCodeError = !state.securityCode.isValid
-        val hasHolderNameError = !state.holderName.isValid
-        val hasSocialSecurityNumberError = !state.socialSecurityNumber.isValid
-        val hasKcpBirthDateOrTaxNumberError = !state.kcpBirthDateOrTaxNumber.isValid
-        val hasKcpCardPasswordError = !state.kcpCardPassword.isValid
-        val hasPostalCodeError = !state.postalCode.isValid
+        // The request has been answered, so it must not outlive the focus change it asked for and make the shopper's
+        // next tap on the same field look programmatic.
+        return if (hasFocus && request != null) updated.copy(focusRequest = null) else updated
+    }
 
-        return state.copy(
-            cardNumber = state.cardNumber.showErrorIfPresent()
-                .copy(isFocused = shouldFocus(hasCardNumberError)),
-            expiryDate = state.expiryDate.showErrorIfPresent()
-                .copy(isFocused = shouldFocus(hasExpiryDateError)),
-            securityCode = state.securityCode.showErrorIfPresent()
-                .copy(isFocused = shouldFocus(hasSecurityCodeError)),
-            holderName = state.holderName.showErrorIfPresent()
-                .copy(isFocused = shouldFocus(hasHolderNameError)),
-            socialSecurityNumber = state.socialSecurityNumber.showErrorIfPresent()
-                .copy(isFocused = shouldFocus(hasSocialSecurityNumberError)),
-            kcpBirthDateOrTaxNumber = state.kcpBirthDateOrTaxNumber.showErrorIfPresent()
-                .copy(isFocused = shouldFocus(hasKcpBirthDateOrTaxNumberError)),
-            kcpCardPassword = state.kcpCardPassword.showErrorIfPresent()
-                .copy(isFocused = shouldFocus(hasKcpCardPasswordError)),
-            postalCode = state.postalCode.showErrorIfPresent()
-                .copy(isFocused = shouldFocus(hasPostalCodeError)),
+    /**
+     * The shopper pressed pay on a form that cannot be submitted: show every error at once, and send focus to the
+     * first field that is wrong in the order the shopper reads them.
+     */
+    // TODO - Form fields rollout: will move to core together with updateFieldFocus. Nothing here is about cards
+    // either. Only isFieldValid stays behind.
+    private fun highlightValidationErrors(state: CardComponentState): CardComponentState {
+        val firstInvalid = state.form.firstInvalid { state.isFieldValid(it) }
+
+        val highlighted = CardFieldId.entries.fold(state) { current, id ->
+            current.updateTextField(id) { field ->
+                // TODO - Form fields cleanup: will be removed. The focusRequest below does this job instead. Setting
+                // the flag on the chosen field and clearing it on the rest is what moves focus until the UI reads it.
+                field.showErrorIfPresent().copy(isFocused = id == firstInvalid)
+            }
+        }
+
+        return highlighted.copy(
+            focusRequest = firstInvalid?.let { FocusRequest(id = it, keepErrorHighlight = true) },
         )
+    }
+
+    /**
+     * Applies [transform] to the text input [id] identifies. Fields that are not text inputs have nothing to
+     * transform, so they are left alone.
+     */
+    private fun CardComponentState.updateTextField(
+        id: CardFieldId,
+        transform: (TextInputComponentState) -> TextInputComponentState,
+    ): CardComponentState = when (id) {
+        CardFieldId.CARD_NUMBER -> copy(cardNumber = transform(cardNumber))
+        CardFieldId.EXPIRY_DATE -> copy(expiryDate = transform(expiryDate))
+        CardFieldId.SECURITY_CODE -> copy(securityCode = transform(securityCode))
+        CardFieldId.HOLDER_NAME -> copy(holderName = transform(holderName))
+        CardFieldId.SOCIAL_SECURITY_NUMBER -> copy(socialSecurityNumber = transform(socialSecurityNumber))
+        CardFieldId.KCP_BIRTH_DATE_OR_TAX_NUMBER -> copy(kcpBirthDateOrTaxNumber = transform(kcpBirthDateOrTaxNumber))
+        CardFieldId.KCP_CARD_PASSWORD -> copy(kcpCardPassword = transform(kcpCardPassword))
+        CardFieldId.POSTAL_CODE -> copy(postalCode = transform(postalCode))
+        CardFieldId.STORE_PAYMENT_METHOD,
+        CardFieldId.INSTALLMENTS -> this
+    }
+
+    /**
+     * Whether the field [id] identifies is currently valid. Nothing that is not a text input can be invalid today, so
+     * those never hold up a submission.
+     */
+    private fun CardComponentState.isFieldValid(id: CardFieldId): Boolean = when (id) {
+        CardFieldId.CARD_NUMBER -> cardNumber.isValid
+        CardFieldId.EXPIRY_DATE -> expiryDate.isValid
+        CardFieldId.SECURITY_CODE -> securityCode.isValid
+        CardFieldId.HOLDER_NAME -> holderName.isValid
+        CardFieldId.SOCIAL_SECURITY_NUMBER -> socialSecurityNumber.isValid
+        CardFieldId.KCP_BIRTH_DATE_OR_TAX_NUMBER -> kcpBirthDateOrTaxNumber.isValid
+        CardFieldId.KCP_CARD_PASSWORD -> kcpCardPassword.isValid
+        CardFieldId.POSTAL_CODE -> postalCode.isValid
+        CardFieldId.STORE_PAYMENT_METHOD,
+        CardFieldId.INSTALLMENTS -> true
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardFieldId.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardFieldId.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 17/8/2026.
+ */
+
+package com.adyen.checkout.card.internal.ui.state
+
+import com.adyen.checkout.core.components.internal.ui.state.form.FormFieldId
+
+/**
+ * Every element of the card form, whether or not the shopper can currently see it.
+ *
+ * The declaration order carries no meaning; the order the shopper sees is `canonicalCardFieldOrder`.
+ */
+internal enum class CardFieldId(override val isTextInput: Boolean) : FormFieldId {
+    CARD_NUMBER(isTextInput = true),
+    EXPIRY_DATE(isTextInput = true),
+    SECURITY_CODE(isTextInput = true),
+    HOLDER_NAME(isTextInput = true),
+    SOCIAL_SECURITY_NUMBER(isTextInput = true),
+    KCP_BIRTH_DATE_OR_TAX_NUMBER(isTextInput = true),
+    KCP_CARD_PASSWORD(isTextInput = true),
+    POSTAL_CODE(isTextInput = true),
+    STORE_PAYMENT_METHOD(isTextInput = false),
+    INSTALLMENTS(isTextInput = false),
+}

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardFieldOrder.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardFieldOrder.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 17/8/2026.
+ */
+
+package com.adyen.checkout.card.internal.ui.state
+
+private val CANONICAL_ORDER = listOf(
+    CardFieldId.CARD_NUMBER,
+    CardFieldId.EXPIRY_DATE,
+    CardFieldId.SECURITY_CODE,
+    CardFieldId.HOLDER_NAME,
+    CardFieldId.SOCIAL_SECURITY_NUMBER,
+    CardFieldId.KCP_BIRTH_DATE_OR_TAX_NUMBER,
+    CardFieldId.KCP_CARD_PASSWORD,
+    CardFieldId.POSTAL_CODE,
+    CardFieldId.STORE_PAYMENT_METHOD,
+    CardFieldId.INSTALLMENTS,
+)
+
+/**
+ * The order the card form is laid out in, ignoring which fields are currently visible. This is the one place the
+ * sequence is decided, so it is also where a future experiment would reorder it.
+ */
+internal fun canonicalCardFieldOrder(): List<CardFieldId> = CANONICAL_ORDER
+
+/**
+ * The fields the shopper can currently see, in the order they see them.
+ *
+ * Visibility is read from the state rather than kept alongside it, so that it cannot drift from what the view state
+ * producer puts on screen.
+ */
+internal fun visibleCardFields(state: CardComponentState): List<CardFieldId> =
+    canonicalCardFieldOrder().filter { state.isVisible(it) }
+
+private fun CardComponentState.isVisible(id: CardFieldId): Boolean = when (id) {
+    CardFieldId.CARD_NUMBER -> cardNumber.isVisible
+    CardFieldId.EXPIRY_DATE -> expiryDate.isVisible
+    CardFieldId.SECURITY_CODE -> securityCode.isVisible
+    CardFieldId.HOLDER_NAME -> holderName.isVisible
+    CardFieldId.SOCIAL_SECURITY_NUMBER -> socialSecurityNumber.isVisible
+    CardFieldId.KCP_BIRTH_DATE_OR_TAX_NUMBER -> kcpBirthDateOrTaxNumber.isVisible
+    CardFieldId.KCP_CARD_PASSWORD -> kcpCardPassword.isVisible
+    CardFieldId.POSTAL_CODE -> postalCode.isVisible
+    CardFieldId.STORE_PAYMENT_METHOD -> isStorePaymentFieldVisible
+    CardFieldId.INSTALLMENTS -> installmentState.installmentOptions.isNotEmpty()
+}

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardIntent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardIntent.kt
@@ -38,6 +38,12 @@ internal sealed interface CardIntent : ComponentStateIntent {
      */
     data class UpdateFieldFocus(val id: CardFieldId, val hasFocus: Boolean) : CardIntent
 
+    /**
+     * A field has acted on a focus request. Normally the resulting focus gain clears the request on its own, so this
+     * only matters when the field could not take focus at all and no gain ever arrives.
+     */
+    data class FocusRequestConsumed(val id: CardFieldId) : CardIntent
+
     data class UpdateStorePaymentMethod(val isChecked: Boolean) : CardIntent
 
     data class SelectBrand(val cardBrand: CardBrand) : CardIntent

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardIntent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardIntent.kt
@@ -18,35 +18,25 @@ internal sealed interface CardIntent : ComponentStateIntent {
     // User input intents
     data class UpdateCardNumber(val number: String) : CardIntent
 
-    data class UpdateCardNumberFocus(val hasFocus: Boolean) : CardIntent
-
     data class UpdateExpiryDate(val expiryDate: String) : CardIntent
-
-    data class UpdateExpiryDateFocus(val hasFocus: Boolean) : CardIntent
 
     data class UpdateSecurityCode(val securityCode: String) : CardIntent
 
-    data class UpdateSecurityCodeFocus(val hasFocus: Boolean) : CardIntent
-
     data class UpdateHolderName(val holderName: String) : CardIntent
-
-    data class UpdateHolderNameFocus(val hasFocus: Boolean) : CardIntent
 
     data class UpdateSocialSecurityNumber(val socialSecurityNumber: String) : CardIntent
 
-    data class UpdateSocialSecurityNumberFocus(val hasFocus: Boolean) : CardIntent
-
     data class UpdateKcpBirthDateOrTaxNumber(val kcpBirthDateOrTaxNumber: String) : CardIntent
-
-    data class UpdateKcpBirthDateOrTaxNumberFocus(val hasFocus: Boolean) : CardIntent
 
     data class UpdateKcpCardPassword(val kcpCardPassword: String) : CardIntent
 
-    data class UpdateKcpCardPasswordFocus(val hasFocus: Boolean) : CardIntent
-
     data class UpdatePostalCode(val postalCode: String) : CardIntent
 
-    data class UpdatePostalCodeFocus(val hasFocus: Boolean) : CardIntent
+    /**
+     * A field has gained or lost focus. Unlike a value change, which carries the meaning of the field it belongs to,
+     * focus is the same event whichever field reports it, so one intent covers all of them.
+     */
+    data class UpdateFieldFocus(val id: CardFieldId, val hasFocus: Boolean) : CardIntent
 
     data class UpdateStorePaymentMethod(val isChecked: Boolean) : CardIntent
 

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewState.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewState.kt
@@ -13,6 +13,8 @@ import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewS
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
 
 internal data class CardViewState(
+    // The fields to render, in the order they appear on screen.
+    val fieldOrder: List<CardFieldId>,
     val cardNumber: TextInputViewState?,
     val expiryDate: TextInputViewState?,
     val securityCode: TextInputViewState?,

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducer.kt
@@ -15,9 +15,13 @@ import com.adyen.checkout.card.internal.ui.model.SecurityCodeTrailingIcon
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.components.data.model.Amount
 import com.adyen.checkout.core.components.internal.ui.state.ViewStateProducer
+import com.adyen.checkout.core.components.internal.ui.state.form.keyboardActionFor
 import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
+import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
+import com.adyen.checkout.core.components.internal.ui.state.model.TrailingIcon
 import com.adyen.checkout.core.components.internal.ui.state.model.toViewState
+import com.adyen.checkout.ui.internal.element.input.FocusRequestToken
 
 internal class CardViewStateProducer(
     private val amount: Amount?,
@@ -50,30 +54,33 @@ internal class CardViewStateProducer(
             null
         }
 
-        val supportedCardBrandsViewState = SupportedCardBrandsViewState(
-            supportedCardBrands = state.supportedCardBrands.filterNot {
-                isHiddenCardType(it.txVariant)
-            },
-            isVisible = isSupportedCardBrandsShown,
-        )
-
         return CardViewState(
-            cardNumber = state.cardNumber.copy(description = cardNumberInputDescription).toViewState(
+            fieldOrder = state.form.order,
+            cardNumber = state.fieldViewState(
+                id = CardFieldId.CARD_NUMBER,
+                field = state.cardNumber.copy(description = cardNumberInputDescription),
                 customTrailingIcon = getCardNumberTrailingIcon(isCardScanButtonVisible),
             ),
-            expiryDate = state.expiryDate.toViewState(
-                customTrailingIcon = getExpiryDateTrailingIcon(state.expiryDate),
+            expiryDate = state.fieldViewState(
+                CardFieldId.EXPIRY_DATE,
+                state.expiryDate,
+                getExpiryDateTrailingIcon(state.expiryDate),
             ),
-            securityCode = state.securityCode.toViewState(
-                customTrailingIcon = getSecurityCodeTrailingIcon(state.securityCode, cardNumberFormat),
+            securityCode = state.fieldViewState(
+                CardFieldId.SECURITY_CODE,
+                state.securityCode,
+                getSecurityCodeTrailingIcon(state.securityCode, cardNumberFormat),
             ),
-            holderName = state.holderName.toViewState(),
-            socialSecurityNumber = state.socialSecurityNumber.toViewState(),
-            kcpBirthDateOrTaxNumber = state.kcpBirthDateOrTaxNumber.toViewState(),
-            kcpCardPassword = state.kcpCardPassword.toViewState(),
-            postalCode = state.postalCode.toViewState(),
+            holderName = state.fieldViewState(CardFieldId.HOLDER_NAME, state.holderName),
+            socialSecurityNumber = state.fieldViewState(CardFieldId.SOCIAL_SECURITY_NUMBER, state.socialSecurityNumber),
+            kcpBirthDateOrTaxNumber = state.fieldViewState(
+                CardFieldId.KCP_BIRTH_DATE_OR_TAX_NUMBER,
+                state.kcpBirthDateOrTaxNumber,
+            ),
+            kcpCardPassword = state.fieldViewState(CardFieldId.KCP_CARD_PASSWORD, state.kcpCardPassword),
+            postalCode = state.fieldViewState(CardFieldId.POSTAL_CODE, state.postalCode),
             storePaymentViewState = storePaymentViewState,
-            supportedCardBrandsViewState = supportedCardBrandsViewState,
+            supportedCardBrandsViewState = getSupportedCardBrandsViewState(state, isSupportedCardBrandsShown),
             cardBrandViewState = cardBrandViewState,
             cardNumberFormat = cardNumberFormat,
             isLoading = state.isLoading,
@@ -82,6 +89,28 @@ internal class CardViewStateProducer(
             payButtonViewState = if (showSubmitButton) PayButtonViewState(amount, state.isLoading) else null,
         )
     }
+
+    private fun getSupportedCardBrandsViewState(
+        state: CardComponentState,
+        isVisible: Boolean,
+    ) = SupportedCardBrandsViewState(
+        supportedCardBrands = state.supportedCardBrands.filterNot { isHiddenCardType(it.txVariant) },
+        isVisible = isVisible,
+    )
+
+    /**
+     * Builds the view state of one field, adding the two things only the form as a whole can answer: which action key
+     * the field shows, and whether it is the one being asked to take focus.
+     */
+    private fun CardComponentState.fieldViewState(
+        id: CardFieldId,
+        field: TextInputComponentState,
+        customTrailingIcon: TrailingIcon? = null,
+    ): TextInputViewState? = field.toViewState(
+        customTrailingIcon = customTrailingIcon,
+        keyboardAction = form.keyboardActionFor(id),
+        focusRequest = form.focusRequest?.takeIf { it.id == id }?.let { FocusRequestToken(it) },
+    )
 
     private fun getCardNumberInputDescription(cardBrandState: CardBrandState): CheckoutLocalizationKey? {
         if (cardBrandState is CardBrandState.DualBrandWithShopperSelection) {

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardContent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardContent.kt
@@ -29,6 +29,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.adyen.checkout.card.internal.ui.model.InstallmentModel
 import com.adyen.checkout.card.internal.ui.model.toDisplayText
 import com.adyen.checkout.card.internal.ui.state.CardBrandViewState
+import com.adyen.checkout.card.internal.ui.state.CardFieldId
 import com.adyen.checkout.card.internal.ui.state.CardIntent
 import com.adyen.checkout.card.internal.ui.state.CardNumberFormat
 import com.adyen.checkout.card.internal.ui.state.CardViewState
@@ -133,7 +134,7 @@ private fun CardDetailsSection(
                 cardBrandViewState = viewState.cardBrandViewState,
                 cardNumberFormat = viewState.cardNumberFormat,
                 onValueChange = { onIntent(CardIntent.UpdateCardNumber(it)) },
-                onFocusChange = { onIntent(CardIntent.UpdateCardNumberFocus(it)) },
+                onFocusChange = { onIntent(CardIntent.UpdateFieldFocus(CardFieldId.CARD_NUMBER, it)) },
                 onScanButtonClick = onScanButtonClick,
                 onBrandSelect = { onIntent(CardIntent.SelectBrand(it)) },
             )
@@ -142,7 +143,7 @@ private fun CardDetailsSection(
             ExpiryDateField(
                 expiryDateState = viewState.expiryDate,
                 onValueChange = { onIntent(CardIntent.UpdateExpiryDate(it)) },
-                onFocusChange = { onIntent(CardIntent.UpdateExpiryDateFocus(it)) },
+                onFocusChange = { onIntent(CardIntent.UpdateFieldFocus(CardFieldId.EXPIRY_DATE, it)) },
             )
         }
         if (viewState.securityCode != null) {
@@ -150,41 +151,41 @@ private fun CardDetailsSection(
                 securityCodeState = viewState.securityCode,
                 cardNumberFormat = viewState.cardNumberFormat,
                 onValueChange = { onIntent(CardIntent.UpdateSecurityCode(it)) },
-                onFocusChange = { onIntent(CardIntent.UpdateSecurityCodeFocus(it)) },
+                onFocusChange = { onIntent(CardIntent.UpdateFieldFocus(CardFieldId.SECURITY_CODE, it)) },
             )
         }
         if (viewState.holderName != null) {
             HolderNameField(
                 holderNameState = viewState.holderName,
                 onValueChange = { onIntent(CardIntent.UpdateHolderName(it)) },
-                onFocusChange = { onIntent(CardIntent.UpdateHolderNameFocus(it)) },
+                onFocusChange = { onIntent(CardIntent.UpdateFieldFocus(CardFieldId.HOLDER_NAME, it)) },
             )
         }
         if (viewState.socialSecurityNumber != null) {
             SocialSecurityNumberField(
                 socialSecurityNumberState = viewState.socialSecurityNumber,
                 onValueChange = { onIntent(CardIntent.UpdateSocialSecurityNumber(it)) },
-                onFocusChange = { onIntent(CardIntent.UpdateSocialSecurityNumberFocus(it)) },
+                onFocusChange = { onIntent(CardIntent.UpdateFieldFocus(CardFieldId.SOCIAL_SECURITY_NUMBER, it)) },
             )
         }
         if (viewState.kcpBirthDateOrTaxNumber != null) {
             KCPBirthDateOrTaxNumberField(
                 kcpBirthDateOrTaxNumberState = viewState.kcpBirthDateOrTaxNumber,
                 onValueChange = { onIntent(CardIntent.UpdateKcpBirthDateOrTaxNumber(it)) },
-                onFocusChange = { onIntent(CardIntent.UpdateKcpBirthDateOrTaxNumberFocus(it)) },
+                onFocusChange = { onIntent(CardIntent.UpdateFieldFocus(CardFieldId.KCP_BIRTH_DATE_OR_TAX_NUMBER, it)) },
             )
         }
         if (viewState.kcpCardPassword != null) {
             KCPCardPasswordField(
                 kcpCardPasswordState = viewState.kcpCardPassword,
                 onValueChange = { onIntent(CardIntent.UpdateKcpCardPassword(it)) },
-                onFocusChange = { onIntent(CardIntent.UpdateKcpCardPasswordFocus(it)) },
+                onFocusChange = { onIntent(CardIntent.UpdateFieldFocus(CardFieldId.KCP_CARD_PASSWORD, it)) },
             )
         }
         if (viewState.postalCode != null) {
             PostalCodeField(
                 postalCodeState = viewState.postalCode,
-                onFocusChange = { onIntent(CardIntent.UpdatePostalCodeFocus(it)) },
+                onFocusChange = { onIntent(CardIntent.UpdateFieldFocus(CardFieldId.POSTAL_CODE, it)) },
                 onValueChange = { onIntent(CardIntent.UpdatePostalCode(it)) },
             )
         }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardContent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardContent.kt
@@ -220,6 +220,12 @@ private fun CardContentPreview(
     CheckoutThemePreviewWrapper(theme) {
         CardContent(
             viewState = CardViewState(
+                fieldOrder = listOf(
+                    CardFieldId.CARD_NUMBER,
+                    CardFieldId.EXPIRY_DATE,
+                    CardFieldId.SECURITY_CODE,
+                    CardFieldId.STORE_PAYMENT_METHOD,
+                ),
                 cardNumber = TextInputViewState(
                     text = "5555444433331111",
                 ),
@@ -263,6 +269,7 @@ private fun CardContentPreviewAllFields(
     CheckoutThemePreviewWrapper(theme) {
         CardContent(
             viewState = CardViewState(
+                fieldOrder = CardFieldId.entries,
                 cardNumber = TextInputViewState(
                     text = "5555444433331111",
                 ),

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardContent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardContent.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
@@ -127,83 +128,131 @@ private fun CardDetailsSection(
         modifier = modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.Large),
     ) {
-        if (viewState.cardNumber != null) {
+        // The order decides both what is shown and in which order, so there is no configuration to read here. A field
+        // is keyed on its id rather than its position, so that its text and focus follow it if the order changes.
+        viewState.fieldOrder.forEach { fieldId ->
+            key(fieldId) {
+                CardField(
+                    fieldId = fieldId,
+                    viewState = viewState,
+                    onIntent = onIntent,
+                    onScanButtonClick = onScanButtonClick,
+                    onInstallmentPickerClick = onInstallmentPickerClick,
+                )
+            }
+        }
+    }
+}
+
+@Suppress("LongMethod", "CyclomaticComplexMethod")
+@Composable
+private fun CardField(
+    fieldId: CardFieldId,
+    viewState: CardViewState,
+    onIntent: (CardIntent) -> Unit,
+    onScanButtonClick: () -> Unit,
+    onInstallmentPickerClick: () -> Unit,
+) {
+    val onFocusChange: (Boolean) -> Unit = { hasFocus -> onIntent(CardIntent.UpdateFieldFocus(fieldId, hasFocus)) }
+    val onFocusRequestConsumed: () -> Unit = { onIntent(CardIntent.FocusRequestConsumed(fieldId)) }
+
+    // A field in the order whose view state is missing is skipped rather than crashing. CardFieldOrderTest is what
+    // makes sure the two never disagree in the first place.
+    when (fieldId) {
+        CardFieldId.CARD_NUMBER -> viewState.cardNumber?.let { fieldViewState ->
             CardNumberField(
-                cardNumberState = viewState.cardNumber,
+                cardNumberState = fieldViewState,
                 supportedCardBrandsViewState = viewState.supportedCardBrandsViewState,
                 cardBrandViewState = viewState.cardBrandViewState,
                 cardNumberFormat = viewState.cardNumberFormat,
                 onValueChange = { onIntent(CardIntent.UpdateCardNumber(it)) },
-                onFocusChange = { onIntent(CardIntent.UpdateFieldFocus(CardFieldId.CARD_NUMBER, it)) },
+                onFocusChange = onFocusChange,
+                onFocusRequestConsumed = onFocusRequestConsumed,
                 onScanButtonClick = onScanButtonClick,
                 onBrandSelect = { onIntent(CardIntent.SelectBrand(it)) },
             )
         }
-        if (viewState.expiryDate != null) {
+
+        CardFieldId.EXPIRY_DATE -> viewState.expiryDate?.let { fieldViewState ->
             ExpiryDateField(
-                expiryDateState = viewState.expiryDate,
+                expiryDateState = fieldViewState,
                 onValueChange = { onIntent(CardIntent.UpdateExpiryDate(it)) },
-                onFocusChange = { onIntent(CardIntent.UpdateFieldFocus(CardFieldId.EXPIRY_DATE, it)) },
+                onFocusChange = onFocusChange,
+                onFocusRequestConsumed = onFocusRequestConsumed,
             )
         }
-        if (viewState.securityCode != null) {
+
+        CardFieldId.SECURITY_CODE -> viewState.securityCode?.let { fieldViewState ->
             SecurityCodeField(
-                securityCodeState = viewState.securityCode,
+                securityCodeState = fieldViewState,
                 cardNumberFormat = viewState.cardNumberFormat,
                 onValueChange = { onIntent(CardIntent.UpdateSecurityCode(it)) },
-                onFocusChange = { onIntent(CardIntent.UpdateFieldFocus(CardFieldId.SECURITY_CODE, it)) },
+                onFocusChange = onFocusChange,
+                onFocusRequestConsumed = onFocusRequestConsumed,
             )
         }
-        if (viewState.holderName != null) {
+
+        CardFieldId.HOLDER_NAME -> viewState.holderName?.let { fieldViewState ->
             HolderNameField(
-                holderNameState = viewState.holderName,
+                holderNameState = fieldViewState,
                 onValueChange = { onIntent(CardIntent.UpdateHolderName(it)) },
-                onFocusChange = { onIntent(CardIntent.UpdateFieldFocus(CardFieldId.HOLDER_NAME, it)) },
+                onFocusChange = onFocusChange,
+                onFocusRequestConsumed = onFocusRequestConsumed,
             )
         }
-        if (viewState.socialSecurityNumber != null) {
+
+        CardFieldId.SOCIAL_SECURITY_NUMBER -> viewState.socialSecurityNumber?.let { fieldViewState ->
             SocialSecurityNumberField(
-                socialSecurityNumberState = viewState.socialSecurityNumber,
+                socialSecurityNumberState = fieldViewState,
                 onValueChange = { onIntent(CardIntent.UpdateSocialSecurityNumber(it)) },
-                onFocusChange = { onIntent(CardIntent.UpdateFieldFocus(CardFieldId.SOCIAL_SECURITY_NUMBER, it)) },
+                onFocusChange = onFocusChange,
+                onFocusRequestConsumed = onFocusRequestConsumed,
             )
         }
-        if (viewState.kcpBirthDateOrTaxNumber != null) {
+
+        CardFieldId.KCP_BIRTH_DATE_OR_TAX_NUMBER -> viewState.kcpBirthDateOrTaxNumber?.let { fieldViewState ->
             KCPBirthDateOrTaxNumberField(
-                kcpBirthDateOrTaxNumberState = viewState.kcpBirthDateOrTaxNumber,
+                kcpBirthDateOrTaxNumberState = fieldViewState,
                 onValueChange = { onIntent(CardIntent.UpdateKcpBirthDateOrTaxNumber(it)) },
-                onFocusChange = { onIntent(CardIntent.UpdateFieldFocus(CardFieldId.KCP_BIRTH_DATE_OR_TAX_NUMBER, it)) },
+                onFocusChange = onFocusChange,
+                onFocusRequestConsumed = onFocusRequestConsumed,
             )
         }
-        if (viewState.kcpCardPassword != null) {
+
+        CardFieldId.KCP_CARD_PASSWORD -> viewState.kcpCardPassword?.let { fieldViewState ->
             KCPCardPasswordField(
-                kcpCardPasswordState = viewState.kcpCardPassword,
+                kcpCardPasswordState = fieldViewState,
                 onValueChange = { onIntent(CardIntent.UpdateKcpCardPassword(it)) },
-                onFocusChange = { onIntent(CardIntent.UpdateFieldFocus(CardFieldId.KCP_CARD_PASSWORD, it)) },
+                onFocusChange = onFocusChange,
+                onFocusRequestConsumed = onFocusRequestConsumed,
             )
         }
-        if (viewState.postalCode != null) {
+
+        CardFieldId.POSTAL_CODE -> viewState.postalCode?.let { fieldViewState ->
             PostalCodeField(
-                postalCodeState = viewState.postalCode,
-                onFocusChange = { onIntent(CardIntent.UpdateFieldFocus(CardFieldId.POSTAL_CODE, it)) },
+                postalCodeState = fieldViewState,
                 onValueChange = { onIntent(CardIntent.UpdatePostalCode(it)) },
+                onFocusChange = onFocusChange,
+                onFocusRequestConsumed = onFocusRequestConsumed,
             )
         }
-        if (viewState.storePaymentViewState != null) {
+
+        CardFieldId.STORE_PAYMENT_METHOD -> viewState.storePaymentViewState?.let { fieldViewState ->
             SwitchContainer(
-                checked = viewState.storePaymentViewState.isSelected,
+                checked = fieldViewState.isSelected,
                 onCheckedChange = { onIntent(CardIntent.UpdateStorePaymentMethod(it)) },
             ) {
                 Body(resolveString(CheckoutLocalizationKey.CARD_STORE_PAYMENT_METHOD))
             }
         }
-        if (viewState.installmentViewState != null) {
+
+        CardFieldId.INSTALLMENTS -> viewState.installmentViewState?.let { fieldViewState ->
             Subtitle(
                 text = resolveString(CheckoutLocalizationKey.CARD_INSTALLMENTS),
                 modifier = Modifier.padding(top = Dimensions.Spacing.Small),
             )
             ValuePickerField(
-                value = viewState.installmentViewState.selectedInstallment?.toDisplayText() ?: "",
+                value = fieldViewState.selectedInstallment?.toDisplayText() ?: "",
                 label = resolveString(CheckoutLocalizationKey.CARD_INSTALLMENTS_TITLE),
                 onClick = onInstallmentPickerClick,
                 modifier = Modifier.fillMaxWidth(),

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/CardNumberField.kt
@@ -48,6 +48,7 @@ import com.adyen.checkout.core.common.internal.properties.CardNumberProperties.C
 import com.adyen.checkout.core.common.internal.properties.CardNumberProperties.CARD_NUMBER_SEPARATOR
 import com.adyen.checkout.core.common.internal.ui.CheckoutNetworkLogo
 import com.adyen.checkout.core.common.internal.ui.CheckoutTextFieldTrailingIcon
+import com.adyen.checkout.core.common.internal.ui.toImeAction
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
@@ -70,6 +71,7 @@ internal fun CardNumberField(
     cardNumberFormat: CardNumberFormat,
     onValueChange: (String) -> Unit,
     onFocusChange: (Boolean) -> Unit,
+    onFocusRequestConsumed: () -> Unit,
     onScanButtonClick: () -> Unit,
     onBrandSelect: (CardBrand) -> Unit,
     modifier: Modifier = Modifier,
@@ -83,6 +85,7 @@ internal fun CardNumberField(
             cardBrandViewState = cardBrandViewState,
             onValueChange = onValueChange,
             onFocusChange = onFocusChange,
+            onFocusRequestConsumed = onFocusRequestConsumed,
             onScanButtonClick = onScanButtonClick,
             onBrandSelect = onBrandSelect,
         )
@@ -100,6 +103,7 @@ private fun CardNumberInputField(
     cardBrandViewState: CardBrandViewState,
     onValueChange: (String) -> Unit,
     onFocusChange: (Boolean) -> Unit,
+    onFocusRequestConsumed: () -> Unit,
     onScanButtonClick: () -> Unit,
     onBrandSelect: (CardBrand) -> Unit,
     modifier: Modifier = Modifier,
@@ -129,7 +133,9 @@ private fun CardNumberInputField(
         onValueChange = onValueChange,
         inputTransformation = inputTransformation,
         outputTransformation = outputTransformation,
-        shouldFocus = cardNumberState.isFocused,
+        focusRequest = cardNumberState.focusRequest,
+        onFocusRequestConsumed = onFocusRequestConsumed,
+        imeAction = cardNumberState.keyboardAction.toImeAction(),
         trailingIcon = {
             CardNumberTrailingIcon(
                 trailingIcon = cardNumberState.trailingIcon,
@@ -321,6 +327,7 @@ private fun CardNumberFieldPreview(
             cardNumberFormat = CardNumberFormat.DEFAULT,
             onValueChange = {},
             onFocusChange = {},
+            onFocusRequestConsumed = {},
             onScanButtonClick = {},
             onBrandSelect = {},
         )
@@ -339,6 +346,7 @@ private fun CardNumberFieldPreview(
             cardNumberFormat = CardNumberFormat.DEFAULT,
             onValueChange = {},
             onFocusChange = {},
+            onFocusRequestConsumed = {},
             onScanButtonClick = {},
             onBrandSelect = {},
         )
@@ -362,6 +370,7 @@ private fun CardNumberFieldPreview(
             cardNumberFormat = CardNumberFormat.AMEX,
             onValueChange = {},
             onFocusChange = {},
+            onFocusRequestConsumed = {},
             onScanButtonClick = {},
             onBrandSelect = {},
         )
@@ -392,6 +401,7 @@ private fun CardNumberFieldPreview(
             cardNumberFormat = CardNumberFormat.DEFAULT,
             onValueChange = {},
             onFocusChange = {},
+            onFocusRequestConsumed = {},
             onScanButtonClick = {},
             onBrandSelect = {},
         )
@@ -411,6 +421,7 @@ private fun CardNumberFieldPreview(
             cardNumberFormat = CardNumberFormat.DEFAULT,
             onValueChange = {},
             onFocusChange = {},
+            onFocusRequestConsumed = {},
             onScanButtonClick = {},
             onBrandSelect = {},
         )

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/ExpiryDateField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/ExpiryDateField.kt
@@ -24,6 +24,7 @@ import com.adyen.checkout.card.R
 import com.adyen.checkout.card.internal.ui.model.ExpiryDateTrailingIcon
 import com.adyen.checkout.core.common.internal.properties.ExpiryDateProperties
 import com.adyen.checkout.core.common.internal.ui.CheckoutTextFieldTrailingIcon
+import com.adyen.checkout.core.common.internal.ui.toImeAction
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
@@ -44,6 +45,7 @@ internal fun ExpiryDateField(
     expiryDateState: TextInputViewState,
     onValueChange: (String) -> Unit,
     onFocusChange: (Boolean) -> Unit,
+    onFocusRequestConsumed: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val supportingTextExpiryDate = expiryDateState.supportingText?.let { resolveString(it) }
@@ -77,7 +79,9 @@ internal fun ExpiryDateField(
         onValueChange = onValueChange,
         inputTransformation = inputTransformation,
         outputTransformation = outputTransformation,
-        shouldFocus = expiryDateState.isFocused,
+        focusRequest = expiryDateState.focusRequest,
+        onFocusRequestConsumed = onFocusRequestConsumed,
+        imeAction = expiryDateState.keyboardAction.toImeAction(),
         trailingIcon = {
             ExpiryDateTrailingIcon(expiryDateState.trailingIcon)
         },
@@ -136,6 +140,7 @@ private fun ExpiryDateFieldPreview(
             ),
             onValueChange = {},
             onFocusChange = {},
+            onFocusRequestConsumed = {},
         )
         ExpiryDateField(
             expiryDateState = TextInputViewState(
@@ -144,6 +149,7 @@ private fun ExpiryDateFieldPreview(
             ),
             onValueChange = {},
             onFocusChange = {},
+            onFocusRequestConsumed = {},
         )
 
         ExpiryDateField(
@@ -153,6 +159,7 @@ private fun ExpiryDateFieldPreview(
             ),
             onValueChange = {},
             onFocusChange = {},
+            onFocusRequestConsumed = {},
         )
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/HolderNameField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/HolderNameField.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.core.common.internal.ui.CheckoutTextFieldTrailingIcon
+import com.adyen.checkout.core.common.internal.ui.toImeAction
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
@@ -32,6 +33,7 @@ internal fun HolderNameField(
     holderNameState: TextInputViewState,
     onValueChange: (String) -> Unit,
     onFocusChange: (Boolean) -> Unit,
+    onFocusRequestConsumed: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val supportingTextHolderName = holderNameState.supportingText?.let { resolveString(it) }
@@ -51,7 +53,9 @@ internal fun HolderNameField(
             keyboardType = KeyboardType.Text,
             capitalization = KeyboardCapitalization.Words,
         ),
-        shouldFocus = holderNameState.isFocused,
+        focusRequest = holderNameState.focusRequest,
+        onFocusRequestConsumed = onFocusRequestConsumed,
+        imeAction = holderNameState.keyboardAction.toImeAction(),
         trailingIcon = {
             CheckoutTextFieldTrailingIcon(holderNameState.trailingIcon)
         },
@@ -70,6 +74,7 @@ private fun HolderNameFieldPreview(
             ),
             onValueChange = {},
             onFocusChange = {},
+            onFocusRequestConsumed = {},
         )
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPBirthDateOrTaxNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPBirthDateOrTaxNumberField.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.card.internal.ui.properties.KCPBirthDateOrTaxNumberProperties.KCP_BIRTH_DATE_OR_TAX_NUMBER_MAX_LENGTH
 import com.adyen.checkout.card.internal.ui.properties.KCPBirthDateOrTaxNumberProperties.KCP_BIRTH_DATE_VALID_LENGTH
 import com.adyen.checkout.core.common.internal.ui.CheckoutTextFieldTrailingIcon
+import com.adyen.checkout.core.common.internal.ui.toImeAction
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
@@ -33,6 +34,7 @@ internal fun KCPBirthDateOrTaxNumberField(
     kcpBirthDateOrTaxNumberState: TextInputViewState,
     onValueChange: (String) -> Unit,
     onFocusChange: (Boolean) -> Unit,
+    onFocusRequestConsumed: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val textLength = kcpBirthDateOrTaxNumberState.text.length
@@ -62,7 +64,9 @@ internal fun KCPBirthDateOrTaxNumberField(
         isError = kcpBirthDateOrTaxNumberState.isError,
         supportingText = supportingText,
         onValueChange = onValueChange,
-        shouldFocus = kcpBirthDateOrTaxNumberState.isFocused,
+        focusRequest = kcpBirthDateOrTaxNumberState.focusRequest,
+        onFocusRequestConsumed = onFocusRequestConsumed,
+        imeAction = kcpBirthDateOrTaxNumberState.keyboardAction.toImeAction(),
         inputTransformation = inputTransformation,
         trailingIcon = {
             CheckoutTextFieldTrailingIcon(kcpBirthDateOrTaxNumberState.trailingIcon)
@@ -82,6 +86,7 @@ private fun KCPBirthDateOrTaxNumberFieldPreview(
             ),
             onValueChange = {},
             onFocusChange = {},
+            onFocusRequestConsumed = {},
         )
 
         KCPBirthDateOrTaxNumberField(
@@ -91,6 +96,7 @@ private fun KCPBirthDateOrTaxNumberFieldPreview(
             ),
             onValueChange = {},
             onFocusChange = {},
+            onFocusRequestConsumed = {},
         )
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPCardPasswordField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/KCPCardPasswordField.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.card.internal.ui.properties.KCPCardPasswordProperties.KCP_CARD_PASSWORD_MAX_LENGTH
 import com.adyen.checkout.core.common.internal.ui.CheckoutTextFieldTrailingIcon
+import com.adyen.checkout.core.common.internal.ui.toImeAction
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
@@ -32,6 +33,7 @@ internal fun KCPCardPasswordField(
     kcpCardPasswordState: TextInputViewState,
     onValueChange: (String) -> Unit,
     onFocusChange: (Boolean) -> Unit,
+    onFocusRequestConsumed: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val supportingText = kcpCardPasswordState.supportingText?.let { resolveString(it) }
@@ -53,7 +55,9 @@ internal fun KCPCardPasswordField(
         isError = kcpCardPasswordState.isError,
         supportingText = supportingText,
         onValueChange = onValueChange,
-        shouldFocus = kcpCardPasswordState.isFocused,
+        focusRequest = kcpCardPasswordState.focusRequest,
+        onFocusRequestConsumed = onFocusRequestConsumed,
+        imeAction = kcpCardPasswordState.keyboardAction.toImeAction(),
         inputTransformation = inputTransformation,
         isSecureField = true,
         trailingIcon = {
@@ -74,6 +78,7 @@ private fun KCPCardPasswordFieldPreview(
             ),
             onValueChange = {},
             onFocusChange = {},
+            onFocusRequestConsumed = {},
         )
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/PostalCodeField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/PostalCodeField.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.card.internal.ui.properties.PostalCodeProperties
 import com.adyen.checkout.core.common.internal.ui.CheckoutTextFieldTrailingIcon
+import com.adyen.checkout.core.common.internal.ui.toImeAction
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
@@ -27,6 +28,7 @@ internal fun PostalCodeField(
     postalCodeState: TextInputViewState,
     onValueChange: (String) -> Unit,
     onFocusChange: (Boolean) -> Unit,
+    onFocusRequestConsumed: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val supportingTextPostalCode = postalCodeState.supportingText?.let { resolveString(it) }
@@ -47,7 +49,9 @@ internal fun PostalCodeField(
             keyboardType = KeyboardType.Text,
             capitalization = KeyboardCapitalization.Unspecified,
         ),
-        shouldFocus = postalCodeState.isFocused,
+        focusRequest = postalCodeState.focusRequest,
+        onFocusRequestConsumed = onFocusRequestConsumed,
+        imeAction = postalCodeState.keyboardAction.toImeAction(),
         trailingIcon = {
             CheckoutTextFieldTrailingIcon(postalCodeState.trailingIcon)
         },
@@ -65,6 +69,7 @@ private fun PostalCodeFieldPreview(
                 text = "1234 AB",
             ),
             onFocusChange = {},
+            onFocusRequestConsumed = {},
             onValueChange = {},
         )
 
@@ -74,6 +79,7 @@ private fun PostalCodeFieldPreview(
                 isError = true,
             ),
             onFocusChange = {},
+            onFocusRequestConsumed = {},
             onValueChange = {},
         )
     }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SecurityCodeField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SecurityCodeField.kt
@@ -29,6 +29,7 @@ import com.adyen.checkout.card.internal.ui.state.CardNumberFormat
 import com.adyen.checkout.core.common.internal.properties.SecurityCodeProperties.SECURITY_CODE_MAX_LENGTH_AMEX
 import com.adyen.checkout.core.common.internal.properties.SecurityCodeProperties.SECURITY_CODE_MAX_LENGTH_DEFAULT
 import com.adyen.checkout.core.common.internal.ui.CheckoutTextFieldTrailingIcon
+import com.adyen.checkout.core.common.internal.ui.toImeAction
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
@@ -49,6 +50,7 @@ internal fun SecurityCodeField(
     cardNumberFormat: CardNumberFormat,
     onValueChange: (String) -> Unit,
     onFocusChange: (Boolean) -> Unit,
+    onFocusRequestConsumed: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val supportingTextSecurityCode = securityCodeState.supportingText?.let { resolveString(it) }
@@ -87,6 +89,11 @@ internal fun SecurityCodeField(
         supportingText = supportingTextSecurityCode,
         onValueChange = onValueChange,
         inputTransformation = inputTransformation,
+        focusRequest = securityCodeState.focusRequest,
+        onFocusRequestConsumed = onFocusRequestConsumed,
+        imeAction = securityCodeState.keyboardAction.toImeAction(),
+        // TODO - Form fields rollout: will be removed. This field is shared with the stored card screen, which still
+        // moves focus with isFocused. Remove it when stored card moves to the focus request above.
         shouldFocus = securityCodeState.isFocused,
         trailingIcon = {
             SecurityCodeTrailingIcon(securityCodeState.trailingIcon)
@@ -155,6 +162,7 @@ private fun SecurityCodeFieldPreview(
             cardNumberFormat = CardNumberFormat.DEFAULT,
             onValueChange = {},
             onFocusChange = {},
+            onFocusRequestConsumed = {},
         )
 
         SecurityCodeField(
@@ -165,6 +173,7 @@ private fun SecurityCodeFieldPreview(
             cardNumberFormat = CardNumberFormat.AMEX,
             onValueChange = {},
             onFocusChange = {},
+            onFocusRequestConsumed = {},
         )
 
         val focusRequester = remember { FocusRequester() }
@@ -177,6 +186,7 @@ private fun SecurityCodeFieldPreview(
             modifier = Modifier.focusRequester(focusRequester),
             onValueChange = {},
             onFocusChange = {},
+            onFocusRequestConsumed = {},
         )
         LaunchedEffect(Unit) {
             focusRequester.requestFocus()
@@ -190,6 +200,7 @@ private fun SecurityCodeFieldPreview(
             cardNumberFormat = CardNumberFormat.DEFAULT,
             onValueChange = {},
             onFocusChange = {},
+            onFocusRequestConsumed = {},
         )
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SocialSecurityNumberField.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/SocialSecurityNumberField.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.adyen.checkout.card.internal.ui.properties.SocialSecurityNumberProperties.SOCIAL_SECURITY_MAX_LENGTH
 import com.adyen.checkout.card.internal.ui.properties.SocialSecurityNumberProperties.SOCIAL_SECURITY_SEPARATORS
 import com.adyen.checkout.core.common.internal.ui.CheckoutTextFieldTrailingIcon
+import com.adyen.checkout.core.common.internal.ui.toImeAction
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.common.localization.internal.helper.resolveString
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputViewState
@@ -33,6 +34,7 @@ internal fun SocialSecurityNumberField(
     socialSecurityNumberState: TextInputViewState,
     onValueChange: (String) -> Unit,
     onFocusChange: (Boolean) -> Unit,
+    onFocusRequestConsumed: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val supportingTextSocialSecurityNumber = socialSecurityNumberState.supportingText?.let { resolveString(it) }
@@ -56,7 +58,9 @@ internal fun SocialSecurityNumberField(
         isError = socialSecurityNumberState.isError,
         supportingText = supportingTextSocialSecurityNumber,
         onValueChange = onValueChange,
-        shouldFocus = socialSecurityNumberState.isFocused,
+        focusRequest = socialSecurityNumberState.focusRequest,
+        onFocusRequestConsumed = onFocusRequestConsumed,
+        imeAction = socialSecurityNumberState.keyboardAction.toImeAction(),
         inputTransformation = inputTransformation,
         outputTransformation = outputTransformation,
         trailingIcon = {
@@ -77,6 +81,7 @@ private fun SocialSecurityNumberFieldPreview(
             ),
             onValueChange = {},
             onFocusChange = {},
+            onFocusRequestConsumed = {},
         )
 
         SocialSecurityNumberField(
@@ -85,6 +90,7 @@ private fun SocialSecurityNumberFieldPreview(
             ),
             onValueChange = {},
             onFocusChange = {},
+            onFocusRequestConsumed = {},
         )
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardContent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardContent.kt
@@ -71,6 +71,9 @@ private fun StoredCardContent(
                     cardNumberFormat = viewState.cardNumberFormat,
                     onValueChange = { onIntent(StoredCardIntent.UpdateSecurityCode(it)) },
                     onFocusChange = { onIntent(StoredCardIntent.UpdateSecurityCodeFocus(it)) },
+                    // TODO - Form fields rollout: stored card has no form state yet, so it never asks for focus and
+                    // has nothing to report back. Wire this up when stored card gets its form.
+                    onFocusRequestConsumed = {},
                 )
             }
         }

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandlerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardBrandIntentsHandlerTest.kt
@@ -21,6 +21,7 @@ import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.components.internal.ui.state.model.RequirementPolicy
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -643,6 +644,18 @@ internal class CardBrandIntentsHandlerTest(
         val actual = cardBrandIntentsHandler.getUpdatedCardComponentState(createInitialState(), cardBrandState)
 
         assertEquals(RequirementPolicy.Hidden, actual.expiryDate.requirementPolicy)
+    }
+
+    @Test
+    fun `when a card brand hides the security code, then it is removed from the field order`() {
+        whenever(cardComponentParams.cvcVisibility).thenReturn(CVCVisibility.ALWAYS_SHOW)
+        val cardBrandState = CardBrandState.SingleReliableBrand(
+            createCardBrandData().copy(cvcPolicy = Brand.FieldPolicy.HIDDEN),
+        )
+
+        val actual = cardBrandIntentsHandler.getUpdatedCardComponentState(createInitialState(), cardBrandState)
+
+        assertFalse(actual.form.order.contains(CardFieldId.SECURITY_CODE))
     }
 
     @Test

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateFactoryTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateFactoryTest.kt
@@ -18,6 +18,7 @@ import com.adyen.checkout.card.internal.ui.model.InstallmentPlan
 import com.adyen.checkout.card.internal.ui.model.StoredCVCVisibility
 import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.common.CardType
+import com.adyen.checkout.core.components.internal.ui.state.form.FocusRequest
 import com.adyen.checkout.core.components.internal.ui.state.model.RequirementPolicy
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -35,6 +36,13 @@ internal class CardComponentStateFactoryTest {
         assertTrue(state.cardNumber.isFocused)
     }
     // endregion
+
+    @Test
+    fun `when initial state is created, then focus is requested on the card number`() {
+        val state = createFactory().createInitialState()
+
+        assertEquals(FocusRequest(CardFieldId.CARD_NUMBER), state.focusRequest)
+    }
 
     // region form
     @Test

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateFactoryTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateFactoryTest.kt
@@ -36,6 +36,22 @@ internal class CardComponentStateFactoryTest {
     }
     // endregion
 
+    // region form
+    @Test
+    fun `when a field is hidden by configuration, then it is left out of the field order`() {
+        val state = createFactory(showCardholderName = false).createInitialState()
+
+        assertFalse(state.form.order.contains(CardFieldId.HOLDER_NAME))
+    }
+
+    @Test
+    fun `when a field is shown by configuration, then it is part of the field order`() {
+        val state = createFactory(showCardholderName = true).createInitialState()
+
+        assertTrue(state.form.order.contains(CardFieldId.HOLDER_NAME))
+    }
+    // endregion
+
     // region securityCode
     @Test
     fun `when cvcVisibility is ALWAYS_SHOW, then securityCode is Required`() {

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateReducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateReducerTest.kt
@@ -12,9 +12,12 @@ import com.adyen.checkout.card.internal.helper.DetectCardTypeBinHelper
 import com.adyen.checkout.card.internal.ui.model.CardComponentParams
 import com.adyen.checkout.card.internal.ui.model.InstallmentModel
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
+import com.adyen.checkout.core.components.internal.ui.state.form.FocusRequest
+import com.adyen.checkout.core.components.internal.ui.state.model.RequirementPolicy
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -45,10 +48,10 @@ internal class CardComponentStateReducerTest {
     }
 
     @Test
-    fun `when intent is UpdateCardNumberFocus, then cardNumber focus is updated`() {
+    fun `when intent is UpdateFieldFocus for CardNumber, then cardNumber focus is updated`() {
         val state = createInitialState()
 
-        val actual = reducer.reduce(state, CardIntent.UpdateCardNumberFocus(true))
+        val actual = reducer.reduce(state, CardIntent.UpdateFieldFocus(CardFieldId.CARD_NUMBER, true))
 
         assertTrue(actual.cardNumber.isFocused)
     }
@@ -63,10 +66,10 @@ internal class CardComponentStateReducerTest {
     }
 
     @Test
-    fun `when intent is UpdateExpiryDateFocus, then expiryDate focus is updated`() {
+    fun `when intent is UpdateFieldFocus for ExpiryDate, then expiryDate focus is updated`() {
         val state = createInitialState()
 
-        val actual = reducer.reduce(state, CardIntent.UpdateExpiryDateFocus(true))
+        val actual = reducer.reduce(state, CardIntent.UpdateFieldFocus(CardFieldId.EXPIRY_DATE, true))
 
         assertTrue(actual.expiryDate.isFocused)
     }
@@ -81,10 +84,10 @@ internal class CardComponentStateReducerTest {
     }
 
     @Test
-    fun `when intent is UpdateSecurityCodeFocus, then securityCode focus is updated`() {
+    fun `when intent is UpdateFieldFocus for SecurityCode, then securityCode focus is updated`() {
         val state = createInitialState()
 
-        val actual = reducer.reduce(state, CardIntent.UpdateSecurityCodeFocus(true))
+        val actual = reducer.reduce(state, CardIntent.UpdateFieldFocus(CardFieldId.SECURITY_CODE, true))
 
         assertTrue(actual.securityCode.isFocused)
     }
@@ -99,10 +102,10 @@ internal class CardComponentStateReducerTest {
     }
 
     @Test
-    fun `when intent is UpdateHolderNameFocus, then holderName focus is updated`() {
+    fun `when intent is UpdateFieldFocus for HolderName, then holderName focus is updated`() {
         val state = createInitialState()
 
-        val actual = reducer.reduce(state, CardIntent.UpdateHolderNameFocus(true))
+        val actual = reducer.reduce(state, CardIntent.UpdateFieldFocus(CardFieldId.HOLDER_NAME, true))
 
         assertTrue(actual.holderName.isFocused)
     }
@@ -117,10 +120,10 @@ internal class CardComponentStateReducerTest {
     }
 
     @Test
-    fun `when intent is UpdateSocialSecurityNumberFocus, then socialSecurityNumber focus is updated`() {
+    fun `when intent is UpdateFieldFocus for SocialSecurityNumber, then socialSecurityNumber focus is updated`() {
         val state = createInitialState()
 
-        val actual = reducer.reduce(state, CardIntent.UpdateSocialSecurityNumberFocus(true))
+        val actual = reducer.reduce(state, CardIntent.UpdateFieldFocus(CardFieldId.SOCIAL_SECURITY_NUMBER, true))
 
         assertTrue(actual.socialSecurityNumber.isFocused)
     }
@@ -135,10 +138,10 @@ internal class CardComponentStateReducerTest {
     }
 
     @Test
-    fun `when intent is UpdateKcpBirthDateOrTaxNumberFocus, then kcpBirthDateOrTaxNumber focus is updated`() {
+    fun `when intent is UpdateFieldFocus for KcpBirthDateOrTaxNumber, then kcpBirthDateOrTaxNumber focus is updated`() {
         val state = createInitialState()
 
-        val actual = reducer.reduce(state, CardIntent.UpdateKcpBirthDateOrTaxNumberFocus(true))
+        val actual = reducer.reduce(state, CardIntent.UpdateFieldFocus(CardFieldId.KCP_BIRTH_DATE_OR_TAX_NUMBER, true))
 
         assertTrue(actual.kcpBirthDateOrTaxNumber.isFocused)
     }
@@ -153,10 +156,10 @@ internal class CardComponentStateReducerTest {
     }
 
     @Test
-    fun `when intent is UpdateKcpCardPasswordFocus, then kcpCardPassword focus is updated`() {
+    fun `when intent is UpdateFieldFocus for KcpCardPassword, then kcpCardPassword focus is updated`() {
         val state = createInitialState()
 
-        val actual = reducer.reduce(state, CardIntent.UpdateKcpCardPasswordFocus(true))
+        val actual = reducer.reduce(state, CardIntent.UpdateFieldFocus(CardFieldId.KCP_CARD_PASSWORD, true))
 
         assertTrue(actual.kcpCardPassword.isFocused)
     }
@@ -171,10 +174,10 @@ internal class CardComponentStateReducerTest {
     }
 
     @Test
-    fun `when intent is UpdatePostalCodeFocus, then postalCode focus is updated`() {
+    fun `when intent is UpdateFieldFocus for PostalCode, then postalCode focus is updated`() {
         val state = createInitialState()
 
-        val actual = reducer.reduce(state, CardIntent.UpdatePostalCodeFocus(true))
+        val actual = reducer.reduce(state, CardIntent.UpdateFieldFocus(CardFieldId.POSTAL_CODE, true))
 
         assertTrue(actual.postalCode.isFocused)
     }
@@ -246,6 +249,93 @@ internal class CardComponentStateReducerTest {
     }
 
     @Test
+    fun `when intent is HighlightValidationErrors, then the first invalid field is asked to keep its error`() {
+        val state = createInitialState().copy(
+            expiryDate = TextInputComponentState(error = hiddenError()),
+            securityCode = TextInputComponentState(error = hiddenError()),
+        )
+
+        val actual = reducer.reduce(state, CardIntent.HighlightValidationErrors)
+
+        assertEquals(FocusRequest(CardFieldId.EXPIRY_DATE, keepErrorHighlight = true), actual.focusRequest)
+    }
+
+    @Test
+    fun `when intent is HighlightValidationErrors and no errors, then no focus is requested`() {
+        val state = createInitialState()
+
+        val actual = reducer.reduce(state, CardIntent.HighlightValidationErrors)
+
+        assertNull(actual.focusRequest)
+    }
+
+    /**
+     * The bug this whole mechanism exists for: the focus that pay asks for used to arrive as a plain focus gain, which
+     * hid the error it had just revealed. The field flashed an error and lost it again.
+     */
+    @Test
+    fun `when the field pay focused reports the focus gain, then it keeps showing its error`() {
+        val state = createInitialState().copy(
+            expiryDate = TextInputComponentState(error = hiddenError()),
+        )
+        val highlighted = reducer.reduce(state, CardIntent.HighlightValidationErrors)
+
+        val actual = reducer.reduce(highlighted, CardIntent.UpdateFieldFocus(CardFieldId.EXPIRY_DATE, true))
+
+        assertTrue(actual.expiryDate.isErrorVisible)
+    }
+
+    @Test
+    fun `when the shopper taps a field showing an error, then the error is hidden`() {
+        val state = createInitialState().copy(
+            expiryDate = TextInputComponentState(error = visibleError()),
+        )
+
+        val actual = reducer.reduce(state, CardIntent.UpdateFieldFocus(CardFieldId.EXPIRY_DATE, true))
+
+        assertFalse(actual.expiryDate.isErrorVisible)
+    }
+
+    @Test
+    fun `when an invalid field loses focus, then its error is shown`() {
+        val state = createInitialState().copy(
+            expiryDate = TextInputComponentState(error = hiddenError()),
+        )
+
+        val actual = reducer.reduce(state, CardIntent.UpdateFieldFocus(CardFieldId.EXPIRY_DATE, false))
+
+        assertTrue(actual.expiryDate.isErrorVisible)
+    }
+
+    /**
+     * Without this the request would outlive the focus move it asked for, and the shopper's next tap on the same field
+     * would be read as programmatic and keep an error it should clear.
+     */
+    @Test
+    fun `when the requested field gains focus, then the request is cleared`() {
+        val state = createInitialState().copy(
+            expiryDate = TextInputComponentState(error = hiddenError()),
+        )
+        val highlighted = reducer.reduce(state, CardIntent.HighlightValidationErrors)
+
+        val focused = reducer.reduce(highlighted, CardIntent.UpdateFieldFocus(CardFieldId.EXPIRY_DATE, true))
+
+        assertNull(focused.focusRequest)
+    }
+
+    @Test
+    fun `when a field other than the requested one gains focus, then the request is left alone`() {
+        val state = createInitialState().copy(
+            expiryDate = TextInputComponentState(error = hiddenError()),
+        )
+        val highlighted = reducer.reduce(state, CardIntent.HighlightValidationErrors)
+
+        val actual = reducer.reduce(highlighted, CardIntent.UpdateFieldFocus(CardFieldId.CARD_NUMBER, true))
+
+        assertEquals(FocusRequest(CardFieldId.EXPIRY_DATE, keepErrorHighlight = true), actual.focusRequest)
+    }
+
+    @Test
     fun `when intent is UpdateCardScanningAvailability with true, then isCardScanningAvailable is true`() {
         val state = createInitialState()
 
@@ -303,6 +393,114 @@ internal class CardComponentStateReducerTest {
     }
 
     @Test
+    fun `when a card is scanned, then focus is requested on the field after the expiry date`() {
+        val state = createInitialState()
+
+        val actual = reducer.reduce(
+            state,
+            CardIntent.UpdateCardScanResult(pan = "4111111111111111", expiryMonth = 12, expiryYear = 2025),
+        )
+
+        assertEquals(FocusRequest(CardFieldId.SECURITY_CODE), actual.focusRequest)
+    }
+
+    @Test
+    fun `when a card is scanned and the security code is hidden, then focus is requested on the next visible field`() {
+        val state = createInitialState().copy(
+            securityCode = TextInputComponentState(requirementPolicy = RequirementPolicy.Hidden),
+        )
+
+        val actual = reducer.reduce(
+            state,
+            CardIntent.UpdateCardScanResult(pan = "4111111111111111", expiryMonth = 12, expiryYear = 2025),
+        )
+
+        assertEquals(FocusRequest(CardFieldId.HOLDER_NAME), actual.focusRequest)
+    }
+
+    /**
+     * A scan can come back with only part of a card. Skipping to the field after the expiry date would then send the
+     * shopper past a field the scan did not fill.
+     */
+    @Test
+    fun `when a scan returns only a card number, then focus is requested on the expiry date`() {
+        val state = createInitialState()
+
+        val actual = reducer.reduce(
+            state,
+            CardIntent.UpdateCardScanResult(pan = "4111111111111111", expiryMonth = null, expiryYear = null),
+        )
+
+        assertEquals(FocusRequest(CardFieldId.EXPIRY_DATE), actual.focusRequest)
+    }
+
+    /**
+     * A scan without a card number also wipes the one the shopper had typed, so the card number is what needs filling
+     * again. Reading only the expiry date and jumping forward to the security code would strand them.
+     */
+    @Test
+    fun `when a scan returns no card number, then focus is requested on the card number`() {
+        val state = createInitialState()
+
+        val actual = reducer.reduce(
+            state,
+            CardIntent.UpdateCardScanResult(pan = null, expiryMonth = 12, expiryYear = 2025),
+        )
+
+        assertEquals(FocusRequest(CardFieldId.CARD_NUMBER), actual.focusRequest)
+    }
+
+    @Test
+    fun `when a scan returns nothing usable, then focus is requested on the card number`() {
+        val state = createInitialState()
+
+        val actual = reducer.reduce(
+            state,
+            CardIntent.UpdateCardScanResult(pan = null, expiryMonth = null, expiryYear = null),
+        )
+
+        assertEquals(FocusRequest(CardFieldId.CARD_NUMBER), actual.focusRequest)
+    }
+
+    @Test
+    fun `when a card is scanned and nothing follows the expiry date, then no focus is requested`() {
+        val state = createInitialState().copy(
+            securityCode = hiddenField(),
+            holderName = hiddenField(),
+            socialSecurityNumber = hiddenField(),
+            kcpBirthDateOrTaxNumber = hiddenField(),
+            kcpCardPassword = hiddenField(),
+            postalCode = hiddenField(),
+        )
+
+        val actual = reducer.reduce(
+            state,
+            CardIntent.UpdateCardScanResult(pan = "4111111111111111", expiryMonth = 12, expiryYear = 2025),
+        )
+
+        assertNull(actual.focusRequest)
+    }
+
+    /**
+     * Prefill behaves like a shopper tap, unlike the focus that pay asks for, so the field it lands on must not
+     * surface an error the shopper has not seen yet.
+     */
+    @Test
+    fun `when the field a scan focused was already showing an error, then the error is hidden on arrival`() {
+        val state = createInitialState().copy(
+            securityCode = TextInputComponentState(error = visibleError()),
+        )
+        val scanned = reducer.reduce(
+            state,
+            CardIntent.UpdateCardScanResult(pan = "4111111111111111", expiryMonth = 12, expiryYear = 2025),
+        )
+
+        val actual = reducer.reduce(scanned, CardIntent.UpdateFieldFocus(CardFieldId.SECURITY_CODE, true))
+
+        assertFalse(actual.securityCode.isErrorVisible)
+    }
+
+    @Test
     fun `when intent is UpdateInstallment, then selectedInstallment is updated`() {
         val state = createInitialState()
         val installment = InstallmentModel.Regular(
@@ -337,5 +535,14 @@ internal class CardComponentStateReducerTest {
             installmentOptions = emptyList(),
             selectedInstallment = null,
         ),
+    )
+
+    private fun hiddenField() = TextInputComponentState(requirementPolicy = RequirementPolicy.Hidden)
+
+    private fun hiddenError() = TextInputComponentState.InputError(CheckoutLocalizationKey.GENERAL_CLOSE)
+
+    private fun visibleError() = TextInputComponentState.InputError(
+        message = CheckoutLocalizationKey.GENERAL_CLOSE,
+        isVisible = true,
     )
 }

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardFieldOrderTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardFieldOrderTest.kt
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 17/8/2026.
+ */
+
+package com.adyen.checkout.card.internal.ui.state
+
+import com.adyen.checkout.card.internal.ui.model.InstallmentModel
+import com.adyen.checkout.core.components.internal.ui.state.form.lastTextInput
+import com.adyen.checkout.core.components.internal.ui.state.model.RequirementPolicy
+import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests `CardFieldOrder.kt`: which fields the card form shows and in which order.
+ *
+ * The order is the single source of truth for the layout, the keyboard action of each field, and which field receives
+ * focus when the shopper presses pay, so a field missing from it is a field missing from the screen.
+ */
+internal class CardFieldOrderTest {
+
+    @Nested
+    inner class CanonicalOrderTest {
+
+        /**
+         * A field left out of the canonical order can never be displayed, whatever its configuration says.
+         */
+        @Test
+        fun `when the canonical order is read, then it contains every card field exactly once`() {
+            // WHEN
+            val order = canonicalCardFieldOrder()
+
+            // THEN
+            assertEquals(CardFieldId.entries.toSet(), order.toSet())
+            assertEquals(CardFieldId.entries.size, order.size)
+        }
+
+        @Test
+        fun `when the canonical order is read, then the card number comes first`() {
+            // WHEN
+            val order = canonicalCardFieldOrder()
+
+            // THEN
+            assertEquals(CardFieldId.CARD_NUMBER, order.first())
+        }
+    }
+
+    @Nested
+    inner class VisibleCardFieldsTest {
+
+        @Test
+        fun `when every field is configured, then all of them are shown in the canonical order`() {
+            // GIVEN
+            val state = createState(
+                holderName = required(),
+                socialSecurityNumber = required(),
+                kcpBirthDateOrTaxNumber = required(),
+                kcpCardPassword = required(),
+                postalCode = required(),
+                isStorePaymentFieldVisible = true,
+                installmentOptions = listOf(InstallmentModel.OneTime),
+            )
+
+            // WHEN
+            val order = visibleCardFields(state)
+
+            // THEN
+            assertEquals(canonicalCardFieldOrder(), order)
+        }
+
+        @Test
+        fun `when only the mandatory fields are configured, then the optional ones are left out`() {
+            // GIVEN
+            val state = createState()
+
+            // WHEN
+            val order = visibleCardFields(state)
+
+            // THEN
+            assertEquals(
+                listOf(CardFieldId.CARD_NUMBER, CardFieldId.EXPIRY_DATE, CardFieldId.SECURITY_CODE),
+                order,
+            )
+        }
+
+        /**
+         * The security code is hidden for some brands, which is the one visibility change that happens while the
+         * shopper is typing rather than at configuration time.
+         */
+        @Test
+        fun `when the security code is hidden, then the fields around it keep their order`() {
+            // GIVEN
+            val state = createState(
+                securityCode = hidden(),
+                postalCode = required(),
+            )
+
+            // WHEN
+            val order = visibleCardFields(state)
+
+            // THEN
+            assertEquals(
+                listOf(CardFieldId.CARD_NUMBER, CardFieldId.EXPIRY_DATE, CardFieldId.POSTAL_CODE),
+                order,
+            )
+        }
+
+        @Test
+        fun `when an optional field is configured, then it is shown`() {
+            // GIVEN
+            val state = createState(holderName = optional())
+
+            // WHEN
+            val order = visibleCardFields(state)
+
+            // THEN
+            assertTrue(order.contains(CardFieldId.HOLDER_NAME))
+        }
+
+        @Test
+        fun `when no installment options are available, then the installment picker is left out`() {
+            // GIVEN
+            val state = createState(installmentOptions = emptyList())
+
+            // WHEN
+            val order = visibleCardFields(state)
+
+            // THEN
+            assertTrue(!order.contains(CardFieldId.INSTALLMENTS))
+        }
+    }
+
+    /**
+     * The keyboard action of each field falls out of the order, so these are the cases that decide which field closes
+     * the keyboard rather than moving on.
+     */
+    @Nested
+    inner class LastTextInputTest {
+
+        @Test
+        fun `when the last field is a text input, then it is the last text input`() {
+            // GIVEN
+            val state = createState(postalCode = required())
+
+            // WHEN
+            val lastTextInput = state.form.lastTextInput()
+
+            // THEN
+            assertEquals(CardFieldId.POSTAL_CODE, lastTextInput)
+        }
+
+        @Test
+        fun `when the form ends with the store payment switch, then the last text input is the field before it`() {
+            // GIVEN
+            val state = createState(postalCode = required(), isStorePaymentFieldVisible = true)
+
+            // WHEN
+            val lastTextInput = state.form.lastTextInput()
+
+            // THEN
+            assertEquals(CardFieldId.POSTAL_CODE, lastTextInput)
+        }
+
+        @Test
+        fun `when the security code is hidden, then the expiry date becomes the last text input`() {
+            // GIVEN
+            val state = createState(securityCode = hidden())
+
+            // WHEN
+            val lastTextInput = state.form.lastTextInput()
+
+            // THEN
+            assertEquals(CardFieldId.EXPIRY_DATE, lastTextInput)
+        }
+    }
+
+    /**
+     * The UI renders a field by looking up the matching property of the view state, so a field in the order whose
+     * property is null would be silently dropped, and a field on screen that is not in the order would be unreachable
+     * by focus and have the wrong keyboard action. These are the states in which those two can disagree.
+     */
+    @Nested
+    inner class AgreementWithViewStateTest {
+
+        private val producer = CardViewStateProducer(amount = null, showSubmitButton = false)
+
+        @Test
+        fun `when every field is configured, then the order agrees with the view state`() {
+            assertOrderAgreesWithViewState(
+                createState(
+                    holderName = required(),
+                    socialSecurityNumber = required(),
+                    kcpBirthDateOrTaxNumber = required(),
+                    kcpCardPassword = required(),
+                    postalCode = required(),
+                    isStorePaymentFieldVisible = true,
+                    installmentOptions = listOf(InstallmentModel.OneTime),
+                ),
+            )
+        }
+
+        @Test
+        fun `when only the mandatory fields are configured, then the order agrees with the view state`() {
+            assertOrderAgreesWithViewState(createState())
+        }
+
+        @Test
+        fun `when the security code is hidden, then the order agrees with the view state`() {
+            assertOrderAgreesWithViewState(createState(securityCode = hidden()))
+        }
+
+        @Test
+        fun `when a field is optional, then the order agrees with the view state`() {
+            assertOrderAgreesWithViewState(createState(holderName = optional()))
+        }
+
+        private fun assertOrderAgreesWithViewState(state: CardComponentState) {
+            val order = visibleCardFields(state)
+            val viewState = producer.produce(state)
+
+            CardFieldId.entries.forEach { id ->
+                val isDisplayed = when (id) {
+                    CardFieldId.CARD_NUMBER -> viewState.cardNumber != null
+                    CardFieldId.EXPIRY_DATE -> viewState.expiryDate != null
+                    CardFieldId.SECURITY_CODE -> viewState.securityCode != null
+                    CardFieldId.HOLDER_NAME -> viewState.holderName != null
+                    CardFieldId.SOCIAL_SECURITY_NUMBER -> viewState.socialSecurityNumber != null
+                    CardFieldId.KCP_BIRTH_DATE_OR_TAX_NUMBER -> viewState.kcpBirthDateOrTaxNumber != null
+                    CardFieldId.KCP_CARD_PASSWORD -> viewState.kcpCardPassword != null
+                    CardFieldId.POSTAL_CODE -> viewState.postalCode != null
+                    CardFieldId.STORE_PAYMENT_METHOD -> viewState.storePaymentViewState != null
+                    CardFieldId.INSTALLMENTS -> viewState.installmentViewState != null
+                }
+
+                assertEquals(isDisplayed, order.contains(id), "Order and view state disagree on $id")
+            }
+        }
+    }
+
+    @Suppress("LongParameterList")
+    private fun createState(
+        securityCode: TextInputComponentState = required(),
+        holderName: TextInputComponentState = hidden(),
+        socialSecurityNumber: TextInputComponentState = hidden(),
+        kcpBirthDateOrTaxNumber: TextInputComponentState = hidden(),
+        kcpCardPassword: TextInputComponentState = hidden(),
+        postalCode: TextInputComponentState = hidden(),
+        isStorePaymentFieldVisible: Boolean = false,
+        installmentOptions: List<InstallmentModel> = emptyList(),
+    ) = CardComponentState(
+        cardNumber = required(),
+        expiryDate = required(),
+        securityCode = securityCode,
+        holderName = holderName,
+        socialSecurityNumber = socialSecurityNumber,
+        kcpBirthDateOrTaxNumber = kcpBirthDateOrTaxNumber,
+        kcpCardPassword = kcpCardPassword,
+        postalCode = postalCode,
+        storePaymentMethod = false,
+        isStorePaymentFieldVisible = isStorePaymentFieldVisible,
+        supportedCardBrands = emptyList(),
+        showSupportedCardBrandLogos = false,
+        isLoading = false,
+        isCardScanningAvailable = false,
+        cardBrandState = CardBrandState.NoBrandsDetected,
+        networkBinLookupState = null,
+        installmentState = InstallmentState(
+            installmentOptions = installmentOptions,
+            selectedInstallment = installmentOptions.firstOrNull(),
+        ),
+    )
+
+    private fun required() = TextInputComponentState(requirementPolicy = RequirementPolicy.Required)
+
+    private fun optional() = TextInputComponentState(requirementPolicy = RequirementPolicy.Optional)
+
+    private fun hidden() = TextInputComponentState(requirementPolicy = RequirementPolicy.Hidden)
+}

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
@@ -16,6 +16,8 @@ import com.adyen.checkout.card.internal.ui.model.SecurityCodeTrailingIcon
 import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.components.data.model.Amount
+import com.adyen.checkout.core.components.internal.ui.state.form.FocusRequest
+import com.adyen.checkout.core.components.internal.ui.state.form.KeyboardAction
 import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
 import com.adyen.checkout.core.components.internal.ui.state.model.RequirementPolicy
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
@@ -25,6 +27,7 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertNull
 
 internal class CardViewStateProducerTest {
@@ -755,6 +758,85 @@ internal class CardViewStateProducerTest {
         // THEN
         assertEquals(options, viewState.installmentViewState?.installmentOptions)
         assertEquals(selection, viewState.installmentViewState?.selectedInstallment)
+    }
+
+    @Test
+    fun `when the view state is produced, then the field order comes from the form`() {
+        // GIVEN
+        val componentState = createComponentState()
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertEquals(componentState.form.order, viewState.fieldOrder)
+    }
+
+    @Test
+    fun `when a field is not the last text input, then its keyboard moves to the next field`() {
+        // GIVEN
+        val componentState = createComponentState()
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertEquals(KeyboardAction.NEXT, viewState.cardNumber?.keyboardAction)
+    }
+
+    @Test
+    fun `when a field is the last text input, then its keyboard closes`() {
+        // GIVEN
+        val componentState = createComponentState()
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertEquals(KeyboardAction.DONE, viewState.postalCode?.keyboardAction)
+    }
+
+    @Test
+    fun `when the last field is hidden, then the keyboard closes on the one before it`() {
+        // GIVEN
+        val componentState = createComponentState(
+            postalCode = TextInputComponentState(requirementPolicy = RequirementPolicy.Hidden),
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertEquals(KeyboardAction.DONE, viewState.kcpCardPassword?.keyboardAction)
+    }
+
+    @Test
+    fun `when the form asks a field to take focus, then only that field carries the request`() {
+        // GIVEN
+        val componentState = createComponentState().copy(
+            focusRequest = FocusRequest(CardFieldId.SECURITY_CODE),
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertNotNull(viewState.securityCode?.focusRequest)
+        assertNull(viewState.cardNumber?.focusRequest)
+        assertNull(viewState.expiryDate?.focusRequest)
+    }
+
+    @Test
+    fun `when no focus is being requested, then no field carries a request`() {
+        // GIVEN
+        val componentState = createComponentState()
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertNull(viewState.cardNumber?.focusRequest)
+        assertNull(viewState.securityCode?.focusRequest)
     }
 
     @Suppress("LongParameterList")

--- a/core/src/main/java/com/adyen/checkout/core/common/internal/ui/KeyboardActionExt.kt
+++ b/core/src/main/java/com/adyen/checkout/core/common/internal/ui/KeyboardActionExt.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 17/8/2026.
+ */
+
+package com.adyen.checkout.core.common.internal.ui
+
+import androidx.annotation.RestrictTo
+import androidx.compose.ui.text.input.ImeAction
+import com.adyen.checkout.core.components.internal.ui.state.form.KeyboardAction
+
+/**
+ * Maps the keyboard action the form decided on to the one Compose understands.
+ *
+ * The two are kept apart so that the state layer can be tested without Compose, which is why this translation lives
+ * here rather than on [KeyboardAction] itself.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun KeyboardAction.toImeAction(): ImeAction = when (this) {
+    KeyboardAction.NEXT -> ImeAction.Next
+    KeyboardAction.DONE -> ImeAction.Done
+}

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/form/FormFieldId.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/form/FormFieldId.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 17/8/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui.state.form
+
+import androidx.annotation.RestrictTo
+
+/**
+ * Identifies a single element of a form. Every component that has a form declares its own set of ids, usually as an
+ * enum.
+ *
+ * Elements that are not text inputs, such as a switch or a picker, are also form fields: they take part in the
+ * ordering, because the UI renders the form by walking [FormState.order].
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+interface FormFieldId {
+
+    /**
+     * Whether this field is a text input.
+     *
+     * This governs the derivation of the keyboard action only, since only a text input has a keyboard. It has no
+     * effect on ordering or on focus.
+     */
+    val isTextInput: Boolean
+}

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/form/FormState.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/form/FormState.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 17/8/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui.state.form
+
+import androidx.annotation.RestrictTo
+
+/**
+ * The structure of a form: which fields it currently shows, and in which order.
+ *
+ * Compose decides the keyboard action of a text input when the field is created, and offers no way to ask whether
+ * another focusable field follows. The order therefore has to live here, in the state layer, rather than fall out of
+ * the layout.
+ *
+ * @param order The fields the form currently shows, in the order the shopper sees them. Being in the list means the
+ * field is visible, and the position in the list is the position on screen.
+ * @param focusRequest A focus move the state layer is asking the UI to make, or null if there is none pending. The UI
+ * reports back once it has acted on it, which clears it.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class FormState<Id : FormFieldId>(
+    val order: List<Id>,
+    val focusRequest: FocusRequest<Id>? = null,
+)
+
+/**
+ * A request for the UI to move focus to a field.
+ *
+ * @param id The field that should receive focus.
+ * @param keepErrorHighlight Whether the field keeps an error it is already showing while it receives focus. Focus that
+ * follows the shopper pressing pay uses true, because the point of that move is to show the error. Every other
+ * request, such as focusing the field after a prefilled one, uses false so that the field behaves as if the shopper
+ * had tapped it.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class FocusRequest<Id : FormFieldId>(
+    val id: Id,
+    val keepErrorHighlight: Boolean = false,
+)

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/form/FormStateExt.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/form/FormStateExt.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 17/8/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui.state.form
+
+import androidx.annotation.RestrictTo
+
+/**
+ * Returns the last text input of the form, or null if the form has none. This is the field that shows
+ * [KeyboardAction.DONE].
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun <Id : FormFieldId> FormState<Id>.lastTextInput(): Id? = order.lastOrNull { it.isTextInput }
+
+/**
+ * Returns the first text input after [id], or null if [id] is the last one or is not part of the form. Fields that are
+ * not text inputs are skipped, since focus is being moved on behalf of a keyboard.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun <Id : FormFieldId> FormState<Id>.nextTextInputAfter(id: Id): Id? {
+    val index = order.indexOf(id)
+    if (index == -1) return null
+    return order.subList(index + 1, order.size).firstOrNull { it.isTextInput }
+}
+
+/**
+ * Returns the keyboard action [id] should show. Only the last text input closes the keyboard, everything before it
+ * moves on to the next field.
+ *
+ * This is only meaningful for a text input, as it is the only kind of field that has a keyboard.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun <Id : FormFieldId> FormState<Id>.keyboardActionFor(id: Id): KeyboardAction {
+    return if (id == lastTextInput()) KeyboardAction.DONE else KeyboardAction.NEXT
+}
+
+/**
+ * Returns the first invalid field in the order the shopper sees, or null if every field is valid. This is the field
+ * that receives focus when the shopper presses pay on a form that cannot be submitted.
+ *
+ * Validity is passed in as a function so that the form does not need to know how a component stores its values. Any
+ * field can be reported invalid, including one that is not a text input.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun <Id : FormFieldId> FormState<Id>.firstInvalid(isValid: (Id) -> Boolean): Id? {
+    return order.firstOrNull { !isValid(it) }
+}

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/form/KeyboardAction.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/form/KeyboardAction.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 17/8/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui.state.form
+
+import androidx.annotation.RestrictTo
+
+/**
+ * The action key a text input shows on the keyboard.
+ *
+ * This is our own type rather than Compose's `ImeAction` so that the state layer stays free of Compose and can be
+ * tested on the JVM. The view layer maps it to an `ImeAction`.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+enum class KeyboardAction {
+
+    /**
+     * Moves focus to the next text input.
+     */
+    NEXT,
+
+    /**
+     * Closes the keyboard. Shown on the last text input of a form. It does not submit.
+     */
+    DONE,
+}

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputComponentState.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputComponentState.kt
@@ -35,6 +35,13 @@ data class TextInputComponentState(
     val isValid: Boolean
         get() = error == null
 
+    /**
+     * Whether the shopper can see this field at all. A hidden field is not on screen, so it is neither rendered nor
+     * part of the form's order.
+     */
+    val isVisible: Boolean
+        get() = requirementPolicy != RequirementPolicy.Hidden
+
     val isErrorVisible: Boolean
         get() = error?.isVisible == true
 

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputComponentState.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputComponentState.kt
@@ -9,7 +9,6 @@
 package com.adyen.checkout.core.components.internal.ui.state.model
 
 import androidx.annotation.RestrictTo
-import androidx.annotation.VisibleForTesting
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -67,7 +66,6 @@ data class TextInputComponentState(
     /**
      * Hides the error, if there is one.
      */
-    @VisibleForTesting
     fun hideErrorIfPresent() = copy(error = error?.copy(isVisible = false))
 
     // TODO - Form fields cleanup: will be removed. Reducers call showErrorIfPresent and hideErrorIfPresent themselves

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputComponentState.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputComponentState.kt
@@ -17,6 +17,8 @@ data class TextInputComponentState(
     val text: String = "",
     val description: CheckoutLocalizationKey? = null,
     val error: InputError? = null,
+    // TODO - Form fields cleanup: will be removed. FormState.focusRequest does this job instead. It stays until every
+    // component has moved over to it.
     val isFocused: Boolean = false,
     val requirementPolicy: RequirementPolicy = RequirementPolicy.Required,
 ) {
@@ -61,6 +63,9 @@ data class TextInputComponentState(
     @VisibleForTesting
     fun hideErrorIfPresent() = copy(error = error?.copy(isVisible = false))
 
+    // TODO - Form fields cleanup: will be removed. Reducers call showErrorIfPresent and hideErrorIfPresent themselves
+    // instead, because only the reducer can tell a focus gain the shopper caused from one a FormState.focusRequest
+    // caused. It stays until every component has moved over.
     fun updateFocus(hasFocus: Boolean): TextInputComponentState {
         val focused = copy(isFocused = hasFocus)
         return if (hasFocus) focused.hideErrorIfPresent() else focused.showErrorIfPresent()

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputViewState.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputViewState.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.core.components.internal.ui.state.model
 
 import androidx.annotation.RestrictTo
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
+import com.adyen.checkout.core.components.internal.ui.state.form.KeyboardAction
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class TextInputViewState(
@@ -17,12 +18,17 @@ data class TextInputViewState(
     // with the latest value of the input field.
     val text: String = "",
     val supportingText: CheckoutLocalizationKey? = null,
+    // TODO - Form fields cleanup: will be removed. FormState.focusRequest does this job instead. It stays until every
+    // component has moved over to it.
     val isFocused: Boolean = false,
     val isError: Boolean = false,
     // The field specific icon, shown while the field is not in an error state. Do not render this directly, use
     // [trailingIcon] instead.
     val customTrailingIcon: TrailingIcon? = null,
     val isOptional: Boolean = false,
+    // The action key this field shows on the keyboard. Only the last text input of a form closes the keyboard, so this
+    // can only be derived from the form as a whole, through `FormState.keyboardActionFor`.
+    val keyboardAction: KeyboardAction = KeyboardAction.DONE,
 ) {
 
     /**
@@ -39,6 +45,10 @@ data class TextInputViewState(
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun TextInputComponentState.toViewState(
     customTrailingIcon: TrailingIcon? = null,
+    // TODO - Form fields rollout: the default will be removed, so that every producer states the action its own form
+    // decided on. DONE until then, because every component still without a form has a single text field, and that
+    // field closes the keyboard.
+    keyboardAction: KeyboardAction = KeyboardAction.DONE,
 ): TextInputViewState? {
     if (requirementPolicy == RequirementPolicy.Hidden) return null
     return TextInputViewState(
@@ -48,5 +58,6 @@ fun TextInputComponentState.toViewState(
         isError = isErrorVisible,
         customTrailingIcon = customTrailingIcon,
         isOptional = requirementPolicy is RequirementPolicy.Optional,
+        keyboardAction = keyboardAction,
     )
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputViewState.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputViewState.kt
@@ -50,7 +50,7 @@ fun TextInputComponentState.toViewState(
     // field closes the keyboard.
     keyboardAction: KeyboardAction = KeyboardAction.DONE,
 ): TextInputViewState? {
-    if (requirementPolicy == RequirementPolicy.Hidden) return null
+    if (!isVisible) return null
     return TextInputViewState(
         text = text,
         supportingText = if (isErrorVisible) error?.message else description,

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputViewState.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputViewState.kt
@@ -11,6 +11,7 @@ package com.adyen.checkout.core.components.internal.ui.state.model
 import androidx.annotation.RestrictTo
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.components.internal.ui.state.form.KeyboardAction
+import com.adyen.checkout.ui.internal.element.input.FocusRequestToken
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class TextInputViewState(
@@ -29,6 +30,8 @@ data class TextInputViewState(
     // The action key this field shows on the keyboard. Only the last text input of a form closes the keyboard, so this
     // can only be derived from the form as a whole, through `FormState.keyboardActionFor`.
     val keyboardAction: KeyboardAction = KeyboardAction.DONE,
+    // Set when the form is asking this field to take focus. The field reports back once it has acted on it.
+    val focusRequest: FocusRequestToken? = null,
 ) {
 
     /**
@@ -49,6 +52,7 @@ fun TextInputComponentState.toViewState(
     // decided on. DONE until then, because every component still without a form has a single text field, and that
     // field closes the keyboard.
     keyboardAction: KeyboardAction = KeyboardAction.DONE,
+    focusRequest: FocusRequestToken? = null,
 ): TextInputViewState? {
     if (!isVisible) return null
     return TextInputViewState(
@@ -59,5 +63,6 @@ fun TextInputComponentState.toViewState(
         customTrailingIcon = customTrailingIcon,
         isOptional = requirementPolicy is RequirementPolicy.Optional,
         keyboardAction = keyboardAction,
+        focusRequest = focusRequest,
     )
 }

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/ui/state/form/FormStateExtTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/ui/state/form/FormStateExtTest.kt
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 17/8/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui.state.form
+
+import com.adyen.checkout.core.components.internal.ui.state.form.FormStateExtTest.TestFieldId.HOLDER_NAME
+import com.adyen.checkout.core.components.internal.ui.state.form.FormStateExtTest.TestFieldId.NUMBER
+import com.adyen.checkout.core.components.internal.ui.state.form.FormStateExtTest.TestFieldId.STORE_DETAILS
+import com.adyen.checkout.core.components.internal.ui.state.form.FormStateExtTest.TestFieldId.VERIFICATION_CODE
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests `FormStateExt.kt`: the pure derivations every one of the form behaviours is built on. A field that is not a
+ * text input, such as [STORE_DETAILS], takes part in the order but never in a keyboard decision.
+ */
+internal class FormStateExtTest {
+
+    @Nested
+    inner class LastTextInputTest {
+
+        @Test
+        fun `when the form has several text inputs, then the last one is returned`() {
+            // GIVEN
+            val form = formOf(NUMBER, VERIFICATION_CODE, HOLDER_NAME)
+
+            // WHEN
+            val lastTextInput = form.lastTextInput()
+
+            // THEN
+            assertEquals(HOLDER_NAME, lastTextInput)
+        }
+
+        @Test
+        fun `when the form ends with a field that is not a text input, then the last text input is returned`() {
+            // GIVEN
+            val form = formOf(NUMBER, VERIFICATION_CODE, STORE_DETAILS)
+
+            // WHEN
+            val lastTextInput = form.lastTextInput()
+
+            // THEN
+            assertEquals(VERIFICATION_CODE, lastTextInput)
+        }
+
+        @Test
+        fun `when the form has no text input at all, then null is returned`() {
+            // GIVEN
+            val form = formOf(STORE_DETAILS)
+
+            // WHEN
+            val lastTextInput = form.lastTextInput()
+
+            // THEN
+            assertNull(lastTextInput)
+        }
+
+        @Test
+        fun `when the form is empty, then null is returned`() {
+            // GIVEN
+            val form = formOf()
+
+            // WHEN
+            val lastTextInput = form.lastTextInput()
+
+            // THEN
+            assertNull(lastTextInput)
+        }
+    }
+
+    @Nested
+    inner class NextTextInputAfterTest {
+
+        @Test
+        fun `when a text input follows, then it is returned`() {
+            // GIVEN
+            val form = formOf(NUMBER, VERIFICATION_CODE, HOLDER_NAME)
+
+            // WHEN
+            val next = form.nextTextInputAfter(NUMBER)
+
+            // THEN
+            assertEquals(VERIFICATION_CODE, next)
+        }
+
+        @Test
+        fun `when the next field is not a text input, then it is skipped`() {
+            // GIVEN
+            val form = formOf(NUMBER, STORE_DETAILS, HOLDER_NAME)
+
+            // WHEN
+            val next = form.nextTextInputAfter(NUMBER)
+
+            // THEN
+            assertEquals(HOLDER_NAME, next)
+        }
+
+        @Test
+        fun `when nothing follows the field, then null is returned`() {
+            // GIVEN
+            val form = formOf(NUMBER, HOLDER_NAME)
+
+            // WHEN
+            val next = form.nextTextInputAfter(HOLDER_NAME)
+
+            // THEN
+            assertNull(next)
+        }
+
+        /**
+         * The field can be hidden by configuration, in which case it is not part of the order at all.
+         */
+        @Test
+        fun `when the field is not part of the form, then null is returned`() {
+            // GIVEN
+            val form = formOf(NUMBER, HOLDER_NAME)
+
+            // WHEN
+            val next = form.nextTextInputAfter(VERIFICATION_CODE)
+
+            // THEN
+            assertNull(next)
+        }
+    }
+
+    @Nested
+    inner class KeyboardActionForTest {
+
+        @Test
+        fun `when the field is not the last text input, then the keyboard moves to the next field`() {
+            // GIVEN
+            val form = formOf(NUMBER, VERIFICATION_CODE)
+
+            // WHEN
+            val keyboardAction = form.keyboardActionFor(NUMBER)
+
+            // THEN
+            assertEquals(KeyboardAction.NEXT, keyboardAction)
+        }
+
+        @Test
+        fun `when the field is the last text input, then the keyboard closes`() {
+            // GIVEN
+            val form = formOf(NUMBER, VERIFICATION_CODE)
+
+            // WHEN
+            val keyboardAction = form.keyboardActionFor(VERIFICATION_CODE)
+
+            // THEN
+            assertEquals(KeyboardAction.DONE, keyboardAction)
+        }
+
+        /**
+         * A field that is not a text input can be the last field on screen without taking the closing action away from
+         * the text input before it.
+         */
+        @Test
+        fun `when a field that is not a text input follows the last text input, then the text input still closes`() {
+            // GIVEN
+            val form = formOf(NUMBER, VERIFICATION_CODE, STORE_DETAILS)
+
+            // WHEN
+            val keyboardAction = form.keyboardActionFor(VERIFICATION_CODE)
+
+            // THEN
+            assertEquals(KeyboardAction.DONE, keyboardAction)
+        }
+
+        @Test
+        fun `when the form has a single text input, then it closes the keyboard`() {
+            // GIVEN
+            val form = formOf(NUMBER)
+
+            // WHEN
+            val keyboardAction = form.keyboardActionFor(NUMBER)
+
+            // THEN
+            assertEquals(KeyboardAction.DONE, keyboardAction)
+        }
+    }
+
+    @Nested
+    inner class FirstInvalidTest {
+
+        @Test
+        fun `when several fields are invalid, then the first one in visual order is returned`() {
+            // GIVEN
+            val form = formOf(NUMBER, VERIFICATION_CODE, HOLDER_NAME)
+
+            // WHEN
+            val firstInvalid = form.firstInvalid { it != VERIFICATION_CODE && it != HOLDER_NAME }
+
+            // THEN
+            assertEquals(VERIFICATION_CODE, firstInvalid)
+        }
+
+        @Test
+        fun `when every field is valid, then null is returned`() {
+            // GIVEN
+            val form = formOf(NUMBER, VERIFICATION_CODE)
+
+            // WHEN
+            val firstInvalid = form.firstInvalid { true }
+
+            // THEN
+            assertNull(firstInvalid)
+        }
+
+        /**
+         * No field that is not a text input can currently be invalid, but the lookup is keyed on any id so that the
+         * first one that can does not need new logic.
+         */
+        @Test
+        fun `when the invalid field is not a text input, then it is still returned`() {
+            // GIVEN
+            val form = formOf(NUMBER, STORE_DETAILS, HOLDER_NAME)
+
+            // WHEN
+            val firstInvalid = form.firstInvalid { it != STORE_DETAILS }
+
+            // THEN
+            assertEquals(STORE_DETAILS, firstInvalid)
+        }
+
+        @Test
+        fun `when the form is empty, then null is returned`() {
+            // GIVEN
+            val form = formOf()
+
+            // WHEN
+            val firstInvalid = form.firstInvalid { false }
+
+            // THEN
+            assertNull(firstInvalid)
+        }
+    }
+
+    private fun formOf(vararg ids: TestFieldId) = FormState(order = ids.toList())
+
+    private enum class TestFieldId(override val isTextInput: Boolean) : FormFieldId {
+        NUMBER(true),
+        VERIFICATION_CODE(true),
+        HOLDER_NAME(true),
+        STORE_DETAILS(false),
+    }
+}

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/SearchField.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/SearchField.kt
@@ -43,6 +43,8 @@ fun SearchField(
     enabled: Boolean = true,
     supportingText: String? = null,
     isError: Boolean = false,
+    // TODO - Form fields cleanup: will either be removed, or be changed to pass CheckoutTextField.focusRequest. No
+    // caller sets it today, so decide first whether a search field should focus itself at all.
     shouldFocus: Boolean = false,
 ) {
     val state = rememberTextFieldState()

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/input/CheckoutTextField.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/input/CheckoutTextField.kt
@@ -11,6 +11,8 @@ package com.adyen.checkout.ui.internal.element.input
 import androidx.annotation.RestrictTo
 import androidx.compose.foundation.Indication
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.text.BasicSecureTextField
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
@@ -26,6 +28,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
@@ -36,6 +39,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.sp
@@ -45,6 +49,7 @@ import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
 import com.adyen.checkout.ui.internal.theme.CheckoutThemeProvider
 import com.adyen.checkout.ui.theme.CheckoutTheme
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 /**
  * A composable that provides a styled text field with Adyen's theming.
@@ -63,10 +68,16 @@ import kotlinx.coroutines.flow.collectLatest
  * @param isError Indicates whether the text field is in an error state. When `true`,
  * the text field's appearance may change to reflect an error.
  * @param keyboardOptions Optional keyboard options that can be used to configure the keyboard.
+ * @param imeAction The action key the keyboard shows. It takes precedence over the one in [keyboardOptions] and over
+ * the one an [inputTransformation] asks for, so that the field the form considers last is the one that closes the
+ * keyboard. Leave it unspecified to keep whatever those two ask for.
  * @param interactionSource Optional [MutableInteractionSource] representing the stream of
  * interactions for this text field.
  * @param innerIndication Optional [Indication] that will be used for the internal
  * [CheckoutTextFieldDecorationBox].
+ * @param focusRequest A pending request to give this field focus, or null if there is none. Each new request moves
+ * focus once, and is reported back through [onFocusRequestConsumed].
+ * @param onFocusRequestConsumed Called after a [focusRequest] has been acted on, so that the state layer can clear it.
  * @param prefix An optional string to be displayed at the beginning of the input area,
  * before the user's input.
  * @param trailingIcon A composable function that provides a trailing icon to be displayed at the end
@@ -88,9 +99,14 @@ fun CheckoutTextField(
     inputTransformation: InputTransformation? = null,
     outputTransformation: OutputTransformation? = null,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    imeAction: ImeAction = ImeAction.Unspecified,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     innerIndication: Indication? = null,
+    // TODO - Form fields cleanup: will be removed. Use focusRequest below instead. This stays until every field
+    // composable has moved over to it.
     shouldFocus: Boolean = false,
+    focusRequest: FocusRequestToken? = null,
+    onFocusRequestConsumed: (() -> Unit)? = null,
     prefix: String? = null,
     hint: String? = null,
     isSecureField: Boolean = false,
@@ -99,7 +115,11 @@ fun CheckoutTextField(
     val style = CheckoutThemeProvider.elements.textField
     val innerTextStyle = CheckoutThemeProvider.textStyles.body
     val focusRequester = remember { FocusRequester() }
-    val focusModifier = modifier.focusRequester(focusRequester)
+    val bringIntoViewRequester = remember { BringIntoViewRequester() }
+    val coroutineScope = rememberCoroutineScope()
+    val focusModifier = modifier
+        .focusRequester(focusRequester)
+        .bringIntoViewRequester(bringIntoViewRequester)
     val textStyle = TextStyle(
         color = style.textColor,
         fontSize = innerTextStyle.size.sp,
@@ -107,6 +127,7 @@ fun CheckoutTextField(
         lineHeight = innerTextStyle.lineHeight.sp,
     )
     val cursorBrush = SolidColor(style.activeColor)
+    val resolvedKeyboardOptions = keyboardOptions.merge(KeyboardOptions(imeAction = imeAction))
     val decorator = TextFieldDecorator { innerTextField ->
         CheckoutTextFieldDecorationBox(
             label = label,
@@ -131,7 +152,7 @@ fun CheckoutTextField(
             textStyle = textStyle,
             lineLimits = TextFieldLineLimits.SingleLine,
             cursorBrush = cursorBrush,
-            keyboardOptions = keyboardOptions,
+            keyboardOptions = resolvedKeyboardOptions,
             interactionSource = interactionSource,
             decorator = decorator,
         )
@@ -143,7 +164,7 @@ fun CheckoutTextField(
             inputTransformation = inputTransformation,
             textStyle = textStyle,
             cursorBrush = cursorBrush,
-            keyboardOptions = keyboardOptions,
+            keyboardOptions = resolvedKeyboardOptions,
             interactionSource = interactionSource,
             decorator = decorator,
         )
@@ -159,11 +180,28 @@ fun CheckoutTextField(
         }
     }
 
+    // TODO - Form fields cleanup: will be removed together with the shouldFocus parameter. The focusRequest effect
+    // below does the same job.
     LaunchedEffect(shouldFocus) {
         if (shouldFocus) {
             // Throws if the requester is not attached to a focusable node, which can happen when the field leaves
             // composition between composition and this effect running. Losing the focus is preferable to crashing.
             runCatching { focusRequester.requestFocus() }
+        }
+    }
+
+    LaunchedEffect(focusRequest) {
+        if (focusRequest != null) {
+            // Throws if the requester is not attached to a focusable node, which can happen when the field leaves
+            // composition between composition and this effect running. Losing the focus is preferable to crashing.
+            runCatching { focusRequester.requestFocus() }
+
+            // Taking focus scrolls the field into view on its own, but a field that already has focus is told nothing
+            // and would stay off screen, so ask directly. This runs outside the effect because acting on the request
+            // clears it, which would otherwise cancel the scroll a frame or two in.
+            coroutineScope.launch { bringIntoViewRequester.bringIntoView() }
+
+            onFocusRequestConsumed?.invoke()
         }
     }
 }

--- a/ui/src/main/java/com/adyen/checkout/ui/internal/element/input/FocusRequestToken.kt
+++ b/ui/src/main/java/com/adyen/checkout/ui/internal/element/input/FocusRequestToken.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 17/8/2026.
+ */
+
+package com.adyen.checkout.ui.internal.element.input
+
+import androidx.annotation.RestrictTo
+import androidx.compose.runtime.Immutable
+
+/**
+ * A pending request to move focus to a field, as far as the field itself is concerned.
+ *
+ * The state layer decides which field should receive focus and why, but it lives in a module this one cannot see, so
+ * the request arrives here as an opaque value. All a field needs from it is to tell one request from the next, which
+ * is why the wrapped value is not readable: wrap whatever the state layer uses to describe the request, and make sure
+ * it is comparable by equality.
+ *
+ * **Only wrap an immutable value.** [Any] tells the Compose compiler nothing, so without the [Immutable] promise below
+ * every view state holding a token would be treated as unstable, and every field would recompose on every keystroke.
+ * The annotation is what buys that back, and it is only true if callers keep their end of the bargain.
+ */
+@Immutable
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@JvmInline
+value class FocusRequestToken(private val request: Any)


### PR DESCRIPTION
## Description
> **This is a POC for discussion, not a merge candidate.** It is the combined view of a stack of four layers, so that the whole change can be read and tried in one place. Merging it would collapse the stack — the individual layer PRs come after this discussion, and this one gets closed. Trimmed tests are also still missing, see below.

Field order currently lives in three places that nothing keeps in sync: the sequence of `if` blocks in `CardContent`, the sequence of a `copy(...)` call in the reducer for focus priority, and implicitly in Compose's focus search for the keyboard's `Next` key. This makes three things impossible: the IME action cannot be derived at all (Compose fixes it when a field is created and offers no way to ask whether another focusable field follows), prefill cannot know where to send focus, and pay focuses the first invalid field in declaration order rather than the order the shopper reads.

This publishes the order from the state layer and has everything derive from it.

What that gives us, all working on a device:
- Pay highlights every error and focuses the first invalid field **in visual order**, and that field now keeps the error it just revealed. It used to hide it, because a requested focus was indistinguishable from a shopper tap.
- Every text field shows `Next` except the last visible one, which shows `Done`. `Done` closes the keyboard and does not submit.
- Card scanning moves focus to the first field it did not fill.
- Which fields are visible and in which order is answered once, so the screen reads no configuration at all.

### Reviewing
Six commits in four layers, bottom-up. Each compiles and, except where stated, changes no behaviour.

1. **Add the form unit that owns field order and focus requests** — `FormState`, `FormFieldId`, `FocusRequest`, `KeyboardAction` and four pure functions. Nothing reads them yet.
2. **Give the card form an explicit field order** — card's field ids, the canonical sequence, and visibility derived from the same properties the producer reads. `CardComponentState.form` is computed on every read, so the order cannot go stale.
3. **Keep the error on the field pay focuses** — the one behaviour change in the stack, and the bug this work exists for. Also collapses eight `UpdateXFocus` intents into one.
4. **Carry the pending focus request in a field's view state**
5. **Publish the card field order to the view state** — still nothing reads it.
6. **Render the card form from its field order** — nine `if` blocks become one loop; fields move onto the focus request and the IME action.

### Deliberately not here
- **Tests were trimmed to get to a demo sooner.** The configuration matrix, the exhaustive focus-rule tests and the Compose UI tests all come back before the layer PRs go up.
- Stored card, MB Way and BLIK still use the old focus flag, so `isFocused` is carried unchanged and marked. `rg "TODO - Form fields cleanup"` and `rg "TODO - Form fields rollout"` are the two worklists.
- No field is reordered. The mechanism exists; the sequence is the one we ship today.

### Progress
✅ Phase 1 — Core: the error type ([#2942](https://github.com/Adyen/adyen-android/pull/2942))
➡️ **Phases 2 to 5 — the POC (this PR)**
Phase 6 — Roll out to stored card, MB Way, BLIK
Phase 7 — Cleanup and document

## Checklist
- [x] Code is unit tested
- [x] Changes are tested manually
