### PR TITLE
v6 - Agent docs - Split AGENTS.md into skills

### DIFF
--- a/.agents/skills/android-add-dependency/SKILL.md
+++ b/.agents/skills/android-add-dependency/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: android-add-dependency
-description: Add, remove or update an external dependency in the SDK.
+description: Add, remove or update an external dependency in the SDK. Use before touching gradle/libs.versions.toml, including when the change is a side effect of a larger task.
 ---
 
 # android-add-dependency
@@ -31,7 +31,7 @@ Renovate handles routine version bumps. This skill is for dependency changes mad
 > - **Scope** — which modules, and which configuration (`api`, `implementation`, `compileOnly`, `testImplementation`, `androidTestImplementation`)
 > - **Merchants** — does it end up in merchant builds? Cover version conflicts with libraries merchants commonly use, `minSdk` (ours is 23), download size and method count, and the transitive artifacts it drags in
 > - **Public API** — do its types appear in our public API? If so its version becomes part of our contract and later upgrades turn into breaking changes. Prefer keeping it out of signatures and off `api`
-> - **R8 / ProGuard** — consumer rules or `dontwarn` needed? If it is an optional external SDK, does it need the `compileOnly` + `runCompileOnly` treatment from the "Adding New Modules" section of `AGENTS.md`?
+> - **R8 / ProGuard** — consumer rules or `dontwarn` needed? If it is an optional external SDK, does it need the `compileOnly` + `runCompileOnly` treatment described in the `android-add-module` skill (`.agents/skills/android-add-module/SKILL.md`)?
 > - **Release notes** — `[included]` or `[excluded]`, and why (step 4 works out the exact entry)
 > - **Build and CI** — verification metadata churn, build and CI time, added Renovate surface
 > - **Tests** — impact on the test suite, if any
@@ -40,7 +40,7 @@ Renovate handles routine version bumps. This skill is for dependency changes mad
 
 For a **change**, also state what moves: the size of the version jump, breaking changes in the new version, and any coordinate or artifact swap.
 
-For a **removal**, also state whether anything still uses it, whether its types were exposed in our public API, and whether merchants may be resolving it through us. Removing a dependency merchants rely on transitively is a breaking change — follow the breaking change rules in `AGENTS.md`.
+For a **removal**, also state whether anything still uses it, whether its types were exposed in our public API, and whether merchants may be resolving it through us. Removing a dependency merchants rely on transitively is a breaking change — follow the `android-public-api-change` skill (`.agents/skills/android-public-api-change/SKILL.md`).
 
 **Ask for explicit approval and wait for an answer.** This holds even when the developer already asked for this exact dependency; they should see the impact before it lands. If they have clearly already decided, keep the summary short, but still show it.
 

--- a/.agents/skills/android-add-module/SKILL.md
+++ b/.agents/skills/android-add-module/SKILL.md
@@ -20,7 +20,14 @@ Invoke this skill when creating a new module (for example a new payment method o
 
 Copy the Gradle setup from the existing module closest to what you are adding, then diff the two files and account for every difference. Add the module to `settings.gradle`, keeping the list alphabetical.
 
-### 2. Handle optional external SDKs with compileOnly
+### 2. Register a published module elsewhere
+
+A published module is not done when its own `build.gradle` is right — two lists outside it have to know about it:
+
+- **Documentation.** Add `dokka(project(':<module>'))` to the `dependencies` block at the bottom of the root `build.gradle`. Every published module has an entry there, so a missing one means the module is silently absent from the generated API documentation.
+- **Drop-in.** If merchants reach the payment method through Drop-in, add `api project(':<module>')` to `drop-in/build.gradle` so it ships with Drop-in. Shared infrastructure such as `core`, `ui-core` and `components-core`, and action modules such as `redirect` and `await`, arrive transitively and are not listed.
+
+### 3. Handle optional external SDKs with compileOnly
 
 Some modules wrap a third-party SDK: 3DS2, Twint, WeChat Pay, Cash App Pay, Google Pay, card scanning. Merchants who use standalone components should not be forced to pull these in, so the dependent module declares them as `compileOnly` and tolerates their absence at runtime.
 
@@ -37,7 +44,7 @@ Because the classes are absent at runtime, R8 warns about the missing references
 -dontwarn com.adyen.checkout.adyen3ds2.**
 ```
 
-### 3. Guard every call into an optional SDK
+### 4. Guard every call into an optional SDK
 
 Never touch a `compileOnly` type directly. Wrap the call so a missing class degrades gracefully instead of throwing `NoClassDefFoundError`:
 
@@ -51,7 +58,7 @@ The optional type must not appear outside the `runCompileOnly` block — not in 
 
 For a boolean availability check, use `checkCompileOnly`.
 
-### 4. Verify
+### 5. Verify
 
 Run the `android-check` skill (`.agents/skills/android-check/SKILL.md`) for the new module and for every module that depends on it.
 

--- a/.agents/skills/android-add-module/SKILL.md
+++ b/.agents/skills/android-add-module/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: android-add-module
+description: Add a new Gradle module and wire in optional external SDKs.
+---
+
+# android-add-module
+
+Add a new Gradle module to the Adyen Android SDK with the right publishing and dependency setup.
+
+## Usage
+
+Invoke this skill when creating a new module (for example a new payment method or an internal helper module), or when an existing module needs to depend on an optional external SDK.
+
+## Steps
+
+### 1. Decide whether the module is published
+
+- **Published** — anything merchants integrate, such as a new payment method. It uses the `checkout.android.library` convention plugin plus a `checkoutPublishing { id, name, description }` block, and gets an `api/<module>.api` dump file. Compare with `card/build.gradle`.
+- **Not published** — internal tooling and test support. These skip both: `test-core` uses the plain `android.library` plugin, and `lint` is a Kotlin JVM module.
+
+Copy the Gradle setup from the existing module closest to what you are adding, then diff the two files and account for every difference. Add the module to `settings.gradle`, keeping the list alphabetical.
+
+### 2. Handle optional external SDKs with compileOnly
+
+Some modules wrap a third-party SDK: 3DS2, Twint, WeChat Pay, Cash App Pay, Google Pay, card scanning. Merchants who use standalone components should not be forced to pull these in, so the dependent module declares them as `compileOnly` and tolerates their absence at runtime.
+
+Ask during planning whether the new module needs this treatment — it is not automatic.
+
+```gradle
+// In the dependent module, e.g. action-core/build.gradle
+compileOnly project(':3ds2')
+```
+
+Because the classes are absent at runtime, R8 warns about the missing references. Suppress that in the dependent module's `consumer-rules.pro` so merchant builds stay clean:
+
+```proguard
+-dontwarn com.adyen.checkout.adyen3ds2.**
+```
+
+### 3. Guard every call into an optional SDK
+
+Never touch a `compileOnly` type directly. Wrap the call so a missing class degrades gracefully instead of throwing `NoClassDefFoundError`:
+
+```kotlin
+import com.adyen.checkout.core.common.helper.runCompileOnly
+
+val sdkVersion = runCompileOnly { ThreeDS2Service.INSTANCE.sdkVersion }.getOrNull()
+```
+
+The optional type must not appear outside the `runCompileOnly` block — not in a signature, a field, or a local variable — or the JVM resolves it before the guard runs. See `card/src/main/java/com/adyen/checkout/card/internal/util/CardScannerWrapper.kt` for the pattern and the reason.
+
+For a boolean availability check, use `checkCompileOnly`.
+
+### 4. Verify
+
+Run the `android-check` skill (`.agents/skills/android-check/SKILL.md`) for the new module and for every module that depends on it.
+
+For an optional SDK, also verify the fallback path: the dependent module must compile and behave sensibly when the optional module is absent.
+
+## Important
+
+- A new published module is a public API addition — apply the `android-public-api-change` skill (`.agents/skills/android-public-api-change/SKILL.md`) to whatever it exposes.
+- A new external library, as opposed to a new project module, goes through the `android-add-dependency` skill (`.agents/skills/android-add-dependency/SKILL.md`) first.

--- a/.agents/skills/android-branch-create/SKILL.md
+++ b/.agents/skills/android-branch-create/SKILL.md
@@ -65,14 +65,7 @@ Present the proposed branch name and base branch. Ask for approval before creati
 
 ### 5. Create and checkout
 
-**Single branch** (not part of a chain):
-
-```bash
-git checkout <base-branch>
-git pull
-git checkout -b <branch-name>
-git push --set-upstream origin <branch-name>
-```
+**Single branch** (not part of a chain): create it from an up-to-date base branch, then push it with upstream tracking so it is ready for a PR.
 
 **Chained branches** — build a stack so each layer targets the one below it, with `main`/`v5` as the trunk. If stacking is unavailable, base each branch on the previous phase and set each PR's base manually.
 

--- a/.agents/skills/android-check/SKILL.md
+++ b/.agents/skills/android-check/SKILL.md
@@ -26,7 +26,7 @@ Run the full check task (compile, lint, unit tests):
 
 - **On success:** Confirm all checks passed.
 - **On failure:** Parse the Gradle output and provide a concise summary of what failed (compilation errors, test failures, lint violations). Include file paths and line numbers when available. Do not dump the entire Gradle log.
-  - **If the failure is a public API mismatch** (e.g., `apiCheck` task fails): This means `.api` dump files are out of date. Inform the developer that they need to run `./gradlew apiDump` (or `./gradlew :<module>:apiDump` if module-scoped) to regenerate the `.api` files, and include those files in their commit.
+  - **If the failure is a public API mismatch** (e.g., `apiCheck` task fails): the public API changed. Report *what* changed, and do not run `apiDump` to silence it — an unintended API change is a real failure. Follow the `android-public-api-change` skill (`.agents/skills/android-public-api-change/SKILL.md`) to confirm the change is intended before the dump files are regenerated.
 
 ## Important
 

--- a/.agents/skills/android-commit/SKILL.md
+++ b/.agents/skills/android-commit/SKILL.md
@@ -15,7 +15,7 @@ Invoke this skill after completing a phase of work and you are ready to commit. 
 
 ### 1. Verify branch
 
-Check the current branch with `git rev-parse --abbrev-ref HEAD`. If the current branch is `main` or `v5`, **stop immediately** and warn the user. Never commit directly to `main` or `v5`. Suggest using the `android-branch-create` skill to create a feature/fix/chore branch first.
+Check the current branch. If it is `main` or `v5`, **stop immediately** and warn the user. Never commit directly to `main` or `v5`. Suggest using the `android-branch-create` skill to create a feature/fix/chore branch first.
 
 Also ensure the branch is up to date with its upstream branch. If behind, pull the latest changes before proceeding.
 
@@ -27,7 +27,7 @@ Use the `android-check` skill (`.agents/skills/android-check/SKILL.md`) to run v
 
 ### 3. Review changes
 
-Run `git status` and `git diff` to understand what will be committed. Present a brief summary of changed files to the user.
+Understand what will be committed, and present a brief summary of the changed files to the user.
 
 ### 4. Ask for ticket number
 
@@ -43,7 +43,7 @@ Include any `.api` files if they were updated (e.g., after running `apiDump` for
 
 ### 6. Security scan
 
-Run `git diff --cached` to review the staged diff for:
+Review the staged diff for:
 - API keys, tokens, or secrets
 - Credentials or passwords
 - `.env` values or sensitive configuration
@@ -73,9 +73,7 @@ Ask for approval before executing the commit. If the user wants changes, adjust 
 
 ### 9. Execute commit
 
-Run `git commit -m "..."` with the approved message.
-
-Confirm the commit was created successfully by running `git log --oneline -1`.
+Create the commit with the approved message, then confirm it was created and contains exactly the intended files.
 
 ## Important
 

--- a/.agents/skills/android-migrate-payment-method-v6/SKILL.md
+++ b/.agents/skills/android-migrate-payment-method-v6/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: android-migrate-payment-method-v6
-description: Plan and execute the migration of a v5 payment method to the v6 component architecture.
+description: Plan and execute the migration of a v5 payment method to the v6 component architecture. Use when moving an existing payment method module to v6.
 ---
 
 # android-migrate-payment-method-v6
@@ -34,7 +34,7 @@ Each v6 payment method is a small set of collaborators wired by a factory. No si
 
 ## Before you start
 
-1. **Read `AGENTS.md`.** This skill defers to it for visibility/API rules, sealed-vs-abstract, styles/strings, external-SDK handling, and TDD.
+1. **Read `AGENTS.md`.** This skill defers to it for the working agreement and testing rules, and to the skills it routes to: `android-public-api-change` (visibility, sealed vs abstract), `android-ui-resources` (styles and strings), and `android-add-module` (external SDK handling).
 2. **Create a plan document first.** Per `AGENTS.md`, write `<METHOD>_V6_MIGRATION_PLAN.md`, get it approved, and do not start coding until then. Keep it updated as phases complete. Do not commit the plan file.
 3. **Inventory the v5 sources.** List the existing v5 files (delegate, views, provider, configuration, tests) and map each onto the v6 collaborators above. Note what already exists (some methods are partially migrated — e.g. Google Pay's `XDetails` already existed) so you don't recreate it.
 4. **Flag method-specific concerns** in the plan: external SDK handoff (`compileOnly` + `runCompileOnly`/`checkCompileOnly` + ProGuard `dontwarn`), availability pre-checks, action/redirect handling, and any bridging of out-of-composition events into the Composable (see Google Pay's `viewEventChannel`). Also decide which **optional capabilities** apply: a params/mapper, **input fields** (validation + error display), a **stored variant**, and a **secondary screen** (pickers/sheets).
@@ -93,7 +93,7 @@ Use the `android-branch-create` skill to create a `chore/` branch (base `main` d
 - Add `XContent`: a wrapper that collects the view-state flow and hosts effects/launchers, delegating to a **private pure-UI composable**. **Reuse shared composables from the `ui` module** (`ComponentScaffold`, `PayButton`, input fields, `ValuePickerField`) instead of building from scratch.
 - **If the method has a secondary screen**, add its `SecondaryContent` composable (e.g. `XSecondaryContent`) to render the component's `SecondaryScreenComponent.SecondaryContent()` slot (see MBWay's picker).
 - **Add `@Preview` composables for the meaningful UI cases**, not just one happy path — e.g. default/empty, loading, validation error, available vs unavailable, and any method-specific variants (light/dark via `uiMode`, RTL, different styles). Previews take the `ViewState` (or a small UI model) directly so each case is rendered in isolation.
-- Follow `AGENTS.md` and other payment methods for styles and strings.
+- Follow the `android-ui-resources` skill and other payment methods for styles and strings.
 - **Tests:** logic/UI tests where applicable.
 - **Gate:** `:module:check`. Commit.
 
@@ -117,7 +117,7 @@ Use the `android-branch-create` skill to create a `chore/` branch (base `main` d
 
 ### 10. Public configuration / DSL
 
-- Add/confirm the public `XConfiguration` and the `CheckoutConfiguration.x { }` DSL extension. Everything else stays `internal` or `@RestrictTo(LIBRARY_GROUP)`. Prefer abstract classes over sealed for merchant-facing `when` safety (see `AGENTS.md`).
+- Add/confirm the public `XConfiguration` and the `CheckoutConfiguration.x { }` DSL extension. Everything else stays `internal` or `@RestrictTo(LIBRARY_GROUP)`. Prefer abstract classes over sealed for merchant-facing `when` safety (see the `android-public-api-change` skill).
 - **Gate:** if the public API changed intentionally, run `:module:apiDump` and commit the `.api` files. Commit.
 
 ### 11. Example-app wiring

--- a/.agents/skills/android-migrate-payment-method-v6/SKILL.md
+++ b/.agents/skills/android-migrate-payment-method-v6/SKILL.md
@@ -47,7 +47,7 @@ Follow this loop for each phase below:
 
 1. **Tests first.** Write/move the tests for the layer before (or alongside) the implementation, using the given-when-then style. Every phase that adds a class adds its unit tests; the v5 tests for any code you move go with it.
 2. **Implement** the layer, defaulting to `internal` visibility.
-3. **Make it green**, then run the `android-check` skill scoped to the touched module(s) (`./gradlew :<module>:check`, plus `:core:check` when core changed).
+3. **Make it green**, then run the `android-check` skill scoped to the touched modules, plus `core` when core changed.
 4. **Commit** that single phase via the `android-commit` skill (one logical change per commit, `COSDK-XXXX` ticket). Never bundle multiple phases.
 
 ## Steps

--- a/.agents/skills/android-pr-create/SKILL.md
+++ b/.agents/skills/android-pr-create/SKILL.md
@@ -15,13 +15,7 @@ Invoke this skill when you are ready to open a PR for the current branch. The sk
 
 ### 1. Gather context
 
-Collect the following information:
-
-```bash
-git rev-parse --abbrev-ref HEAD              # current branch name
-git log --oneline <base-branch>..HEAD        # commits on this branch (base is main, v5, or parent branch)
-git diff <base-branch> --stat                # files changed summary
-```
+Collect the current branch name, the commits it adds on top of its base (`main`, `v5`, or the parent branch in a stack), and a summary of the files they change.
 
 Determine from the branch name:
 - **Branch type**: `feature/`, `fix/`, `chore/`, or `renovate/`
@@ -74,10 +68,7 @@ Rules:
 - ✅ for completed phases — include a link to the PR
 - ➡️ **bold** for the current phase (this PR)
 - Plain text (no emoji) for future phases
-- To find links for completed phases, search for related PRs:
-  ```bash
-  gh pr list --state all --base <base-branch> --search "<search term>" --json number,title,url
-  ```
+- To find links for completed phases, search the repository's open and merged PRs on the same base branch
 - If there is an implementation plan file (`*_IMPLEMENTATION_PLAN.md`), use it to identify the phases
 - If the work is not phased, omit this section entirely
 

--- a/.agents/skills/android-public-api-change/SKILL.md
+++ b/.agents/skills/android-public-api-change/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: android-public-api-change
+description: Change the public API surface: visibility, breaking changes, and apiDump.
+---
+
+# android-public-api-change
+
+Keep the public API surface of the Adyen Android SDK small, stable, and intentional.
+
+## Usage
+
+Invoke this skill as soon as work looks like it will touch the public API: adding a class, function, or property that is not `internal`, widening visibility, changing or removing a public signature, or when `apiCheck` fails during verification.
+
+Every published module has `.api` dump files, so any change to the public surface shows up as a diff. An unexpected diff is the signal to come back here.
+
+## Steps
+
+### 1. Default to internal
+
+Classes, functions, and properties are `internal` unless they are deliberately part of the public API.
+
+```kotlin
+// Default — internal visibility
+internal class CardViewStateFactory
+
+// Used across modules, not by merchants — restrict to the library group
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class SomeSharedClass
+
+// Public API — a deliberate decision
+class CardConfiguration
+```
+
+If a type is only needed across our own modules, use `@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)` rather than making it public.
+
+### 2. Prove the change is necessary
+
+Making something public later is easy; making it internal again is a breaking change. So the bar is asymmetric.
+
+- Look for an existing implementation of the same idea in the codebase first. Whatever you are working on most likely has a close precedent — follow it.
+- Try to find a solution that needs no public API change at all.
+- Even a non-breaking addition makes the API more complex. Additions are not free.
+- If you are unsure whether something should be public, make it `internal` or annotate it with `@RestrictTo`.
+
+Review each individual change in the `.api` diff and be able to justify it. If in doubt, ask.
+
+### 3. Check for breaking changes
+
+Breaking changes can come from removed **or** modified code — a changed parameter, return type, default value, or supertype all count.
+
+Only the merchant-facing surface can break. `internal` and `@RestrictTo` declarations are excluded from the `.api` dumps (`nonPublicMarkers` in `config/gradle/apiValidator.gradle`), so changing or removing them is not a breaking change — which is exactly why step 1 defaults to them.
+
+- **Do not proceed with a breaking change until it has been discussed and confirmed with the developer.**
+- Breaking changes belong in a major release.
+- Raise the question during planning: ask whether breaking changes are acceptable for the current work, rather than discovering it mid-implementation.
+
+### 4. Choose a shape that can evolve
+
+**Prefer abstract classes over sealed classes** for new types that merchants might use in a `when` expression. Adding an entry to a sealed class breaks exhaustive `when` blocks in merchant code.
+
+```kotlin
+// AVOID — adding an entry breaks merchant code
+sealed class DropInResult {
+    class CancelledByUser : DropInResult()
+    class Error(val reason: String?) : DropInResult()
+}
+
+// PREFER — abstract class with an internal constructor.
+// Merchants must write an `else` branch, so new entries are safe.
+abstract class DropInResult internal constructor() {
+    class CancelledByUser : DropInResult()
+    class Error(val reason: String?) : DropInResult()
+}
+```
+
+Sealed classes are fine when merchants pass them as parameters instead of matching on them — `AddressConfiguration` is an example. In that case, **add new entries as `class`, never `object`**, so optional arguments can be added later without breaking anything:
+
+```kotlin
+sealed class AddressConfiguration : Parcelable {
+    object None : AddressConfiguration()
+    data class PostalCode() : AddressConfiguration()
+    class Lookup : AddressConfiguration()
+}
+
+// Merchant usage — passed as a parameter, so new entries do not affect it
+setAddressConfiguration(AddressConfiguration.None)
+```
+
+Converting an existing sealed class to an abstract class is itself a breaking change. Use abstract classes for new code only.
+
+### 5. Update the API dump
+
+Once the API change is confirmed as intentional, regenerate the dump files and include them in the commit:
+
+```bash
+./gradlew apiDump              # whole project
+./gradlew :<module>:apiDump    # single module
+```
+
+Do **not** run `apiDump` reflexively. Running it only after confirming intent is what allows `apiCheck` to catch accidental API changes during verification.
+
+## Important
+
+- An `apiCheck` failure is not a task to silence with `apiDump` — first work out whether the API change was intended.
+- A public API change means the branch and PR are merchant-observable: use a `feature/` or `fix/` prefix, not `chore/`.

--- a/.agents/skills/android-ui-resources/SKILL.md
+++ b/.agents/skills/android-ui-resources/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: android-ui-resources
+description: Add or change XML layouts, styles, and string resources.
+---
+
+# android-ui-resources
+
+Add or change XML resources in the Adyen Android SDK without breaking merchant themes or shopper localization.
+
+## Usage
+
+Invoke this skill when touching a module's `res/` directory: layouts, styles, or strings. These rules apply to the XML-based views (v5 and the modules that still use them); Compose UI follows the theme system in `docs/v6/theme.md` instead.
+
+Search the codebase for a similar existing view before writing a new one — the correct style, attribute, and string pattern almost always already exists somewhere.
+
+## Layouts and styles
+
+### Give every new view a style
+
+Merchants customize our UI through styles, so a view without one cannot be customized. Follow the naming of the surrounding styles.
+
+### Use theme-safe attributes
+
+Only reference attributes that are guaranteed to exist in a merchant's theme. Default Material attributes are safe; framework attributes often are not.
+
+- **Avoid** `?android:attr/textColor` — it may be undefined in a merchant theme and crashes at inflation time.
+- **Prefer** `?attr/colorOnSurface` and the other Material defaults.
+
+### Keep the style hierarchy complete
+
+A style like `AdyenCheckout.Image.Logo.Large` requires every ancestor to exist as a declared style, even if empty. Without them, merchants who override a parent style hit errors.
+
+```xml
+<!-- All three must exist, even though the parents are empty -->
+<style name="AdyenCheckout.Image" />
+<style name="AdyenCheckout.Image.Logo" parent="AdyenCheckout.Image" />
+<style name="AdyenCheckout.Image.Logo.Large" parent="AdyenCheckout.Image.Logo">
+    <item name="android:layout_width">48dp</item>
+    <item name="android:layout_height">48dp</item>
+</style>
+```
+
+## Strings
+
+### Always use the shopper locale
+
+Components must render in the shopper locale, not the device locale. This covers every displayed string: labels, hints, errors, and content descriptions. Resolve them through `localizedContext`, never through the plain view or activity context.
+
+```kotlin
+val label = localizedContext.getString(R.string.checkout_card_holder_name_label)
+```
+
+Search for `localizedContext` and `localizedContext.getString` for examples.
+
+### Set strings through styles, not layouts
+
+Text belongs in the style so merchants can override it. In a layout, use `tools:text` for preview only:
+
+```xml
+<TextView
+    style="@style/AdyenCheckout.TextView.Title"
+    tools:text="@string/checkout_card_holder_name_label" />
+```
+
+Do not use `android:text` in a component layout.
+
+## Important
+
+- Adding or changing a merchant-visible string or style is merchant-observable: use a `feature/` or `fix/` branch prefix, not `chore/`.
+- When strings change, confirm translations are present for all supported locales.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,325 +1,68 @@
 # Agent Guidelines for Adyen Android SDK
 
-This document outlines important patterns, practices, and rules to follow when working with the Adyen Android SDK codebase.
+How to work in this repository. Detailed procedures live in skills under `.agents/skills/` — this file covers what applies to every task and points to the rest.
 
-## Core Principles
+## The project
 
-### 1. Never Make Assumptions
-**ALWAYS ask questions if you are uncertain about:**
-- Code patterns or conventions
-- Expected behavior
-- Implementation details
-- Migration strategies
-- Whether a change is needed or correct
+Adyen Android is a modular payments SDK: merchants integrate either Drop-in or individual payment method components, published as ~58 Gradle modules (see `settings.gradle`).
 
-**Do not proceed with uncertain changes.** It's better to ask and get clarification than to implement incorrect solutions.
+- `main` is **v6, in alpha** — the public API can still change, but it is released, so changes on `main` are already merchant-observable.
+- `v5` is the stable maintenance branch. Only essential v5 work goes there.
+- v6 is **Compose-first**. The XML-based v5 UI still lives in the repo, largely under `old/` packages.
 
-### 2. Always Work with a Plan
+For the architecture and the public surface, read [README.md](README.md), the v6 guides in [docs/v6/](docs/v6/README.md). Manual testing happens in [example-app/](example-app/README.md).
 
-**CRITICAL: Create plan FIRST, implement AFTER approval:**
-- **NEVER start implementation without a plan**
-- First, create a comprehensive implementation plan document (e.g., `*_IMPLEMENTATION_PLAN.md`)
-- Present the plan to the user for review and approval
-- Only after the plan is approved, begin implementation
-- Do not execute any code changes during the planning phase
+## Working agreement
 
-**Before starting any task:**
-- Ensure there is an implementation plan document (e.g., `*_IMPLEMENTATION_PLAN.md`)
-- If no plan exists, guide the user to create one before proceeding with implementation
-- Break down the work into clear, manageable phases
-- Identify dependencies, risks, and testing strategy upfront
+**Plan before implementing.** For anything beyond a small, local change, present a plan and wait for approval before editing code. Break the work into phases and state the dependencies, risks, and testing strategy upfront. Multi-phase work gets a plan document (for example `*_IMPLEMENTATION_PLAN.md`) that you keep updated as phases complete — mark items done, note deviations. Plan documents are working artifacts: do not commit them unless asked.
 
-**When working on multi-phase tasks with a plan document:**
-- Update the plan file as you complete tasks/phases
-- Mark checkboxes as completed
-- Add notes about any deviations or discoveries
-- This helps if work needs to be continued later or by someone else
-- **Do not commit plan files to the repository** as they are temporary working documents. They should only be committed manually if specifically needed.
+**One phase, one commit.** Finish a phase, commit it with the `android-commit` skill, then start the next. Never accumulate several phases in one commit.
 
-**Commit workflow - CRITICAL:**
-- **Complete one phase fully before moving to the next**
-- After completing a phase, use the `android-commit` skill (`.agents/skills/android-commit/SKILL.md`) to commit
-- Never accumulate multiple phases in a single commit
-- Each commit should represent a logical, complete unit of work
-- This ensures work can be reviewed incrementally and rolled back if needed
+**Find the precedent first.** Whatever you are building almost certainly has a close analogue in the codebase. Locate it and match it, rather than introducing a second way of doing the same thing.
 
-### 3. Test-Driven Development
+**Ask instead of assuming.** If the convention, the expected behavior, or whether the change is wanted at all is unclear, ask. Do not implement through uncertainty.
 
-**Write tests first, then make them green:**
-- Before implementing new functionality, write the tests that define the expected behavior
-- Follow existing test patterns in the codebase to understand our testing structure
-- Search for similar tests to understand naming conventions and structure
+## Testing
 
-**Test structure example:**
-```kotlin
-@Test
-fun `when holder name is empty then validation fails`() {
-    // GIVEN
-    val input = ""
-    
-    // WHEN
-    val result = validator.validate(input)
-    
-    // THEN
-    assertFalse(result.isValid)
-}
-```
+- **Write the test first**, then make it pass. Before refactoring, make sure the affected code is already covered — if it is not, write those tests first to capture current behavior.
+- New tests use JUnit 5 with Mockito-Kotlin, and Turbine for flows. A handful of older tests still use JUnit 4 or Robolectric; do not copy that as the default.
+- Name tests `when <condition> then <expectation>` and structure the body as GIVEN / WHEN / THEN, following neighboring tests.
+- Run checks through the `android-check` skill rather than calling Gradle directly, and run them as you go rather than accumulating unverified work.
 
-**Ensure test coverage before refactoring:**
-- Always ensure there is adequate test coverage before making any internal refactors
-- If tests don't exist, write them first to capture current behavior
-- This ensures refactoring doesn't introduce regressions
+## Rules that always apply
 
-**Pause and verify between big steps:**
-- After completing significant changes, pause to run tests
-- Ensure all tests that cover your code changes pass before proceeding
-- Don't accumulate too many changes without verification
+- New code is `internal` by default. Cross-module but not merchant-facing means `@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)`, not `public`.
+- No breaking change lands without explicit agreement from the developer.
+- Everything shown to a shopper uses the **shopper locale**, never the device locale.
+- Never commit to `main` or `v5` — branch first.
+- Never run `apiDump` just to make `apiCheck` pass. An unexpected `.api` diff means the API changed by accident.
 
-## Implementation Guidelines
+## Task routing
 
-### Public API Changes
+| When the work involves | Use |
+|------------------------|-----|
+| Starting new work | `android-branch-create` |
+| Compiling, linting, running tests | `android-check` |
+| Committing a finished phase | `android-commit` |
+| Opening a pull request | `android-pr-create` |
+| Public API: visibility, signatures, `apiDump`, sealed vs abstract | `android-public-api-change` |
+| Files under a module's `res/`: layouts, styles, strings | `android-ui-resources` |
+| A new Gradle module, or an optional external SDK | `android-add-module` |
+| Adding, updating, or removing an external library | `android-add-dependency` |
+| Moving a v5 payment method to v6 | `android-migrate-payment-method-v6` |
+| Addressing review comments on a PR | [.agents/PR_REVIEWS.md](.agents/PR_REVIEWS.md) |
 
-**Default to internal visibility for all new code:**
-- Classes, functions, properties should be `internal` unless they need to be public
-- If a class/function is used across modules, use `@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)` annotation
-- Only make things `public` if they are part of the public API
-- This helps maintain a clean public API surface and prevents accidental exposure
+Skills live in `.agents/skills/<name>/SKILL.md`. Not every skill might be mentioned above.
 
-**Example:**
-```kotlin
-// Default - internal visibility
-internal class CardViewStateFactory { }
+## Before calling work done
 
-// Used across modules - restrict to library group
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class SomeSharedClass { }
-
-// Public API
-class CardConfiguration { }
-```
-
-**When making public API changes:**
-
-**Update API dump files:**
-- When you intentionally change the public API, run `./gradlew apiDump` (or `./gradlew :<module>:apiDump`) to regenerate the `.api` files
-- These files document the public API surface and must be included in your commit
-- Do **not** run `apiDump` automatically — only run it after confirming the API change is intentional. This ensures accidental API changes are caught by `apiCheck` during verification.
-
-**Carefully review all changes:**
-- Review each change carefully to ensure it's necessary and correct. If in doubt, ask questions.
-
-**Never make breaking changes without discussion:**
-- Breaking changes can happen through removed OR modified code
-- **Do not proceed with breaking changes until discussed and confirmed with the user**
-- Breaking changes should only be done in a major release
-- Always ask during planning phase whether breaking changes are acceptable for the current work
-
-**Ensure changes are necessary:**
-- Even non-breaking changes can make the API more complex
-- Try to find a solution without any public API changes
-- If unsure whether something should be public or not, make it internal or annotate with `@RestrictTo`
-- We can always make things public later, but making things internal causes a breaking change
-
-**Maintain consistency:**
-- Look for similar examples or use cases in the existing codebase. Whatever you work on will most probably have a similar implementation in the codebase.
-- Follow established patterns and conventions
-- Ask questions if uncertain about the correct approach
-
-**Sealed classes vs abstract classes:**
-
-When creating new classes that merchants might use with `when` expressions, prefer abstract classes over sealed classes to avoid breaking changes:
-
-```kotlin
-// ❌ AVOID - Adding new entries will break merchant code
-sealed class DropInResult {
-    class CancelledByUser : DropInResult()
-    class Error(val reason: String?) : DropInResult()
-    class Finished(val result: String) : DropInResult()
-}
-
-// Merchant code - breaks when we add new entries
-val message = when (dropInResult) {
-    is DropInResult.CancelledByUser -> "CancelledByUser"
-    is DropInResult.Error -> "Error"
-    is DropInResult.Finished -> "Finished"
-    // No else clause - breaks if we add a new entry
-}
-
-// ✅ PREFER - Abstract classes with internal constructor
-abstract class DropInResult internal constructor() {
-    class CancelledByUser : DropInResult()
-    class Error(val reason: String?) : DropInResult()
-    class Finished(val result: String) : DropInResult()
-}
-
-// Merchant code - doesn't break when we add new entries
-val message = when (dropInResult) {
-    is DropInResult.CancelledByUser -> "CancelledByUser"
-    is DropInResult.Error -> "Error"
-    is DropInResult.Finished -> "Finished"
-    else -> "else"
-}
-```
-
-**For sealed classes that are safe to use:**
-- If adding a new entry with no arguments to an existing sealed class, always make it a `class` and not an `object`
-- This allows adding optional arguments in the future without a breaking change
-- Example: `AddressConfiguration` is safe because merchants use it as a parameter, not in `when` expressions
-
-```kotlin
-// This is okay - merchants don't use when with it
-sealed class AddressConfiguration : Parcelable {
-    object None : AddressConfiguration()
-    data class PostalCode() : AddressConfiguration()
-    data class FullAddress() : AddressConfiguration()
-    class Lookup : AddressConfiguration()
-}
-
-// Merchant usage - adding new entries doesn't affect this
-setAddressConfiguration(AddressConfiguration.None)
-```
-
-**Note:** Changing an existing sealed class to abstract creates a breaking change. Use abstract classes for new code only.
-
-### Layout and Styles (For XML)
-
-**When making changes to layout or styles XML files:**
-
-**Add styles to newly added views:**
-- Always define styles for new views to allow merchant customization
-- Follow existing style naming conventions
-
-**Use correct colors and attributes:**
-- Follow default Material colors to ensure compatibility
-- Use attributes that exist in themes by default
-- **Avoid:** `?android:attr/textColor` (may not be defined in merchant themes, causes crashes)
-- **Prefer:** `?attr/colorOnSurface` (Material default for text colors, always available)
-- Search for similar views in the codebase to find the correct attributes
-
-**Maintain style hierarchy:**
-- If introducing a style like `AdyenCheckout.Image.Logo.Large`, also declare parent styles:
-  - `AdyenCheckout.Image.Logo`
-  - `AdyenCheckout.Image`
-- Parent styles can be empty but must exist
-- Without proper hierarchy, merchants who override styles may encounter errors
-
-**Example:**
-```xml
-<!-- All three must exist, even if parents are empty -->
-<style name="AdyenCheckout.Image" />
-<style name="AdyenCheckout.Image.Logo" parent="AdyenCheckout.Image" />
-<style name="AdyenCheckout.Image.Logo.Large" parent="AdyenCheckout.Image.Logo">
-    <item name="android:layout_width">48dp</item>
-    <item name="android:layout_height">48dp</item>
-</style>
-```
-
-### String Resources
-
-**When making changes to strings:**
-
-**Apply localized context in components:**
-- Components must be displayed in the shopper locale, not device locale
-- This includes texts, hints, errors, and all displayed string resources
-- Search for `localizedContext` in the codebase for examples
-
-**Add strings to styles, not views:**
-- Define strings in styles to allow merchant customization
-- In view XML files, use `tools:text` instead of `android:text`
-- For programmatic strings, search for `localizedContext.getString` for examples
-
-**Example:**
-```xml
-<!-- In layout XML -->
-<TextView
-    style="@style/AdyenCheckout.TextView.Title"
-    tools:text="@string/checkout_card_holder_name_label" />
-```
-
-```kotlin
-// In code - apply localized context
-val localizedString = localizedContext.getString(R.string.checkout_card_holder_name_label)
-```
-
-### Adding New Modules
-
-**When adding a new module:**
-
-**Review Gradle configuration:**
-- Determine if the module should be published (e.g., new payment method) or stay internal (e.g., test module)
-- Compare new Gradle files with similar existing modules
-- Ensure all necessary configuration is included
-
-**For modules with external SDKs:**
-
-Examples of modules with external SDKs: Twint, WeChat Pay, 3DS2, Cash App Pay, Google Pay
-
-**If the module should be excluded by default in standalone components:**
-- Add as `compileOnly` in Gradle files. You can always ask if this is necessary or not while planning.
-- Add `dontwarn` rules to ProGuard to avoid R8 issues
-
-**Example Gradle configuration:**
-```gradle
-// In dependent modules
-compileOnly project(':external-sdk-module')
-```
-
-**Example ProGuard rule:**
-```proguard
--dontwarn com.external.sdk.**
-```
-
-**Use safe access functions:**
-- Surround code from external SDK modules with safe access functions
-- Use `runCompileOnly` and `checkCompileOnly` to handle missing dependencies gracefully
-- Search for existing examples in modules like Twint, WeChat Pay, or 3DS2
-
-**Example:**
-```kotlin
-// Check if external SDK is available
-if (checkCompileOnly("com.external.sdk.SomeClass")) {
-    runCompileOnly {
-        // Code using external SDK
-        ExternalSDK.initialize()
-    }
-}
-```
-
-### Adding or Modifying Dependencies
-
-If a new dependency needs to be added, or an existing dependency needs to be updated or removed, use the `android-add-dependency` skill (`.agents/skills/android-add-dependency/SKILL.md`). It covers the full procedure, including getting approval, the impact assessment template, updating `gradle/libs.versions.toml` and `.github/release_notes_dependency_list.toml`, and regenerating `gradle/verification-metadata.xml`.
-
-## Verification Checklist
-
-Before considering work complete:
-1. Implementation plan exists and is updated with progress
-2. Tests written first and are passing (`./gradlew test`)
-3. All checks pass (`./gradlew check`)
-4. Code follows existing patterns in the codebase
-5. If public API changed: Reviewed for breaking changes (discussed with user) and necessity
-6. If layout/styles changed: Styles added, proper attributes used, hierarchy maintained
-7. If strings changed: All translations present, localized context applied
-8. If new module added: Gradle configuration reviewed, external SDKs handled properly
-9. If dependencies changed: Dependency approved by the developer with its impact explained, release notes dependency list updated and confirmed, verification metadata regenerated
-10. If refactoring: Test coverage exists for affected code
-11. Added classes and functions have unit tests following given-when-then structure
-
-## When in Doubt
-
-1. **Search for similar patterns** in the existing codebase
-2. **Ask questions** rather than making assumptions
-3. **Run `./gradlew check`** to catch issues early
-4. **Read compiler error messages carefully** - they often tell you exactly what's wrong
+1. Checks pass for every affected module (`android-check`).
+2. New classes and functions have unit tests, and the tests were written first.
+3. The plan document, if there is one, reflects what was actually done.
+4. The rules from every skill the work touched have been followed.
+5. Changes match existing patterns, and each one is necessary.
 
 ## Resources
-[Public Documentation](https://docs.adyen.com/online-payments/build-your-integration/?platform=Android)
 
-## Additional Agent Guides
-
-For specific workflows, refer to these detailed guides in the `.agents/` directory:
-
-- **[PR Reviews](.agents/PR_REVIEWS.md)** - Addressing review comments, resolving conversations
-
----
-
-**Remember:** The goal is to maintain consistency with the existing codebase and ensure all changes are correct and tested. Taking time to verify and ask questions prevents technical debt and bugs.
+- [Public documentation](https://docs.adyen.com/online-payments/build-your-integration/?platform=Android)
+- [Migration guide](MIGRATION.md)


### PR DESCRIPTION
## Description
AGENTS.md is loaded into context on every agent turn, and had grown to 325 lines / 13.3 KB.
Roughly 70% of it was conditional procedure that only applies to a minority of tasks, while the
orientation an agent cannot cheaply infer was missing.

This continues the extraction pattern already used for `android-check`, `android-commit`,
`android-branch-create` and `android-pr-create`.

**Extracted into skills:**
- `android-public-api-change` — internal-by-default, `@RestrictTo`, breaking changes, sealed vs abstract, `apiDump`
- `android-ui-resources` — style hierarchy, theme-safe attributes, shopper-locale strings
- `android-add-module` — publishing setup, `compileOnly` + `dontwarn` + `runCompileOnly` for optional external SDKs

**AGENTS.md now carries** only what applies to every task: branch model (v6 alpha on `main`), the
working agreement, testing conventions, always-on rules, and a routing table to the skills.
325 → 68 lines (13.3 KB → 4.4 KB).
