### PR TITLE
v6 - Components - Submit button in every component

### DIFF
--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/BlikFactory.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/BlikFactory.kt
@@ -20,6 +20,10 @@ import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPayment
 import com.adyen.checkout.core.components.internal.PaymentComponentFactory
 import com.adyen.checkout.core.components.internal.StoredPaymentComponentFactory
 import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateFactory
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateReducer
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateValidator
+import com.adyen.checkout.core.components.internal.ui.state.GenericViewStateProducer
 import kotlinx.coroutines.CoroutineScope
 
 internal class BlikFactory :
@@ -56,6 +60,11 @@ internal class BlikFactory :
             storedPaymentMethod = storedPaymentMethod,
             analyticsManager = analyticsManager,
             sdkDataProvider = sdkDataProvider,
+            componentStateValidator = GenericComponentStateValidator(),
+            componentStateFactory = GenericComponentStateFactory(),
+            componentStateReducer = GenericComponentStateReducer(),
+            viewStateProducer = GenericViewStateProducer(params.amount, params.showSubmitButton),
+            coroutineScope = coroutineScope,
         )
     }
 }

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/StoredBlikComponent.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/StoredBlikComponent.kt
@@ -18,19 +18,42 @@ import com.adyen.checkout.core.components.data.PaymentComponentData
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPaymentMethod
 import com.adyen.checkout.core.components.internal.PaymentComponentEvent
 import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
+import com.adyen.checkout.core.components.internal.ui.GenericContent
 import com.adyen.checkout.core.components.internal.ui.PaymentComponent
+import com.adyen.checkout.core.components.internal.ui.state.ComponentStateFlow
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateFactory
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateReducer
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateValidator
+import com.adyen.checkout.core.components.internal.ui.state.GenericIntent
+import com.adyen.checkout.core.components.internal.ui.state.GenericViewStateProducer
+import com.adyen.checkout.core.components.internal.ui.state.viewState
 import com.adyen.checkout.core.components.paymentmethod.BlikDetails
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.receiveAsFlow
 
+@Suppress("LongParameterList")
 internal class StoredBlikComponent(
     private val storedPaymentMethod: StoredPaymentMethod,
     private val analyticsManager: AnalyticsManager,
     private val sdkDataProvider: SdkDataProvider,
+    private val componentStateValidator: GenericComponentStateValidator,
+    componentStateFactory: GenericComponentStateFactory,
+    componentStateReducer: GenericComponentStateReducer,
+    viewStateProducer: GenericViewStateProducer,
+    coroutineScope: CoroutineScope,
 ) : PaymentComponent {
 
     private val eventChannel = bufferedChannel<PaymentComponentEvent>()
     override val eventFlow: Flow<PaymentComponentEvent> = eventChannel.receiveAsFlow()
+
+    private val componentState = ComponentStateFlow(
+        initialState = componentStateFactory.createInitialState(),
+        reducer = componentStateReducer,
+        validator = componentStateValidator,
+    )
+
+    internal val viewState = componentState.viewState(viewStateProducer, coroutineScope)
 
     init {
         trackRenderEvent()
@@ -46,12 +69,21 @@ internal class StoredBlikComponent(
 
     @Composable
     override fun Content(modifier: Modifier) {
-        // This component has no UI
+        GenericContent(
+            viewStateFlow = viewState,
+            onSubmitClick = ::submit,
+            modifier = modifier,
+        )
     }
 
     override fun submit() {
-        val paymentComponentState = createPaymentComponentState()
-        eventChannel.trySend(PaymentComponentEvent.Submit(paymentComponentState))
+        // extra safety call, expected to always be valid
+        if (componentStateValidator.isValid(componentState.value)) {
+            val paymentComponentState = createPaymentComponentState()
+            eventChannel.trySend(
+                PaymentComponentEvent.Submit(paymentComponentState),
+            )
+        }
     }
 
     private fun createPaymentComponentState(): BlikPaymentComponentState {
@@ -75,7 +107,9 @@ internal class StoredBlikComponent(
 
     override fun requiresUserInteraction(): Boolean = false
 
-    override fun setLoading(isLoading: Boolean) = Unit
+    override fun setLoading(isLoading: Boolean) {
+        componentState.handleIntent(GenericIntent.UpdateLoading(isLoading))
+    }
 
     override fun onCleared() = Unit
 }

--- a/blik/src/test/java/com/adyen/checkout/blik/internal/ui/StoredBlikComponentTest.kt
+++ b/blik/src/test/java/com/adyen/checkout/blik/internal/ui/StoredBlikComponentTest.kt
@@ -10,14 +10,23 @@ package com.adyen.checkout.blik.internal.ui
 
 import com.adyen.checkout.core.analytics.internal.GenericEvents
 import com.adyen.checkout.core.analytics.internal.TestAnalyticsManager
+import com.adyen.checkout.core.components.data.model.Amount
 import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPaymentMethod
 import com.adyen.checkout.core.components.internal.PaymentComponentEvent
 import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateFactory
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateReducer
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateValidator
+import com.adyen.checkout.core.components.internal.ui.state.GenericViewStateProducer
 import com.adyen.checkout.test.extensions.test
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -89,15 +98,87 @@ internal class StoredBlikComponentTest(
         assertFalse(result)
     }
 
-    private fun createComponent(): StoredBlikComponent {
+    @Test
+    fun `when component is created then the pay button is shown`() = runTest {
+        // GIVEN
+        whenever(storedPaymentMethod.type) doReturn PAYMENT_METHOD_TYPE
+        val component = createComponent(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+
+        // WHEN
+        val viewState = component.viewState.test(testScheduler)
+
+        // THEN
+        assertNotNull(viewState.latestValue.payButtonViewState)
+    }
+
+    @Test
+    fun `when show submit button is false then the pay button is not shown`() = runTest {
+        // GIVEN
+        whenever(storedPaymentMethod.type) doReturn PAYMENT_METHOD_TYPE
+        val component = createComponent(
+            coroutineScope = CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
+            showSubmitButton = false,
+        )
+
+        // WHEN
+        val viewState = component.viewState.test(testScheduler)
+
+        // THEN
+        assertNull(viewState.latestValue.payButtonViewState)
+    }
+
+    @Test
+    fun `when setLoading is called with true then the button is loading`() = runTest {
+        // GIVEN
+        whenever(storedPaymentMethod.type) doReturn PAYMENT_METHOD_TYPE
+        val component = createComponent(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+        val viewState = component.viewState.test(testScheduler)
+
+        // WHEN
+        component.setLoading(true)
+
+        // THEN
+        assertTrue(viewState.latestValue.isLoading)
+        assertTrue(requireNotNull(viewState.latestValue.payButtonViewState).isLoading)
+    }
+
+    @Test
+    fun `when setLoading is called with false then the button is not loading`() = runTest {
+        // GIVEN
+        whenever(storedPaymentMethod.type) doReturn PAYMENT_METHOD_TYPE
+        val component = createComponent(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+        val viewState = component.viewState.test(testScheduler)
+        component.setLoading(true)
+
+        // WHEN
+        component.setLoading(false)
+
+        // THEN
+        assertFalse(viewState.latestValue.isLoading)
+        assertFalse(requireNotNull(viewState.latestValue.payButtonViewState).isLoading)
+    }
+
+    private fun createComponent(
+        coroutineScope: CoroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+        showSubmitButton: Boolean = true,
+    ): StoredBlikComponent {
         return StoredBlikComponent(
             storedPaymentMethod = storedPaymentMethod,
             analyticsManager = analyticsManager,
             sdkDataProvider = sdkDataProvider,
+            componentStateValidator = GenericComponentStateValidator(),
+            componentStateFactory = GenericComponentStateFactory(),
+            componentStateReducer = GenericComponentStateReducer(),
+            viewStateProducer = GenericViewStateProducer(
+                amount = TEST_AMOUNT,
+                showSubmitButton = showSubmitButton,
+            ),
+            coroutineScope = coroutineScope,
         )
     }
 
     companion object {
         private const val PAYMENT_METHOD_TYPE = "blik"
+        private val TEST_AMOUNT = Amount(currency = "EUR", value = 1337)
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/StoredCardComponent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/StoredCardComponent.kt
@@ -159,8 +159,13 @@ constructor(
         )
     }
 
-    override fun requiresUserInteraction(): Boolean =
-        componentState.value.securityCode.requirementPolicy == RequirementPolicy.Required
+    override fun requiresUserInteraction(): Boolean {
+        return when (componentState.value.securityCode.requirementPolicy) {
+            RequirementPolicy.Hidden -> false
+            RequirementPolicy.Optional -> true
+            RequirementPolicy.Required -> true
+        }
+    }
 
     override fun setLoading(isLoading: Boolean) {
         onIntent(StoredCardIntent.UpdateLoading(isLoading))

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardContent.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/view/StoredCardContent.kt
@@ -55,26 +55,27 @@ private fun StoredCardContent(
     onSubmitClick: () -> Unit,
     modifier: Modifier,
 ) {
-    // If security code is not displayed, we should not display anything
-    if (viewState.securityCode != null) {
-        ComponentScaffold(
-            modifier = modifier,
-            disableInteraction = viewState.isLoading,
-            footer = payButtonAsComponentScaffoldFooter(viewState.payButtonViewState, onSubmitClick),
-        ) {
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.ExtraLarge),
-            ) {
-                SecurityCodeField(
-                    securityCodeState = viewState.securityCode,
-                    cardNumberFormat = viewState.cardNumberFormat,
-                    onValueChange = { onIntent(StoredCardIntent.UpdateSecurityCode(it)) },
-                    onFocusChange = { onIntent(StoredCardIntent.UpdateSecurityCodeFocus(it)) },
-                )
+    ComponentScaffold(
+        modifier = modifier,
+        disableInteraction = viewState.isLoading,
+        footer = payButtonAsComponentScaffoldFooter(viewState.payButtonViewState, onSubmitClick),
+        // If security code is not displayed, we should not display any content
+        content = viewState.securityCode?.let { securityCodeState ->
+            @Composable {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(Dimensions.Spacing.ExtraLarge),
+                ) {
+                    SecurityCodeField(
+                        securityCodeState = securityCodeState,
+                        cardNumberFormat = viewState.cardNumberFormat,
+                        onValueChange = { onIntent(StoredCardIntent.UpdateSecurityCode(it)) },
+                        onFocusChange = { onIntent(StoredCardIntent.UpdateSecurityCodeFocus(it)) },
+                    )
+                }
             }
-        }
-    }
+        },
+    )
 }
 
 @Preview
@@ -87,6 +88,29 @@ private fun StoredCardContentPreview(
             securityCode = TextInputViewState(
                 customTrailingIcon = SecurityCodeTrailingIcon.PlaceholderDefault,
             ),
+            brand = CardBrand(""),
+            cardNumberFormat = CardNumberFormat.DEFAULT,
+            isLoading = false,
+            payButtonViewState = PayButtonViewState(null, false),
+        )
+
+        StoredCardContent(
+            viewState = viewState,
+            onIntent = {},
+            onSubmitClick = {},
+            modifier = Modifier,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun StoredCardContentWithoutSecurityCodePreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        val viewState = StoredCardViewState(
+            securityCode = null,
             brand = CardBrand(""),
             cardNumberFormat = CardNumberFormat.DEFAULT,
             isLoading = false,

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewStateProducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewStateProducerTest.kt
@@ -15,6 +15,7 @@ import com.adyen.checkout.core.common.CardBrand
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import com.adyen.checkout.core.components.data.model.Amount
 import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
+import com.adyen.checkout.core.components.internal.ui.state.model.RequirementPolicy
 import com.adyen.checkout.core.components.internal.ui.state.model.TextInputComponentState
 import com.adyen.checkout.core.components.internal.ui.state.model.TrailingIcon
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -54,6 +55,21 @@ internal class StoredCardViewStateProducerTest {
 
         // THEN
         assertNull(viewState.payButtonViewState)
+    }
+
+    @Test
+    fun `when security code is hidden, then it is not in the view state but the pay button still is`() {
+        // GIVEN
+        val componentState = createComponentState(
+            securityCode = TextInputComponentState(requirementPolicy = RequirementPolicy.Hidden),
+        )
+
+        // WHEN
+        val viewState = producer.produce(componentState)
+
+        // THEN
+        assertNull(viewState.securityCode)
+        assertEquals(PayButtonViewState(TEST_AMOUNT, false), viewState.payButtonViewState)
     }
 
     @Test

--- a/core/src/main/java/com/adyen/checkout/core/components/CheckoutController.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/CheckoutController.kt
@@ -115,7 +115,9 @@ class CheckoutController internal constructor(
      * After calling this method, the input data is validated. If validation fails, the corresponding errors
      * are displayed in the UI and the submission is aborted.
      *
-     * If [requiresUserInteraction] returns `false`, this can be called directly without waiting for
+     * This method should be used when displaying a custom submit button.
+     *
+     * When [requiresUserInteraction] returns `false`, this can be called directly without waiting for
      * user input.
      */
     fun submit() {
@@ -125,8 +127,8 @@ class CheckoutController internal constructor(
     /**
      * Indicates whether the payment method requires user interaction before submitting.
      *
-     * When this returns `false`, no UI needs to be rendered and [submit] can be called directly
-     * without requiring a user action (e.g. a button click).
+     * When this returns `false`, [submit] can be called directly to skip a user action (e.g. a button click).
+     * Rendering the payment method UI is optional.
      *
      * When this returns `true`, the payment method UI should be displayed so the user can provide
      * the required input before calling [submit].

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/GenericContent.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/GenericContent.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 11/8/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui
+
+import androidx.annotation.RestrictTo
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.adyen.checkout.core.components.internal.ui.state.GenericViewState
+import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
+import com.adyen.checkout.ui.internal.element.ComponentScaffold
+import com.adyen.checkout.ui.internal.helper.CheckoutThemePreviewWrapper
+import com.adyen.checkout.ui.internal.helper.ThemePreviewParameterProvider
+import com.adyen.checkout.ui.theme.CheckoutTheme
+import kotlinx.coroutines.flow.StateFlow
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Composable
+fun GenericContent(
+    viewStateFlow: StateFlow<GenericViewState>,
+    onSubmitClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val viewState by viewStateFlow.collectAsStateWithLifecycle()
+    GenericContent(
+        viewState = viewState,
+        onSubmitClick = onSubmitClick,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun GenericContent(
+    viewState: GenericViewState,
+    onSubmitClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    ComponentScaffold(
+        modifier = modifier,
+        disableInteraction = viewState.isLoading,
+        footer = payButtonAsComponentScaffoldFooter(viewState.payButtonViewState, onSubmitClick),
+        content = null,
+    )
+}
+
+@Preview
+@Composable
+private fun GenericContentPreview(
+    @PreviewParameter(ThemePreviewParameterProvider::class) theme: CheckoutTheme,
+) {
+    CheckoutThemePreviewWrapper(theme) {
+        val viewState = GenericViewState(
+            isLoading = false,
+            payButtonViewState = PayButtonViewState(null, false),
+        )
+
+        GenericContent(
+            viewState = viewState,
+            onSubmitClick = {},
+            modifier = Modifier,
+        )
+    }
+}

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/GenericPaymentComponent.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/GenericPaymentComponent.kt
@@ -16,19 +16,41 @@ import com.adyen.checkout.core.common.internal.helper.bufferedChannel
 import com.adyen.checkout.core.components.data.PaymentComponentData
 import com.adyen.checkout.core.components.internal.PaymentComponentEvent
 import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
+import com.adyen.checkout.core.components.internal.ui.state.ComponentStateFlow
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateFactory
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateReducer
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateValidator
+import com.adyen.checkout.core.components.internal.ui.state.GenericIntent
 import com.adyen.checkout.core.components.internal.ui.state.GenericPaymentComponentState
+import com.adyen.checkout.core.components.internal.ui.state.GenericViewStateProducer
+import com.adyen.checkout.core.components.internal.ui.state.viewState
 import com.adyen.checkout.core.components.paymentmethod.GenericDetails
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.receiveAsFlow
 
+@Suppress("LongParameterList")
 internal class GenericPaymentComponent(
     private val analyticsManager: AnalyticsManager,
     private val paymentMethodType: String,
     private val sdkDataProvider: SdkDataProvider,
+    private val componentStateValidator: GenericComponentStateValidator,
+    componentStateFactory: GenericComponentStateFactory,
+    componentStateReducer: GenericComponentStateReducer,
+    viewStateProducer: GenericViewStateProducer,
+    coroutineScope: CoroutineScope,
 ) : PaymentComponent {
 
     private val eventChannel = bufferedChannel<PaymentComponentEvent>()
     override val eventFlow: Flow<PaymentComponentEvent> = eventChannel.receiveAsFlow()
+
+    private val componentState = ComponentStateFlow(
+        initialState = componentStateFactory.createInitialState(),
+        reducer = componentStateReducer,
+        validator = componentStateValidator,
+    )
+
+    internal val viewState = componentState.viewState(viewStateProducer, coroutineScope)
 
     init {
         trackRenderEvent()
@@ -41,11 +63,25 @@ internal class GenericPaymentComponent(
 
     @Composable
     override fun Content(modifier: Modifier) {
-        // This component has no UI
+        GenericContent(
+            viewStateFlow = viewState,
+            onSubmitClick = ::submit,
+            modifier = modifier,
+        )
     }
 
     override fun submit() {
-        val paymentComponentState = GenericPaymentComponentState(
+        // extra safety call, expected to always be valid
+        if (componentStateValidator.isValid(componentState.value)) {
+            val paymentComponentState = createPaymentComponentState()
+            eventChannel.trySend(
+                PaymentComponentEvent.Submit(paymentComponentState),
+            )
+        }
+    }
+
+    private fun createPaymentComponentState(): GenericPaymentComponentState {
+        return GenericPaymentComponentState(
             data = PaymentComponentData(
                 paymentMethod = GenericDetails(
                     type = paymentMethodType,
@@ -57,16 +93,12 @@ internal class GenericPaymentComponent(
             ),
             isValid = true,
         )
-
-        eventChannel.trySend(
-            PaymentComponentEvent.Submit(paymentComponentState),
-        )
     }
 
     override fun requiresUserInteraction(): Boolean = false
 
     override fun setLoading(isLoading: Boolean) {
-        // There is no UI to display a loading state
+        componentState.handleIntent(GenericIntent.UpdateLoading(isLoading))
     }
 
     override fun onCleared() = Unit

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/GenericPaymentComponentFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/GenericPaymentComponentFactory.kt
@@ -14,6 +14,10 @@ import com.adyen.checkout.core.components.CheckoutAdditionalCallback
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
 import com.adyen.checkout.core.components.internal.PaymentComponentFactory
 import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateFactory
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateReducer
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateValidator
+import com.adyen.checkout.core.components.internal.ui.state.GenericViewStateProducer
 import kotlinx.coroutines.CoroutineScope
 
 internal object GenericPaymentComponentFactory : PaymentComponentFactory<GenericPaymentComponent> {
@@ -30,6 +34,11 @@ internal object GenericPaymentComponentFactory : PaymentComponentFactory<Generic
             analyticsManager = analyticsManager,
             paymentMethodType = paymentMethod.type,
             sdkDataProvider = sdkDataProvider,
+            componentStateValidator = GenericComponentStateValidator(),
+            componentStateFactory = GenericComponentStateFactory(),
+            componentStateReducer = GenericComponentStateReducer(),
+            viewStateProducer = GenericViewStateProducer(params.amount, params.showSubmitButton),
+            coroutineScope = coroutineScope,
         )
     }
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericComponentState.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericComponentState.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 11/8/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui.state
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class GenericComponentState(
+    val isLoading: Boolean,
+) : ComponentState

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericComponentStateFactory.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericComponentStateFactory.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 11/8/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui.state
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class GenericComponentStateFactory : ComponentStateFactory<GenericComponentState> {
+
+    override fun createInitialState() = GenericComponentState(
+        isLoading = false,
+    )
+}

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericComponentStateReducer.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericComponentStateReducer.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 11/8/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui.state
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class GenericComponentStateReducer : ComponentStateReducer<GenericComponentState, GenericIntent> {
+
+    override fun reduce(state: GenericComponentState, intent: GenericIntent): GenericComponentState {
+        return when (intent) {
+            is GenericIntent.UpdateLoading -> state.copy(isLoading = intent.isLoading)
+        }
+    }
+}

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericComponentStateValidator.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericComponentStateValidator.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 11/8/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui.state
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class GenericComponentStateValidator : ComponentStateValidator<GenericComponentState> {
+
+    override fun validate(state: GenericComponentState): GenericComponentState {
+        return state
+    }
+
+    override fun isValid(state: GenericComponentState): Boolean {
+        return true
+    }
+}

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericIntent.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericIntent.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 11/8/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui.state
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+sealed interface GenericIntent : ComponentStateIntent {
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class UpdateLoading(val isLoading: Boolean) : GenericIntent
+}

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericViewState.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericViewState.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 11/8/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui.state
+
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class GenericViewState(
+    val isLoading: Boolean,
+    val payButtonViewState: PayButtonViewState?
+) : ViewState

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericViewStateProducer.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/GenericViewStateProducer.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 11/8/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui.state
+
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.core.components.data.model.Amount
+import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class GenericViewStateProducer(
+    private val amount: Amount?,
+    private val showSubmitButton: Boolean,
+) : ViewStateProducer<GenericComponentState, GenericViewState> {
+
+    override fun produce(state: GenericComponentState): GenericViewState {
+        return GenericViewState(
+            isLoading = state.isLoading,
+            payButtonViewState = if (showSubmitButton) PayButtonViewState(amount, state.isLoading) else null,
+        )
+    }
+}

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentMethodProviderTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/PaymentMethodProviderTest.kt
@@ -211,7 +211,8 @@ internal class PaymentMethodProviderTest {
         runTest {
             val actualComponent = PaymentMethodProvider.getPaymentComponent(
                 paymentMethod = GenericPaymentMethod(type = "unregistered_txVariant", name = "name"),
-                coroutineScope = this,
+                // The component keeps its view state alive in this scope, so it has to be one that the test cancels
+                coroutineScope = backgroundScope,
                 analyticsManager = TestAnalyticsManager(),
                 sdkDataProvider = generateSdkDataProvider(),
                 params = generateCheckoutParams(),

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/ui/GenericPaymentComponentTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/ui/GenericPaymentComponentTest.kt
@@ -11,14 +11,23 @@ package com.adyen.checkout.core.components.internal.ui
 import com.adyen.checkout.core.analytics.internal.GenericEvents
 import com.adyen.checkout.core.analytics.internal.TestAnalyticsManager
 import com.adyen.checkout.core.common.test
+import com.adyen.checkout.core.components.data.model.Amount
 import com.adyen.checkout.core.components.internal.PaymentComponentEvent
 import com.adyen.checkout.core.components.internal.data.provider.SdkDataProvider
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateFactory
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateReducer
+import com.adyen.checkout.core.components.internal.ui.state.GenericComponentStateValidator
 import com.adyen.checkout.core.components.internal.ui.state.GenericPaymentComponentState
+import com.adyen.checkout.core.components.internal.ui.state.GenericViewStateProducer
 import com.adyen.checkout.core.components.paymentmethod.GenericDetails
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -160,16 +169,96 @@ internal class GenericPaymentComponentTest(
         verify(sdkDataProvider).createEncodedSdkData()
     }
 
-    private fun createComponent(): GenericPaymentComponent {
+    @Test
+    fun `when requiresUserInteraction is called, then it returns false`() {
+        // GIVEN
+        val component = createComponent()
+
+        // WHEN
+        val result = component.requiresUserInteraction()
+
+        // THEN
+        assertFalse(result)
+    }
+
+    @Test
+    fun `when component is created, then the pay button is shown`() = runTest {
+        // GIVEN
+        val component = createComponent(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+
+        // WHEN
+        val viewState = component.viewState.test(testScheduler)
+
+        // THEN
+        assertNotNull(viewState.latestValue.payButtonViewState)
+    }
+
+    @Test
+    fun `when show submit button is false, then the pay button is not shown`() = runTest {
+        // GIVEN
+        val component = createComponent(
+            coroutineScope = CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
+            showSubmitButton = false,
+        )
+
+        // WHEN
+        val viewState = component.viewState.test(testScheduler)
+
+        // THEN
+        assertNull(viewState.latestValue.payButtonViewState)
+    }
+
+    @Test
+    fun `when setLoading is called with true, then the button is loading`() = runTest {
+        // GIVEN
+        val component = createComponent(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+        val viewState = component.viewState.test(testScheduler)
+
+        // WHEN
+        component.setLoading(true)
+
+        // THEN
+        assertTrue(viewState.latestValue.isLoading)
+        assertTrue(requireNotNull(viewState.latestValue.payButtonViewState).isLoading)
+    }
+
+    @Test
+    fun `when setLoading is called with false, then the button is not loading`() = runTest {
+        // GIVEN
+        val component = createComponent(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+        val viewState = component.viewState.test(testScheduler)
+        component.setLoading(true)
+
+        // WHEN
+        component.setLoading(false)
+
+        // THEN
+        assertFalse(viewState.latestValue.isLoading)
+        assertFalse(requireNotNull(viewState.latestValue.payButtonViewState).isLoading)
+    }
+
+    private fun createComponent(
+        coroutineScope: CoroutineScope = CoroutineScope(UnconfinedTestDispatcher()),
+        showSubmitButton: Boolean = true,
+    ): GenericPaymentComponent {
         return GenericPaymentComponent(
             analyticsManager = analyticsManager,
             paymentMethodType = TEST_PAYMENT_METHOD_TYPE,
             sdkDataProvider = sdkDataProvider,
+            componentStateValidator = GenericComponentStateValidator(),
+            componentStateFactory = GenericComponentStateFactory(),
+            componentStateReducer = GenericComponentStateReducer(),
+            viewStateProducer = GenericViewStateProducer(
+                amount = TEST_AMOUNT,
+                showSubmitButton = showSubmitButton,
+            ),
+            coroutineScope = coroutineScope,
         )
     }
 
     companion object {
         private const val TEST_PAYMENT_METHOD_TYPE = "test_payment_method"
         private const val TEST_SDK_DATA = "test_sdk_data"
+        private val TEST_AMOUNT = Amount(currency = "EUR", value = 1337)
     }
 }

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/ui/state/GenericComponentStateFactoryTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/ui/state/GenericComponentStateFactoryTest.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 17/8/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui.state
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class GenericComponentStateFactoryTest {
+
+    private lateinit var factory: GenericComponentStateFactory
+
+    @BeforeEach
+    fun beforeEach() {
+        factory = GenericComponentStateFactory()
+    }
+
+    @Test
+    fun `when creating initial state, then conform with expected state`() {
+        // WHEN
+        val actual = factory.createInitialState()
+
+        // THEN
+        val expected = GenericComponentState(isLoading = false)
+        assertEquals(expected, actual)
+    }
+}

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/ui/state/GenericComponentStateReducerTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/ui/state/GenericComponentStateReducerTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 17/8/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui.state
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class GenericComponentStateReducerTest {
+
+    private lateinit var reducer: GenericComponentStateReducer
+
+    @BeforeEach
+    fun beforeEach() {
+        reducer = GenericComponentStateReducer()
+    }
+
+    @Test
+    fun `when intent is UpdateLoading with true, then state is loading`() {
+        // GIVEN
+        val state = GenericComponentState(isLoading = false)
+
+        // WHEN
+        val actual = reducer.reduce(state, GenericIntent.UpdateLoading(true))
+
+        // THEN
+        assertEquals(state.copy(isLoading = true), actual)
+    }
+
+    @Test
+    fun `when intent is UpdateLoading with false, then state is not loading`() {
+        // GIVEN
+        val state = GenericComponentState(isLoading = true)
+
+        // WHEN
+        val actual = reducer.reduce(state, GenericIntent.UpdateLoading(false))
+
+        // THEN
+        assertEquals(state.copy(isLoading = false), actual)
+    }
+}

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/ui/state/GenericComponentStateValidatorTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/ui/state/GenericComponentStateValidatorTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 17/8/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui.state
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class GenericComponentStateValidatorTest {
+
+    private lateinit var validator: GenericComponentStateValidator
+
+    @BeforeEach
+    fun beforeEach() {
+        validator = GenericComponentStateValidator()
+    }
+
+    @Test
+    fun `when validating a state, then the state is returned unchanged`() {
+        // GIVEN
+        val state = GenericComponentState(isLoading = true)
+
+        // WHEN
+        val actual = validator.validate(state)
+
+        // THEN
+        assertEquals(state, actual)
+    }
+
+    @Test
+    fun `when checking a state, then it is always valid`() {
+        // GIVEN
+        val state = GenericComponentState(isLoading = false)
+
+        // WHEN
+        val actual = validator.isValid(state)
+
+        // THEN
+        assertTrue(actual)
+    }
+}

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/ui/state/GenericViewStateProducerTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/ui/state/GenericViewStateProducerTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 17/8/2026.
+ */
+
+package com.adyen.checkout.core.components.internal.ui.state
+
+import com.adyen.checkout.core.components.data.model.Amount
+import com.adyen.checkout.core.components.internal.ui.state.model.PayButtonViewState
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class GenericViewStateProducerTest {
+
+    private lateinit var producer: GenericViewStateProducer
+
+    @BeforeEach
+    fun beforeEach() {
+        producer = GenericViewStateProducer(amount = TEST_AMOUNT, showSubmitButton = true)
+    }
+
+    @Test
+    fun `when produce is called, then view state is created`() {
+        // GIVEN
+        val componentState = GenericComponentState(isLoading = false)
+
+        // WHEN
+        val actual = producer.produce(componentState)
+
+        // THEN
+        val expected = GenericViewState(
+            isLoading = false,
+            payButtonViewState = PayButtonViewState(amount = TEST_AMOUNT, isLoading = false),
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `when state is loading, then loading is propagated to the view state and the pay button`() {
+        // GIVEN
+        val componentState = GenericComponentState(isLoading = true)
+
+        // WHEN
+        val actual = producer.produce(componentState)
+
+        // THEN
+        val expected = GenericViewState(
+            isLoading = true,
+            payButtonViewState = PayButtonViewState(amount = TEST_AMOUNT, isLoading = true),
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `when show submit button is false, then pay button view state is null`() {
+        // GIVEN
+        val producer = GenericViewStateProducer(amount = TEST_AMOUNT, showSubmitButton = false)
+        val componentState = GenericComponentState(isLoading = false)
+
+        // WHEN
+        val actual = producer.produce(componentState)
+
+        // THEN
+        assertNull(actual.payButtonViewState)
+    }
+
+    @Test
+    fun `when amount is null, then pay button view state carries a null amount`() {
+        // GIVEN
+        val producer = GenericViewStateProducer(amount = null, showSubmitButton = true)
+        val componentState = GenericComponentState(isLoading = false)
+
+        // WHEN
+        val actual = producer.produce(componentState)
+
+        // THEN
+        assertEquals(PayButtonViewState(amount = null, isLoading = false), actual.payButtonViewState)
+    }
+
+    companion object {
+        private val TEST_AMOUNT = Amount(currency = "EUR", value = 1337)
+    }
+}

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6SessionsViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6SessionsViewModel.kt
@@ -105,7 +105,7 @@ internal class V6SessionsViewModel @Inject constructor(
                     storedPaymentMethods = checkoutContext.getStoredPaymentMethods(),
                     selectedPaymentMethod = paymentMethods.first(),
                     checkoutController = checkoutController,
-                    showCustomButton = showCustomButton(checkoutController),
+                    showCustomButton = showCustomButton(),
                 )
             }
         }
@@ -137,7 +137,7 @@ internal class V6SessionsViewModel @Inject constructor(
         val newState = (uiState as? V6UiState.Component)?.copy(
             selectedPaymentMethod = paymentMethod,
             checkoutController = checkoutController,
-            showCustomButton = showCustomButton(checkoutController),
+            showCustomButton = showCustomButton(),
         )
 
         if (newState != null) {
@@ -174,8 +174,8 @@ internal class V6SessionsViewModel @Inject constructor(
         }
     }
 
-    private fun showCustomButton(checkoutController: CheckoutController): Boolean {
-        return checkoutConfiguration.showSubmitButton == false || !checkoutController.requiresUserInteraction()
+    private fun showCustomButton(): Boolean {
+        return checkoutConfiguration.showSubmitButton == false
     }
 
     fun onNewIntent(intent: Intent) {

--- a/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6ViewModel.kt
+++ b/example-app/src/main/java/com/adyen/checkout/example/ui/v6/V6ViewModel.kt
@@ -106,7 +106,7 @@ internal class V6ViewModel @Inject constructor(
                     storedPaymentMethods = checkoutContext.getStoredPaymentMethods(),
                     selectedPaymentMethod = paymentMethods.first(),
                     checkoutController = checkoutController,
-                    showCustomButton = showCustomButton(checkoutController),
+                    showCustomButton = showCustomButton(),
                 )
             }
         }
@@ -189,7 +189,7 @@ internal class V6ViewModel @Inject constructor(
         val newState = (uiState as? V6UiState.Component)?.copy(
             selectedPaymentMethod = paymentMethod,
             checkoutController = checkoutController,
-            showCustomButton = showCustomButton(checkoutController),
+            showCustomButton = showCustomButton(),
         )
 
         if (newState != null) {
@@ -227,8 +227,8 @@ internal class V6ViewModel @Inject constructor(
         }
     }
 
-    private fun showCustomButton(checkoutController: CheckoutController): Boolean {
-        return checkoutConfiguration.showSubmitButton == false || !checkoutController.requiresUserInteraction()
+    private fun showCustomButton(): Boolean {
+        return checkoutConfiguration.showSubmitButton == false
     }
 
     fun onNewIntent(intent: Intent) {


### PR DESCRIPTION
## Description

Every payment component now renders a submit button by default, including the ones that previously rendered no UI at all. Previously a component that collected no shopper input rendered nothing, and could only be submitted by merchant-written code:

```kotlin
if (!controller.requiresUserInteraction()) {
    controller.submit()
}
```

If that code was missing, the shopper was left on a blank screen with no way to pay and no error. Now every payment method works the same way with no custom integration code: the shopper presses the button and the payment is submitted.

`submit()` and `requiresUserInteraction()` are unchanged and remain available. They are only needed by merchants who hide our button and drive submission themselves.

### Per component

| Component | Renders by default | `requiresUserInteraction()` |
|---|---|---|
| Generic / instant | Button | `false` |
| Stored Blik | Button | `false` |
| Stored card, CVC shown | CVC field and button | `true` |
| Stored card, CVC hidden | Button | `false` |
| Card, MB Way, Blik | Form and button | `true` |
| Google Pay | Google Pay button | `true` |

The stored card component deliberately keeps its own UI and state instead of adopting the generic scaffolding, so that both flows work: `requiresUserInteraction()` follows the security code requirement policy.

Google Pay stays `requiresUserInteraction() == true` even though it is button-only, because its own sheet is the interaction. This is intentional.

### Internal

The generic and stored Blik components now have the same scaffolding as every other component — state, intent, factory, reducer, validator and view state producer — so a component with no input fields is structurally the same as one with fields, just with no content above the button.

### Example app

Both v6 flows now only fall back to a custom button when the submit button is explicitly hidden in the configuration, instead of also doing it for components that used to render nothing.

## Checklist
- [x] Code is unit tested
- [x] Changes are tested manually
- [x] Aligned public API changes with other platforms (if applicable)

## Ticket Number
COSDK-1487


## Release notes
### Changed
- All components now have a submit button by default. For payment methods that do not require any shopper input, `CheckoutController.requiresUserInteraction()` will return false to indicate that you can skip the button click and submit the component automatically using `CheckoutController.submit()`.