### PR TITLE
v6 - Core - Fall back to the device locale when the session locale cannot be parsed

### DIFF
--- a/core/src/main/java/com/adyen/checkout/core/common/internal/CheckoutParamsFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/common/internal/CheckoutParamsFactory.kt
@@ -50,9 +50,7 @@ internal class CheckoutParamsFactory(
 
     private fun CheckoutSession.getShopperLocale(): Locale? {
         val shopperLocaleString = sessionSetupResponse.shopperLocale ?: return null
-        return runCatching {
-            LocaleUtil.fromLanguageTag(shopperLocaleString)
-        }.getOrElse {
+        return LocaleUtil.fromLanguageTagOrNull(shopperLocaleString) ?: run {
             // if we cannot parse the locale coming from the API we should not fail the payment
             adyenLog(AdyenLogLevel.ERROR) { "Failed to parse sessions locale $shopperLocaleString" }
             null

--- a/core/src/main/java/com/adyen/checkout/core/common/internal/helper/LocaleUtil.kt
+++ b/core/src/main/java/com/adyen/checkout/core/common/internal/helper/LocaleUtil.kt
@@ -41,10 +41,14 @@ internal object LocaleUtil {
     /**
      * Creates a Locale instance for a specific language tag.
      *
+     * [Locale.forLanguageTag] is lenient: when it cannot parse a tag it returns [Locale.ROOT] instead of
+     * failing, which is indistinguishable from a caller explicitly asking for the root locale. An empty
+     * language means nothing usable came out of the tag, so it is reported as a failure instead.
+     *
      * @param tag The tag of the language.
-     * @return The locale associated with that tag or null if tag in invalid.
+     * @return The locale associated with that tag, or null if the tag could not be parsed.
      */
-    fun fromLanguageTag(tag: String): Locale {
-        return Locale.forLanguageTag(tag)
+    fun fromLanguageTagOrNull(tag: String): Locale? {
+        return Locale.forLanguageTag(tag).takeIf { it.language.isNotEmpty() }
     }
 }

--- a/core/src/main/java/com/adyen/checkout/core/sessions/internal/model/SessionParamsFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/sessions/internal/model/SessionParamsFactory.kt
@@ -55,9 +55,7 @@ object SessionParamsFactory {
 
     private fun getShopperLocale(shopperLocaleString: String?): Locale? {
         if (shopperLocaleString == null) return null
-        return runCatching {
-            LocaleUtil.fromLanguageTag(shopperLocaleString)
-        }.getOrElse {
+        return LocaleUtil.fromLanguageTagOrNull(shopperLocaleString) ?: run {
             // if we cannot parse the locale coming from the API we should not fail the payment
             adyenLog(AdyenLogLevel.ERROR) { "Failed to parse sessions locale $shopperLocaleString" }
             null

--- a/core/src/test/java/com/adyen/checkout/core/common/internal/CheckoutParamsFactoryTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/common/internal/CheckoutParamsFactoryTest.kt
@@ -67,6 +67,17 @@ internal class CheckoutParamsFactoryTest {
         }
 
         @Test
+        fun `when configuration has no shopperLocale and session locale is malformed, then use device locale`() {
+            val configuration = createConfiguration(shopperLocale = null)
+            // Underscores instead of hyphens, a common mistake when a Java Locale is stringified
+            val session = createSession(shopperLocale = "en_US")
+
+            val result = factory.create(configuration, session, null)
+
+            assertEquals(deviceLocale, result.shopperLocale)
+        }
+
+        @Test
         fun `when configuration has no shopperLocale and session is null, then use device locale`() {
             val configuration = createConfiguration(shopperLocale = null)
 

--- a/core/src/test/java/com/adyen/checkout/core/common/internal/helper/LocaleUtilTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/common/internal/helper/LocaleUtilTest.kt
@@ -60,17 +60,30 @@ internal class LocaleUtilTest {
     }
 
     @Test
-    fun `when fromLanguageTag is called with valid tag then return locale`() {
-        val result = LocaleUtil.fromLanguageTag("en-US")
+    fun `when fromLanguageTagOrNull is called with valid tag then return locale`() {
+        val result = LocaleUtil.fromLanguageTagOrNull("en-US")
 
         assertEquals(Locale.US, result)
     }
 
-    @Test
-    fun `when fromLanguageTag is called with empty tag then return empty locale`() {
-        val result = LocaleUtil.fromLanguageTag("")
+    @ParameterizedTest
+    @MethodSource("unparsableLanguageTagsSource")
+    fun `when fromLanguageTagOrNull is called with an unparsable tag then return null`(tag: String) {
+        val result = LocaleUtil.fromLanguageTagOrNull(tag)
 
-        assertEquals(Locale(""), result)
+        assertNull(result)
+    }
+
+    // Locale.forLanguageTag recovers a usable language from these, so they are not treated as failures.
+    @ParameterizedTest
+    @MethodSource("leniantlyParsedLanguageTagsSource")
+    fun `when fromLanguageTagOrNull is called with a partially valid tag then return locale`(
+        tag: String,
+        expected: Locale,
+    ) {
+        val result = LocaleUtil.fromLanguageTagOrNull(tag)
+
+        assertEquals(expected, result)
     }
 
     companion object {
@@ -103,6 +116,25 @@ internal class LocaleUtilTest {
             arguments(Locale("toolongcode")),
             // Invalid characters in language
             arguments(Locale("en-US")),
+        )
+
+        @JvmStatic
+        fun unparsableLanguageTagsSource() = listOf(
+            arguments(""),
+            // Underscores instead of hyphens, a common mistake when a Java Locale is stringified
+            arguments("en_US"),
+            arguments("not a language tag"),
+            arguments("-en"),
+            // Language subtag longer than the 8 characters BCP 47 allows
+            arguments("abcdefghi"),
+        )
+
+        @JvmStatic
+        fun leniantlyParsedLanguageTagsSource() = listOf(
+            arguments("en-US", Locale.US),
+            arguments("en-", Locale("en")),
+            arguments("en--US", Locale("en")),
+            arguments("en-US-u-", Locale.US),
         )
     }
 }

--- a/core/src/test/java/com/adyen/checkout/core/sessions/internal/model/SessionParamsFactoryTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/sessions/internal/model/SessionParamsFactoryTest.kt
@@ -184,15 +184,12 @@ internal class SessionParamsFactoryTest {
         }
 
         @Test
-        fun `when the shopper locale is malformed, then the root locale is returned`() {
-            // Documents current behaviour rather than intended behaviour: Locale.forLanguageTag does not throw
-            // for malformed tags, it returns the root locale, so the runCatching fallback in
-            // SessionParamsFactory is unreachable and the malformed locale is never turned into null.
+        fun `when the shopper locale is malformed, then the shopper locale is null`() {
             val session = createSession(shopperLocale = "not a language tag")
 
             val result = SessionParamsFactory.create(session)
 
-            assertEquals(Locale.ROOT, result.shopperLocale)
+            assertNull(result.shopperLocale)
         }
     }
 


### PR DESCRIPTION
## Description

`LocaleUtil.fromLanguageTag` delegated to `Locale.forLanguageTag`, which returns `Locale.ROOT` for a tag it cannot parse instead of throwing. Both call sites wrapped it in `runCatching { ... }.getOrElse { log; null }`, so that fallback never fired: a malformed session locale was applied as `Locale.ROOT` rather than falling back to the device locale, and nothing was logged. The existing KDoc already promised `null` for an invalid tag, which the non-nullable return type could not deliver.

This matters because `CheckoutParams.shopperLocale` builds the localized `Context` for every string resource and supplies the locale to `Amount.format` and `String.format`, so the whole checkout rendered in the root locale. The realistic trigger is `nl_NL` instead of `nl-NL` — the form `Locale.toString()` produces.

```kotlin
fun fromLanguageTagOrNull(tag: String): Locale? {
    return Locale.forLanguageTag(tag).takeIf { it.language.isNotEmpty() }
}
```

| Session `shopperLocale` | Before | After |
|---|---|---|
| `nl-NL`, `en-`, `en--US` | parsed locale | unchanged |
| `nl_NL`, empty, `not a language tag` | `Locale.ROOT` applied | device locale, error logged |

Not switched to the strict `Locale.Builder().setLanguageTag(...)` parser, since that would also reject `en-` and `en--US`, which resolve to a usable `en` today. This reduces the failure mode rather than eliminating it — structurally valid nonsense such as `english` still parses.

Only the v6 `core` copy is changed; the v5 `checkout-core` equivalent has the same issue but is in maintenance.

Raised from Oscar's review comment on #2950.

## Checklist
- [x] Code is unit tested

## Ticket Number
COSDK-546

## Release notes
### Fixed
- A shopper locale that cannot be parsed from the session response now falls back to the device locale instead of being applied as the root locale.
