### PR TITLE
v6 - Drop-in - Checkout controller provider

### DIFF
--- a/core/src/testFixtures/java/com/adyen/checkout/core/common/TestCheckoutContext.kt
+++ b/core/src/testFixtures/java/com/adyen/checkout/core/common/TestCheckoutContext.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 26/8/2026.
+ */
+
+package com.adyen.checkout.core.common
+
+import com.adyen.checkout.core.components.CheckoutConfiguration
+import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethods
+
+/**
+ * Builds real [CheckoutContext] instances for tests.
+ *
+ * The constructors of the [CheckoutContext] subtypes are internal to this module, since an instance is only ever
+ * meant to come out of `Checkout.setup`. Tests in other modules therefore cannot build one, and cannot fake one
+ * either: [CheckoutContext] is a sealed interface and its subtypes are final data classes. This fixture hands out
+ * the real thing instead, so that no test has to mock a sealed subtype.
+ */
+object TestCheckoutContext {
+
+    const val TEST_CHECKOUT_ATTEMPT_ID = "test_checkout_attempt_id"
+
+    fun advanced(
+        paymentMethods: PaymentMethods,
+        checkoutConfiguration: CheckoutConfiguration,
+        checkoutAttemptId: String = TEST_CHECKOUT_ATTEMPT_ID,
+        publicKey: String? = null,
+    ): CheckoutContext.Advanced = CheckoutContext.Advanced(
+        paymentMethods = paymentMethods,
+        checkoutConfiguration = checkoutConfiguration,
+        checkoutAttemptId = checkoutAttemptId,
+        publicKey = publicKey,
+    )
+}

--- a/drop-in/build.gradle
+++ b/drop-in/build.gradle
@@ -88,6 +88,7 @@ dependencies {
     //Tests
     testImplementation testFixtures(project(':test-core'))
     testImplementation testFixtures(project(':components-core'))
+    testImplementation testFixtures(project(':core'))
     testImplementation libs.androidx.test.lifecycle
     testImplementation libs.json
     testImplementation libs.bundles.junit

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInControllerProvider.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInControllerProvider.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 26/8/2026.
+ */
+
+package com.adyen.checkout.dropin.internal.ui
+
+import com.adyen.checkout.core.action.data.ActionComponentData
+import com.adyen.checkout.core.common.CheckoutContext
+import com.adyen.checkout.core.components.AdditionalDetailsResult
+import com.adyen.checkout.core.components.AdvancedCheckoutCallbacks
+import com.adyen.checkout.core.components.BeforeSubmitResult
+import com.adyen.checkout.core.components.CheckoutController
+import com.adyen.checkout.core.components.CheckoutTarget
+import com.adyen.checkout.core.components.SessionCheckoutCallbacks
+import com.adyen.checkout.core.components.SessionCheckoutResult
+import com.adyen.checkout.core.components.SubmitResult
+import com.adyen.checkout.core.components.data.BeforeSubmitData
+import com.adyen.checkout.core.components.data.PaymentComponentData
+import com.adyen.checkout.core.error.CheckoutError
+import com.adyen.checkout.dropin.internal.service.DropInServiceManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * Creates the [CheckoutController] that drives a single Drop-in checkout flow.
+ */
+internal fun interface DropInControllerProvider {
+
+    /**
+     * @param paymentFlowType The payment method the flow is started for.
+     * @param coroutineScope The scope tied to the lifetime of the flow. Cancelling it tears the flow down.
+     */
+    fun provide(
+        paymentFlowType: DropInPaymentFlowType,
+        coroutineScope: CoroutineScope,
+    ): CheckoutController
+}
+
+internal class DefaultDropInControllerProvider(
+    private val checkoutContext: CheckoutContext,
+    private val dropInServiceManager: DropInServiceManager,
+) : DropInControllerProvider {
+
+    override fun provide(
+        paymentFlowType: DropInPaymentFlowType,
+        coroutineScope: CoroutineScope,
+    ): CheckoutController {
+        val target = createTarget(paymentFlowType)
+
+        return when (checkoutContext) {
+            is CheckoutContext.Advanced -> {
+                CheckoutController(
+                    target = target,
+                    context = checkoutContext,
+                    callbacks = AdvancedCheckoutCallbacks(
+                        onSubmit = ::onSubmit,
+                        onAdditionalDetails = ::onAdditionalDetails,
+                        onFailure = { error -> onFailure(coroutineScope, error) },
+                    ),
+                    coroutineScope = coroutineScope,
+                )
+            }
+
+            is CheckoutContext.Sessions -> {
+                CheckoutController(
+                    target = target,
+                    context = checkoutContext,
+                    callbacks = SessionCheckoutCallbacks(
+                        onBeforeSubmit = ::onBeforeSubmit,
+                        onFailure = { error -> onFailure(coroutineScope, error) },
+                        onComplete = { result -> onComplete(coroutineScope, result) },
+                    ),
+                    coroutineScope = coroutineScope,
+                )
+            }
+
+            is CheckoutContext.ActionOnly -> error("Unsupported context: $checkoutContext")
+        }
+    }
+
+    private fun createTarget(paymentFlowType: DropInPaymentFlowType): CheckoutTarget {
+        return when (paymentFlowType) {
+            is DropInPaymentFlowType.RegularPaymentMethod -> {
+                CheckoutTarget.PaymentMethod(type = paymentFlowType.txVariant)
+            }
+
+            is DropInPaymentFlowType.StoredPaymentMethod -> {
+                CheckoutTarget.StoredPaymentMethod(id = paymentFlowType.id)
+            }
+        }
+    }
+
+    private suspend fun onBeforeSubmit(data: BeforeSubmitData): BeforeSubmitResult {
+        // TODO - Implement after beforeSubmit is added to DropInService
+        return BeforeSubmitResult.Proceed(data)
+    }
+
+    private suspend fun onSubmit(paymentComponentData: PaymentComponentData<*>): SubmitResult {
+        return dropInServiceManager.requestOnSubmit(paymentComponentData)
+    }
+
+    private suspend fun onAdditionalDetails(data: ActionComponentData): AdditionalDetailsResult {
+        return dropInServiceManager.requestOnAdditionalDetails(data)
+    }
+
+    private fun onFailure(coroutineScope: CoroutineScope, error: CheckoutError) {
+        coroutineScope.launch {
+            dropInServiceManager.onFailure(error)
+        }
+    }
+
+    private fun onComplete(coroutineScope: CoroutineScope, result: SessionCheckoutResult) {
+        // TODO - Implement after signature of onFinished is updated
+        coroutineScope.launch {
+            dropInServiceManager.onPaymentCompleted(result.resultCode)
+        }
+    }
+}

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInViewModel.kt
@@ -31,18 +31,16 @@ import kotlin.reflect.KClass
 
 internal class DropInViewModel(
     private val input: DropInResultContract.Input,
-    val navigator: DropInNavigator
+    val navigator: DropInNavigator,
+    val controllerProvider: DropInControllerProvider,
+    private val dropInServiceManager: DropInServiceManager,
 ) : ViewModel() {
 
     lateinit var dropInParams: DropInParams
 
     lateinit var paymentMethodRepository: PaymentMethodRepository
 
-    val checkoutContext = input.checkoutContext
-
     val theme = input.theme
-
-    val dropInServiceManager = DropInServiceManager(input.serviceClass)
 
     val resultFlow: Flow<DropInResult> = merge(
         dropInServiceManager.paymentResultFlow.map { DropInResult.Completed(it) },
@@ -112,13 +110,21 @@ internal class DropInViewModel(
 
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: KClass<T>, extras: CreationExtras): T {
+            val input = inputProvider()
+            val dropInServiceManager = DropInServiceManager(input.serviceClass)
+
             return DropInViewModel(
-                input = inputProvider(),
+                input = input,
                 navigator = DropInNavigator(
                     backStackPersister = SavedStateBackStackPersister(
                         savedStateHandle = extras.createSavedStateHandle(),
                     ),
                 ),
+                controllerProvider = DefaultDropInControllerProvider(
+                    checkoutContext = input.checkoutContext,
+                    dropInServiceManager = dropInServiceManager,
+                ),
+                dropInServiceManager = dropInServiceManager,
             ) as T
         }
     }

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/NavigationStack.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/NavigationStack.kt
@@ -115,8 +115,7 @@ private fun paymentMethodNavEntry(
                 factory = PaymentMethodViewModel.Factory(
                     paymentFlowType = key.paymentFlowType,
                     paymentMethodRepository = viewModel.paymentMethodRepository,
-                    checkoutContext = viewModel.checkoutContext,
-                    dropInServiceManager = viewModel.dropInServiceManager,
+                    controllerProvider = viewModel.controllerProvider,
                 ),
                 key = key.paymentFlowType.hashCode().toString(),
             ),

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodViewModel.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodViewModel.kt
@@ -12,40 +12,32 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
-import com.adyen.checkout.core.action.data.ActionComponentData
-import com.adyen.checkout.core.common.CheckoutContext
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
-import com.adyen.checkout.core.components.AdditionalDetailsResult
-import com.adyen.checkout.core.components.AdvancedCheckoutCallbacks
-import com.adyen.checkout.core.components.BeforeSubmitResult
 import com.adyen.checkout.core.components.CheckoutController
-import com.adyen.checkout.core.components.CheckoutTarget
-import com.adyen.checkout.core.components.SessionCheckoutCallbacks
-import com.adyen.checkout.core.components.SessionCheckoutResult
-import com.adyen.checkout.core.components.SubmitResult
-import com.adyen.checkout.core.components.data.BeforeSubmitData
-import com.adyen.checkout.core.components.data.PaymentComponentData
 import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethodResponse
 import com.adyen.checkout.core.components.paymentmethod.PaymentMethodTypes
-import com.adyen.checkout.core.error.CheckoutError
 import com.adyen.checkout.dropin.internal.data.PaymentMethodRepository
-import com.adyen.checkout.dropin.internal.service.DropInServiceManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 
+/**
+ * Owns the [CheckoutController] that drives the payment flow of a single payment method, on top of the state its
+ * screen renders.
+ *
+ * The controller is created in [viewModelScope], so it lives exactly as long as the [PaymentMethodNavKey] entry this
+ * view model belongs to and is torn down when nav3 clears that entry's store.
+ */
 internal class PaymentMethodViewModel(
     private val paymentFlowType: DropInPaymentFlowType,
     private val paymentMethodRepository: PaymentMethodRepository,
-    private val checkoutContext: CheckoutContext,
-    private val dropInServiceManager: DropInServiceManager,
+    controllerProvider: DropInControllerProvider,
 ) : ViewModel() {
+
+    val controller: CheckoutController = controllerProvider.provide(paymentFlowType, viewModelScope)
 
     private val _viewState = MutableStateFlow(createViewState())
     val viewState: StateFlow<PaymentMethodViewState> = _viewState.asStateFlow()
-
-    val controller = createCheckoutController()
 
     private fun createViewState(): PaymentMethodViewState {
         val paymentMethod = when (paymentFlowType) {
@@ -73,87 +65,17 @@ internal class PaymentMethodViewModel(
         }
     }
 
-    private fun createCheckoutController(): CheckoutController {
-        val target = when (paymentFlowType) {
-            is DropInPaymentFlowType.RegularPaymentMethod -> {
-                CheckoutTarget.PaymentMethod(type = paymentFlowType.txVariant)
-            }
-
-            is DropInPaymentFlowType.StoredPaymentMethod -> {
-                CheckoutTarget.StoredPaymentMethod(id = paymentFlowType.id)
-            }
-        }
-
-        return when (checkoutContext) {
-            is CheckoutContext.Advanced -> {
-                CheckoutController(
-                    target = target,
-                    context = checkoutContext,
-                    callbacks = AdvancedCheckoutCallbacks(
-                        onSubmit = ::onSubmit,
-                        onAdditionalDetails = ::onAdditionalDetails,
-                        onFailure = ::onFailure,
-                    ),
-                    coroutineScope = viewModelScope,
-                )
-            }
-
-            is CheckoutContext.Sessions -> {
-                CheckoutController(
-                    target = target,
-                    context = checkoutContext,
-                    callbacks = SessionCheckoutCallbacks(
-                        onBeforeSubmit = ::onBeforeSubmit,
-                        onFailure = ::onFailure,
-                        onComplete = ::onComplete,
-                    ),
-                    coroutineScope = viewModelScope,
-                )
-            }
-
-            is CheckoutContext.ActionOnly -> error("Unsupported context: $checkoutContext")
-        }
-    }
-
-    private suspend fun onBeforeSubmit(data: BeforeSubmitData): BeforeSubmitResult {
-        // TODO - Implement after beforeSubmit is added to DropInService
-        return BeforeSubmitResult.Proceed(data)
-    }
-
-    private suspend fun onSubmit(paymentComponentData: PaymentComponentData<*>): SubmitResult {
-        return dropInServiceManager.requestOnSubmit(paymentComponentData)
-    }
-
-    private suspend fun onAdditionalDetails(data: ActionComponentData): AdditionalDetailsResult {
-        return dropInServiceManager.requestOnAdditionalDetails(data)
-    }
-
-    private fun onFailure(error: CheckoutError) {
-        viewModelScope.launch {
-            dropInServiceManager.onFailure(error)
-        }
-    }
-
-    private fun onComplete(result: SessionCheckoutResult) {
-        // TODO - Implement after signature of onFinished is updated
-        viewModelScope.launch {
-            dropInServiceManager.onPaymentCompleted(result.resultCode)
-        }
-    }
-
     class Factory(
         private val paymentFlowType: DropInPaymentFlowType,
         private val paymentMethodRepository: PaymentMethodRepository,
-        private val checkoutContext: CheckoutContext,
-        private val dropInServiceManager: DropInServiceManager,
+        private val controllerProvider: DropInControllerProvider,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
             return PaymentMethodViewModel(
                 paymentFlowType = paymentFlowType,
                 paymentMethodRepository = paymentMethodRepository,
-                checkoutContext = checkoutContext,
-                dropInServiceManager = dropInServiceManager,
+                controllerProvider = controllerProvider,
             ) as T
         }
     }

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/DropInViewModelTest.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/DropInViewModelTest.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 26/8/2026.
+ */
+
+package com.adyen.checkout.dropin.internal.ui
+
+import androidx.compose.runtime.mutableStateListOf
+import com.adyen.checkout.core.common.Environment
+import com.adyen.checkout.core.common.TestCheckoutContext
+import com.adyen.checkout.core.components.CheckoutConfiguration
+import com.adyen.checkout.core.components.CheckoutController
+import com.adyen.checkout.core.components.data.model.Amount
+import com.adyen.checkout.core.components.data.model.paymentmethod.GenericPaymentMethod
+import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethod
+import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethods
+import com.adyen.checkout.core.components.data.model.paymentmethod.StoredCardPaymentMethod
+import com.adyen.checkout.core.components.data.model.paymentmethod.StoredPaymentMethod
+import com.adyen.checkout.core.components.paymentmethod.PaymentMethodTypes
+import com.adyen.checkout.dropin.DropInService
+import com.adyen.checkout.dropin.internal.DropInResultContract
+import com.adyen.checkout.dropin.internal.helper.BackStackPersister
+import com.adyen.checkout.dropin.internal.helper.InMemoryBackStackPersister
+import com.adyen.checkout.dropin.internal.service.DropInServiceManager
+import com.adyen.checkout.test.LoggingExtension
+import com.adyen.checkout.test.TestDispatcherExtension
+import com.adyen.checkout.ui.theme.CheckoutTheme
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.kotlin.mock
+import java.util.Locale
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(LoggingExtension::class, TestDispatcherExtension::class)
+internal class DropInViewModelTest {
+
+    private val controllerProvider = DropInControllerProvider { _, _ -> mock<CheckoutController>() }
+
+    @Test
+    fun `when there are no stored payment methods, then the payment method list is the starting point`() {
+        val viewModel = createViewModel(storedPaymentMethods = emptyList())
+
+        assertEquals(listOf(EmptyNavKey, PaymentMethodListNavKey), viewModel.navigator.backStack)
+    }
+
+    @Test
+    fun `when there are stored payment methods, then the first one is preselected`() {
+        val viewModel = createViewModel(storedPaymentMethods = listOf(storedPaymentMethod(STORED_ID)))
+
+        assertEquals(
+            listOf(EmptyNavKey, PreselectedPaymentMethodNavKey(STORED_ID)),
+            viewModel.navigator.backStack,
+        )
+    }
+
+    @Test
+    fun `when the back stack was restored, then no starting point is added`() {
+        // A persister that already holds a back stack stands in for a recreated Drop-in.
+        val persister = InMemoryBackStackPersister()
+        persister.store(mutableStateListOf(EmptyNavKey, StoredPaymentMethodsNavKey))
+
+        val viewModel = createViewModel(storedPaymentMethods = emptyList(), persister = persister)
+
+        assertEquals(listOf(EmptyNavKey, StoredPaymentMethodsNavKey), viewModel.navigator.backStack)
+    }
+
+    @Test
+    fun `when created, then the injected controller provider is exposed`() {
+        val viewModel = createViewModel()
+
+        // The payment method entries resolve their controllers through this instance.
+        assertSame(controllerProvider, viewModel.controllerProvider)
+    }
+
+    @Test
+    fun `when created, then the drop in params are mapped from the checkout configuration`() {
+        val viewModel = createViewModel()
+
+        assertEquals(Locale.US, viewModel.dropInParams.shopperLocale)
+        assertEquals(Environment.TEST, viewModel.dropInParams.environment)
+        assertEquals(AMOUNT, viewModel.dropInParams.amount)
+    }
+
+    private fun createViewModel(
+        storedPaymentMethods: List<StoredPaymentMethod> = emptyList(),
+        paymentMethods: List<PaymentMethod> = listOf(
+            GenericPaymentMethod(type = PaymentMethodTypes.SCHEME, name = "Cards"),
+        ),
+        persister: BackStackPersister = InMemoryBackStackPersister(),
+    ): DropInViewModel {
+        val checkoutContext = TestCheckoutContext.advanced(
+            paymentMethods = PaymentMethods(
+                storedPaymentMethods = storedPaymentMethods,
+                paymentMethods = paymentMethods,
+            ),
+            checkoutConfiguration = CheckoutConfiguration(
+                environment = Environment.TEST,
+                clientKey = CLIENT_KEY,
+                shopperLocale = Locale.US,
+                amount = AMOUNT,
+            ),
+        )
+
+        return DropInViewModel(
+            input = DropInResultContract.Input(
+                checkoutContext = checkoutContext,
+                serviceClass = DropInService::class.java,
+                theme = CheckoutTheme(),
+            ),
+            navigator = DropInNavigator(persister),
+            controllerProvider = controllerProvider,
+            dropInServiceManager = DropInServiceManager(DropInService::class.java),
+        )
+    }
+
+    private fun storedPaymentMethod(id: String) = StoredCardPaymentMethod(
+        type = PaymentMethodTypes.SCHEME,
+        name = "Visa",
+        id = id,
+        supportedShopperInteractions = listOf("Ecommerce"),
+        brand = "visa",
+        lastFour = "1234",
+        expiryMonth = "01",
+        expiryYear = "2030",
+        holderName = null,
+        fundingSource = null,
+    )
+
+    private companion object {
+        private const val STORED_ID = "stored-id-1"
+        private const val CLIENT_KEY = "test_client_key"
+        private val AMOUNT = Amount(currency = "USD", value = 999L)
+    }
+}

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodViewModelTest.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/PaymentMethodViewModelTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 26/8/2026.
+ */
+
+package com.adyen.checkout.dropin.internal.ui
+
+import androidx.lifecycle.viewModelScope
+import com.adyen.checkout.core.components.CheckoutController
+import com.adyen.checkout.core.components.data.model.paymentmethod.CardPaymentMethod
+import com.adyen.checkout.core.components.data.model.paymentmethod.StoredCardPaymentMethod
+import com.adyen.checkout.core.components.paymentmethod.PaymentMethodTypes
+import com.adyen.checkout.dropin.internal.data.TestPaymentMethodRepository
+import com.adyen.checkout.test.LoggingExtension
+import com.adyen.checkout.test.TestDispatcherExtension
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.kotlin.mock
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(LoggingExtension::class, TestDispatcherExtension::class)
+internal class PaymentMethodViewModelTest {
+
+    private val requestedPaymentFlowTypes = mutableListOf<DropInPaymentFlowType>()
+    private val createdFlowScopes = mutableListOf<CoroutineScope>()
+    private val createdControllers = mutableListOf<CheckoutController>()
+
+    private val controllerProvider = DropInControllerProvider { paymentFlowType, coroutineScope ->
+        requestedPaymentFlowTypes += paymentFlowType
+        createdFlowScopes += coroutineScope
+        mock<CheckoutController>().also { createdControllers += it }
+    }
+
+    private val paymentMethodRepository = TestPaymentMethodRepository(
+        storedMethods = listOf(
+            StoredCardPaymentMethod(
+                type = PaymentMethodTypes.SCHEME,
+                name = "Visa",
+                id = STORED_ID,
+                supportedShopperInteractions = listOf("Ecommerce"),
+                brand = "visa",
+                lastFour = "1234",
+                expiryMonth = "01",
+                expiryYear = "2030",
+                holderName = null,
+                fundingSource = null,
+            ),
+        ),
+        paymentMethods = listOf(
+            CardPaymentMethod(
+                type = PaymentMethodTypes.SCHEME,
+                name = "Cards",
+                brands = listOf("visa"),
+                fundingSource = null,
+            ),
+        ),
+    )
+
+    @Test
+    fun `when created, then the view state describes the payment method`() {
+        val viewModel = createViewModel(REGULAR_TYPE)
+
+        assertEquals("Cards", viewModel.viewState.value.paymentMethodName)
+    }
+
+    @Test
+    fun `when created for a stored payment method, then the view state describes that payment method`() {
+        val viewModel = createViewModel(STORED_TYPE)
+
+        assertEquals("Visa", viewModel.viewState.value.paymentMethodName)
+    }
+
+    @Test
+    fun `when created, then a single controller is created for the payment flow type`() {
+        val viewModel = createViewModel(REGULAR_TYPE)
+
+        assertEquals(listOf(REGULAR_TYPE), requestedPaymentFlowTypes)
+        assertSame(createdControllers.single(), viewModel.controller)
+    }
+
+    @Test
+    fun `when created for a stored payment method, then a controller is created for that flow type`() {
+        val viewModel = createViewModel(STORED_TYPE)
+
+        assertEquals(listOf(STORED_TYPE), requestedPaymentFlowTypes)
+        assertSame(createdControllers.single(), viewModel.controller)
+    }
+
+    @Test
+    fun `when created, then the controller is scoped to the view model`() {
+        val viewModel = createViewModel(REGULAR_TYPE)
+
+        // The scope the controller runs on is the one cancelled when nav3 clears the store of the flow.
+        assertSame(viewModel.viewModelScope, createdFlowScopes.single())
+    }
+
+    private fun createViewModel(paymentFlowType: DropInPaymentFlowType) = PaymentMethodViewModel(
+        paymentFlowType = paymentFlowType,
+        paymentMethodRepository = paymentMethodRepository,
+        controllerProvider = controllerProvider,
+    )
+
+    private companion object {
+        private const val STORED_ID = "stored-id-1"
+        private val REGULAR_TYPE = DropInPaymentFlowType.RegularPaymentMethod(PaymentMethodTypes.SCHEME)
+        private val STORED_TYPE = DropInPaymentFlowType.StoredPaymentMethod(STORED_ID)
+    }
+}


### PR DESCRIPTION
## Description

- `CheckoutController` creation moves out of `PaymentMethodViewModel` into a new `DropInControllerProvider`, so the
  view model receives a provider instead of building a controller from `CheckoutContext` and `DropInServiceManager`
  itself. This is the seam later phases need to share one controller across screens.
- `DropInViewModel` gets `controllerProvider` and `dropInServiceManager` injected from its factory, matching how
  `DropInNavigator` was already built there.
- New `TestCheckoutContext` fixture in `core/src/testFixtures`, since `CheckoutContext` subtypes have `internal`
  constructors and can't be faked. Not a public API change — `testFixtures` isn't in the API dump.

### Progress

✅ Phase 0 — Lifecycle 2.11.0 and compile SDK 37 (#2962)
➡️ **Phase 2 — Controller ownership (this PR)**
Phase 3a — View model store per nav entry
Phase 3b — Action screen loading UI
Phase 3c — Action destination
Phase 4 — Payment method screen states
Phase 5 — Action screen design
Phase 6 — Secondary content
Phase 7 — Google Pay on the payment method list

## Checklist
- [x] Code is unit tested

## Ticket Number
COSDK-1420
