### PR TITLE
v6 - Core - Format localized strings using the shopper locale

### DIFF
--- a/core/src/main/java/com/adyen/checkout/core/common/localization/internal/LocalizationResolver.kt
+++ b/core/src/main/java/com/adyen/checkout/core/common/localization/internal/LocalizationResolver.kt
@@ -28,7 +28,7 @@ internal class LocalizationResolver(
             ?: defaultLocalizationSource.getString(context, key)
         return if (formatArgs.isNotEmpty()) {
             @Suppress("SpreadOperator")
-            string.format(*formatArgs)
+            string.format(locale, *formatArgs)
         } else {
             string
         }


### PR DESCRIPTION
## Description

`LocalizationResolver.getLocalizedStringFor` receives the shopper `locale`, but applied the format arguments with `string.format(*formatArgs)`. That Kotlin extension delegates to `Locale.getDefault()`, so any locale-sensitive format argument was rendered with the **device** locale instead of the shopper locale. The locale is now passed explicitly.

```diff
-            string.format(*formatArgs)
+            string.format(locale, *formatArgs)
```

### Impact

Not reachable through the SDK's own default strings: every localization key that receives format arguments uses `%s`, and amounts are pre-formatted with `Amount.format(locale)` before being passed in, so `toString()` is locale-blind either way.

It is reachable through `CheckoutLocalizationProvider`, which is public API. A merchant-supplied string using a locale-sensitive specifier — `%d` (digit shaping), `%,d` (grouping) or `%.2f` (decimal separator) — was formatted with the device locale. For example, overriding `CARD_INSTALLMENTS_REGULAR` with `"%d months"` and a shopper locale of `ar-EG` rendered Western digits on an English device instead of Arabic-Indic digits.

Found by the Gemini review on #2950.

### Tests

The unit tests for this behaviour live in the PR stacked on top of this one (#2950), which is where the `LocalizationResolver` test suite is introduced. It covers the shopper locale being honoured by asserting that the same format string yields different output for `Locale.US` and `Locale.FRANCE` — an assertion that fails against the previous implementation regardless of the machine's default locale.

## Checklist
- [x] Code is unit tested

## Ticket Number
COSDK-546

## Release notes
### Fixed
- Localized strings with format arguments are now formatted using the shopper locale instead of the device locale.