### PR TITLE
v6 - Drop-in - Always show the submit button

### DIFF
--- a/core/src/main/java/com/adyen/checkout/core/common/internal/CheckoutContextExt.kt
+++ b/core/src/main/java/com/adyen/checkout/core/common/internal/CheckoutContextExt.kt
@@ -16,7 +16,10 @@
 
 package com.adyen.checkout.core.common.internal
 
+import androidx.annotation.RestrictTo
 import com.adyen.checkout.core.common.CheckoutContext
+import com.adyen.checkout.core.components.Checkout
+import com.adyen.checkout.core.components.CheckoutConfiguration
 
 internal val CheckoutContext.checkoutAttemptId: String
     get() = when (this) {
@@ -31,3 +34,18 @@ internal val CheckoutContext.publicKey: String?
         is CheckoutContext.Advanced -> publicKey
         is CheckoutContext.ActionOnly -> publicKey
     }
+
+/**
+ * Creates a copy of this context with a different [checkoutConfiguration], keeping the subtype and all of its other
+ * values.
+ *
+ * The copy of each subtype is internal, since a [CheckoutContext] is only ever meant to come out of [Checkout.setup].
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun CheckoutContext.withCheckoutConfiguration(checkoutConfiguration: CheckoutConfiguration): CheckoutContext {
+    return when (this) {
+        is CheckoutContext.Advanced -> copy(checkoutConfiguration = checkoutConfiguration)
+        is CheckoutContext.Sessions -> copy(checkoutConfiguration = checkoutConfiguration)
+        is CheckoutContext.ActionOnly -> copy(checkoutConfiguration = checkoutConfiguration)
+    }
+}

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutConfigurationExt.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/CheckoutConfigurationExt.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 2/9/2026.
+ */
+
+package com.adyen.checkout.core.components.internal
+
+import androidx.annotation.RestrictTo
+import com.adyen.checkout.core.components.CheckoutConfiguration
+
+/**
+ * Creates a copy of this configuration with a different [showSubmitButton].
+ *
+ * Every other value is carried over unchanged, including the configurations that were added through the
+ * configuration block. The block itself is not run again, since applying it only adds those configurations.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun CheckoutConfiguration.copy(showSubmitButton: Boolean?): CheckoutConfiguration {
+    return CheckoutConfiguration(
+        environment = environment,
+        clientKey = clientKey,
+        shopperLocale = shopperLocale,
+        amount = amount,
+        analyticsConfiguration = analyticsConfiguration,
+        showSubmitButton = showSubmitButton,
+    ).also { copy ->
+        getAvailableConfigurations().values.forEach { configuration ->
+            copy.addConfiguration(configuration)
+        }
+    }
+}

--- a/core/src/test/java/com/adyen/checkout/core/common/internal/CheckoutContextExtTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/common/internal/CheckoutContextExtTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 2/9/2026.
+ */
+
+package com.adyen.checkout.core.common.internal
+
+import com.adyen.checkout.core.action.data.RedirectAction
+import com.adyen.checkout.core.common.CheckoutContext
+import com.adyen.checkout.core.common.Environment
+import com.adyen.checkout.core.components.CheckoutConfiguration
+import com.adyen.checkout.core.components.data.model.paymentmethod.GenericPaymentMethod
+import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethods
+import com.adyen.checkout.core.sessions.CheckoutSession
+import com.adyen.checkout.core.sessions.internal.data.model.SessionSetupResponse
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertInstanceOf
+
+internal class CheckoutContextExtTest {
+
+    @Nested
+    inner class WithCheckoutConfigurationTest {
+
+        @Test
+        fun `when copying advanced context then configuration is replaced and everything else is kept`() {
+            val context = CheckoutContext.Advanced(
+                paymentMethods = paymentMethods,
+                checkoutConfiguration = createConfiguration(showSubmitButton = false),
+                checkoutAttemptId = TEST_CHECKOUT_ATTEMPT_ID,
+                publicKey = TEST_PUBLIC_KEY,
+            )
+
+            val actual = context.withCheckoutConfiguration(createConfiguration(showSubmitButton = true))
+
+            val advanced = assertInstanceOf<CheckoutContext.Advanced>(actual)
+            assertEquals(true, advanced.checkoutConfiguration.showSubmitButton)
+            assertEquals(paymentMethods, advanced.paymentMethods)
+            assertEquals(TEST_CHECKOUT_ATTEMPT_ID, advanced.checkoutAttemptId)
+            assertEquals(TEST_PUBLIC_KEY, advanced.publicKey)
+        }
+
+        @Test
+        fun `when copying sessions context then configuration is replaced and everything else is kept`() {
+            val context = CheckoutContext.Sessions(
+                checkoutSession = checkoutSession,
+                checkoutConfiguration = createConfiguration(showSubmitButton = false),
+                checkoutAttemptId = TEST_CHECKOUT_ATTEMPT_ID,
+                publicKey = TEST_PUBLIC_KEY,
+            )
+
+            val actual = context.withCheckoutConfiguration(createConfiguration(showSubmitButton = true))
+
+            val sessions = assertInstanceOf<CheckoutContext.Sessions>(actual)
+            assertEquals(true, sessions.checkoutConfiguration.showSubmitButton)
+            assertEquals(checkoutSession, sessions.checkoutSession)
+            assertEquals(TEST_CHECKOUT_ATTEMPT_ID, sessions.checkoutAttemptId)
+            assertEquals(TEST_PUBLIC_KEY, sessions.publicKey)
+        }
+
+        @Test
+        fun `when copying action only context then configuration is replaced and everything else is kept`() {
+            val context = CheckoutContext.ActionOnly(
+                action = action,
+                checkoutConfiguration = createConfiguration(showSubmitButton = false),
+                checkoutAttemptId = TEST_CHECKOUT_ATTEMPT_ID,
+                publicKey = TEST_PUBLIC_KEY,
+            )
+
+            val actual = context.withCheckoutConfiguration(createConfiguration(showSubmitButton = true))
+
+            val actionOnly = assertInstanceOf<CheckoutContext.ActionOnly>(actual)
+            assertEquals(true, actionOnly.checkoutConfiguration.showSubmitButton)
+            assertEquals(action, actionOnly.action)
+            assertEquals(TEST_CHECKOUT_ATTEMPT_ID, actionOnly.checkoutAttemptId)
+            assertEquals(TEST_PUBLIC_KEY, actionOnly.publicKey)
+        }
+    }
+
+    private val paymentMethods = PaymentMethods(
+        paymentMethods = listOf(GenericPaymentMethod(type = "ideal", name = "iDEAL")),
+    )
+
+    private val checkoutSession = CheckoutSession(
+        sessionSetupResponse = SessionSetupResponse(
+            id = "test_session_id",
+            sessionData = "test_session_data",
+            amount = null,
+            expiresAt = "2026-12-31T23:59:59Z",
+            paymentMethods = null,
+            returnUrl = null,
+            configuration = null,
+            shopperLocale = null,
+        ),
+        order = null,
+        environment = Environment.TEST,
+        clientKey = TEST_CLIENT_KEY,
+    )
+
+    private val action = RedirectAction(
+        type = RedirectAction.ACTION_TYPE,
+        paymentData = null,
+        paymentMethodType = "scheme",
+        method = null,
+        url = null,
+        nativeRedirectData = null,
+    )
+
+    private fun createConfiguration(showSubmitButton: Boolean?) = CheckoutConfiguration(
+        environment = Environment.TEST,
+        clientKey = TEST_CLIENT_KEY,
+        showSubmitButton = showSubmitButton,
+    )
+
+    companion object {
+        private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfgh"
+        private const val TEST_CHECKOUT_ATTEMPT_ID = "test_checkout_attempt_id"
+        private const val TEST_PUBLIC_KEY = "test_public_key"
+    }
+}

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/CheckoutConfigurationExtTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/CheckoutConfigurationExtTest.kt
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 2/9/2026.
+ */
+
+package com.adyen.checkout.core.components.internal
+
+import com.adyen.checkout.core.common.Environment
+import com.adyen.checkout.core.components.AnalyticsConfiguration
+import com.adyen.checkout.core.components.AnalyticsLevel
+import com.adyen.checkout.core.components.CheckoutConfiguration
+import com.adyen.checkout.core.components.data.model.Amount
+import kotlinx.parcelize.Parcelize
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.Locale
+
+internal class CheckoutConfigurationExtTest {
+
+    @Test
+    fun `when copying then submit button visibility is replaced`() {
+        val configuration = createConfiguration(showSubmitButton = false)
+
+        val actual = configuration.copy(showSubmitButton = true)
+
+        assertEquals(true, actual.showSubmitButton)
+    }
+
+    @Test
+    fun `when copying without submit button visibility then it is not set`() {
+        val configuration = createConfiguration(showSubmitButton = true)
+
+        val actual = configuration.copy(showSubmitButton = null)
+
+        assertNull(actual.showSubmitButton)
+    }
+
+    @Test
+    fun `when copying then all other values are kept`() {
+        val configuration = createConfiguration(
+            environment = Environment.LIVE_UNITED_STATES,
+            clientKey = "test_client_key",
+            shopperLocale = Locale.FRANCE,
+            amount = Amount("EUR", 1337),
+            analyticsConfiguration = AnalyticsConfiguration(AnalyticsLevel.NONE),
+            showSubmitButton = false,
+        )
+
+        val actual = configuration.copy(showSubmitButton = true)
+
+        assertEquals(Environment.LIVE_UNITED_STATES, actual.environment)
+        assertEquals("test_client_key", actual.clientKey)
+        assertEquals(Locale.FRANCE, actual.shopperLocale)
+        assertEquals(Amount("EUR", 1337), actual.amount)
+        assertEquals(AnalyticsLevel.NONE, actual.analyticsConfiguration?.level)
+    }
+
+    @Test
+    fun `when copying then configurations added through the configuration block are kept`() {
+        val paymentMethodConfiguration = TestConfiguration("test_value")
+        val configuration = CheckoutConfiguration(
+            environment = Environment.TEST,
+            clientKey = TEST_CLIENT_KEY,
+        ) {
+            addConfiguration(paymentMethodConfiguration)
+        }
+
+        val actual = configuration.copy(showSubmitButton = true)
+
+        assertEquals(
+            mapOf(TestConfiguration::class.java.name to paymentMethodConfiguration),
+            actual.getAvailableConfigurations(),
+        )
+    }
+
+    @Test
+    fun `when copying then the original configuration is not modified`() {
+        val configuration = createConfiguration(showSubmitButton = false)
+
+        configuration.copy(showSubmitButton = true)
+
+        assertEquals(false, configuration.showSubmitButton)
+    }
+
+    @Test
+    fun `when copying then a new instance is returned`() {
+        val configuration = createConfiguration()
+
+        val actual = configuration.copy(showSubmitButton = true)
+
+        assertTrue(configuration !== actual)
+    }
+
+    /**
+     * [copy] has to list every value of [CheckoutConfiguration] to carry it over. A value that is added to the class
+     * but not to [copy] is silently dropped for every caller of [copy], which is why this test fails when the primary
+     * constructor changes.
+     */
+    @Test
+    fun `when CheckoutConfiguration gains a value then copy has to be updated`() {
+        val expected = listOf(
+            Environment::class.java,
+            String::class.java,
+            Locale::class.java,
+            Amount::class.java,
+            AnalyticsConfiguration::class.java,
+            Boolean::class.javaObjectType,
+            Function1::class.java,
+        )
+
+        val actual = CheckoutConfiguration::class.java.declaredConstructors
+            .filterNot { constructor ->
+                constructor.parameterTypes.any { it.name.endsWith("DefaultConstructorMarker") }
+            }
+            .maxBy { it.parameterCount }
+            .parameterTypes
+            .toList()
+
+        assertEquals(
+            expected,
+            actual,
+            "The primary constructor of CheckoutConfiguration changed. Update CheckoutConfiguration.copy() to " +
+                "carry the new value over, then update this test.",
+        )
+    }
+
+    @Suppress("LongParameterList")
+    private fun createConfiguration(
+        environment: Environment = Environment.TEST,
+        clientKey: String = TEST_CLIENT_KEY,
+        shopperLocale: Locale? = null,
+        amount: Amount? = null,
+        analyticsConfiguration: AnalyticsConfiguration? = null,
+        showSubmitButton: Boolean? = null,
+    ) = CheckoutConfiguration(
+        environment = environment,
+        clientKey = clientKey,
+        shopperLocale = shopperLocale,
+        amount = amount,
+        analyticsConfiguration = analyticsConfiguration,
+        showSubmitButton = showSubmitButton,
+    )
+
+    @Parcelize
+    private data class TestConfiguration(val value: String) : Configuration
+
+    companion object {
+        private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfgh"
+    }
+}

--- a/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInControllerProvider.kt
+++ b/drop-in/src/main/java/com/adyen/checkout/dropin/internal/ui/DropInControllerProvider.kt
@@ -10,6 +10,7 @@ package com.adyen.checkout.dropin.internal.ui
 
 import com.adyen.checkout.core.action.data.ActionComponentData
 import com.adyen.checkout.core.common.CheckoutContext
+import com.adyen.checkout.core.common.internal.withCheckoutConfiguration
 import com.adyen.checkout.core.components.AdditionalDetailsResult
 import com.adyen.checkout.core.components.AdvancedCheckoutCallbacks
 import com.adyen.checkout.core.components.BeforeSubmitResult
@@ -20,6 +21,7 @@ import com.adyen.checkout.core.components.SessionCheckoutResult
 import com.adyen.checkout.core.components.SubmitResult
 import com.adyen.checkout.core.components.data.BeforeSubmitData
 import com.adyen.checkout.core.components.data.PaymentComponentData
+import com.adyen.checkout.core.components.internal.copy
 import com.adyen.checkout.core.error.CheckoutError
 import com.adyen.checkout.dropin.internal.service.DropInServiceManager
 import kotlinx.coroutines.CoroutineScope
@@ -41,9 +43,11 @@ internal fun interface DropInControllerProvider {
 }
 
 internal class DefaultDropInControllerProvider(
-    private val checkoutContext: CheckoutContext,
+    checkoutContext: CheckoutContext,
     private val dropInServiceManager: DropInServiceManager,
 ) : DropInControllerProvider {
+
+    private val checkoutContext = checkoutContext.withSubmitButtonEnforced()
 
     override fun provide(
         paymentFlowType: DropInPaymentFlowType,
@@ -119,4 +123,8 @@ internal class DefaultDropInControllerProvider(
             dropInServiceManager.onPaymentCompleted(result.resultCode)
         }
     }
+}
+
+internal fun CheckoutContext.withSubmitButtonEnforced(): CheckoutContext {
+    return withCheckoutConfiguration(checkoutConfiguration.copy(showSubmitButton = true))
 }

--- a/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/DropInControllerProviderTest.kt
+++ b/drop-in/src/test/java/com/adyen/checkout/dropin/internal/ui/DropInControllerProviderTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by ararat on 2/9/2026.
+ */
+
+package com.adyen.checkout.dropin.internal.ui
+
+import com.adyen.checkout.core.common.Environment
+import com.adyen.checkout.core.common.TestCheckoutContext
+import com.adyen.checkout.core.components.CheckoutConfiguration
+import com.adyen.checkout.core.components.data.model.paymentmethod.PaymentMethods
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class DropInControllerProviderTest {
+
+    @Test
+    fun `when configuration hides the submit button then context enforces it`() {
+        val checkoutContext = createCheckoutContext(showSubmitButton = false)
+
+        val actual = checkoutContext.withSubmitButtonEnforced()
+
+        assertEquals(true, actual.checkoutConfiguration.showSubmitButton)
+    }
+
+    @Test
+    fun `when configuration does not set the submit button then context enforces it`() {
+        val checkoutContext = createCheckoutContext(showSubmitButton = null)
+
+        val actual = checkoutContext.withSubmitButtonEnforced()
+
+        assertEquals(true, actual.checkoutConfiguration.showSubmitButton)
+    }
+
+    @Test
+    fun `when enforcing the submit button then the rest of the configuration is kept`() {
+        val checkoutContext = createCheckoutContext(showSubmitButton = false)
+
+        val actual = checkoutContext.withSubmitButtonEnforced()
+
+        assertEquals(Environment.TEST, actual.checkoutConfiguration.environment)
+        assertEquals(TEST_CLIENT_KEY, actual.checkoutConfiguration.clientKey)
+    }
+
+    private fun createCheckoutContext(showSubmitButton: Boolean?) = TestCheckoutContext.advanced(
+        paymentMethods = PaymentMethods(),
+        checkoutConfiguration = CheckoutConfiguration(
+            environment = Environment.TEST,
+            clientKey = TEST_CLIENT_KEY,
+            showSubmitButton = showSubmitButton,
+        ),
+    )
+
+    companion object {
+        private const val TEST_CLIENT_KEY = "test_qwertyuiopasdfgh"
+    }
+}


### PR DESCRIPTION
## Description
Drop-in submits a payment through the submit button that the component renders itself, so a merchant setting
`showSubmitButton = false` would leave Drop-in with a card form and no way to pay. Drop-in now ignores that value
and always turns the button on, which is what `CheckoutConfiguration.showSubmitButton` already documents.

The rule lives entirely in Drop-in. Core only gains two restricted extensions in its `internal` packages:

- `CheckoutConfiguration.copy(showSubmitButton)` — carries over every other value, including the payment method
  configurations added through the configuration block, so the merchant configuration is never partially lost.
- `CheckoutContext.withCheckoutConfiguration(...)` — swaps the configuration while keeping the subtype, next to the
  existing `checkoutAttemptId` and `publicKey` extensions.

`DefaultDropInControllerProvider` applies both once, at the boundary, before it creates any controller. Both
extensions are `@RestrictTo(LIBRARY_GROUP)`, so there is no public API change and no `.api` diff.

A copy that lists fields silently drops any field added later, so `CheckoutConfigurationExtTest` pins the primary
constructor of `CheckoutConfiguration` by reflection and fails with an explicit message when it changes.

### Progress

✅ Phase 0 — Dependencies and compile SDK ([#2962](https://github.com/Adyen/adyen-android/pull/2962))
✅ Phase 2 — Controller ownership in a flow-scoped view model ([#2963](https://github.com/Adyen/adyen-android/pull/2963))
✅ Phase 3a — A view model store per nav entry ([#2964](https://github.com/Adyen/adyen-android/pull/2964))
✅ Phase 3b — Payment progress content ([#2967](https://github.com/Adyen/adyen-android/pull/2967))
✅ Phase 3c — Action destination ([#2968](https://github.com/Adyen/adyen-android/pull/2968))
➡️ **Phase 4a — Always show the submit button in Drop-in (this PR)**
Phase 4b — `PaymentMethodScreen`: no-UI routing and payment progress
Phase 5 — Action screen design and behaviour
Phase 6 — Secondary content
Phase 7 — Google Pay on the payment method list

## Checklist
- [x] Code is unit tested

## Ticket Number
COSDK-1420
