### PR TITLE
v6 - POC - Button in every component

### DIFF
--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/BlikFactory.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/BlikFactory.kt
@@ -20,6 +20,10 @@ import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPayment
 import com.adyen.checkout.core.components.internal.PaymentComponentFactory
 import com.adyen.checkout.core.components.internal.StoredPaymentComponentFactory
 import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateFactory
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateReducer
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateValidator
+import com.adyen.checkout.core.components.internal.ui.state.GenericViewStateProducer
 import kotlinx.coroutines.CoroutineScope
 
 internal class BlikFactory :
@@ -56,6 +60,11 @@ internal class BlikFactory :
             storedPaymentMethod = storedPaymentMethod,
             analyticsManager = analyticsManager,
             sdkDataProvider = sdkDataProvider,
+            componentStateValidator = GenericComponentStateValidator(),
+            componentStateFactory = GenericComponentStateFactory(),
+            componentStateReducer = GenericComponentStateReducer(),
+            viewStateProducer = GenericViewStateProducer(params.amount, params.showSubmitButton),
+            coroutineScope = coroutineScope,
         )
     }
 }

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/StoredBlikComponent.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/StoredBlikComponent.kt
@@ -18,19 +18,42 @@ import com.adyen.checkout.core.components.data.PaymentComponentData
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPaymentMethod
 import com.adyen.checkout.core.components.internal.PaymentComponentEvent
 import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
+import com.adyen.checkout.core.components.internal.ui.GenericContent
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
+import com.adyen.checkout.core.components.internal.ui.state.ComponentStateFlow
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateFactory
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateReducer
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateValidator
+import com.adyen.checkout.core.components.internal.ui.state.GenericIntent
+import com.adyen.checkout.core.components.internal.ui.state.GenericViewStateProducer
+import com.adyen.checkout.core.components.internal.ui.state.viewState
 import com.adyen.checkout.core.components.paymentmethod.BlikDetails
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.receiveAsFlow
 
+@Suppress("LongParameterList")
 internal class StoredBlikComponent(
     private val storedPaymentMethod: StoredPaymentMethod,
     private val analyticsManager: AnalyticsManager,
     private val sdkDataProvider: SdkDataProvider,
+    private val componentStateValidator: GenericComponentStateValidator,
+    componentStateFactory: GenericComponentStateFactory,
+    componentStateReducer: GenericComponentStateReducer,
+    viewStateProducer: GenericViewStateProducer,
+    coroutineScope: CoroutineScope,
 ) : PaymentComponent {
 
     private val eventChannel = bufferedChannel<PaymentComponentEvent>()
     override val eventFlow: Flow<PaymentComponentEvent> = eventChannel.receiveAsFlow()
+
+    private val componentState = ComponentStateFlow(
+        initialState = componentStateFactory.createInitialState(),
+        reducer = componentStateReducer,
+        validator = componentStateValidator,
+    )
+
+    private val viewState = componentState.viewState(viewStateProducer, coroutineScope)
 
     init {
         trackRenderEvent()
@@ -46,12 +69,21 @@ internal class StoredBlikComponent(
 
     @Composable
     override fun Content(modifier: Modifier) {
-        // This component has no UI
+        GenericContent(
+            viewStateFlow = viewState,
+            onSubmitClick = ::submit,
+            modifier = modifier,
+        )
     }
 
     override fun submit() {
-        val paymentComponentState = createPaymentComponentState()
-        eventChannel.trySend(PaymentComponentEvent.Submit(paymentComponentState))
+        // extra safety call, expected to always be valid
+        if (componentStateValidator.isValid(componentState.value)) {
+            val paymentComponentState = createPaymentComponentState()
+            eventChannel.trySend(
+                PaymentComponentEvent.Submit(paymentComponentState),
+            )
+        }
     }
 
     private fun createPaymentComponentState(): BlikPaymentComponentState {
@@ -75,7 +107,9 @@ internal class StoredBlikComponent(
 
     override fun requiresUserInteraction(): Boolean = false
 
-    override fun setLoading(isLoading: Boolean) = Unit
+    override fun setLoading(isLoading: Boolean) {
+        componentState.handleIntent(GenericIntent.UpdateLoading(isLoading))
+    }
 
     override fun onCleared() = Unit
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/StoredCardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/StoredCardComponent.kt
@@ -159,8 +159,13 @@ constructor(
         )
     }
 
-    override fun requiresUserInteraction(): Boolean =
-        componentState.value.securityCode.requirementPolicy == RequirementPolicy.Required
+    override fun requiresUserInteraction(): Boolean {
+        return when (componentState.value.securityCode.requirementPolicy) {
+            RequirementPolicy.Hidden -> false
+            RequirementPolicy.Optional -> true
+            RequirementPolicy.Required -> true
+        }
+    }
 
     override fun setLoading(isLoading: Boolean) {
         onIntent(StoredCardIntent.UpdateLoading(isLoading))

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardContent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardContent.kt
@@ -55,26 +55,27 @@ private fun StoredCardContent(
     onSubmitClick: () -> Unit,
     modifier: Modifier,
 ) {
-    // If security code is not displayed, we should not display anything
-    if (viewState.securityCode != null) {
-        ComponentScaffold(
-            modifier = modifier,
-            disableInteraction = viewState.isLoading,
-            footer = payButtonAsComponentScaffoldFooter(viewState.payButtonViewState, onSubmitClick),
-        ) {
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.ExtraLarge),
-            ) {
-                SecurityCodeField(
-                    securityCodeState = viewState.securityCode,
-                    cardNumberFormat = viewState.cardNumberFormat,
-                    onValueChange = { onIntent(StoredCardIntent.UpdateSecurityCode(it)) },
-                    onFocusChange = { onIntent(StoredCardIntent.UpdateSecurityCodeFocus(it)) },
-                )
+    ComponentScaffold(
+        modifier = modifier,
+        disableInteraction = viewState.isLoading,
+        footer = payButtonAsComponentScaffoldFooter(viewState.payButtonViewState, onSubmitClick),
+        // If security code is not displayed, we should not display any content
+        content = viewState.securityCode?.let { securityCodeState ->
+            @Composable {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.ExtraLarge),
+                ) {
+                    SecurityCodeField(
+                        securityCodeState = securityCodeState,
+                        cardNumberFormat = viewState.cardNumberFormat,
+                        onValueChange = { onIntent(StoredCardIntent.UpdateSecurityCode(it)) },
+                        onFocusChange = { onIntent(StoredCardIntent.UpdateSecurityCodeFocus(it)) },
+                    )
+                }
             }
-        }
-    }
+        },
+    )
 }
 
 @Preview

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/GenericContent.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/GenericContent.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 11/8/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui
+
+import androidx.annotation.RestrictTo
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.adyen.checkout.core.components.internal.ui.state.GenericViewState
+import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
+import com.adyen.checkout.ui.internal.element.ComponentScaffold
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
+import com.adyen.checkout.ui.theme.CheckoutTheme
+import kotlinx.coroutines.flow.StateFlow
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Composable
+fun GenericContent(
+    viewStateFlow: StateFlow<GenericViewState>,
+    onSubmitClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val viewState by viewStateFlow.collectAsStateWithLifecycle()
+    GenericContent(
+        viewState = viewState,
+        onSubmitClick = onSubmitClick,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun GenericContent(
+    viewState: GenericViewState,
+    onSubmitClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    ComponentScaffold(
+        modifier = modifier,
+        disableInteraction = viewState.isLoading,
+        footer = payButtonAsComponentScaffoldFooter(viewState.payButtonViewState, onSubmitClick),
+        content = null,
+    )
+}
+
+@Preview
+@Composable
+private fun GenericContentPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        val viewState = GenericViewState(
+            isLoading = false,
+            payButtonViewState = PayButtonViewState(null, false),
+        )
+
+        GenericContent(
+            viewState = viewState,
+            onSubmitClick = {},
+            modifier = Modifier,
+        )
+    }
+}

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/GenericPaymentComponent.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/GenericPaymentComponent.kt
@@ -16,19 +16,41 @@ import com.adyen.checkout.core.common.internal.helper.bufferedChannel
 import com.adyen.checkout.core.components.data.PaymentComponentData
 import com.adyen.checkout.core.components.internal.PaymentComponentEvent
 import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
+import com.adyen.checkout.core.components.internal.ui.state.ComponentStateFlow
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateFactory
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateReducer
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateValidator
+import com.adyen.checkout.core.components.internal.ui.state.GenericIntent
 import com.adyen.checkout.core.components.internal.ui.state.GenericPaymentComponentState
+import com.adyen.checkout.core.components.internal.ui.state.GenericViewStateProducer
+import com.adyen.checkout.core.components.internal.ui.state.viewState
 import com.adyen.checkout.core.components.paymentmethod.GenericDetails
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.receiveAsFlow
 
+@Suppress("LongParameterList")
 internal class GenericPaymentComponent(
     private val analyticsManager: AnalyticsManager,
     private val paymentMethodType: String,
     private val sdkDataProvider: SdkDataProvider,
+    private val componentStateValidator: GenericComponentStateValidator,
+    componentStateFactory: GenericComponentStateFactory,
+    componentStateReducer: GenericComponentStateReducer,
+    viewStateProducer: GenericViewStateProducer,
+    coroutineScope: CoroutineScope,
 ) : PaymentComponent {
 
     private val eventChannel = bufferedChannel<PaymentComponentEvent>()
     override val eventFlow: Flow<PaymentComponentEvent> = eventChannel.receiveAsFlow()
+
+    private val componentState = ComponentStateFlow(
+        initialState = componentStateFactory.createInitialState(),
+        reducer = componentStateReducer,
+        validator = componentStateValidator,
+    )
+
+    private val viewState = componentState.viewState(viewStateProducer, coroutineScope)
 
     init {
         trackRenderEvent()
@@ -41,11 +63,25 @@ internal class GenericPaymentComponent(
 
     @Composable
     override fun Content(modifier: Modifier) {
-        // This component has no UI
+        GenericContent(
+            viewState,
+            onSubmitClick = ::submit,
+            modifier = modifier,
+        )
     }
 
     override fun submit() {
-        val paymentComponentState = GenericPaymentComponentState(
+        // extra safety call, expected to always be valid
+        if (componentStateValidator.isValid(componentState.value)) {
+            val paymentComponentState = createPaymentComponentState()
+            eventChannel.trySend(
+                PaymentComponentEvent.Submit(paymentComponentState),
+            )
+        }
+    }
+
+    private fun createPaymentComponentState(): GenericPaymentComponentState {
+        return GenericPaymentComponentState(
             data = PaymentComponentData(
                 paymentMethod = GenericDetails(
                     type = paymentMethodType,
@@ -57,16 +93,12 @@ internal class GenericPaymentComponent(
             ),
             isValid = true,
         )
-
-        eventChannel.trySend(
-            PaymentComponentEvent.Submit(paymentComponentState),
-        )
     }
 
     override fun requiresUserInteraction(): Boolean = false
 
     override fun setLoading(isLoading: Boolean) {
-        // There is no UI to display a loading state
+        componentState.handleIntent(GenericIntent.UpdateLoading(isLoading))
     }
 
     override fun onCleared() = Unit

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/GenericPaymentComponentFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/GenericPaymentComponentFactory.kt
@@ -14,6 +14,10 @@ import com.adyen.checkout.core.components.CheckoutAdditionalCallback
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
 import com.adyen.checkout.core.components.internal.PaymentComponentFactory
 import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateFactory
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateReducer
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateValidator
+import com.adyen.checkout.core.components.internal.ui.state.GenericViewStateProducer
 import kotlinx.coroutines.CoroutineScope
 
 internal object GenericPaymentComponentFactory : PaymentComponentFactory<GenericPaymentComponent> {
@@ -30,6 +34,11 @@ internal object GenericPaymentComponentFactory : PaymentComponentFactory<Generic
             analyticsManager = analyticsManager,
             paymentMethodType = paymentMethod.type,
             sdkDataProvider = sdkDataProvider,
+            componentStateValidator = GenericComponentStateValidator(),
+            componentStateFactory = GenericComponentStateFactory(),
+            componentStateReducer = GenericComponentStateReducer(),
+            viewStateProducer = GenericViewStateProducer(params.amount, params.showSubmitButton),
+            coroutineScope = coroutineScope,
         )
     }
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericComponentState.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericComponentState.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 11/8/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui.state
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class GenericComponentState(
+    val isLoading: Boolean,
+) : ComponentState

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericComponentStateFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericComponentStateFactory.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 11/8/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui.state
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class GenericComponentStateFactory : ComponentStateFactory<GenericComponentState> {
+
+    override fun createInitialState() = GenericComponentState(
+        isLoading = false,
+    )
+}

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericComponentStateReducer.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericComponentStateReducer.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 11/8/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui.state
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class GenericComponentStateReducer : ComponentStateReducer<GenericComponentState, GenericIntent> {
+
+    override fun reduce(state: GenericComponentState, intent: GenericIntent): GenericComponentState {
+        return when (intent) {
+            is GenericIntent.UpdateLoading -> state.copy(isLoading = intent.isLoading)
+        }
+    }
+}

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericComponentStateValidator.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericComponentStateValidator.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 11/8/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui.state
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class GenericComponentStateValidator : ComponentStateValidator<GenericComponentState> {
+
+    override fun validate(state: GenericComponentState): GenericComponentState {
+        return state
+    }
+
+    override fun isValid(state: GenericComponentState): Boolean {
+        return true
+    }
+}

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericIntent.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericIntent.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 11/8/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui.state
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+sealed interface GenericIntent : ComponentStateIntent {
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class UpdateLoading(val isLoading: Boolean) : GenericIntent
+}

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericViewState.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericViewState.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 11/8/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui.state
+
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class GenericViewState(
+    val isLoading: Boolean,
+    val payButtonViewState: PayButtonViewState?
+) : ViewState

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericViewStateProducer.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericViewStateProducer.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 11/8/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui.state
+
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.core.components.data.model.Amount
+import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class GenericViewStateProducer(
+    private val amount: Amount?,
+    private val showSubmitButton: Boolean,
+) : ViewStateProducer<GenericComponentState, GenericViewState> {
+
+    override fun produce(state: GenericComponentState): GenericViewState {
+        return GenericViewState(
+            isLoading = state.isLoading,
+            payButtonViewState = if (showSubmitButton) PayButtonViewState(amount, state.isLoading) else null,
+        )
+    }
+}

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6SessionsViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6SessionsViewModel.kt
@@ -105,7 +105,7 @@ internal class V6SessionsViewModel @Inject constructor(
                     storedPaymentMethods = checkoutContext.getStoredPaymentMethods(),
                     selectedPaymentMethod = paymentMethods.first(),
                     checkoutController = checkoutController,
-                    showCustomButton = showCustomButton(checkoutController),
+                    showCustomButton = showCustomButton(),
                 )
             }
         }
@@ -137,7 +137,7 @@ internal class V6SessionsViewModel @Inject constructor(
         val newState = (uiState as? V6UiState.Component)?.copy(
             selectedPaymentMethod = paymentMethod,
             checkoutController = checkoutController,
-            showCustomButton = showCustomButton(checkoutController),
+            showCustomButton = showCustomButton(),
         )
 
         if (newState != null) {
@@ -174,8 +174,8 @@ internal class V6SessionsViewModel @Inject constructor(
         }
     }
 
-    private fun showCustomButton(checkoutController: CheckoutController): Boolean {
-        return checkoutConfiguration.showSubmitButton == false || !checkoutController.requiresUserInteraction()
+    private fun showCustomButton(): Boolean {
+        return checkoutConfiguration.showSubmitButton == false
     }
 
     fun onNewIntent(intent: Intent) {

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6ViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6ViewModel.kt
@@ -106,7 +106,7 @@ internal class V6ViewModel @Inject constructor(
                     storedPaymentMethods = checkoutContext.getStoredPaymentMethods(),
                     selectedPaymentMethod = paymentMethods.first(),
                     checkoutController = checkoutController,
-                    showCustomButton = showCustomButton(checkoutController),
+                    showCustomButton = checkoutConfiguration.showSubmitButton == false,
                 )
             }
         }
@@ -189,7 +189,6 @@ internal class V6ViewModel @Inject constructor(
         val newState = (uiState as? V6UiState.Component)?.copy(
             selectedPaymentMethod = paymentMethod,
             checkoutController = checkoutController,
-            showCustomButton = showCustomButton(checkoutController),
         )
 
         if (newState != null) {
@@ -222,13 +221,12 @@ internal class V6ViewModel @Inject constructor(
                 )
             },
             coroutineScope = viewModelScope,
-        ).also {
-            checkoutController = it
+        ).also { controller ->
+            checkoutController = controller
+            if (!controller.requiresUserInteraction()) {
+                controller.submit()
+            }
         }
-    }
-
-    private fun showCustomButton(checkoutController: CheckoutController): Boolean {
-        return checkoutConfiguration.showSubmitButton == false || !checkoutController.requiresUserInteraction()
     }
 
     fun onNewIntent(intent: Intent) {


### PR DESCRIPTION
> **Approved.** The behaviour in this POC was agreed, and the changes are implemented for real in #2957. This PR is closed and its branch deleted.

## Description

POC exploring what it looks like when every component has a submit button by default, aligning the Android SDK with Web.

### What changes for merchants

- Every component now renders a submit button by default, including the ones that previously had no UI at all.
- Merchants no longer have to call `controller.submit()` themselves to make those flows work. Previously a component without UI would sit there doing nothing unless the merchant wrote:

  ```kotlin
  if (!controller.requiresUserInteraction()) {
      controller.submit()
  }
  ```

  That is now opt-in: call it only if you actually want to skip the button and submit immediately.
- `requiresUserInteraction()` keeps its meaning — it tells you whether the shopper *must* interact before the component can be submitted, not whether the component has UI.
- Google Pay stays `requiresUserInteraction() == true` even though it is a button-only component; that is intended.
- The stored card component deliberately does not use the generic scaffolding. It manages its own UI and state, and its `requiresUserInteraction()` reflects the security code requirement policy, so both flows (with a CVC field and without) keep working.

### Internal

All components now have aligned scaffolding — validator, reducer, state factory, view state producer — so a component without input fields is structurally the same as one with fields, it just has no content above the button.

### Example app

Modified for the POC only: the advanced flow example auto-submits, while the sessions flow relies on the button. This is purely to exercise both paths side by side.

### Not ready to merge

This is a POC. Before it can be merged tests need to be added and the code tidied up.

## Checklist
- [ ] If applicable, make sure Breaking change label is added.
- [ ] Code is unit tested
- [x] Changes are tested manually
- [ ] Aligned public API changes with other platforms (if applicable)
- [ ] Related issues are linked

