### PR TITLE
Fix android-public-api-change skill

### DIFF
--- a/.agents/skills/android-public-api-change/SKILL.md
+++ b/.agents/skills/android-public-api-change/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: android-public-api-change
-description: Change the public API surface: visibility, breaking changes, and apiDump.
+description: "Change the public API surface: visibility, breaking changes, and apiDump."
 ---
 
 # android-public-api-change


### PR DESCRIPTION
Escape the description of android-public-api-change skill. The ":" character is not allowed without escaping.
