### PR TITLE
v6 - Renovate - Open the full monthly batch of PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,9 @@
   "prHourlyLimit": 10,
   "packageRules": [
     {
+      "description": [
+        "[main] Group Kotlin Coroutines updates."
+      ],
       "matchBaseBranches": [
         "main"
       ],
@@ -24,6 +27,9 @@
       ]
     },
     {
+      "description": [
+        "[main] Group Kotlin updates."
+      ],
       "matchBaseBranches": [
         "main"
       ],
@@ -35,6 +41,9 @@
       ]
     },
     {
+      "description": [
+        "[main] Open PRs on the second Sunday of the month."
+      ],
       "matchBaseBranches": [
         "main"
       ],
@@ -44,6 +53,9 @@
       ]
     },
     {
+      "description": [
+        "[v5] Open one PR on the second Sunday of the month, every three months."
+      ],
       "matchBaseBranches": [
         "v5"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -40,7 +40,7 @@
       ],
       "minimumReleaseAge": "14 days",
       "schedule": [
-        "on the first day of the month"
+        "* * 8-14 * 0"
       ]
     },
     {
@@ -52,7 +52,7 @@
       "separateMajorMinor": false,
       "minimumReleaseAge": "14 days",
       "schedule": [
-        "* * 1 */3 *"
+        "* * 8-14 */3 0"
       ]
     }
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,8 @@
     "main",
     "v5"
   ],
+  "prConcurrentLimit": 0,
+  "prHourlyLimit": 10,
   "packageRules": [
     {
       "matchBaseBranches": [

--- a/renovate.json
+++ b/renovate.json
@@ -8,17 +8,23 @@
     "Dependencies"
   ],
   "baseBranchPatterns": [
-    "$default",
+    "main",
     "v5"
   ],
   "packageRules": [
     {
+      "matchBaseBranches": [
+        "main"
+      ],
       "groupName": "Kotlin Coroutines",
       "matchPackageNames": [
         "/org.jetbrains.kotlinx:kotlinx-coroutines.*/"
       ]
     },
     {
+      "matchBaseBranches": [
+        "main"
+      ],
       "groupName": "Kotlin",
       "matchPackageNames": [
         "/androidx.compose.compiler:compiler/",
@@ -27,12 +33,12 @@
       ]
     },
     {
+      "matchBaseBranches": [
+        "main"
+      ],
       "minimumReleaseAge": "14 days",
       "schedule": [
         "on the first day of the month"
-      ],
-      "matchPackageNames": [
-        "*"
       ]
     },
     {
@@ -42,6 +48,7 @@
       "groupName": "All v5 dependencies",
       "groupSlug": "all-v5",
       "separateMajorMinor": false,
+      "minimumReleaseAge": "14 days",
       "schedule": [
         "* * 1 */3 *"
       ]


### PR DESCRIPTION
## Description
The monthly window never opened the whole batch. `prHourlyLimit` defaults to 2 and is enforced per clock hour, and Mend's Community plan schedules a job only every 4 hours, so a one-day window could not clear the queue — 1 September produced 18 PRs, exactly 2 per hour across 9 hours. The rest stayed queued until the next month, and the backlog grew every cycle.

Changes:
- Scope each rule to a single base branch. The `main` rules had no `matchBaseBranches`, so they also applied to `v5` and were overridden by the `v5` rule further down the list. No behaviour change: the `v5` rule now carries `minimumReleaseAge` itself instead of inheriting it.
- Remove the concurrent cap and raise `prHourlyLimit` to 10, so one scheduled day opens the whole batch and it can be merged over the following days.
- Move the windows to the second Sunday. The first of the month is the busiest window for Maven Central. `v5` moves to the same day and keeps its three month cadence.
- Describe each rule and the branch it targets.

Renovate ANDs day-of-month with day-of-week, so `8-14` combined with `0` is always the second Sunday, verified against the next 12 months. Config validated with `renovate-config-validator`.

## Checklist
- [x] Changes are tested manually
