### PR TITLE
v6 - CI - Scope workflow permissions to what each job uses

### DIFF
--- a/.github/workflows/add_pr_label.yml
+++ b/.github/workflows/add_pr_label.yml
@@ -38,13 +38,11 @@ jobs:
   add_label_to_pr:
     needs: get_label
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
+    # This job adds the label with the bot token, so it never needs GITHUB_TOKEN.
+    # Without the empty permissions object it would inherit the repository default, which it doesn't need.
+    permissions: { }
 
     steps:
-      - name: Checkout to current branch
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
       - name: Add label
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:

--- a/.github/workflows/check_dependency_changes.yml
+++ b/.github/workflows/check_dependency_changes.yml
@@ -7,7 +7,7 @@ jobs:
   get_base_dependency_list:
     name: Fetch dependency list in BASE
     permissions:
-      contents: write
+      contents: read
     # This step will only run on pull_request events.
     # PR information is only available when workflow gets triggered with pull_request event.
     if: github.event_name == 'pull_request'
@@ -19,7 +19,7 @@ jobs:
   get_head_dependency_list:
     name: Fetch dependency list in HEAD
     permissions:
-      contents: write
+      contents: read
     # This step will only run on pull_request events.
     # PR information is only available when workflow gets triggered with pull_request event.
     if: github.event_name == 'pull_request'

--- a/.github/workflows/check_labels.yml
+++ b/.github/workflows/check_labels.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -36,6 +36,6 @@ jobs:
   check_dependency_changes:
     name: Check dependency changes
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     uses: ./.github/workflows/check_dependency_changes.yml

--- a/.github/workflows/create_github_release.yml
+++ b/.github/workflows/create_github_release.yml
@@ -13,12 +13,11 @@ on:
       github-token:
         required: true
 
-permissions:
-  contents: write
-
 jobs:
   create_github_release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/create_release_notes_pr.yml
+++ b/.github/workflows/create_release_notes_pr.yml
@@ -10,13 +10,12 @@ on:
       github-token:
         required: true
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   create_release_notes_pr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/deprecate_releases.yml
+++ b/.github/workflows/deprecate_releases.yml
@@ -20,12 +20,11 @@ on:
           - '[DEPRECATED]'
           - '[END-OF-LIFE]'
 
-permissions:
-  contents: write
-
 jobs:
   deprecate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/finalize_release.yml
+++ b/.github/workflows/finalize_release.yml
@@ -96,7 +96,6 @@ jobs:
     name: Publish docs to Github pages
     permissions:
       contents: write
-      deployments: write
     uses: ./.github/workflows/publish_docs.yml
     secrets:
       GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}

--- a/.github/workflows/generate_dependency_graph.yml
+++ b/.github/workflows/generate_dependency_graph.yml
@@ -3,12 +3,11 @@ name: Generate Dependency Graph
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 jobs:
   generate-dependency-graph:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/generate_release_notes.yml
+++ b/.github/workflows/generate_release_notes.yml
@@ -43,7 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: get_allowed_labels
     permissions:
-      contents: write
+      contents: read
+      pull-requests: read
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/label_pr_size.yml
+++ b/.github/workflows/label_pr_size.yml
@@ -3,13 +3,12 @@ name: Label PR size
 on:
   pull_request:
 
-permissions:
-  pull-requests: write
-  contents: read
-
 jobs:
   label_pr_size:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Label PR size
         uses: codelytv/pr-size-labeler@095a41fca88b8764fd9e008ad269bcdb82bb38b9 # v1.10.4

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -47,7 +47,8 @@ jobs:
   generate_release_notes:
     name: Generate release notes
     permissions:
-      contents: write
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/generate_release_notes.yml
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -7,13 +7,12 @@ on:
         required: true
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 jobs:
 
   publish-to-github-pages:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -9,12 +9,11 @@ on:
   schedule:
     - cron: '0 0 * * *'  # Run every day at midnight
 
-permissions:
-  issues: write
-
 jobs:
   close_stale_prs:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Close stale issues
         uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0

--- a/.github/workflows/update_verification_metadata.yml
+++ b/.github/workflows/update_verification_metadata.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   update-verification-metadata:

--- a/.github/workflows/validate_public_api.yml
+++ b/.github/workflows/validate_public_api.yml
@@ -6,14 +6,13 @@ on:
       GRADLE_ENCRYPTION_KEY:
         required: true
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   validate_public_api:
     name: Validate public API
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Description
Audit of all 29 workflows against what each job actually does with `GITHUB_TOKEN`.

- Drops write scopes no job uses: the dependency list jobs are downgraded by their callee anyway, the release notes job only reads, and the verification metadata and label jobs authenticate with the automation bot token.
- Moves workflow-level permissions to job level, so a future second job in these workflows cannot silently inherit write access.
- Removes the unused `pull-requests: read` from `check_labels.yml`, which reads its PR data from the event payload rather than the API. Closes code scanning alert 134.

No runtime behaviour changes. Repository settings were updated separately: the default workflow permission is now read, and SHA pinning is enforced.

## Checklist
- [x] Changes are tested manually