### PR TITLE
v5 - CI - Verification metadata workflow trigger

### DIFF
--- a/.agents/skills/android-update-dependencies-v5/DIFFERENCES.md
+++ b/.agents/skills/android-update-dependencies-v5/DIFFERENCES.md
@@ -37,6 +37,7 @@ This is expected and self-correcting — the next quarterly run takes them. Do n
 | No `merge_group` triggers, no `github.event_name == 'pull_request'` guards, and simpler concurrency groups | v5 does not use merge queues. `main` needs the `pull_request.number \|\| sha` fallback because `head_ref` is empty in a merge group | #2886 |
 | `check_v5.yml` in place of `check_main.yml`, and `v5` branch triggers throughout | Branch identity | #2886 |
 | No prerelease handling — `create_github_release` has no `prerelease` input, `generate_version_name` has no prerelease outputs and uses `version_name.sh` rather than `version_info.sh` and `version_name_from_branch.sh`, `finalize_release` has no `version_info` job or `omitPrereleaseDuringUpdate`, and `update_release_notes` sets `draft: true` | v5 ships stable releases only; prereleases are a v6 concept | #2886 |
+| `update_verification_metadata.yml` has no `push` trigger | Step 7 regenerates the metadata once, when versions are final. On `main` the trigger serves single-dependency branches nobody touches. Kept dispatchable | #2956 |
 | `release_nightly_app.yml` absent | v5 has no nightly builds | #2886 |
 | `release_acceptance_app.yml` has no `workflow_call` block | That block exists on `main` only so `release_nightly_app.yml` can call it, and v5 does not have that workflow | #2886 |
 | `run_ui_tests.yml` absent | v5 is a maintenance branch and does not run instrumentation tests | #2886 |

--- a/.agents/skills/android-update-dependencies-v5/SKILL.md
+++ b/.agents/skills/android-update-dependencies-v5/SKILL.md
@@ -144,11 +144,7 @@ Account for every removed line. If something does not fit a known codegen catego
 
 Do this **last**, once versions are final, as its own commit.
 
-```
-./gradlew --write-verification-metadata sha256 resolveDependencies assembleDebug --refresh-dependencies
-```
-
-`--refresh-dependencies` matters. The writer only records what the build actually resolves, so with a warm cache it silently misses artifacts and the failure surfaces later as a verification error on a cold CI runner.
+Run the command from `.github/workflows/update_verification_metadata.yml`, which step 1 keeps in sync with `main`.
 
 ### 8. Verify
 

--- a/.github/workflows/update_verification_metadata.yml
+++ b/.github/workflows/update_verification_metadata.yml
@@ -1,9 +1,6 @@
 name: Update verification metadata
 
 on:
-  push:
-    branches:
-      - 'renovate/v5-all-v5'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Description
Step 7 of the dependency update skill regenerates the verification metadata on the branch, so the workflow no longer needs to run on every push to `renovate/v5-all-v5`. `workflow_dispatch` is kept in case the job is.

Step 7 also stopped spelling out its own `--write-verification-metadata` command. It duplicated the one in the workflow, which step 1 syncs from `main`, so when `main` changed that command the copy in the skill would have been left behind — as it already has been, since `main` dropped `assembleDebug` from it.

## Checklist
- [x] Changes are tested manually
