### PR TITLE
v6 - CI - Stop the stale workflow from processing pull requests

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -13,7 +13,7 @@ permissions:
   issues: write
 
 jobs:
-  close_stale_prs:
+  close_stale_issues:
     runs-on: ubuntu-latest
     steps:
       - name: Close stale issues
@@ -24,3 +24,7 @@ jobs:
           close-issue-message: 'This issue is now closed because it has been stalled for 14 days with no activity.'
           days-before-issue-stale: 14
           days-before-issue-close: 14
+          # Only issues are managed here. Without this, pull requests fall back to the 60 day
+          # default of days-before-stale, which this job has no permissions to act on.
+          days-before-pr-stale: -1
+          days-before-pr-close: -1


### PR DESCRIPTION
## Description
`days-before-pr-stale` was unset, so pull requests fell back to the 60 day default of `days-before-stale`, and `any-of-labels` applies to them too. A labelled pull request would be picked up by a job that only holds `issues: write`, and the run would fail. Stale handling is only meant to apply to issues here.

Also renames the job from `close_stale_prs` to `close_stale_issues` to match what it does.

## Checklist
- [x] Changes are tested manually