### PR TITLE
v6 - Build - Raise the Java target to 17

### DIFF
--- a/.github/release_notes_dependency_list.toml
+++ b/.github/release_notes_dependency_list.toml
@@ -61,6 +61,7 @@
 "checkout.dependency.resolve" = ""
 "checkout.detekt" = ""
 "checkout.dokka" = ""
+"checkout.java" = ""
 "checkout.kover" = ""
 "checkout.ktlint" = ""
 "checkout.publish" = ""

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -6,11 +6,25 @@
  * Created by oscars on 3/12/2025.
  */
 
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     `kotlin-dsl`
 }
 
 group = "com.adyen.checkout.buildlogic"
+
+// build-logic is a separate build, so nothing the main build configures reaches it and it has to pin the version here.
+java {
+    sourceCompatibility = JavaVersion.toVersion(libs.versions.jvm.target.get())
+    targetCompatibility = JavaVersion.toVersion(libs.versions.jvm.target.get())
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.fromTarget(libs.versions.jvm.target.get())
+    }
+}
 
 dependencies {
     compileOnly(libs.android.gradle.plugin)

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -64,6 +64,11 @@ gradlePlugin {
             implementationClass = "DokkaConventionPlugin"
         }
 
+        register("checkoutJava") {
+            id = libs.plugins.checkout.java.get().pluginId
+            implementationClass = "JavaConventionPlugin"
+        }
+
         register("checkoutKover") {
             id = libs.plugins.checkout.kover.get().pluginId
             implementationClass = "KoverConventionPlugin"

--- a/build-logic/convention/src/main/kotlin/CheckoutAndroidLibraryPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/CheckoutAndroidLibraryPlugin.kt
@@ -27,6 +27,7 @@ class CheckoutAndroidLibraryPlugin : Plugin<Project> {
             apply(plugin = "checkout.dependency.list.generate")
             apply(plugin = "checkout.detekt")
             apply(plugin = "checkout.dokka")
+            apply(plugin = "checkout.java")
             apply(plugin = "checkout.kover")
             apply(plugin = "checkout.ktlint")
             apply(plugin = "checkout.publish")

--- a/build-logic/convention/src/main/kotlin/DetektConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/DetektConventionPlugin.kt
@@ -9,7 +9,6 @@
 import com.adyen.checkout.libs
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
-import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
@@ -41,8 +40,6 @@ class DetektConventionPlugin : Plugin<Project> {
                     }
                     html.required = false
                 }
-
-                jvmTarget = JavaVersion.VERSION_11.toString()
             }
 
             dependencies {

--- a/build-logic/convention/src/main/kotlin/JavaConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/JavaConventionPlugin.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Adyen N.V.
+ *
+ * This file is open source and available under the MIT license. See the LICENSE file for more info.
+ *
+ * Created by josephj on 3/9/2026.
+ */
+
+import com.adyen.checkout.libs
+import com.android.build.api.dsl.CommonExtension
+import com.android.build.gradle.BasePlugin
+import org.gradle.api.JavaVersion
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
+
+/**
+ * Applies the JVM target every module is built against, so that it is declared in a single place.
+ *
+ * The two kinds of module are pinned differently. Android modules only get a bytecode target, and are compiled by
+ * whichever JDK runs Gradle, which is what AGP expects. Plain Kotlin JVM modules get a toolchain, because nothing
+ * else would pin them at all.
+ */
+class JavaConventionPlugin : Plugin<Project> {
+
+    override fun apply(target: Project) {
+        with(target) {
+            val jvmTarget = JavaVersion.toVersion(libs.versions.jvm.target.get())
+
+            // The Kotlin support built into AGP derives its own JVM target from these values, so there is nothing to
+            // configure on the Kotlin side.
+            plugins.withType<BasePlugin> {
+                extensions.configure<CommonExtension> {
+                    compileOptions.sourceCompatibility = jvmTarget
+                    compileOptions.targetCompatibility = jvmTarget
+                }
+            }
+
+            plugins.withType<KotlinPluginWrapper> {
+                extensions.configure<KotlinJvmProjectExtension> {
+                    jvmToolchain(jvmTarget.majorVersion.toInt())
+                }
+            }
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,9 @@ ext {
     checkoutRedirectScheme = "adyencheckout"
 }
 
-subprojects {
-    def javaVersion = 11
+def javaVersion = libs.versions.jvm.target.get().toInteger()
 
+subprojects {
     plugins.withType(com.android.build.gradle.BasePlugin).configureEach {
         android {
             if (project.hasProperty("strip-resources") && project.property("strip-resources") == "true") {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,4 @@
 import com.android.build.gradle.LibraryPlugin
-import org.jetbrains.kotlin.gradle.plugin.KotlinAndroidPluginWrapper
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -28,8 +27,6 @@ ext {
     checkoutRedirectScheme = "adyencheckout"
 }
 
-def javaVersion = libs.versions.jvm.target.get().toInteger()
-
 subprojects {
     plugins.withType(com.android.build.gradle.BasePlugin).configureEach {
         android {
@@ -43,11 +40,6 @@ subprojects {
                         crunchPngs false
                     }
                 }
-            }
-
-            compileOptions {
-                sourceCompatibility = javaVersion
-                targetCompatibility = javaVersion
             }
 
             packagingOptions {
@@ -65,12 +57,6 @@ subprojects {
     plugins.withType(LibraryPlugin).configureEach {
         dependencies {
             lintChecks project(':lint')
-        }
-    }
-
-    plugins.withType(KotlinAndroidPluginWrapper).configureEach {
-        kotlin {
-            jvmToolchain(javaVersion)
         }
     }
 

--- a/example-app/build.gradle
+++ b/example-app/build.gradle
@@ -12,6 +12,7 @@ plugins {
     alias libs.plugins.ksp
     alias libs.plugins.hilt
     alias libs.plugins.checkout.detekt
+    alias libs.plugins.checkout.java
     alias libs.plugins.checkout.ktlint
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -217,6 +217,7 @@ binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibil
 checkout-android-library = { id = "checkout.android.library" }
 checkout-detekt = { id = "checkout.detekt" }
 checkout-dokka = { id = "checkout.dokka" }
+checkout-java = { id = "checkout.java" }
 checkout-kover = { id = "checkout.kover" }
 checkout-ktlint = { id = "checkout.ktlint" }
 checkout-publish = { id = "checkout.publish" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ min-sdk = "23"
 version-code = "1"
 
 # Build script
+jvm-target = "17"
 android-gradle-plugin = "9.3.1"
 kotlin = "2.4.10"
 ksp = "2.3.11"

--- a/lint/build.gradle
+++ b/lint/build.gradle
@@ -10,13 +10,15 @@ plugins {
     alias libs.plugins.kotlin
 }
 
+def javaVersion = libs.versions.jvm.target.get().toInteger()
+
 java {
-    targetCompatibility = JavaVersion.VERSION_17
-    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = javaVersion
+    sourceCompatibility = javaVersion
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(javaVersion)
 }
 
 dependencies {

--- a/lint/build.gradle
+++ b/lint/build.gradle
@@ -8,17 +8,7 @@
 
 plugins {
     alias libs.plugins.kotlin
-}
-
-def javaVersion = libs.versions.jvm.target.get().toInteger()
-
-java {
-    targetCompatibility = javaVersion
-    sourceCompatibility = javaVersion
-}
-
-kotlin {
-    jvmToolchain(javaVersion)
+    alias libs.plugins.checkout.java
 }
 
 dependencies {

--- a/test-core/build.gradle
+++ b/test-core/build.gradle
@@ -9,6 +9,7 @@
 plugins {
     alias libs.plugins.android.library
     alias libs.plugins.checkout.detekt
+    alias libs.plugins.checkout.java
     alias libs.plugins.checkout.ktlint
 }
 


### PR DESCRIPTION
## Description
JUnit 6 and Android Lint 32 both require a Java 17 baseline. Lint had already moved to 17 on its own, which left the rest of the project on 11 and blocked the JUnit 6 upgrade.

This raises every module to 17 and removes the duplication that allowed the drift:

- The version is declared once, in the version catalog.
- A new `checkout.java` convention plugin applies it to every subproject, covering both Android modules and plain Kotlin JVM modules like `:lint`. The root build only ever configured the Android plugins, so `:lint` had to repeat the setting, which is exactly why it drifted.
- `build-logic` was never pinned at all and compiled against whichever JDK ran Gradle. It now pins the same version.
- Detekt no longer sets a JVM target. It derives one from the toolchain, and this project never sets a `classpath` on the Detekt tasks, so the value only applied to type resolution that is not enabled.
- The `jvmToolchain` block for Kotlin Android is removed because it never ran: AGP 9 does not apply the `kotlin-android` plugin.

Verified against the emitted bytecode: `:card`, `:lint` and `build-logic` all produce class file major version 61. The branch was also validated against the JUnit 6 upgrade before those changes were taken back out of it.

## Checklist
- [x] If applicable, make sure Breaking change label is added.
- [x] Changes are tested manually

## Release notes
### Breaking changes
- The SDK is now compiled with a Java 17 target. Building an integration requires JDK 17 or newer.