### PR TITLE
v6 - Sessions - Surface sessionResult on SessionCheckoutResult

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -966,8 +966,8 @@ public final class com/adyen/checkout/core/components/SessionCheckoutResult {
 	public static synthetic fun copy$default (Lcom/adyen/checkout/core/components/SessionCheckoutResult;Lcom/adyen/checkout/core/common/CheckoutResultCode;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/adyen/checkout/core/components/SessionCheckoutResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getResultCode ()Lcom/adyen/checkout/core/common/CheckoutResultCode;
-	public final fun getSessionData ()Ljava/lang/String;
 	public final fun getSessionId ()Ljava/lang/String;
+	public final fun getSessionResult ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/SessionCheckoutResult.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/SessionCheckoutResult.kt
@@ -15,11 +15,11 @@ import com.adyen.checkout.core.common.CheckoutResultCode
  *
  * @property resultCode The result code of the payment.
  * @property sessionId A unique identifier of the session.
- * @property sessionData The payment session data. You can forward this alongside [sessionId] to your server to fetch
- * the result of the payment.
+ * @property sessionResult You can forward this alongside [sessionId] to your server to fetch the result of the
+ * payment.
  */
 data class SessionCheckoutResult(
     val resultCode: CheckoutResultCode,
     val sessionId: String,
-    val sessionData: String,
+    val sessionResult: String,
 )

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/SessionComponentRequestDispatcher.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/SessionComponentRequestDispatcher.kt
@@ -9,7 +9,9 @@
 package com.adyen.checkout.core.components.internal
 
 import com.adyen.checkout.core.action.data.ActionComponentData
+import com.adyen.checkout.core.common.AdyenLogLevel
 import com.adyen.checkout.core.common.CheckoutResultCode
+import com.adyen.checkout.core.common.internal.helper.adyenLog
 import com.adyen.checkout.core.components.AdditionalDetailsResult
 import com.adyen.checkout.core.components.BeforeSubmitResult
 import com.adyen.checkout.core.components.SessionCheckoutCallbacks
@@ -30,6 +32,7 @@ internal class SessionComponentRequestDispatcher(
 ) : SubmittableComponentRequestDispatcher {
 
     private var sessionData: String = initialSessionData
+    private var sessionResult: String = ""
 
     override suspend fun submit(data: PaymentComponentData<*>): SubmitResult {
         val beforeSubmitResult = handleBeforeSubmit(data)
@@ -46,6 +49,7 @@ internal class SessionComponentRequestDispatcher(
                 ).fold(
                     onSuccess = { response ->
                         sessionData = response.sessionData
+                        sessionResult = response.sessionResult.orEmpty()
                         // TODO - Check if we need to support partial payment flow
                         when {
                             response.action != null -> SubmitResult.Action(response.action)
@@ -86,6 +90,7 @@ internal class SessionComponentRequestDispatcher(
         ).fold(
             onSuccess = { response ->
                 sessionData = response.sessionData
+                sessionResult = response.sessionResult.orEmpty()
                 return AdditionalDetailsResult.Completion(response.resultCode ?: RESULT_CODE_MISSING)
             },
             onFailure = { error ->
@@ -96,10 +101,14 @@ internal class SessionComponentRequestDispatcher(
     }
 
     override fun complete(resultCode: CheckoutResultCode) {
+        if (sessionId.isBlank() || sessionResult.isBlank()) {
+            adyenLog(AdyenLogLevel.ERROR) { "Session completion called without sessionId or sessionResult." }
+        }
+
         val result = SessionCheckoutResult(
             resultCode = resultCode,
             sessionId = sessionId,
-            sessionData = sessionData,
+            sessionResult = sessionResult,
         )
         callbacks.onComplete(result)
     }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/SessionComponentRequestDispatcher.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/SessionComponentRequestDispatcher.kt
@@ -101,9 +101,12 @@ internal class SessionComponentRequestDispatcher(
     }
 
     override fun complete(resultCode: CheckoutResultCode) {
-        val isExpectedToBeMissing = resultCode == CheckoutResultCode.CANCELLED || resultCode == CheckoutResultCode.ERROR
-        if (sessionId.isBlank() || (sessionResult.isBlank() && !isExpectedToBeMissing)) {
-            adyenLog(AdyenLogLevel.ERROR) { "Session completion called without sessionId or sessionResult." }
+        val isSessionResultExpectedToBeMissing = resultCode == CheckoutResultCode.CANCELLED ||
+            resultCode == CheckoutResultCode.ERROR
+        if (sessionId.isBlank()) {
+            adyenLog(AdyenLogLevel.ERROR) { "Session completion called without a sessionId." }
+        } else if (sessionResult.isBlank() && !isSessionResultExpectedToBeMissing) {
+            adyenLog(AdyenLogLevel.ERROR) { "Session completion called without a sessionResult." }
         }
 
         val result = SessionCheckoutResult(

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/SessionComponentRequestDispatcher.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/SessionComponentRequestDispatcher.kt
@@ -31,7 +31,7 @@ internal class SessionComponentRequestDispatcher(
     private val sessionRepository: SessionRepository,
 ) : SubmittableComponentRequestDispatcher {
 
-    private var sessionData: String = initialSessionData
+    private var currentSessionData: String = initialSessionData
     private var sessionResult: String = ""
 
     override suspend fun submit(data: PaymentComponentData<*>): SubmitResult {
@@ -40,15 +40,15 @@ internal class SessionComponentRequestDispatcher(
         return when (beforeSubmitResult) {
             is BeforeSubmitResult.Abort -> SubmitResult.Retry()
             is BeforeSubmitResult.Proceed -> {
-                beforeSubmitResult.sessionData?.let { sessionData = it }
+                beforeSubmitResult.sessionData?.let { currentSessionData = it }
                 val finalData = data.applyBeforeSubmitData(beforeSubmitResult.data)
                 sessionRepository.submitPayment(
                     sessionId = sessionId,
-                    sessionData = sessionData,
+                    sessionData = currentSessionData,
                     paymentComponentData = finalData,
                 ).fold(
                     onSuccess = { response ->
-                        sessionData = response.sessionData
+                        currentSessionData = response.sessionData
                         sessionResult = response.sessionResult.orEmpty()
                         // TODO - Check if we need to support partial payment flow
                         when {
@@ -85,11 +85,11 @@ internal class SessionComponentRequestDispatcher(
     override suspend fun additionalDetails(data: ActionComponentData): AdditionalDetailsResult {
         sessionRepository.submitDetails(
             sessionId = sessionId,
-            sessionData = sessionData,
+            sessionData = currentSessionData,
             actionComponentData = data,
         ).fold(
             onSuccess = { response ->
-                sessionData = response.sessionData
+                currentSessionData = response.sessionData
                 sessionResult = response.sessionResult.orEmpty()
                 return AdditionalDetailsResult.Completion(response.resultCode ?: RESULT_CODE_MISSING)
             },
@@ -101,7 +101,8 @@ internal class SessionComponentRequestDispatcher(
     }
 
     override fun complete(resultCode: CheckoutResultCode) {
-        if (sessionId.isBlank() || sessionResult.isBlank()) {
+        val isExpectedToBeMissing = resultCode == CheckoutResultCode.CANCELLED || resultCode == CheckoutResultCode.ERROR
+        if (sessionId.isBlank() || (sessionResult.isBlank() && !isExpectedToBeMissing)) {
             adyenLog(AdyenLogLevel.ERROR) { "Session completion called without sessionId or sessionResult." }
         }
 

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/SessionComponentRequestDispatcherTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/SessionComponentRequestDispatcherTest.kt
@@ -275,6 +275,31 @@ internal class SessionComponentRequestDispatcherTest(
                 )
                 assertEquals(listOf(expected), capturedResults)
             }
+
+        @Test
+        fun `when a later response has a null sessionResult, then it overwrites the previous sessionResult`() =
+            runTest {
+                val paymentsResponse = createPaymentsResponse(
+                    action = mock(),
+                    sessionResult = "payments-session-result",
+                )
+                whenever(sessionRepository.submitPayment(any(), any(), any())) doReturn Result.success(paymentsResponse)
+
+                val detailsResponse = createDetailsResponse(
+                    resultCode = "Authorised",
+                    sessionResult = null,
+                )
+                whenever(sessionRepository.submitDetails(any(), any(), any())) doReturn Result.success(detailsResponse)
+
+                val capturedResults = mutableListOf<SessionCheckoutResult>()
+                val dispatcher = createDispatcher(onComplete = { capturedResults += it })
+
+                dispatcher.submit(emptyPaymentComponentData())
+                dispatcher.additionalDetails(ActionComponentData())
+                dispatcher.complete(CheckoutResultCode.AUTHORISED)
+
+                assertEquals("", capturedResults.single().sessionResult)
+            }
     }
 
     @Nested

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/SessionComponentRequestDispatcherTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/SessionComponentRequestDispatcherTest.kt
@@ -205,7 +205,7 @@ internal class SessionComponentRequestDispatcherTest(
     inner class CompleteTest {
 
         @Test
-        fun `when complete is called, then onComplete callback is invoked with AdvancedCheckoutResult`() {
+        fun `when complete is called, then onComplete callback is invoked with SessionCheckoutResult`() {
             val capturedResults = mutableListOf<SessionCheckoutResult>()
             val dispatcher = createDispatcher(onComplete = { capturedResults += it })
 
@@ -214,7 +214,7 @@ internal class SessionComponentRequestDispatcherTest(
             val expected = SessionCheckoutResult(
                 CheckoutResultCode.AUTHORISED,
                 sessionId = "session-id",
-                sessionData = "session-data",
+                sessionResult = "",
             )
             assertEquals(listOf(expected), capturedResults)
         }
@@ -228,6 +228,53 @@ internal class SessionComponentRequestDispatcherTest(
 
             assertEquals(CheckoutResultCode("CustomResultCode"), capturedResults.single().resultCode)
         }
+
+        @Test
+        fun `when submit succeeds with sessionResult, then complete uses the latest sessionResult`() = runTest {
+            val response = createPaymentsResponse(
+                resultCode = "Authorised",
+                sessionData = "updated-session-data",
+                sessionResult = "payments-session-result",
+            )
+            whenever(sessionRepository.submitPayment(any(), any(), any())) doReturn Result.success(response)
+
+            val capturedResults = mutableListOf<SessionCheckoutResult>()
+            val dispatcher = createDispatcher(onComplete = { capturedResults += it })
+
+            dispatcher.submit(emptyPaymentComponentData())
+            dispatcher.complete(CheckoutResultCode.AUTHORISED)
+
+            val expected = SessionCheckoutResult(
+                CheckoutResultCode.AUTHORISED,
+                sessionId = "session-id",
+                sessionResult = "payments-session-result",
+            )
+            assertEquals(listOf(expected), capturedResults)
+        }
+
+        @Test
+        fun `when additionalDetails succeeds with sessionResult, then complete uses the latest sessionResult`() =
+            runTest {
+                val response = createDetailsResponse(
+                    resultCode = "Authorised",
+                    sessionData = "updated-session-data",
+                    sessionResult = "details-session-result",
+                )
+                whenever(sessionRepository.submitDetails(any(), any(), any())) doReturn Result.success(response)
+
+                val capturedResults = mutableListOf<SessionCheckoutResult>()
+                val dispatcher = createDispatcher(onComplete = { capturedResults += it })
+
+                dispatcher.additionalDetails(ActionComponentData())
+                dispatcher.complete(CheckoutResultCode.AUTHORISED)
+
+                val expected = SessionCheckoutResult(
+                    CheckoutResultCode.AUTHORISED,
+                    sessionId = "session-id",
+                    sessionResult = "details-session-result",
+                )
+                assertEquals(listOf(expected), capturedResults)
+            }
     }
 
     @Nested
@@ -421,23 +468,27 @@ internal class SessionComponentRequestDispatcherTest(
     private fun createPaymentsResponse(
         resultCode: String? = "",
         action: Action? = null,
+        sessionData: String = "session-data",
+        sessionResult: String? = null,
     ) = SessionPaymentsResponse(
-        sessionData = "session-data",
+        sessionData = sessionData,
         status = null,
         resultCode = resultCode,
         action = action,
         order = null,
-        sessionResult = null,
+        sessionResult = sessionResult,
     )
 
     private fun createDetailsResponse(
         resultCode: String?,
+        sessionData: String = "session-data",
+        sessionResult: String? = null,
     ) = SessionDetailsResponse(
-        sessionData = "session-data",
+        sessionData = sessionData,
         status = null,
         resultCode = resultCode,
         action = null,
-        sessionResult = null,
+        sessionResult = sessionResult,
         order = null,
     )
 


### PR DESCRIPTION
## Description
The sessions `/payments` and `/payments/details` responses include a `sessionResult` field meant to be forwarded to the merchant's server for the documented [GET /sessions/{id}?sessionResult=...](https://docs.adyen.com/standard/integration/drop-in/optional-server-configuration) verification call. It was deserialized (`SessionPaymentsResponse.sessionResult`, `SessionDetailsResponse.sessionResult`) but discarded - `SessionCheckoutResult` only exposed `sessionData`, which is internal session state and cannot be used for that call.

Changes:
- `SessionComponentRequestDispatcher` now tracks `sessionResult` from `submitPayment()`/`submitDetails()` responses and forwards it on `complete()`.
- `SessionCheckoutResult.sessionData` is replaced with `sessionResult: String` (non-optional).
- Added a defensive log if `complete()` is reached without a `sessionId`, or without a `sessionResult` when one is expected (not `Cancelled`/`Error`).

### iOS parity
Checked against `AdyenSession/Session.swift` and `CheckoutResultCallbackStore.swift`. One intentional divergence:

| | iOS | Android (this PR) |
|---|---|---|
| Missing `sessionId`/`sessionResult` at completion | Skips `onComplete` entirely | Always invokes `onComplete` (empty `sessionResult`) + defensive log |

Everything else (`sessionResult` shape, "last response always wins" overwrite semantics) matches iOS.

## Checklist
- [x] If applicable, make sure Breaking change label is added.
- [x] Code is unit tested
- [ ] Changes are tested manually
- [x] Aligned public API changes with other platforms (if applicable)
- [ ] Related issues are linked

## Ticket Number
COSDK-1532

## Release notes
### Breaking changes
- `SessionCheckoutResult.sessionData` has been removed and replaced with `SessionCheckoutResult.sessionResult`, which can be forwarded to your server together with `sessionId` to fetch the result of the payment.

### Fixed
- Fixed a bug where the sessions flow's `sessionResult` was never surfaced to the merchant, making server-side payment verification impossible.
