### PR TITLE
v6 - Core - Group error message and visibility

### DIFF
--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/state/BlikComponentStateReducer.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/state/BlikComponentStateReducer.kt
@@ -25,12 +25,10 @@ internal class BlikComponentStateReducer : ComponentStateReducer<BlikComponentSt
             is BlikIntent.UpdateLoading -> state.copy(isLoading = intent.isLoading)
 
             is BlikIntent.HighlightValidationErrors -> {
-                val hasBlikCodeError = state.blikCode.errorMessage != null
+                val hasBlikCodeError = !state.blikCode.isValid
                 state.copy(
-                    blikCode = state.blikCode.copy(
-                        showError = hasBlikCodeError,
-                        isFocused = hasBlikCodeError,
-                    ),
+                    blikCode = state.blikCode.showErrorIfPresent()
+                        .copy(isFocused = hasBlikCodeError),
                 )
             }
         }

--- a/blik/src/main/java/com/adyen/checkout/blik/internal/ui/state/BlikComponentStateValidator.kt
+++ b/blik/src/main/java/com/adyen/checkout/blik/internal/ui/state/BlikComponentStateValidator.kt
@@ -20,12 +20,12 @@ internal class BlikComponentStateValidator : ComponentStateValidator<BlikCompone
             null
         }
         return state.copy(
-            blikCode = state.blikCode.copy(errorMessage = blikCodeError),
+            blikCode = state.blikCode.updateError(blikCodeError),
         )
     }
 
     override fun isValid(state: BlikComponentState): Boolean {
-        return state.blikCode.errorMessage == null
+        return state.blikCode.isValid
     }
 
     private fun isBlikCodeValid(blikCode: String): Boolean {

--- a/blik/src/test/java/com/adyen/checkout/blik/internal/ui/state/BlikComponentStateFactoryTest.kt
+++ b/blik/src/test/java/com/adyen/checkout/blik/internal/ui/state/BlikComponentStateFactoryTest.kt
@@ -31,9 +31,8 @@ internal class BlikComponentStateFactoryTest {
             blikCode = TextInputComponentState(
                 text = "",
                 description = CheckoutLocalizationKey.BLIK_CODE_HINT,
-                errorMessage = null,
-                isFocused = true,
-                showError = false,
+                error = null,
+                isFocused = true
             ),
             isLoading = false,
         )

--- a/blik/src/test/java/com/adyen/checkout/blik/internal/ui/state/BlikComponentStateReducerTest.kt
+++ b/blik/src/test/java/com/adyen/checkout/blik/internal/ui/state/BlikComponentStateReducerTest.kt
@@ -61,14 +61,13 @@ internal class BlikComponentStateReducerTest {
             blikCode = TextInputComponentState(
                 text = "",
                 isFocused = false,
-                errorMessage = CheckoutLocalizationKey.BLIK_CODE_INVALID,
-                showError = false,
+                error = TextInputComponentState.InputError(CheckoutLocalizationKey.BLIK_CODE_INVALID)
             ),
         )
 
         val actual = reducer.reduce(state, BlikIntent.HighlightValidationErrors)
 
-        assertTrue(actual.blikCode.showError)
+        assertTrue(actual.blikCode.isErrorVisible)
         assertTrue(actual.blikCode.isFocused)
     }
 
@@ -78,7 +77,7 @@ internal class BlikComponentStateReducerTest {
 
         val actual = reducer.reduce(state, BlikIntent.HighlightValidationErrors)
 
-        assertFalse(actual.blikCode.showError)
+        assertFalse(actual.blikCode.isErrorVisible)
         assertFalse(actual.blikCode.isFocused)
     }
 
@@ -86,8 +85,7 @@ internal class BlikComponentStateReducerTest {
         blikCode = TextInputComponentState(
             text = "",
             isFocused = false,
-            errorMessage = null,
-            showError = false,
+            error = null
         ),
         isLoading = false,
     )

--- a/blik/src/test/java/com/adyen/checkout/blik/internal/ui/state/BlikComponentStateValidatorTest.kt
+++ b/blik/src/test/java/com/adyen/checkout/blik/internal/ui/state/BlikComponentStateValidatorTest.kt
@@ -36,7 +36,7 @@ internal class BlikComponentStateValidatorTest {
 
             val actual = validator.validate(state)
 
-            assertNull(actual.blikCode.errorMessage)
+            assertNull(actual.blikCode.error?.message)
         }
 
         @Test
@@ -45,7 +45,7 @@ internal class BlikComponentStateValidatorTest {
 
             val actual = validator.validate(state)
 
-            assertEquals(CheckoutLocalizationKey.BLIK_CODE_INVALID, actual.blikCode.errorMessage)
+            assertEquals(CheckoutLocalizationKey.BLIK_CODE_INVALID, actual.blikCode.error?.message)
         }
 
         @Test
@@ -54,7 +54,7 @@ internal class BlikComponentStateValidatorTest {
 
             val actual = validator.validate(state)
 
-            assertEquals(CheckoutLocalizationKey.BLIK_CODE_INVALID, actual.blikCode.errorMessage)
+            assertEquals(CheckoutLocalizationKey.BLIK_CODE_INVALID, actual.blikCode.error?.message)
         }
 
         @Test
@@ -63,7 +63,7 @@ internal class BlikComponentStateValidatorTest {
 
             val actual = validator.validate(state)
 
-            assertEquals(CheckoutLocalizationKey.BLIK_CODE_INVALID, actual.blikCode.errorMessage)
+            assertEquals(CheckoutLocalizationKey.BLIK_CODE_INVALID, actual.blikCode.error?.message)
         }
 
         @Test
@@ -72,7 +72,7 @@ internal class BlikComponentStateValidatorTest {
 
             val actual = validator.validate(state)
 
-            assertEquals(CheckoutLocalizationKey.BLIK_CODE_INVALID, actual.blikCode.errorMessage)
+            assertEquals(CheckoutLocalizationKey.BLIK_CODE_INVALID, actual.blikCode.error?.message)
         }
     }
 
@@ -81,7 +81,7 @@ internal class BlikComponentStateValidatorTest {
 
         @Test
         fun `when blik code has no error, then isValid should return true`() {
-            val state = createState(blikCode = VALID_BLIK_CODE, errorMessage = null)
+            val state = createState(blikCode = VALID_BLIK_CODE, errorKey = null)
 
             val actual = validator.isValid(state)
 
@@ -92,7 +92,7 @@ internal class BlikComponentStateValidatorTest {
         fun `when blik code has an error, then isValid should return false`() {
             val state = createState(
                 blikCode = "123",
-                errorMessage = CheckoutLocalizationKey.BLIK_CODE_INVALID,
+                errorKey = CheckoutLocalizationKey.BLIK_CODE_INVALID,
             )
 
             val actual = validator.isValid(state)
@@ -103,13 +103,12 @@ internal class BlikComponentStateValidatorTest {
 
     private fun createState(
         blikCode: String,
-        errorMessage: CheckoutLocalizationKey? = null,
+        errorKey: CheckoutLocalizationKey? = null,
     ) = BlikComponentState(
         blikCode = TextInputComponentState(
             text = blikCode,
-            errorMessage = errorMessage,
+            error = errorKey?.let { TextInputComponentState.InputError(it) },
             isFocused = false,
-            showError = false,
         ),
         isLoading = false,
     )

--- a/blik/src/test/java/com/adyen/checkout/blik/internal/ui/state/BlikViewStateProducerTest.kt
+++ b/blik/src/test/java/com/adyen/checkout/blik/internal/ui/state/BlikViewStateProducerTest.kt
@@ -33,8 +33,7 @@ internal class BlikViewStateProducerTest {
             blikCode = TextInputComponentState(
                 text = "123456",
                 isFocused = true,
-                errorMessage = CheckoutLocalizationKey.BLIK_CODE_INVALID,
-                showError = true,
+                error = TextInputComponentState.InputError(CheckoutLocalizationKey.BLIK_CODE_INVALID, isVisible = true)
             ),
             isLoading = true,
         )

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateReducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateReducer.kt
@@ -126,48 +126,32 @@ internal class CardComponentStateReducer(
             }
         }
 
-        val hasCardNumberError = state.cardNumber.errorMessage != null
-        val hasExpiryDateError = state.expiryDate.errorMessage != null
-        val hasSecurityCodeError = state.securityCode.errorMessage != null
-        val hasHolderNameError = state.holderName.errorMessage != null
-        val hasSocialSecurityNumberError = state.socialSecurityNumber.errorMessage != null
-        val hasKcpBirthDateOrTaxNumberError = state.kcpBirthDateOrTaxNumber.errorMessage != null
-        val hasKcpCardPasswordError = state.kcpCardPassword.errorMessage != null
-        val hasPostalCodeError = state.postalCode.errorMessage != null
+        val hasCardNumberError = !state.cardNumber.isValid
+        val hasExpiryDateError = !state.expiryDate.isValid
+        val hasSecurityCodeError = !state.securityCode.isValid
+        val hasHolderNameError = !state.holderName.isValid
+        val hasSocialSecurityNumberError = !state.socialSecurityNumber.isValid
+        val hasKcpBirthDateOrTaxNumberError = !state.kcpBirthDateOrTaxNumber.isValid
+        val hasKcpCardPasswordError = !state.kcpCardPassword.isValid
+        val hasPostalCodeError = !state.postalCode.isValid
 
         return state.copy(
-            cardNumber = state.cardNumber.copy(
-                showError = hasCardNumberError,
-                isFocused = shouldFocus(hasCardNumberError),
-            ),
-            expiryDate = state.expiryDate.copy(
-                showError = hasExpiryDateError,
-                isFocused = shouldFocus(hasExpiryDateError),
-            ),
-            securityCode = state.securityCode.copy(
-                showError = hasSecurityCodeError,
-                isFocused = shouldFocus(hasSecurityCodeError),
-            ),
-            holderName = state.holderName.copy(
-                showError = hasHolderNameError,
-                isFocused = shouldFocus(hasHolderNameError),
-            ),
-            socialSecurityNumber = state.socialSecurityNumber.copy(
-                showError = hasSocialSecurityNumberError,
-                isFocused = shouldFocus(hasSocialSecurityNumberError),
-            ),
-            kcpBirthDateOrTaxNumber = state.kcpBirthDateOrTaxNumber.copy(
-                showError = hasKcpBirthDateOrTaxNumberError,
-                isFocused = shouldFocus(hasKcpBirthDateOrTaxNumberError),
-            ),
-            kcpCardPassword = state.kcpCardPassword.copy(
-                showError = hasKcpCardPasswordError,
-                isFocused = shouldFocus(hasKcpCardPasswordError),
-            ),
-            postalCode = state.postalCode.copy(
-                showError = hasPostalCodeError,
-                isFocused = shouldFocus(hasPostalCodeError)
-            )
+            cardNumber = state.cardNumber.showErrorIfPresent()
+                .copy(isFocused = shouldFocus(hasCardNumberError)),
+            expiryDate = state.expiryDate.showErrorIfPresent()
+                .copy(isFocused = shouldFocus(hasExpiryDateError)),
+            securityCode = state.securityCode.showErrorIfPresent()
+                .copy(isFocused = shouldFocus(hasSecurityCodeError)),
+            holderName = state.holderName.showErrorIfPresent()
+                .copy(isFocused = shouldFocus(hasHolderNameError)),
+            socialSecurityNumber = state.socialSecurityNumber.showErrorIfPresent()
+                .copy(isFocused = shouldFocus(hasSocialSecurityNumberError)),
+            kcpBirthDateOrTaxNumber = state.kcpBirthDateOrTaxNumber.showErrorIfPresent()
+                .copy(isFocused = shouldFocus(hasKcpBirthDateOrTaxNumberError)),
+            kcpCardPassword = state.kcpCardPassword.showErrorIfPresent()
+                .copy(isFocused = shouldFocus(hasKcpCardPasswordError)),
+            postalCode = state.postalCode.showErrorIfPresent()
+                .copy(isFocused = shouldFocus(hasPostalCodeError)),
         )
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateValidator.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateValidator.kt
@@ -45,26 +45,26 @@ internal class CardComponentStateValidator(
         val postalCodeError = validatePostalCode(state.postalCode)
 
         return state.copy(
-            cardNumber = state.cardNumber.copy(errorMessage = cardNumberError),
-            expiryDate = state.expiryDate.copy(errorMessage = expiryDateError),
-            securityCode = state.securityCode.copy(errorMessage = securityCodeError),
-            holderName = state.holderName.copy(errorMessage = holderNameError),
-            socialSecurityNumber = state.socialSecurityNumber.copy(errorMessage = socialSecurityNumberError),
-            kcpBirthDateOrTaxNumber = state.kcpBirthDateOrTaxNumber.copy(errorMessage = kcpBirthDateOrTaxNumberError),
-            kcpCardPassword = state.kcpCardPassword.copy(errorMessage = kcpCardPasswordError),
-            postalCode = state.postalCode.copy(errorMessage = postalCodeError),
+            cardNumber = state.cardNumber.updateError(cardNumberError),
+            expiryDate = state.expiryDate.updateError(expiryDateError),
+            securityCode = state.securityCode.updateError(securityCodeError),
+            holderName = state.holderName.updateError(holderNameError),
+            socialSecurityNumber = state.socialSecurityNumber.updateError(socialSecurityNumberError),
+            kcpBirthDateOrTaxNumber = state.kcpBirthDateOrTaxNumber.updateError(kcpBirthDateOrTaxNumberError),
+            kcpCardPassword = state.kcpCardPassword.updateError(kcpCardPasswordError),
+            postalCode = state.postalCode.updateError(postalCodeError),
         )
     }
 
     override fun isValid(state: CardComponentState): Boolean {
-        return state.cardNumber.errorMessage == null &&
-            state.expiryDate.errorMessage == null &&
-            state.securityCode.errorMessage == null &&
-            state.holderName.errorMessage == null &&
-            state.socialSecurityNumber.errorMessage == null &&
-            state.kcpBirthDateOrTaxNumber.errorMessage == null &&
-            state.kcpCardPassword.errorMessage == null &&
-            state.postalCode.errorMessage == null
+        return state.cardNumber.isValid &&
+            state.expiryDate.isValid &&
+            state.securityCode.isValid &&
+            state.holderName.isValid &&
+            state.socialSecurityNumber.isValid &&
+            state.kcpBirthDateOrTaxNumber.isValid &&
+            state.kcpCardPassword.isValid &&
+            state.postalCode.isValid
     }
 
     private fun validateCardNumber(

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardComponentStateReducer.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardComponentStateReducer.kt
@@ -31,13 +31,11 @@ internal class StoredCardComponentStateReducer : ComponentStateReducer<StoredCar
     }
 
     private fun highlightValidationErrors(state: StoredCardComponentState): StoredCardComponentState {
-        val hasSecurityCodeError = state.securityCode.errorMessage != null
+        val hasSecurityCodeError = !state.securityCode.isValid
 
         return state.copy(
-            securityCode = state.securityCode.copy(
-                showError = hasSecurityCodeError,
-                isFocused = hasSecurityCodeError,
-            ),
+            securityCode = state.securityCode.showErrorIfPresent()
+                .copy(isFocused = hasSecurityCodeError),
         )
     }
 }

--- a/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardComponentStateValidator.kt
+++ b/card/src/main/java/com/adyen/checkout/card/internal/ui/state/StoredCardComponentStateValidator.kt
@@ -25,12 +25,12 @@ internal class StoredCardComponentStateValidator(
             )
 
         return state.copy(
-            securityCode = state.securityCode.copy(errorMessage = securityCodeError),
+            securityCode = state.securityCode.updateError(securityCodeError),
         )
     }
 
     override fun isValid(state: StoredCardComponentState): Boolean {
-        return state.securityCode.errorMessage == null
+        return state.securityCode.isValid
     }
 
     private fun validateSecurityCode(

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateReducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateReducerTest.kt
@@ -198,19 +198,18 @@ internal class CardComponentStateReducerTest {
     }
 
     @Test
-    fun `when intent is HighlightValidationErrors and cardNumber has error, then cardNumber showError and focus are set`() {
+    fun `when intent is HighlightValidationErrors and cardNumber has error, then the cardNumber error is shown and focus is set`() {
         val state = createInitialState().copy(
             cardNumber = TextInputComponentState(
                 text = "",
                 isFocused = false,
-                errorMessage = CheckoutLocalizationKey.GENERAL_CLOSE,
-                showError = false,
+                error = TextInputComponentState.InputError(CheckoutLocalizationKey.GENERAL_CLOSE)
             ),
         )
 
         val actual = reducer.reduce(state, CardIntent.HighlightValidationErrors)
 
-        assertTrue(actual.cardNumber.showError)
+        assertTrue(actual.cardNumber.isErrorVisible)
         assertTrue(actual.cardNumber.isFocused)
     }
 
@@ -220,19 +219,23 @@ internal class CardComponentStateReducerTest {
 
         val actual = reducer.reduce(state, CardIntent.HighlightValidationErrors)
 
-        assertFalse(actual.cardNumber.showError)
-        assertFalse(actual.expiryDate.showError)
-        assertFalse(actual.securityCode.showError)
-        assertFalse(actual.holderName.showError)
-        assertFalse(actual.postalCode.showError)
+        assertFalse(actual.cardNumber.isErrorVisible)
+        assertFalse(actual.expiryDate.isErrorVisible)
+        assertFalse(actual.securityCode.isErrorVisible)
+        assertFalse(actual.holderName.isErrorVisible)
+        assertFalse(actual.postalCode.isErrorVisible)
     }
 
     @Test
     fun `when intent is HighlightValidationErrors with multiple errors, then first field with error gets focus`() {
         val state = createInitialState().copy(
-            cardNumber = TextInputComponentState(errorMessage = null),
-            expiryDate = TextInputComponentState(errorMessage = CheckoutLocalizationKey.GENERAL_CLOSE),
-            securityCode = TextInputComponentState(errorMessage = CheckoutLocalizationKey.GENERAL_CLOSE),
+            cardNumber = TextInputComponentState(error = null),
+            expiryDate = TextInputComponentState(
+                error = TextInputComponentState.InputError(CheckoutLocalizationKey.GENERAL_CLOSE)
+            ),
+            securityCode = TextInputComponentState(
+                error = TextInputComponentState.InputError(CheckoutLocalizationKey.GENERAL_CLOSE)
+            ),
         )
 
         val actual = reducer.reduce(state, CardIntent.HighlightValidationErrors)

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateValidatorTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardComponentStateValidatorTest.kt
@@ -47,7 +47,7 @@ internal class CardComponentStateValidatorTest {
         val result = validator.isValid(validatedState)
 
         assertFalse(result)
-        assertNotNull(validatedState.cardNumber.errorMessage)
+        assertNotNull(validatedState.cardNumber.error?.message)
     }
 
     @Test
@@ -60,7 +60,7 @@ internal class CardComponentStateValidatorTest {
         val result = validator.isValid(validatedState)
 
         assertFalse(result)
-        assertNotNull(validatedState.expiryDate.errorMessage)
+        assertNotNull(validatedState.expiryDate.error?.message)
     }
 
     @Test
@@ -73,7 +73,7 @@ internal class CardComponentStateValidatorTest {
         val result = validator.isValid(validatedState)
 
         assertFalse(result)
-        assertNotNull(validatedState.securityCode.errorMessage)
+        assertNotNull(validatedState.securityCode.error?.message)
     }
 
     @Test
@@ -86,7 +86,7 @@ internal class CardComponentStateValidatorTest {
         val result = validator.isValid(validatedState)
 
         assertFalse(result)
-        assertNotNull(validatedState.holderName.errorMessage)
+        assertNotNull(validatedState.holderName.error?.message)
     }
 
     @Test
@@ -99,7 +99,7 @@ internal class CardComponentStateValidatorTest {
         val result = validator.isValid(validatedState)
 
         assertTrue(result)
-        assertNull(validatedState.holderName.errorMessage)
+        assertNull(validatedState.holderName.error?.message)
     }
 
     @Test
@@ -112,7 +112,7 @@ internal class CardComponentStateValidatorTest {
         val result = validator.isValid(validatedState)
 
         assertFalse(result)
-        assertNotNull(validatedState.socialSecurityNumber.errorMessage)
+        assertNotNull(validatedState.socialSecurityNumber.error?.message)
     }
 
     @Test
@@ -128,7 +128,7 @@ internal class CardComponentStateValidatorTest {
         val result = validator.isValid(validatedState)
 
         assertFalse(result)
-        assertNotNull(validatedState.socialSecurityNumber.errorMessage)
+        assertNotNull(validatedState.socialSecurityNumber.error?.message)
     }
 
     @Test
@@ -141,7 +141,7 @@ internal class CardComponentStateValidatorTest {
         val result = validator.isValid(validatedState)
 
         assertTrue(result)
-        assertNull(validatedState.socialSecurityNumber.errorMessage)
+        assertNull(validatedState.socialSecurityNumber.error?.message)
     }
 
     @Test
@@ -157,7 +157,7 @@ internal class CardComponentStateValidatorTest {
         val result = validator.isValid(validatedState)
 
         assertFalse(result)
-        assertNotNull(validatedState.kcpBirthDateOrTaxNumber.errorMessage)
+        assertNotNull(validatedState.kcpBirthDateOrTaxNumber.error?.message)
     }
 
     @Test
@@ -173,7 +173,7 @@ internal class CardComponentStateValidatorTest {
         val result = validator.isValid(validatedState)
 
         assertFalse(result)
-        assertNotNull(validatedState.kcpBirthDateOrTaxNumber.errorMessage)
+        assertNotNull(validatedState.kcpBirthDateOrTaxNumber.error?.message)
     }
 
     @Test
@@ -186,7 +186,7 @@ internal class CardComponentStateValidatorTest {
         val result = validator.isValid(validatedState)
 
         assertTrue(result)
-        assertNull(validatedState.kcpBirthDateOrTaxNumber.errorMessage)
+        assertNull(validatedState.kcpBirthDateOrTaxNumber.error?.message)
     }
 
     @Test
@@ -199,7 +199,7 @@ internal class CardComponentStateValidatorTest {
         val result = validator.isValid(validatedState)
 
         assertFalse(result)
-        assertNotNull(validatedState.kcpCardPassword.errorMessage)
+        assertNotNull(validatedState.kcpCardPassword.error?.message)
     }
 
     @Test
@@ -215,7 +215,7 @@ internal class CardComponentStateValidatorTest {
         val result = validator.isValid(validatedState)
 
         assertFalse(result)
-        assertNotNull(validatedState.kcpCardPassword.errorMessage)
+        assertNotNull(validatedState.kcpCardPassword.error?.message)
     }
 
     @Test
@@ -228,7 +228,7 @@ internal class CardComponentStateValidatorTest {
         val result = validator.isValid(validatedState)
 
         assertTrue(result)
-        assertNull(validatedState.kcpCardPassword.errorMessage)
+        assertNull(validatedState.kcpCardPassword.error?.message)
     }
 
     @Test
@@ -241,7 +241,7 @@ internal class CardComponentStateValidatorTest {
         val result = validator.isValid(validatedState)
 
         assertFalse(result)
-        assertNotNull(validatedState.postalCode.errorMessage)
+        assertNotNull(validatedState.postalCode.error?.message)
     }
 
     @Test
@@ -257,7 +257,7 @@ internal class CardComponentStateValidatorTest {
         val result = validator.isValid(validatedState)
 
         assertFalse(result)
-        assertNotNull(validatedState.postalCode.errorMessage)
+        assertNotNull(validatedState.postalCode.error?.message)
     }
 
     @Test
@@ -270,7 +270,7 @@ internal class CardComponentStateValidatorTest {
         val result = validator.isValid(validatedState)
 
         assertTrue(result)
-        assertNull(validatedState.postalCode.errorMessage)
+        assertNull(validatedState.postalCode.error?.message)
     }
 
     @Test
@@ -281,7 +281,7 @@ internal class CardComponentStateValidatorTest {
 
         val validatedState = validator.validate(state)
 
-        assertNotNull(validatedState.cardNumber.errorMessage)
+        assertNotNull(validatedState.cardNumber.error?.message)
     }
 
     private fun createValidState() = CardComponentState(

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/CardViewStateProducerTest.kt
@@ -314,8 +314,10 @@ internal class CardViewStateProducerTest {
         val componentState = createComponentState(
             cardNumber = TextInputComponentState(
                 text = "4111",
-                errorMessage = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
-                showError = true,
+                error = TextInputComponentState.InputError(
+                    message = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
+                    isVisible = true
+                )
             ),
             cardBrandState = CardBrandState.SingleReliableBrand(getCardBrandData()),
         )
@@ -338,9 +340,8 @@ internal class CardViewStateProducerTest {
         val componentState = createComponentState(
             cardNumber = TextInputComponentState(
                 text = "4111",
-                errorMessage = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
-                isFocused = true,
-                showError = false, // Focus gain clears showError
+                error = TextInputComponentState.InputError(CheckoutLocalizationKey.CARD_NUMBER_INVALID),
+                isFocused = true, // Focus gain hides the error
             ),
             cardBrandState = CardBrandState.SingleReliableBrand(getCardBrandData()),
         )
@@ -360,9 +361,8 @@ internal class CardViewStateProducerTest {
         val componentState = createComponentState(
             cardNumber = TextInputComponentState(
                 text = "123",
-                errorMessage = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
-                isFocused = true,
-                showError = false, // Focus gain clears showError
+                error = TextInputComponentState.InputError(CheckoutLocalizationKey.CARD_NUMBER_INVALID),
+                isFocused = true, // Focus gain hides the error
             ),
             cardBrandState = CardBrandState.NoBrandsDetected,
         )
@@ -382,8 +382,7 @@ internal class CardViewStateProducerTest {
         val componentState = createComponentState(
             cardNumber = TextInputComponentState(
                 text = "4111111111111111",
-                errorMessage = null,
-                showError = false,
+                error = null
             ),
             cardBrandState = CardBrandState.SingleReliableBrand(getCardBrandData()),
         )
@@ -407,17 +406,15 @@ internal class CardViewStateProducerTest {
         val componentStateWithHiddenError = createComponentState(
             cardNumber = TextInputComponentState(
                 text = "4111",
-                errorMessage = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
-                isFocused = true,
-                showError = false, // Text change sets showError to false
+                error = TextInputComponentState.InputError(CheckoutLocalizationKey.CARD_NUMBER_INVALID),
+                isFocused = true, // Text change hides the error
             ),
             cardBrandState = CardBrandState.SingleReliableBrand(getCardBrandData()),
         )
         val componentStateWithoutError = createComponentState(
             cardNumber = TextInputComponentState(
                 text = "4111",
-                isFocused = true,
-                showError = false,
+                isFocused = true
             ),
             cardBrandState = CardBrandState.SingleReliableBrand(getCardBrandData()),
         )
@@ -527,8 +524,10 @@ internal class CardViewStateProducerTest {
         val componentState = createComponentState(
             cardNumber = TextInputComponentState(
                 text = "",
-                errorMessage = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
-                showError = true,
+                error = TextInputComponentState.InputError(
+                    message = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
+                    isVisible = true
+                )
             ),
             isCardScanningAvailable = true,
         )
@@ -575,7 +574,7 @@ internal class CardViewStateProducerTest {
         val componentState = createComponentState(
             expiryDate = TextInputComponentState(
                 text = "12",
-                errorMessage = CheckoutLocalizationKey.CARD_EXPIRY_DATE_INVALID,
+                error = TextInputComponentState.InputError(CheckoutLocalizationKey.CARD_EXPIRY_DATE_INVALID)
             ),
         )
 
@@ -609,8 +608,10 @@ internal class CardViewStateProducerTest {
         val componentState = createComponentState(
             expiryDate = TextInputComponentState(
                 text = "6415",
-                errorMessage = CheckoutLocalizationKey.CARD_EXPIRY_DATE_INVALID,
-                showError = true,
+                error = TextInputComponentState.InputError(
+                    CheckoutLocalizationKey.CARD_EXPIRY_DATE_INVALID,
+                    isVisible = true
+                )
             ),
         )
 
@@ -671,7 +672,7 @@ internal class CardViewStateProducerTest {
         val componentState = createComponentState(
             securityCode = TextInputComponentState(
                 text = "12",
-                errorMessage = CheckoutLocalizationKey.CARD_SECURITY_CODE_INVALID,
+                error = TextInputComponentState.InputError(CheckoutLocalizationKey.CARD_SECURITY_CODE_INVALID)
             ),
             cardBrandState = CardBrandState.SingleReliableBrand(getCardBrandData(CardBrand("visa"))),
         )
@@ -707,8 +708,10 @@ internal class CardViewStateProducerTest {
         val componentState = createComponentState(
             securityCode = TextInputComponentState(
                 text = "12",
-                errorMessage = CheckoutLocalizationKey.CARD_SECURITY_CODE_INVALID,
-                showError = true,
+                error = TextInputComponentState.InputError(
+                    CheckoutLocalizationKey.CARD_SECURITY_CODE_INVALID,
+                    isVisible = true
+                )
             ),
             cardBrandState = CardBrandState.SingleReliableBrand(getCardBrandData(CardBrand("visa"))),
         )

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/StoredCardComponentStateReducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/StoredCardComponentStateReducerTest.kt
@@ -73,19 +73,18 @@ internal class StoredCardComponentStateReducerTest {
     }
 
     @Test
-    fun `when intent is HighlightValidationErrors and securityCode has error, then securityCode showError and focus are set`() {
+    fun `when intent is HighlightValidationErrors and securityCode has error, then the securityCode error is shown and focus is set`() {
         val state = createInitialState().copy(
             securityCode = TextInputComponentState(
                 text = "",
                 isFocused = false,
-                errorMessage = CheckoutLocalizationKey.GENERAL_CLOSE,
-                showError = false,
+                error = TextInputComponentState.InputError(CheckoutLocalizationKey.GENERAL_CLOSE)
             ),
         )
 
         val actual = reducer.reduce(state, StoredCardIntent.HighlightValidationErrors)
 
-        assertTrue(actual.securityCode.showError)
+        assertTrue(actual.securityCode.isErrorVisible)
         assertTrue(actual.securityCode.isFocused)
     }
 
@@ -95,7 +94,7 @@ internal class StoredCardComponentStateReducerTest {
 
         val actual = reducer.reduce(state, StoredCardIntent.HighlightValidationErrors)
 
-        assertFalse(actual.securityCode.showError)
+        assertFalse(actual.securityCode.isErrorVisible)
         assertFalse(actual.securityCode.isFocused)
     }
 

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/StoredCardComponentStateValidatorTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/StoredCardComponentStateValidatorTest.kt
@@ -49,7 +49,7 @@ internal class StoredCardComponentStateValidatorTest {
         val result = validator.isValid(validatedState)
 
         assertFalse(result)
-        assertNotNull(validatedState.securityCode.errorMessage)
+        assertNotNull(validatedState.securityCode.error?.message)
     }
 
     @Test
@@ -62,7 +62,7 @@ internal class StoredCardComponentStateValidatorTest {
         val result = validator.isValid(validatedState)
 
         assertFalse(result)
-        assertNotNull(validatedState.securityCode.errorMessage)
+        assertNotNull(validatedState.securityCode.error?.message)
     }
 
     @Test
@@ -76,7 +76,7 @@ internal class StoredCardComponentStateValidatorTest {
         val result = validator.isValid(validatedState)
 
         assertTrue(result)
-        assertNull(validatedState.securityCode.errorMessage)
+        assertNull(validatedState.securityCode.error?.message)
     }
 
     @Test
@@ -90,7 +90,7 @@ internal class StoredCardComponentStateValidatorTest {
         val result = validator.isValid(validatedState)
 
         assertTrue(result)
-        assertNull(validatedState.securityCode.errorMessage)
+        assertNull(validatedState.securityCode.error?.message)
     }
 
     private fun createValidState() = StoredCardComponentState(

--- a/card/src/test/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewStateProducerTest.kt
+++ b/card/src/test/java/com/adyen/checkout/card/internal/ui/state/StoredCardViewStateProducerTest.kt
@@ -135,8 +135,7 @@ internal class StoredCardViewStateProducerTest {
         val componentState = createComponentState(
             securityCode = TextInputComponentState(
                 text = "123",
-                errorMessage = null,
-                showError = false,
+                error = null
             ),
         )
 
@@ -153,8 +152,10 @@ internal class StoredCardViewStateProducerTest {
         val componentState = createComponentState(
             securityCode = TextInputComponentState(
                 text = "12",
-                errorMessage = CheckoutLocalizationKey.CARD_SECURITY_CODE_INVALID,
-                showError = true,
+                error = TextInputComponentState.InputError(
+                    CheckoutLocalizationKey.CARD_SECURITY_CODE_INVALID,
+                    isVisible = true
+                )
             ),
             detectedCardType = getDetectedCardType(CardBrand("visa")),
         )
@@ -172,8 +173,7 @@ internal class StoredCardViewStateProducerTest {
         val componentState = createComponentState(
             securityCode = TextInputComponentState(
                 text = "",
-                errorMessage = null,
-                showError = false,
+                error = null
             ),
             detectedCardType = getDetectedCardType(CardBrand("amex")),
         )
@@ -191,8 +191,7 @@ internal class StoredCardViewStateProducerTest {
         val componentState = createComponentState(
             securityCode = TextInputComponentState(
                 text = "",
-                errorMessage = null,
-                showError = false,
+                error = null
             ),
             detectedCardType = getDetectedCardType(CardBrand("visa")),
         )
@@ -210,8 +209,7 @@ internal class StoredCardViewStateProducerTest {
         val componentState = createComponentState(
             securityCode = TextInputComponentState(
                 text = "12",
-                errorMessage = CheckoutLocalizationKey.CARD_SECURITY_CODE_INVALID,
-                showError = false,
+                error = TextInputComponentState.InputError(CheckoutLocalizationKey.CARD_SECURITY_CODE_INVALID)
             ),
             detectedCardType = getDetectedCardType(CardBrand("visa")),
         )

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/ComponentStateFlow.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/ComponentStateFlow.kt
@@ -51,8 +51,8 @@ private class ComponentStateFlowImplementation<C : ComponentState, I : Component
     private val validator: ComponentStateValidator<C>,
 ) : ComponentStateFlow<C, I> {
 
-    // Validated up front: isValid reads the errorMessage that validate() writes, so an unvalidated state reports
-    // itself valid no matter what it contains.
+    // Validated up front: isValid reads the error that validate() writes, so an unvalidated state reports itself
+    // valid no matter what it contains.
     private val state = MutableStateFlow(validator.validate(initialState))
 
     override val value: C

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputComponentState.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputComponentState.kt
@@ -9,32 +9,60 @@
 package com.adyen.checkout.core.components.internal.ui.state.model
 
 import androidx.annotation.RestrictTo
+import androidx.annotation.VisibleForTesting
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class TextInputComponentState(
     val text: String = "",
     val description: CheckoutLocalizationKey? = null,
-    val errorMessage: CheckoutLocalizationKey? = null,
+    val error: InputError? = null,
     val isFocused: Boolean = false,
-    val showError: Boolean = false,
     val requirementPolicy: RequirementPolicy = RequirementPolicy.Required,
 ) {
 
+    /**
+     * An error on the field, together with whether the shopper should see it yet.
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class InputError(
+        val message: CheckoutLocalizationKey,
+        val isVisible: Boolean = false,
+    )
+
     val isValid: Boolean
-        get() = errorMessage == null
+        get() = error == null
+
+    val isErrorVisible: Boolean
+        get() = error?.isVisible == true
+
+    fun updateText(text: String) = copy(text = text).hideErrorIfPresent()
 
     /**
-     * Whether the error message should be displayed, which requires both an error to be present and the field to be
-     * showing its errors.
+     * Replaces the error, keeping whether it is currently visible. Validators call this on every pass, so replacing a
+     * message must not hide an error the shopper is already looking at.
      */
-    val showErrorMessage: Boolean
-        get() = showError && errorMessage != null
+    fun updateError(message: CheckoutLocalizationKey?): TextInputComponentState {
+        return when {
+            message == null -> copy(error = null)
+            error == null -> copy(error = InputError(message, isVisible = false))
+            else -> copy(error = InputError(message, isVisible = error.isVisible))
+        }
+    }
 
-    fun updateText(text: String) = copy(text = text, showError = false)
+    /**
+     * Shows the error, if there is one.
+     */
+    fun showErrorIfPresent() = copy(error = error?.copy(isVisible = true))
 
-    fun updateFocus(hasFocus: Boolean) = copy(
-        isFocused = hasFocus,
-        showError = !hasFocus,
-    )
+    /**
+     * Hides the error, if there is one.
+     */
+    @VisibleForTesting
+    fun hideErrorIfPresent() = copy(error = error?.copy(isVisible = false))
+
+    fun updateFocus(hasFocus: Boolean): TextInputComponentState {
+        val focused = copy(isFocused = hasFocus)
+        return if (hasFocus) focused.hideErrorIfPresent() else focused.showErrorIfPresent()
+    }
 }

--- a/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputViewState.kt
+++ b/core/src/main/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputViewState.kt
@@ -43,9 +43,9 @@ fun TextInputComponentState.toViewState(
     if (requirementPolicy == RequirementPolicy.Hidden) return null
     return TextInputViewState(
         text = text,
-        supportingText = if (showErrorMessage) errorMessage else description,
+        supportingText = if (isErrorVisible) error?.message else description,
         isFocused = isFocused,
-        isError = showErrorMessage,
+        isError = isErrorVisible,
         customTrailingIcon = customTrailingIcon,
         isOptional = requirementPolicy is RequirementPolicy.Optional,
     )

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputComponentStateTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputComponentStateTest.kt
@@ -11,293 +11,326 @@ package com.adyen.checkout.core.components.internal.ui.state.model
 import com.adyen.checkout.core.common.localization.CheckoutLocalizationKey
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 /**
  * Tests `TextInputComponentState.kt`: how the state of a field evolves as the shopper types, focuses and blurs, and
- * when that results in an error being displayed. Some tests observe the outcome through `toViewState`, as that is what
- * the UI ends up rendering.
+ * when that results in an error being displayed. A few tests observe the outcome through `toViewState`, where the
+ * point is the transition rather than the mapping.
  *
  * Tests for the mapping itself live in `TextInputViewStateTest`.
  */
 internal class TextInputComponentStateTest {
 
-    // UC1: Error on Explicit Validation
-    @Test
-    fun `when state has error message and showError is true, then error is displayed`() {
-        // GIVEN
-        val state = TextInputComponentState(
-            text = "invalid",
-            errorMessage = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
-            showError = true,
-        )
+    @Nested
+    inner class IsValidTest {
 
-        // WHEN
-        val viewState = state.toViewState()
+        // UC1: Error on Explicit Validation - verify isValid
+        @Test
+        fun `when state has an error, then isValid returns false`() {
+            // GIVEN
+            val state = TextInputComponentState(text = "invalid", error = hiddenError())
 
-        // THEN
-        assertEquals(true, viewState?.isError)
-        assertEquals(CheckoutLocalizationKey.CARD_NUMBER_INVALID, viewState?.supportingText)
+            // WHEN
+            val isValid = state.isValid
+
+            // THEN
+            assertFalse(isValid)
+        }
+
+        // UC14: Empty Field - verify empty is considered valid
+        @Test
+        fun `when field is empty with no error, then isValid returns true`() {
+            // GIVEN
+            val state = TextInputComponentState(text = "", error = null)
+
+            // WHEN
+            val isValid = state.isValid
+
+            // THEN
+            assertTrue(isValid)
+        }
     }
 
-    // UC1: Error on Explicit Validation - verify isValid
-    @Test
-    fun `when state has error message, then isValid returns false`() {
-        // GIVEN
-        val state = TextInputComponentState(
-            text = "invalid",
-            errorMessage = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
-        )
+    /**
+     * There are only three states, because [TextInputComponentState.InputError] holds the message and its visibility
+     * together. A field that shows an error without having one cannot be built.
+     */
+    @Nested
+    inner class IsErrorVisibleTest {
 
-        // WHEN
-        val isValid = state.isValid
+        @Test
+        fun `when there is no error, then it is not visible`() {
+            // GIVEN
+            val state = TextInputComponentState(error = null)
 
-        // THEN
-        assertFalse(isValid)
+            // WHEN
+            val isErrorVisible = state.isErrorVisible
+
+            // THEN
+            assertFalse(isErrorVisible)
+        }
+
+        @Test
+        fun `when there is a hidden error, then it is not visible`() {
+            // GIVEN
+            val state = TextInputComponentState(error = hiddenError())
+
+            // WHEN
+            val isErrorVisible = state.isErrorVisible
+
+            // THEN
+            assertFalse(isErrorVisible)
+        }
+
+        @Test
+        fun `when there is a visible error, then it is visible`() {
+            // GIVEN
+            val state = TextInputComponentState(error = visibleError())
+
+            // WHEN
+            val isErrorVisible = state.isErrorVisible
+
+            // THEN
+            assertTrue(isErrorVisible)
+        }
     }
 
-    // UC2: Error Cleared on Focus
-    @Test
-    fun `when field gains focus, then showError is set to false`() {
-        // GIVEN
-        val state = TextInputComponentState(
-            text = "invalid",
-            errorMessage = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
-            showError = true,
-            isFocused = false,
-        )
+    /**
+     * Validators call `updateError` on every pass, including passes triggered by a different field, so it must not
+     * disturb whether the shopper is currently looking at the error.
+     */
+    @Nested
+    inner class UpdateErrorTest {
 
-        // WHEN
-        val updatedState = state.updateFocus(hasFocus = true)
+        @Test
+        fun `when a field has no error, then the new error starts hidden`() {
+            // GIVEN
+            val state = TextInputComponentState(error = null)
 
-        // THEN
-        assertFalse(updatedState.showError)
-        assertTrue(updatedState.isFocused)
+            // WHEN
+            val updatedState = state.updateError(CheckoutLocalizationKey.CARD_NUMBER_INVALID)
+
+            // THEN
+            assertEquals(CheckoutLocalizationKey.CARD_NUMBER_INVALID, updatedState.error?.message)
+            assertFalse(updatedState.isErrorVisible)
+        }
+
+        @Test
+        fun `when the error is visible, then replacing the message keeps it visible`() {
+            // GIVEN
+            val state = TextInputComponentState(error = visibleError())
+
+            // WHEN
+            val updatedState = state.updateError(CheckoutLocalizationKey.CARD_NUMBER_INVALID_UNSUPPORTED_BRAND)
+
+            // THEN
+            assertEquals(CheckoutLocalizationKey.CARD_NUMBER_INVALID_UNSUPPORTED_BRAND, updatedState.error?.message)
+            assertTrue(updatedState.isErrorVisible)
+        }
+
+        @Test
+        fun `when the error is hidden, then replacing the message keeps it hidden`() {
+            // GIVEN
+            val state = TextInputComponentState(error = hiddenError())
+
+            // WHEN
+            val updatedState = state.updateError(CheckoutLocalizationKey.CARD_NUMBER_INVALID_UNSUPPORTED_BRAND)
+
+            // THEN
+            assertEquals(CheckoutLocalizationKey.CARD_NUMBER_INVALID_UNSUPPORTED_BRAND, updatedState.error?.message)
+            assertFalse(updatedState.isErrorVisible)
+        }
+
+        @Test
+        fun `when the field becomes valid, then the error is removed`() {
+            // GIVEN
+            val state = TextInputComponentState(error = visibleError())
+
+            // WHEN
+            val updatedState = state.updateError(null)
+
+            // THEN
+            assertNull(updatedState.error)
+            assertTrue(updatedState.isValid)
+        }
     }
 
-    // UC2: Error Cleared on Focus - verify view state
-    @Test
-    fun `when field gains focus with error, then error is not displayed in view state`() {
-        // GIVEN
-        val state = TextInputComponentState(
-            text = "invalid",
-            errorMessage = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
-            showError = true,
-        )
+    @Nested
+    inner class UpdateTextTest {
 
-        // WHEN
-        val focusedState = state.updateFocus(hasFocus = true)
-        val viewState = focusedState.toViewState()
+        // UC4: No Error While Typing
+        @Test
+        fun `when text is updated, then the error is hidden`() {
+            // GIVEN
+            val state = TextInputComponentState(text = "old", error = visibleError())
 
-        // THEN
-        assertEquals(false, viewState?.isError)
+            // WHEN
+            val updatedState = state.updateText("new")
+
+            // THEN
+            assertEquals("new", updatedState.text)
+            assertFalse(updatedState.isErrorVisible)
+        }
+
+        // UC4: No Error While Typing - verify error not shown even if an error exists
+        @Test
+        fun `when user is typing with an error present, then error is not displayed in view state`() {
+            // GIVEN
+            val state = TextInputComponentState(text = "invalid", error = visibleError(), isFocused = true)
+
+            // WHEN
+            val typingState = state.updateText("still_invalid")
+            val viewState = typingState.toViewState()
+
+            // THEN
+            assertEquals(false, viewState?.isError)
+            assertFalse(typingState.isErrorVisible)
+        }
     }
 
-    // UC3: Error on Focus Loss
-    @Test
-    fun `when field loses focus, then showError is set to true`() {
-        // GIVEN
-        val state = TextInputComponentState(
-            text = "invalid",
-            errorMessage = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
-            isFocused = true,
-            showError = false,
-        )
+    @Nested
+    inner class UpdateFocusTest {
 
-        // WHEN
-        val updatedState = state.updateFocus(hasFocus = false)
+        // UC2: Error Cleared on Focus
+        @Test
+        fun `when field gains focus, then the error is hidden`() {
+            // GIVEN
+            val state = TextInputComponentState(text = "invalid", error = visibleError(), isFocused = false)
 
-        // THEN
-        assertTrue(updatedState.showError)
-        assertFalse(updatedState.isFocused)
+            // WHEN
+            val updatedState = state.updateFocus(hasFocus = true)
+
+            // THEN
+            assertFalse(updatedState.isErrorVisible)
+            assertTrue(updatedState.isFocused)
+        }
+
+        // UC2: Error Cleared on Focus - verify view state
+        @Test
+        fun `when field gains focus with error, then error is not displayed in view state`() {
+            // GIVEN
+            val state = TextInputComponentState(text = "invalid", error = visibleError())
+
+            // WHEN
+            val focusedState = state.updateFocus(hasFocus = true)
+            val viewState = focusedState.toViewState()
+
+            // THEN
+            assertEquals(false, viewState?.isError)
+        }
+
+        // UC3: Error on Focus Loss
+        @Test
+        fun `when field loses focus, then the error is shown`() {
+            // GIVEN
+            val state = TextInputComponentState(text = "invalid", error = hiddenError(), isFocused = true)
+
+            // WHEN
+            val updatedState = state.updateFocus(hasFocus = false)
+
+            // THEN
+            assertTrue(updatedState.isErrorVisible)
+            assertFalse(updatedState.isFocused)
+        }
+
+        // UC3: Error on Focus Loss - verify view state displays error
+        @Test
+        fun `when field loses focus with invalid input, then error is displayed in view state`() {
+            // GIVEN
+            val state = TextInputComponentState(text = "invalid", error = hiddenError(), isFocused = true)
+
+            // WHEN
+            val blurredState = state.updateFocus(hasFocus = false)
+            val viewState = blurredState.toViewState()
+
+            // THEN
+            assertEquals(true, viewState?.isError)
+            assertEquals(CheckoutLocalizationKey.CARD_NUMBER_INVALID, viewState?.supportingText)
+        }
+
+        // UC14: Empty Field - No Error on Focus Loss
+        @Test
+        fun `when a valid field loses focus, then no error is shown`() {
+            // GIVEN
+            val state = TextInputComponentState(text = "", error = null, isFocused = true)
+
+            // WHEN
+            val blurredState = state.updateFocus(hasFocus = false)
+            val viewState = blurredState.toViewState()
+
+            // THEN
+            assertEquals(false, viewState?.isError)
+        }
     }
 
-    // UC3: Error on Focus Loss - verify view state displays error
-    @Test
-    fun `when field loses focus with invalid input, then error is displayed in view state`() {
-        // GIVEN
-        val state = TextInputComponentState(
-            text = "invalid",
-            errorMessage = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
-            isFocused = true,
-        )
+    @Nested
+    inner class ShowAndHideErrorTest {
 
-        // WHEN
-        val blurredState = state.updateFocus(hasFocus = false)
-        val viewState = blurredState.toViewState()
+        @Test
+        fun `when the error is shown on an invalid field, then it becomes visible`() {
+            // GIVEN
+            val state = TextInputComponentState(text = "invalid", error = hiddenError())
 
-        // THEN
-        assertEquals(true, viewState?.isError)
-        assertEquals(CheckoutLocalizationKey.CARD_NUMBER_INVALID, viewState?.supportingText)
+            // WHEN
+            val updatedState = state.showErrorIfPresent()
+
+            // THEN
+            assertTrue(updatedState.isErrorVisible)
+        }
+
+        /**
+         * A field with nothing wrong with it has nothing to show, so callers do not have to guard against this.
+         */
+        @Test
+        fun `when the error is shown on a valid field, then nothing changes`() {
+            // GIVEN
+            val state = TextInputComponentState(text = "valid", error = null)
+
+            // WHEN
+            val updatedState = state.showErrorIfPresent()
+
+            // THEN
+            assertEquals(state, updatedState)
+            assertFalse(updatedState.isErrorVisible)
+        }
+
+        @Test
+        fun `when the error is hidden on a field showing one, then it stops being visible`() {
+            // GIVEN
+            val state = TextInputComponentState(text = "invalid", error = visibleError())
+
+            // WHEN
+            val updatedState = state.hideErrorIfPresent()
+
+            // THEN
+            assertFalse(updatedState.isErrorVisible)
+            assertEquals(CheckoutLocalizationKey.CARD_NUMBER_INVALID, updatedState.error?.message)
+        }
+
+        @Test
+        fun `when the error is shown twice, then nothing changes`() {
+            // GIVEN
+            val state = TextInputComponentState(text = "invalid", error = visibleError())
+
+            // WHEN
+            val updatedState = state.showErrorIfPresent()
+
+            // THEN
+            assertEquals(state, updatedState)
+        }
     }
 
-    // UC4: No Error While Typing
-    @Test
-    fun `when text is updated, then showError is set to false`() {
-        // GIVEN
-        val state = TextInputComponentState(
-            text = "old",
-            errorMessage = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
-            showError = true,
-        )
+    private fun hiddenError() = TextInputComponentState.InputError(
+        message = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
+        isVisible = false,
+    )
 
-        // WHEN
-        val updatedState = state.updateText("new")
-
-        // THEN
-        assertFalse(updatedState.showError)
-        assertEquals("new", updatedState.text)
-    }
-
-    // UC4: No Error While Typing - verify error not shown even if errorMessage exists
-    @Test
-    fun `when user is typing with error message present, then error is not displayed in view state`() {
-        // GIVEN
-        val state = TextInputComponentState(
-            text = "invalid",
-            errorMessage = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
-            isFocused = true,
-        )
-
-        // WHEN
-        val typingState = state.updateText("still_invalid")
-        val viewState = typingState.toViewState()
-
-        // THEN
-        assertEquals(false, viewState?.isError)
-        assertFalse(typingState.showError)
-    }
-
-    // UC14: Empty Field - No Error on Focus Loss
-    @Test
-    fun `when empty field loses focus, then no error is shown`() {
-        // GIVEN
-        val state = TextInputComponentState(
-            text = "",
-            errorMessage = null,
-            isFocused = true,
-        )
-
-        // WHEN
-        val blurredState = state.updateFocus(hasFocus = false)
-        val viewState = blurredState.toViewState()
-
-        // THEN
-        assertEquals(false, viewState?.isError)
-    }
-
-    // UC14: Empty Field - verify empty is considered valid
-    @Test
-    fun `when field is empty with no error message, then isValid returns true`() {
-        // GIVEN
-        val state = TextInputComponentState(
-            text = "",
-            errorMessage = null,
-        )
-
-        // WHEN
-        val isValid = state.isValid
-
-        // THEN
-        assertTrue(isValid)
-    }
-
-    // Additional test: Verify placeholder is shown when no error
-    @Test
-    fun `when state has description and no error, then description is shown as supporting text`() {
-        // GIVEN
-        val state = TextInputComponentState(
-            text = "text",
-            description = CheckoutLocalizationKey.CARD_NUMBER,
-            errorMessage = null,
-            showError = false,
-        )
-
-        // WHEN
-        val viewState = state.toViewState()
-
-        // THEN
-        assertEquals(false, viewState?.isError)
-        assertEquals(CheckoutLocalizationKey.CARD_NUMBER, viewState?.supportingText)
-    }
-
-    @Test
-    fun `when showError is true and error message is present, then showErrorMessage returns true`() {
-        // GIVEN
-        val state = TextInputComponentState(
-            errorMessage = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
-            showError = true,
-        )
-
-        // WHEN
-        val showErrorMessage = state.showErrorMessage
-
-        // THEN
-        assertTrue(showErrorMessage)
-    }
-
-    @Test
-    fun `when showError is true and error message is absent, then showErrorMessage returns false`() {
-        // GIVEN
-        val state = TextInputComponentState(
-            errorMessage = null,
-            showError = true,
-        )
-
-        // WHEN
-        val showErrorMessage = state.showErrorMessage
-
-        // THEN
-        assertFalse(showErrorMessage)
-    }
-
-    @Test
-    fun `when showError is false and error message is present, then showErrorMessage returns false`() {
-        // GIVEN
-        val state = TextInputComponentState(
-            errorMessage = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
-            showError = false,
-        )
-
-        // WHEN
-        val showErrorMessage = state.showErrorMessage
-
-        // THEN
-        assertFalse(showErrorMessage)
-    }
-
-    @Test
-    fun `when showError is false and error message is absent, then showErrorMessage returns false`() {
-        // GIVEN
-        val state = TextInputComponentState(
-            errorMessage = null,
-            showError = false,
-        )
-
-        // WHEN
-        val showErrorMessage = state.showErrorMessage
-
-        // THEN
-        assertFalse(showErrorMessage)
-    }
-
-    // Additional test: Verify error replaces placeholder
-    @Test
-    fun `when state has both description and error with showError true, then error is shown as supporting text`() {
-        // GIVEN
-        val state = TextInputComponentState(
-            text = "invalid",
-            description = CheckoutLocalizationKey.CARD_NUMBER,
-            errorMessage = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
-            showError = true,
-        )
-
-        // WHEN
-        val viewState = state.toViewState()
-
-        // THEN
-        assertEquals(true, viewState?.isError)
-        assertEquals(CheckoutLocalizationKey.CARD_NUMBER_INVALID, viewState?.supportingText)
-    }
+    private fun visibleError() = TextInputComponentState.InputError(
+        message = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
+        isVisible = true,
+    )
 }

--- a/core/src/test/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputViewStateTest.kt
+++ b/core/src/test/java/com/adyen/checkout/core/components/internal/ui/state/model/TextInputViewStateTest.kt
@@ -74,8 +74,7 @@ internal class TextInputViewStateTest {
         // GIVEN
         val componentState = TextInputComponentState(
             text = "invalid",
-            errorMessage = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
-            showError = true,
+            error = visibleError(),
         )
 
         // WHEN
@@ -90,8 +89,7 @@ internal class TextInputViewStateTest {
         // GIVEN
         val componentState = TextInputComponentState(
             text = "invalid",
-            errorMessage = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
-            showError = false,
+            error = hiddenError(),
         )
 
         // WHEN
@@ -111,6 +109,70 @@ internal class TextInputViewStateTest {
 
         // THEN
         assertEquals(TrailingIcon.Empty, viewState?.trailingIcon)
+    }
+
+    @Test
+    fun `when the error is visible, then it is shown as supporting text`() {
+        // GIVEN
+        val componentState = TextInputComponentState(text = "invalid", error = visibleError())
+
+        // WHEN
+        val viewState = componentState.toViewState()
+
+        // THEN
+        assertEquals(true, viewState?.isError)
+        assertEquals(CheckoutLocalizationKey.CARD_NUMBER_INVALID, viewState?.supportingText)
+    }
+
+    @Test
+    fun `when the error is hidden, then the description is shown as supporting text`() {
+        // GIVEN
+        val componentState = TextInputComponentState(
+            text = "invalid",
+            description = CheckoutLocalizationKey.CARD_NUMBER,
+            error = hiddenError(),
+        )
+
+        // WHEN
+        val viewState = componentState.toViewState()
+
+        // THEN
+        assertEquals(false, viewState?.isError)
+        assertEquals(CheckoutLocalizationKey.CARD_NUMBER, viewState?.supportingText)
+    }
+
+    @Test
+    fun `when there is a description and no error, then the description is shown as supporting text`() {
+        // GIVEN
+        val componentState = TextInputComponentState(
+            text = "text",
+            description = CheckoutLocalizationKey.CARD_NUMBER,
+            error = null,
+        )
+
+        // WHEN
+        val viewState = componentState.toViewState()
+
+        // THEN
+        assertEquals(false, viewState?.isError)
+        assertEquals(CheckoutLocalizationKey.CARD_NUMBER, viewState?.supportingText)
+    }
+
+    @Test
+    fun `when there is a description and a visible error, then the error takes precedence`() {
+        // GIVEN
+        val componentState = TextInputComponentState(
+            text = "invalid",
+            description = CheckoutLocalizationKey.CARD_NUMBER,
+            error = visibleError(),
+        )
+
+        // WHEN
+        val viewState = componentState.toViewState()
+
+        // THEN
+        assertEquals(true, viewState?.isError)
+        assertEquals(CheckoutLocalizationKey.CARD_NUMBER_INVALID, viewState?.supportingText)
     }
 
     @Test
@@ -140,6 +202,16 @@ internal class TextInputViewStateTest {
         // THEN
         assertNotNull(viewState)
     }
+
+    private fun hiddenError() = TextInputComponentState.InputError(
+        message = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
+        isVisible = false,
+    )
+
+    private fun visibleError() = TextInputComponentState.InputError(
+        message = CheckoutLocalizationKey.CARD_NUMBER_INVALID,
+        isVisible = true,
+    )
 
     private data object TestTrailingIcon : TrailingIcon()
 }

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/state/MBWayComponentStateReducer.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/state/MBWayComponentStateReducer.kt
@@ -25,12 +25,10 @@ internal class MBWayComponentStateReducer : ComponentStateReducer<MBWayComponent
             )
 
             is MBWayIntent.HighlightValidationErrors -> {
-                val hasPhoneNumberError = state.phoneNumber.errorMessage != null
+                val hasPhoneNumberError = !state.phoneNumber.isValid
                 state.copy(
-                    phoneNumber = state.phoneNumber.copy(
-                        showError = hasPhoneNumberError,
-                        isFocused = hasPhoneNumberError,
-                    ),
+                    phoneNumber = state.phoneNumber.showErrorIfPresent()
+                        .copy(isFocused = hasPhoneNumberError),
                 )
             }
         }

--- a/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/state/MBWayComponentStateValidator.kt
+++ b/mbway/src/main/java/com/adyen/checkout/mbway/internal/ui/state/MBWayComponentStateValidator.kt
@@ -23,11 +23,11 @@ internal class MBWayComponentStateValidator : ComponentStateValidator<MBWayCompo
             null
         }
         return state.copy(
-            phoneNumber = state.phoneNumber.copy(errorMessage = phoneNumberError),
+            phoneNumber = state.phoneNumber.updateError(phoneNumberError),
         )
     }
 
     override fun isValid(state: MBWayComponentState): Boolean {
-        return state.phoneNumber.errorMessage == null
+        return state.phoneNumber.isValid
     }
 }

--- a/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/state/MBWayComponentStateFactoryTest.kt
+++ b/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/state/MBWayComponentStateFactoryTest.kt
@@ -33,9 +33,8 @@ internal class MBWayComponentStateFactoryTest {
             phoneNumber = TextInputComponentState(
                 text = "",
                 description = null,
-                errorMessage = null,
-                isFocused = true,
-                showError = false,
+                error = null,
+                isFocused = true
             ),
             isLoading = false,
         )

--- a/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/state/MBWayComponentStateReducerTest.kt
+++ b/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/state/MBWayComponentStateReducerTest.kt
@@ -65,14 +65,13 @@ internal class MBWayComponentStateReducerTest {
             phoneNumber = TextInputComponentState(
                 text = "",
                 isFocused = false,
-                errorMessage = CheckoutLocalizationKey.GENERAL_CLOSE,
-                showError = false,
+                error = TextInputComponentState.InputError(CheckoutLocalizationKey.GENERAL_CLOSE)
             ),
         )
 
         val actual = reducer.reduce(state, MBWayIntent.HighlightValidationErrors)
 
-        assertTrue(actual.phoneNumber.showError)
+        assertTrue(actual.phoneNumber.isErrorVisible)
         assertTrue(actual.phoneNumber.isFocused)
     }
 
@@ -82,7 +81,7 @@ internal class MBWayComponentStateReducerTest {
 
         val actual = reducer.reduce(state, MBWayIntent.HighlightValidationErrors)
 
-        assertFalse(actual.phoneNumber.showError)
+        assertFalse(actual.phoneNumber.isErrorVisible)
         assertFalse(actual.phoneNumber.isFocused)
     }
 
@@ -92,8 +91,7 @@ internal class MBWayComponentStateReducerTest {
         phoneNumber = TextInputComponentState(
             text = "",
             isFocused = false,
-            errorMessage = null,
-            showError = false,
+            error = null
         ),
         isLoading = false,
     )

--- a/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/state/MBWayComponentStateValidatorTest.kt
+++ b/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/state/MBWayComponentStateValidatorTest.kt
@@ -30,16 +30,15 @@ internal class MBWayComponentStateValidatorTest {
                 selectedCountryCode = CountryModel(isoCode = "PT", countryName = "Portugal", callingCode = "+351"),
                 phoneNumber = TextInputComponentState(
                     text = VALID_PHONE_NUMBER,
-                    errorMessage = null,
-                    isFocused = false,
-                    showError = false,
+                    error = null,
+                    isFocused = false
                 ),
                 isLoading = false,
             )
 
             val actual = validator.validate(state)
 
-            assertNull(actual.phoneNumber.errorMessage)
+            assertNull(actual.phoneNumber.error?.message)
         }
 
         @Test
@@ -49,16 +48,15 @@ internal class MBWayComponentStateValidatorTest {
                 selectedCountryCode = CountryModel(isoCode = "PT", countryName = "Portugal", callingCode = "+351"),
                 phoneNumber = TextInputComponentState(
                     text = INVALID_PHONE_NUMBER,
-                    errorMessage = null,
-                    isFocused = false,
-                    showError = false,
+                    error = null,
+                    isFocused = false
                 ),
                 isLoading = false,
             )
 
             val actual = validator.validate(viewState)
 
-            assertEquals(CheckoutLocalizationKey.MBWAY_INVALID_PHONE_NUMBER, actual.phoneNumber.errorMessage)
+            assertEquals(CheckoutLocalizationKey.MBWAY_INVALID_PHONE_NUMBER, actual.phoneNumber.error?.message)
         }
     }
 
@@ -72,9 +70,8 @@ internal class MBWayComponentStateValidatorTest {
                 selectedCountryCode = CountryModel(isoCode = "PT", countryName = "Portugal", callingCode = "+351"),
                 phoneNumber = TextInputComponentState(
                     text = VALID_PHONE_NUMBER,
-                    errorMessage = null,
-                    isFocused = false,
-                    showError = false,
+                    error = null,
+                    isFocused = false
                 ),
                 isLoading = false,
             )
@@ -91,9 +88,8 @@ internal class MBWayComponentStateValidatorTest {
                 selectedCountryCode = CountryModel(isoCode = "PT", countryName = "Portugal", callingCode = "+351"),
                 phoneNumber = TextInputComponentState(
                     text = INVALID_PHONE_NUMBER,
-                    errorMessage = CheckoutLocalizationKey.MBWAY_INVALID_PHONE_NUMBER,
-                    isFocused = false,
-                    showError = false,
+                    error = TextInputComponentState.InputError(CheckoutLocalizationKey.MBWAY_INVALID_PHONE_NUMBER),
+                    isFocused = false
                 ),
                 isLoading = false,
             )

--- a/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/state/MBWayViewStateProducerTest.kt
+++ b/mbway/src/test/java/com/adyen/checkout/mbway/internal/ui/state/MBWayViewStateProducerTest.kt
@@ -31,8 +31,7 @@ internal class MBWayViewStateProducerTest {
             phoneNumber = TextInputComponentState(
                 text = "123456789",
                 isFocused = true,
-                errorMessage = CheckoutLocalizationKey.GENERAL_CLOSE,
-                showError = true,
+                error = TextInputComponentState.InputError(CheckoutLocalizationKey.GENERAL_CLOSE, isVisible = true)
             ),
             isLoading = true,
         )


### PR DESCRIPTION
## Description

`TextInputComponentState` stored an error message separately from whether that error should be visible. This allowed an invalid combination where no error existed but the state said to show one, and forced callers to keep both properties synchronized.

`TextInputComponentState.InputError` now holds the message and visibility together. Validators update the message without changing existing visibility, text changes hide an existing error, and focus changes show or hide it without changing validation.

Card, stored card, MB Way, and BLIK now use the unified error state. This is an internal refactor with no behavior or public API change.

### Progress

➡️ **Phase 1 — Core: error type (this PR)**
Phase 2 — Core: form unit, focus handshake, and IME plumbing
Phase 3 — Card: form state and canonical order
Phase 4 — Card: ordered elements and UI
Phase 5 — Card: focus requests and IME actions
Phase 6 — Stored card, MB Way, and BLIK
Phase 7 — Cleanup and ADR

## Checklist
- [x] Code is unit tested
- [x] Changes are tested manually
