### PR TITLE
v6 - CI - Declare workflow permissions on the release notes branch

### DIFF
--- a/.github/workflows/fetch_version_name_from_release_notes.yml
+++ b/.github/workflows/fetch_version_name_from_release_notes.yml
@@ -11,6 +11,8 @@ jobs:
   fetch_version_name:
     name: Fetch Version Name
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       version-name: ${{ steps.fetch_version_name.outputs.version-name }}
 
@@ -18,9 +20,12 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Fetch version name from latest release notes
         id: fetch_version_name
+        # The commit message is passed through the environment rather than interpolated into the
+        # script, so that its contents cannot be executed as shell.
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           chmod +x scripts/fetch_release_notes_version_name.sh
-          commit_message="${{ github.event.head_commit.message }}"
-          VERSION_NAME=$(./scripts/fetch_release_notes_version_name.sh "${commit_message// /}")
-          echo -e "version-name=$VERSION_NAME" >> $GITHUB_OUTPUT
-          echo -e $VERSION_NAME
+          VERSION_NAME=$(./scripts/fetch_release_notes_version_name.sh "${COMMIT_MESSAGE// /}")
+          echo "version-name=$VERSION_NAME" >> $GITHUB_OUTPUT
+          echo "$VERSION_NAME"

--- a/.github/workflows/trigger_finalize_release.yml
+++ b/.github/workflows/trigger_finalize_release.yml
@@ -8,25 +8,34 @@ on:
 jobs:
   fetch_version_name:
     name: Fetch version name
+    permissions:
+      contents: read
     uses: ./.github/workflows/fetch_version_name_from_release_notes.yml
 
   trigger_finalize_release:
     name: Trigger Finalize Release on Release Branch
     runs-on: ubuntu-latest
     needs: fetch_version_name
+    # Dispatching another workflow is what actions: write is for. No other scope is needed here,
+    # since this job never touches the repository itself.
+    permissions:
+      actions: write
     env:
       VERSION_NAME: ${{ needs.fetch_version_name.outputs.version-name }}
 
     steps:
       - name: Checkout to Release and Trigger Finalize Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          curl -X POST \
-          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          # jq builds the payload so that the version name is encoded as JSON rather than pasted
+          # into it.
+          PAYLOAD=$(jq -n --arg version "$VERSION_NAME" \
+            '{ref: "release/\($version)", inputs: {"version-name": $version}}')
+
+          curl --silent --show-error --fail -X POST \
+          -H "Authorization: Bearer $GH_TOKEN" \
           -H "Accept: application/vnd.github.v3+json" \
-          https://api.github.com/repos/${{ github.repository }}/actions/workflows/finalize_release.yml/dispatches \
-          -d '{
-            "ref":"release/${{ env.VERSION_NAME }}",
-            "inputs": {
-              "version-name": "${{ env.VERSION_NAME }}"
-            }
-          }'
+          "https://api.github.com/repos/$REPOSITORY/actions/workflows/finalize_release.yml/dispatches" \
+          -d "$PAYLOAD"


### PR DESCRIPTION
## Description
The repository default workflow permission was changed to read only. Neither workflow on this branch declared `permissions`, so both were relying on that default.

- `trigger_finalize_release` dispatches `finalize_release.yml`, which needs `actions: write`. Without it the dispatch would have failed with a 403 and the release would have stopped at finalization.
- `fetch_version_name` only checks out, so `contents: read` is enough.

While in these files:

- The commit message is passed through `env` rather than interpolated into the `run` block, so its contents cannot be executed as shell.
- The dispatch payload is built with `jq`, so the version name is encoded as JSON rather than pasted into it.
- `curl` now uses `--fail`, so a rejected dispatch fails the job instead of passing silently.

Companion to #3022, which does the same audit on `main`.

## Checklist
- [x] Changes are tested manually