### PR TITLE
v6 - CI - Quote the acceptance app version name

### DIFF
--- a/.github/workflows/release_acceptance_app.yml
+++ b/.github/workflows/release_acceptance_app.yml
@@ -82,7 +82,8 @@ jobs:
           SIGNING_STORE_PASSWORD: ${{ secrets.ADYEN_ANDROID_ACCEPTANCE_SIGNING_PASSWORD }}
           SIGNING_KEY_ALIAS: ${{ secrets.ADYEN_ANDROID_ACCEPTANCE_SIGNING_KEY_ALIAS }}
           SIGNING_KEY_PASSWORD: ${{ secrets.ADYEN_ANDROID_ACCEPTANCE_SIGNING_PASSWORD }}
-        run: ./gradlew :example-app:assembleAcceptance -Pversion-name=$VERSION_NAME
+        # The version name is quoted to allow for spaces
+        run: ./gradlew :example-app:assembleAcceptance "-Pversion-name=$VERSION_NAME"
 
       - name: Upload to Firebase App Distribution
         # The version SHA refers to v1.7.1


### PR DESCRIPTION
## Description
The "Release acceptance app" workflow takes a free-form version name, but passed it to Gradle unquoted. A version name containing spaces was therefore split into separate words, and Gradle read everything after the first word as a task name.

[This run](https://github.com/Adyen/adyen-android/actions/runs/32274048296/job/96137098852) failed with `Task 'system' not found in root project 'adyen-android'` for the version name `Design system updates`, because the step expanded to:

    ./gradlew :example-app:assembleAcceptance -Pversion-name=Design system updates

Quoting the whole `-P` argument keeps it a single argument, whatever the version name contains.

Spaces are fine everywhere else in the pipeline, so the value itself needs no validation or sanitisation: `versionName` is an arbitrary display string for AGP (verified locally — the merged manifest ends up with `android:versionName="design system changes"`), and Firebase App Distribution accepts spaces in the display version.

`publish_to_maven_central.yml` and `release_snapshot.yml` use the same unquoted pattern, but are left alone here: their version names are either validated against the version name regex or derived from `date`, so they can never contain a space.

## Checklist
- [x] Changes are tested manually